### PR TITLE
Adds anonymous viewing for #live channel, chat popout, and theater mode

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -3,17 +3,14 @@ module ApplicationCable
     identified_by :current_hackr
 
     def connect
-      self.current_hackr = find_verified_hackr
+      self.current_hackr = find_hackr
     end
 
     private
 
-    def find_verified_hackr
-      if (verified_hackr = GridHackr.find_by(id: cookies.encrypted[:grid_hackr_id]))
-        verified_hackr
-      else
-        reject_unauthorized_connection
-      end
+    def find_hackr
+      # Allow anonymous connections (return nil if not logged in)
+      GridHackr.find_by(id: cookies.encrypted[:grid_hackr_id])
     end
   end
 end

--- a/app/channels/grid_channel.rb
+++ b/app/channels/grid_channel.rb
@@ -1,5 +1,12 @@
 class GridChannel < ApplicationCable::Channel
   def subscribed
+    # Reject anonymous connections
+    unless current_hackr
+      Rails.logger.warn "=== GridChannel: Rejected anonymous connection ==="
+      reject
+      return
+    end
+
     # Reload hackr to get fresh current_room data from database
     current_hackr.reload
 

--- a/app/channels/live_chat_channel.rb
+++ b/app/channels/live_chat_channel.rb
@@ -22,9 +22,9 @@ class LiveChatChannel < ApplicationCable::Channel
       return
     end
 
-    # Check channel accessibility
-    unless chat_channel.accessible_by?(current_hackr)
-      Rails.logger.warn "=== LiveChatChannel: #{current_hackr&.hackr_alias || "Anonymous"} cannot access channel #{@channel_slug} ==="
+    # Check channel viewability (allows anonymous read-only access for livestream channels)
+    unless chat_channel.viewable_by?(current_hackr)
+      Rails.logger.warn "=== LiveChatChannel: #{current_hackr&.hackr_alias || "Anonymous"} cannot view channel #{@channel_slug} ==="
       reject
       return
     end

--- a/app/javascript/components/LiveStreamEmbed.tsx
+++ b/app/javascript/components/LiveStreamEmbed.tsx
@@ -1,18 +1,193 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 interface LiveStreamEmbedProps {
   url: string
   title?: string
   artistName?: string
   sideContent?: React.ReactNode
+  theaterMode?: boolean
+  onTheaterModeToggle?: () => void
 }
 
 export const LiveStreamEmbed: React.FC<LiveStreamEmbedProps> = ({
   url,
   title,
   artistName,
-  sideContent
+  sideContent,
+  theaterMode = false,
+  onTheaterModeToggle
 }) => {
+  // Handle escape key to exit theater mode
+  useEffect(() => {
+    if (!theaterMode) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && onTheaterModeToggle) {
+        onTheaterModeToggle()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [theaterMode, onTheaterModeToggle])
+
+  // Prevent body scroll in theater mode
+  useEffect(() => {
+    if (theaterMode) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [theaterMode])
+
+  const theaterButton = onTheaterModeToggle && (
+    <button
+      onClick={onTheaterModeToggle}
+      title={theaterMode ? 'Exit theater mode (Esc)' : 'Theater mode'}
+      style={{
+        position: 'absolute',
+        right: '10px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        background: 'rgba(0, 0, 0, 0.6)',
+        border: '1px solid #00ff00',
+        color: '#00ff00',
+        padding: '6px 10px',
+        fontSize: '0.75rem',
+        cursor: 'pointer',
+        fontFamily: 'Terminus, monospace',
+        zIndex: 10
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'rgba(0, 255, 0, 0.2)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'rgba(0, 0, 0, 0.6)'
+      }}
+    >
+      {theaterMode ? '[x] EXIT' : '[=] THEATER'}
+    </button>
+  )
+
+  // Theater mode: full screen overlay
+  if (theaterMode) {
+    return (
+      <div style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: '#000',
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column'
+      }}>
+        {/* Compact header */}
+        <div style={{
+          background: 'linear-gradient(90deg, #001a00 0%, #003300 50%, #001a00 100%)',
+          borderBottom: '2px solid #00ff00',
+          padding: '8px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '16px',
+          position: 'relative',
+          flexShrink: 0
+        }}>
+          <h1 style={{
+            color: '#00ff00',
+            fontSize: '1.1em',
+            margin: 0,
+            textShadow: '0 0 20px #00ff00',
+            fontWeight: 'bold',
+            letterSpacing: '0.1em'
+          }}>
+            LIVE
+          </h1>
+
+          {artistName && (
+            <span style={{ color: '#fff', fontSize: '1em', fontWeight: 'bold' }}>
+              {artistName}
+            </span>
+          )}
+
+          {title && (
+            <span style={{ color: '#888', fontSize: '0.9em' }}>
+              {title}
+            </span>
+          )}
+
+          {theaterButton}
+        </div>
+
+        {/* Video + Chat container */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          gap: '0',
+          minHeight: 0
+        }}>
+          {/* Video */}
+          <div style={{
+            flex: sideContent ? '1 1 auto' : '1 1 100%',
+            minWidth: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#000'
+          }}>
+            <div style={{
+              width: '100%',
+              height: '100%',
+              maxHeight: '100%',
+              position: 'relative'
+            }}>
+              <iframe
+                src={url}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                  border: 'none'
+                }}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                title={title || 'Live Stream'}
+              />
+            </div>
+          </div>
+
+          {/* Chat sidebar */}
+          {sideContent && (
+            <div style={{
+              flex: '0 0 380px',
+              borderLeft: '2px solid #333',
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0
+            }}>
+              {sideContent}
+            </div>
+          )}
+        </div>
+
+        <style>{`
+          @keyframes pulse-wave {
+            0% { left: -100%; }
+            100% { left: 100%; }
+          }
+        `}</style>
+      </div>
+    )
+  }
+
+  // Normal mode
   return (
     <div style={{
       width: '100%',
@@ -53,7 +228,7 @@ export const LiveStreamEmbed: React.FC<LiveStreamEmbedProps> = ({
           fontWeight: 'bold',
           letterSpacing: '0.1em'
         }}>
-          ⚡ LIVE NOW ⚡
+          LIVE NOW
         </h1>
 
         {artistName && (
@@ -76,6 +251,8 @@ export const LiveStreamEmbed: React.FC<LiveStreamEmbedProps> = ({
             {title}
           </p>
         )}
+
+        {theaterButton}
       </div>
 
       {/* Stream Embed + Side Content */}

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -30,6 +30,7 @@ const HotwirePage = lazy(() => import('~/components/pulsewire/HotwirePage').then
 const UserPulsesPage = lazy(() => import('~/components/pulsewire/UserPulsesPage').then(m => ({ default: m.UserPulsesPage })))
 const SinglePulsePage = lazy(() => import('~/components/pulsewire/SinglePulsePage').then(m => ({ default: m.SinglePulsePage })))
 const UplinkPage = lazy(() => import('~/components/pages/uplink/UplinkPage').then(m => ({ default: m.UplinkPage })))
+const UplinkPopoutPage = lazy(() => import('~/components/pages/uplink/UplinkPopoutPage').then(m => ({ default: m.UplinkPopoutPage })))
 const NotFoundPage = lazy(() => import('~/components/errors/NotFoundPage').then(m => ({ default: m.NotFoundPage })))
 
 // Auth components
@@ -96,6 +97,8 @@ export const AppLayout: React.FC = () => {
         <Route path="/wire/pulse/:id" element={<SinglePulsePage />} />
         {/* Uplink routes - protected */}
         <Route path="/uplink" element={<ProtectedRoute><UplinkPage /></ProtectedRoute>} />
+        {/* Uplink popout - public for livestream viewing */}
+        <Route path="/uplink/popout" element={<UplinkPopoutPage />} />
         {/* 404 catch-all - must be last */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/app/javascript/components/pages/HomePage.tsx
+++ b/app/javascript/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { TerminalAnimation } from '~/components/terminal/TerminalAnimation'
 import { LiveStreamEmbed } from '~/components/LiveStreamEmbed'
@@ -18,9 +18,21 @@ interface StreamData {
   started_at?: string
 }
 
+const HEARTBEAT_KEY = 'uplink_popout_heartbeat'
+const HEARTBEAT_STALE_MS = 2000 // Consider popout dead if no heartbeat for 2 seconds
+
+const isPopoutAlive = (): boolean => {
+  const heartbeat = localStorage.getItem(HEARTBEAT_KEY)
+  if (!heartbeat) return false
+  const lastBeat = parseInt(heartbeat, 10)
+  return Date.now() - lastBeat < HEARTBEAT_STALE_MS
+}
+
 export const HomePage: React.FC = () => {
   const [streamData, setStreamData] = useState<StreamData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [chatPoppedOut, setChatPoppedOut] = useState(isPopoutAlive)
+  const [theaterMode, setTheaterMode] = useState(false)
 
   const fetchStreamStatus = async () => {
     try {
@@ -41,6 +53,37 @@ export const HomePage: React.FC = () => {
     const interval = setInterval(fetchStreamStatus, 30000)
 
     return () => clearInterval(interval)
+  }, [])
+
+  // Check popout heartbeat periodically
+  useEffect(() => {
+    const checkPopoutStatus = () => {
+      setChatPoppedOut(isPopoutAlive())
+    }
+
+    // Check frequently to detect when popout closes
+    const checkInterval = setInterval(checkPopoutStatus, 500)
+
+    return () => {
+      clearInterval(checkInterval)
+    }
+  }, [])
+
+  const handlePopout = useCallback(() => {
+    const popoutWindow = window.open(
+      '/uplink/popout',
+      'uplink_popout',
+      'width=400,height=600,resizable=yes,scrollbars=no'
+    )
+
+    if (popoutWindow) {
+      // The popout page will start sending heartbeats, which we'll detect
+      setChatPoppedOut(true)
+    }
+  }, [])
+
+  const toggleTheaterMode = useCallback(() => {
+    setTheaterMode(prev => !prev)
   }, [])
 
   if (loading) {
@@ -66,7 +109,18 @@ export const HomePage: React.FC = () => {
           url={streamData.live_url}
           title={streamData.title}
           artistName={streamData.artist?.name}
-          sideContent={<UplinkPanel defaultChannel="live" livestreamOnly />}
+          theaterMode={theaterMode}
+          onTheaterModeToggle={toggleTheaterMode}
+          sideContent={
+            chatPoppedOut ? undefined : (
+              <UplinkPanel
+                defaultChannel="live"
+                livestreamOnly
+                allowPopout
+                onPopout={handlePopout}
+              />
+            )
+          }
         />
       ) : (
         <TerminalAnimation />

--- a/app/javascript/components/pages/uplink/UplinkPopoutPage.tsx
+++ b/app/javascript/components/pages/uplink/UplinkPopoutPage.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react'
+import { UplinkPanel } from '~/components/uplink/UplinkPanel'
+
+const HEARTBEAT_KEY = 'uplink_popout_heartbeat'
+const HEARTBEAT_INTERVAL = 500 // ms
+
+export const UplinkPopoutPage: React.FC = () => {
+  useEffect(() => {
+    // Send initial heartbeat
+    localStorage.setItem(HEARTBEAT_KEY, Date.now().toString())
+
+    // Send heartbeat periodically so main window knows we're still alive
+    const heartbeatInterval = setInterval(() => {
+      localStorage.setItem(HEARTBEAT_KEY, Date.now().toString())
+    }, HEARTBEAT_INTERVAL)
+
+    // Clean up when window closes
+    const handleBeforeUnload = () => {
+      localStorage.removeItem(HEARTBEAT_KEY)
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      clearInterval(heartbeatInterval)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      localStorage.removeItem(HEARTBEAT_KEY)
+    }
+  }, [])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: '#0a0a0a',
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
+      <UplinkPanel defaultChannel="live" livestreamOnly />
+    </div>
+  )
+}
+
+export default UplinkPopoutPage

--- a/app/javascript/components/uplink/UplinkPanel.tsx
+++ b/app/javascript/components/uplink/UplinkPanel.tsx
@@ -13,9 +13,16 @@ import type { ChatChannel, Packet, UplinkHackr, UplinkMessage, ChannelsResponse,
 interface UplinkPanelProps {
   defaultChannel?: string
   livestreamOnly?: boolean
+  allowPopout?: boolean
+  onPopout?: () => void
 }
 
-export const UplinkPanel: React.FC<UplinkPanelProps> = ({ defaultChannel = 'ambient', livestreamOnly = false }) => {
+export const UplinkPanel: React.FC<UplinkPanelProps> = ({
+  defaultChannel = 'ambient',
+  livestreamOnly = false,
+  allowPopout = false,
+  onPopout
+}) => {
   const [channels, setChannels] = useState<ChatChannel[]>([])
   const [activeChannel, setActiveChannel] = useState<string>(defaultChannel)
   const [packets, setPackets] = useState<Packet[]>([])
@@ -241,11 +248,39 @@ export const UplinkPanel: React.FC<UplinkPanelProps> = ({ defaultChannel = 'ambi
           UPLINK
         </h2>
 
-        {currentHackr && (
-          <span style={{ fontSize: '0.75rem', color: '#666' }}>
-            @{currentHackr.hackr_alias}
-          </span>
-        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          {currentHackr && (
+            <span style={{ fontSize: '0.75rem', color: '#666' }}>
+              @{currentHackr.hackr_alias}
+            </span>
+          )}
+          {allowPopout && onPopout && (
+            <button
+              onClick={onPopout}
+              title="Pop out chat"
+              style={{
+                background: 'none',
+                border: '1px solid #444',
+                color: '#888',
+                padding: '4px 8px',
+                fontSize: '0.75rem',
+                cursor: 'pointer',
+                fontFamily: 'Terminus, monospace',
+                borderRadius: '2px'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = '#7c3aed'
+                e.currentTarget.style.color = '#7c3aed'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = '#444'
+                e.currentTarget.style.color = '#888'
+              }}
+            >
+              [^]
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Channel tabs */}
@@ -330,7 +365,8 @@ export const UplinkPanel: React.FC<UplinkPanelProps> = ({ defaultChannel = 'ambi
               padding: '16px',
               textAlign: 'center',
               backgroundColor: '#111',
-              borderTop: '1px solid #333'
+              borderTop: '1px solid #333',
+              color: '#999'
             }}
           >
             <Link

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -16,7 +16,7 @@ class ChatChannel < ApplicationRecord
     true
   end
 
-  # Check if a hackr can access this channel based on role requirements
+  # Check if a hackr can access this channel based on role requirements (for transmitting)
   def accessible_by?(hackr)
     return false unless hackr
     return false unless currently_available?
@@ -25,6 +25,18 @@ class ChatChannel < ApplicationRecord
     required_level = GridHackr::ROLE_LEVELS[minimum_role] || 0
 
     hackr_level >= required_level
+  end
+
+  # Check if channel is viewable (read-only access)
+  # Anonymous users can only view livestream channels (e.g., #live)
+  def viewable_by?(hackr)
+    return false unless currently_available?
+
+    # Anonymous users can only view livestream channels
+    return requires_livestream? unless hackr
+
+    # Logged-in users must meet role requirements
+    accessible_by?(hackr)
   end
 
   # Get the broadcast stream name for ActionCable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
 
   # Uplink routes - SPA
   get "uplink", to: "pages#spa_root", as: :uplink
+  get "uplink/popout", to: "pages#spa_root", as: :uplink_popout
 
   # Terminal SSH access credentials page
   get "terminal", to: "terminal#index", as: :terminal


### PR DESCRIPTION
Uplink anonymous viewing:
  - Allows anonymous WebSocket connections for read-only access
  - Adds viewable_by? method to ChatChannel for livestream-only anonymous access
  - Logged-out users can view #live channel packets but cannot transmit
  - Updates login prompt text color for better visibility

Chat popout feature:
  - Adds /uplink/popout route for standalone chat window
  - Implements heartbeat mechanism for reliable popout state detection
  - Adds popout button [^] to UplinkPanel header
  - Video expands to full width when chat is popped out
  - Main window detects popout close within 2 seconds

Theater mode:
  - Adds fullscreen theater mode for livestream viewing
  - Toggle via [=] THEATER button in LIVE header
  - Exit via [x] EXIT button or Escape key
  - Video fills screen with chat sidebar (380px)
  - Prevents body scroll when active