### PR TITLE
 Email OTP registration and weak password rejection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.1)
+    brakeman (8.0.2)
       racc
     browser (6.2.0)
     builder (3.3.0)

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -21,6 +21,15 @@ class Api::GridController < ApplicationController
     hackr = GridHackr.find_by(hackr_alias: params[:hackr_alias])
 
     if hackr&.authenticate(params[:password])
+      # Ensure hackr has a current room (spawn point if missing)
+      if hackr.current_room.nil?
+        starting_room = GridRoom.joins(:grid_zone)
+          .where(grid_zones: {slug: "hackr_tv_central"})
+          .where(room_type: "hub")
+          .first
+        hackr.update!(current_room: starting_room) if starting_room
+      end
+
       log_in(hackr)
       hackr.touch_activity!
       Rails.logger.info("[AUTH] Login success: hackr_alias=#{hackr.hackr_alias} ip=#{request.remote_ip}")
@@ -45,17 +54,104 @@ class Api::GridController < ApplicationController
     end
   end
 
-  # POST /api/grid/register - Create new hackr account
+  # POST /api/grid/register - Request registration verification email
   def register
-    # Block registration during prerelease mode
-    if APP_SETTINGS[:prerelease_mode].present?
+    email = params[:email].to_s.downcase.strip
+
+    if email.blank?
       return render json: {
         success: false,
-        error: "Registration is temporarily disabled during #{APP_SETTINGS[:prerelease_mode]} phase. Existing users can still log in."
-      }, status: :forbidden
+        error: "Email address is required."
+      }, status: :unprocessable_entity
     end
 
-    @hackr = GridHackr.new(hackr_params)
+    unless email.match?(URI::MailTo::EMAIL_REGEXP)
+      return render json: {
+        success: false,
+        error: "Please enter a valid email address."
+      }, status: :unprocessable_entity
+    end
+
+    # Check if email is already registered
+    if GridHackr.exists?(email: email)
+      return render json: {
+        success: false,
+        error: "This email address is already registered. Try logging in instead."
+      }, status: :unprocessable_entity
+    end
+
+    # Create registration token
+    token = GridRegistrationToken.create!(
+      email: email,
+      ip_address: request.remote_ip
+    )
+
+    # Send verification email
+    GridMailer.registration_verification(token).deliver_later
+
+    Rails.logger.info("[AUTH] Registration email sent: email=#{email} ip=#{request.remote_ip}")
+    render json: {
+      success: true,
+      message: "Verification email sent. Check your inbox to complete registration."
+    }
+  end
+
+  # GET /api/grid/verify/:token - Check if registration token is valid
+  def verify_token
+    token = GridRegistrationToken.find_by(token: params[:token])
+
+    if token.nil?
+      return render json: {
+        valid: false,
+        error: "Invalid verification link."
+      }
+    end
+
+    if token.used?
+      return render json: {
+        valid: false,
+        error: "This verification link has already been used."
+      }
+    end
+
+    if token.expired?
+      return render json: {
+        valid: false,
+        error: "This verification link has expired. Please register again."
+      }
+    end
+
+    render json: {
+      valid: true,
+      email: token.email
+    }
+  end
+
+  # POST /api/grid/complete_registration - Complete registration with alias and password
+  def complete_registration
+    token = GridRegistrationToken.find_by(token: params[:token])
+
+    if token.nil?
+      return render json: {
+        success: false,
+        error: "Invalid verification token."
+      }, status: :unprocessable_entity
+    end
+
+    unless token.valid_for_use?
+      error_message = token.used? ? "This verification link has already been used." : "This verification link has expired."
+      return render json: {
+        success: false,
+        error: error_message
+      }, status: :unprocessable_entity
+    end
+
+    @hackr = GridHackr.new(
+      email: token.email,
+      hackr_alias: params[:hackr_alias],
+      password: params[:password],
+      password_confirmation: params[:password_confirmation]
+    )
     @hackr.enforce_alias_length = true
 
     # Set starting room (hackr.tv Broadcast Station)
@@ -66,27 +162,29 @@ class Api::GridController < ApplicationController
 
     @hackr.current_room = starting_room
 
-    if @hackr.save
-      log_in(@hackr)
-      @hackr.touch_activity!
-      Rails.logger.info("[AUTH] Registration success: hackr_alias=#{@hackr.hackr_alias} ip=#{request.remote_ip}")
-      render json: {
-        success: true,
-        message: "Welcome to THE PULSE GRID, #{@hackr.hackr_alias}. Your journey with the Fracture Network begins now.",
-        hackr: {
-          id: @hackr.id,
-          hackr_alias: @hackr.hackr_alias,
-          role: @hackr.role,
-          current_room: @hackr.current_room ? room_json(@hackr.current_room) : nil
-        }
-      }, status: :created
-    else
-      attempted_alias = params[:hackr_alias].to_s.truncate(50)
-      Rails.logger.warn("[AUTH] Registration failed: attempted_alias=#{attempted_alias} errors=#{@hackr.errors.full_messages.join("; ")} ip=#{request.remote_ip}")
-      render json: {
-        success: false,
-        error: "Registration failed: #{@hackr.errors.full_messages.join(", ")}"
-      }, status: :unprocessable_entity
+    ActiveRecord::Base.transaction do
+      if @hackr.save
+        token.mark_used!
+        log_in(@hackr)
+        @hackr.touch_activity!
+        Rails.logger.info("[AUTH] Registration completed: hackr_alias=#{@hackr.hackr_alias} email=#{token.email} ip=#{request.remote_ip}")
+        render json: {
+          success: true,
+          message: "Welcome to THE PULSE GRID, #{@hackr.hackr_alias}. Your journey with the Fracture Network begins now.",
+          hackr: {
+            id: @hackr.id,
+            hackr_alias: @hackr.hackr_alias,
+            role: @hackr.role,
+            current_room: @hackr.current_room ? room_json(@hackr.current_room) : nil
+          }
+        }, status: :created
+      else
+        Rails.logger.warn("[AUTH] Registration completion failed: email=#{token.email} errors=#{@hackr.errors.full_messages.join("; ")} ip=#{request.remote_ip}")
+        render json: {
+          success: false,
+          error: "Registration failed: #{@hackr.errors.full_messages.join(", ")}"
+        }, status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -22,6 +22,7 @@ const TrackDetailPage = lazy(() => import('~/components/pages/tracks/TrackDetail
 const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').then(m => ({ default: m.GridGamePage })))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
+const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
 const LogsIndexPage = lazy(() => import('~/components/pages/logs/LogsIndexPage').then(m => ({ default: m.LogsIndexPage })))
 const LogDetailPage = lazy(() => import('~/components/pages/logs/LogDetailPage').then(m => ({ default: m.LogDetailPage })))
 const CodexIndexPage = lazy(() => import('~/components/pages/codex/CodexIndexPage').then(m => ({ default: m.CodexIndexPage })))
@@ -85,6 +86,7 @@ export const AppLayout: React.FC = () => {
         <Route path="/grid" element={<GridGamePage />} />
         <Route path="/grid/login" element={<GridLoginPage />} />
         <Route path="/grid/register" element={<GridRegisterPage />} />
+        <Route path="/grid/verify/:token" element={<GridVerifyPage />} />
         {/* Hackr Logs routes */}
         <Route path="/logs" element={<LogsIndexPage />} />
         <Route path="/logs/:slug" element={<LogDetailPage />} />

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -208,35 +208,7 @@ export const HeaderMenu: React.FC = () => {
               </div>
 
               <div className="mobile-menu-section">
-                <div className="mobile-menu-section-title">3. THE PULSE GRID</div>
-                <Link to="/grid" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">/</span>grid
-                </Link>
-                {isLoggedIn ? (
-                  <a
-                    href="#"
-                    className="mobile-menu-item"
-                    onClick={(e) => {
-                      handleDisconnect(e)
-                      setMobileMenuOpen(false)
-                    }}
-                  >
-                    <span className="purple-168-text">/</span>disconnect
-                  </a>
-                ) : (
-                  <>
-                    <Link to="/grid/login" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
-                      <span className="purple-168-text">/</span>login
-                    </Link>
-                    <Link to="/grid/register" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
-                      <span className="purple-168-text">/</span>register
-                    </Link>
-                  </>
-                )}
-              </div>
-
-              <div className="mobile-menu-section">
-                <div className="mobile-menu-section-title">4. The WIRE</div>
+                <div className="mobile-menu-section-title">3. The WIRE</div>
                 <Link to="/wire" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>hotwire
                 </Link>
@@ -254,14 +226,47 @@ export const HeaderMenu: React.FC = () => {
               <div className="mobile-menu-section">
                 <div className="mobile-menu-section-title">MORE</div>
                 <Link to="/codex" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '6' : '5'}</span> The Codex
+                  <span className="purple-168-text">{isLoggedIn ? '5' : '4'}</span> The Codex
                 </Link>
                 <Link to="/logs" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '7' : '6'}</span> Hackr Logs
+                  <span className="purple-168-text">{isLoggedIn ? '6' : '5'}</span> Hackr Logs
                 </Link>
+              </div>
+
+              <div className="mobile-menu-section">
+                <div className="mobile-menu-section-title">{isLoggedIn ? '7' : '6'}. THE PULSE GRID</div>
+                <Link to="/grid" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>grid
+                </Link>
+                {!isLoggedIn && (
+                  <>
+                    <Link to="/grid/login" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>login
+                    </Link>
+                    <Link to="/grid/register" className="mobile-menu-item" onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>register
+                    </Link>
+                  </>
+                )}
                 {hackr?.role === 'admin' && (
                   <a href="/root" className="mobile-menu-item">
                     <span className="red-255-text">{isLoggedIn ? '8' : '7'}</span> /root <span className="red-255-text">[ADMIN]</span>
+                  </a>
+                )}
+              </div>
+
+              <div className="mobile-menu-section">
+                {isLoggedIn && (
+                  <a
+                    href="#"
+                    className="mobile-menu-item"
+                    style={{ color: '#dc2626' }}
+                    onClick={(e) => {
+                      handleDisconnect(e)
+                      setMobileMenuOpen(false)
+                    }}
+                  >
+                    × Disconnect
                   </a>
                 )}
               </div>
@@ -408,9 +413,39 @@ export const HeaderMenu: React.FC = () => {
             </div>
           </li>
 
-          {/* 3: THE PULSE GRID */}
+          {/* 3: The WIRE */}
+          <li className="header-nav-item">
+            <Link to="/wire">
+              <span className="purple-168-text">3</span> The WIRE&nbsp;
+            </Link>
+          </li>
+
+          {/* 4: Uplink (logged in only) */}
+          {isLoggedIn && (
+            <li className="header-nav-item">
+              <Link to="/uplink">
+                <span className="purple-168-text">4</span> Uplink&nbsp;
+              </Link>
+            </li>
+          )}
+
+          {/* The Codex */}
+          <li className="header-nav-item">
+            <Link to="/codex">
+              <span className="purple-168-text">{isLoggedIn ? '5' : '4'}</span> The Codex&nbsp;
+            </Link>
+          </li>
+
+          {/* Hackr Logs */}
+          <li className="header-nav-item">
+            <Link to="/logs">
+              <span className="purple-168-text">{isLoggedIn ? '6' : '5'}</span> Hackr Logs&nbsp;
+            </Link>
+          </li>
+
+          {/* THE PULSE GRID */}
           <li className="header-dropdown" onClick={() => toggleDropdown('grid')}>
-            <span className="purple-168-text">3</span>&nbsp;THE PULSE GRID&nbsp;
+            <span className="purple-168-text">{isLoggedIn ? '7' : '6'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
                 <li>
@@ -418,13 +453,7 @@ export const HeaderMenu: React.FC = () => {
                     <span className="purple-168-text">/</span>grid
                   </Link>
                 </li>
-                {isLoggedIn ? (
-                  <li>
-                    <a href="#" onClick={(e) => { handleDisconnect(e); closeDropdown() }}>
-                      <span className="purple-168-text">/</span>disconnect
-                    </a>
-                  </li>
-                ) : (
+                {!isLoggedIn && (
                   <>
                     <li>
                       <Link to="/grid/login" onClick={closeDropdown}>
@@ -442,41 +471,20 @@ export const HeaderMenu: React.FC = () => {
             </div>
           </li>
 
-          {/* 4: The WIRE */}
-          <li className="header-nav-item">
-            <Link to="/wire">
-              <span className="purple-168-text">4</span> The WIRE&nbsp;
-            </Link>
-          </li>
-
-          {/* 5: Uplink (logged in only) */}
-          {isLoggedIn && (
-            <li className="header-nav-item">
-              <Link to="/uplink">
-                <span className="purple-168-text">5</span> Uplink&nbsp;
-              </Link>
-            </li>
-          )}
-
-          {/* The Codex */}
-          <li className="header-nav-item">
-            <Link to="/codex">
-              <span className="purple-168-text">{isLoggedIn ? '6' : '5'}</span> The Codex&nbsp;
-            </Link>
-          </li>
-
-          {/* Hackr Logs */}
-          <li className="header-nav-item">
-            <Link to="/logs">
-              <span className="purple-168-text">{isLoggedIn ? '7' : '6'}</span> Hackr Logs&nbsp;
-            </Link>
-          </li>
-
           {/* Admin (only show if user is admin) */}
           {hackr?.role === 'admin' && (
             <li className="header-nav-item">
               <a href="/root">
                 <span className="red-255-text">{isLoggedIn ? '8' : '7'}</span> /root <span className="red-255-text">[ADMIN]</span>&nbsp;
+              </a>
+            </li>
+          )}
+
+          {/* Disconnect (only show if logged in) */}
+          {isLoggedIn && (
+            <li className="header-nav-item">
+              <a href="#" onClick={handleDisconnect} style={{ color: '#dc2626' }}>
+                <span>×</span> Disconnect&nbsp;
               </a>
             </li>
           )}

--- a/app/javascript/components/pages/grid/GridGamePage.tsx
+++ b/app/javascript/components/pages/grid/GridGamePage.tsx
@@ -10,6 +10,9 @@ import { ZonePlaylistData, TrackData } from '~/types/track'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { apiJson } from '~/utils/apiClient'
 
+// Feature flag to disable ambient audio
+const AMBIENT_AUDIO_ENABLED = false
+
 const getWelcomeMessage = (isMobile: boolean) => {
   const divider = isMobile
     ? '══════════════════════════════════'
@@ -272,7 +275,7 @@ export const GridGamePage: React.FC = () => {
             )}
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: isMobile ? 'space-between' : 'flex-end' }}>
-            {ambientPlaylist && (
+            {AMBIENT_AUDIO_ENABLED && ambientPlaylist && (
               <div style={{ fontSize: '0.85em', color: '#888', marginRight: isMobile ? '0' : '8px', display: 'flex', alignItems: 'center', gap: '8px', flex: isMobile ? 1 : 'none', overflow: 'hidden' }}>
                 <span style={{ color: '#a78bfa' }}>🎵</span>
                 <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: isMobile ? '100px' : 'none' }}>{currentTrack?.title || ambientPlaylist.name}</span>
@@ -324,7 +327,7 @@ export const GridGamePage: React.FC = () => {
                 flexShrink: 0
               }}
             >
-              {isMobile ? 'EXIT' : 'DISCONNECT'}
+              {isMobile ? 'EXIT' : 'KILLSWITCH'}
             </button>
           </div>
         </div>
@@ -333,20 +336,22 @@ export const GridGamePage: React.FC = () => {
         <CommandInput ref={commandInputRef} onSubmit={handleCommand} disabled={executing} />
       </div>
 
-      <GridAmbientPlayer
-        playlist={ambientPlaylist}
-        muted={ambientMuted}
-        volume={ambientVolume}
-        onMutedChange={(muted) => {
-          setAmbientMuted(muted)
-          localStorage.setItem('grid_ambient_muted', String(muted))
-        }}
-        onVolumeChange={(volume) => {
-          setAmbientVolume(volume)
-          localStorage.setItem('grid_ambient_volume', String(volume))
-        }}
-        onTrackChange={setCurrentTrack}
-      />
+      {AMBIENT_AUDIO_ENABLED && (
+        <GridAmbientPlayer
+          playlist={ambientPlaylist}
+          muted={ambientMuted}
+          volume={ambientVolume}
+          onMutedChange={(muted) => {
+            setAmbientMuted(muted)
+            localStorage.setItem('grid_ambient_muted', String(muted))
+          }}
+          onVolumeChange={(volume) => {
+            setAmbientVolume(volume)
+            localStorage.setItem('grid_ambient_volume', String(volume))
+          }}
+          onTrackChange={setCurrentTrack}
+        />
+      )}
     </GridLayout>
   )
 }

--- a/app/javascript/components/pages/grid/GridRegisterPage.tsx
+++ b/app/javascript/components/pages/grid/GridRegisterPage.tsx
@@ -1,46 +1,80 @@
 import React, { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { GridLayout } from '~/components/layouts/GridLayout'
 import { useGridAuth } from '~/hooks/useGridAuth'
-import { PrereleaseModal } from '~/components/prerelease/PrereleaseModal'
 
 export const GridRegisterPage: React.FC = () => {
-  const [hackrAlias, setHackrAlias] = useState('')
-  const [password, setPassword] = useState('')
-  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [email, setEmail] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
-  const { register } = useGridAuth()
-  const navigate = useNavigate()
+  const [success, setSuccess] = useState(false)
+  const { requestRegistration } = useGridAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
     setLoading(true)
 
-    const result = await register(hackrAlias, password, passwordConfirmation)
+    const result = await requestRegistration(email)
 
     if (result.success) {
-      navigate('/grid')
+      setSuccess(true)
     } else {
-      setError(result.error || 'Registration failed')
+      setError(result.error || 'Failed to send verification email')
     }
 
     setLoading(false)
   }
 
+  if (success) {
+    return (
+      <GridLayout>
+        <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+          <fieldset className="cyan-168-border">
+            <legend className="center">THE PULSE GRID :: REGISTRATION</legend>
+
+            <div className="center" style={{ margin: '30px 0' }}>
+              <h1 className="green-255-text" style={{ fontSize: '2.5em', letterSpacing: '0.1em', margin: 0 }}>
+                CHECK YOUR INBOX
+              </h1>
+              <p style={{ margin: '20px 0', fontSize: '1.2em', lineHeight: '1.6' }}>
+                A verification link has been sent to<br />
+                <span className="cyan-255-text" style={{ fontWeight: 'bold' }}>{email}</span>
+              </p>
+              <p style={{ margin: '20px 0', color: '#ccc' }}>
+                Click the link in the email to complete your registration and join the Fracture Network.
+              </p>
+              <p style={{ margin: '20px 0', color: '#bbb', fontSize: '0.9em' }}>
+                The link expires in 24 hours.
+              </p>
+            </div>
+
+            <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
+
+            <div className="center" style={{ margin: '20px 0' }}>
+              <p className="white-text" style={{ marginBottom: '10px' }}>DIDN'T RECEIVE IT?</p>
+              <button
+                onClick={() => setSuccess(false)}
+                className="tui-button purple-168"
+              >
+                TRY AGAIN
+              </button>
+            </div>
+          </fieldset>
+        </div>
+      </GridLayout>
+    )
+  }
+
   return (
     <GridLayout>
-      {/* Prerelease modal overlay - persistent, cannot be dismissed */}
-      <PrereleaseModal />
-
       <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
         <fieldset className="cyan-168-border">
           <legend className="center">THE PULSE GRID :: REGISTRATION</legend>
 
           {error && (
             <div style={{ background: '#330000', border: '2px solid #ff0000', padding: '15px', margin: '20px 0', borderRadius: '4px' }}>
-              <p className="red-255-text" style={{ margin: 0, fontWeight: 'bold' }}>⚠ ERROR</p>
+              <p className="red-255-text" style={{ margin: 0, fontWeight: 'bold' }}>ERROR</p>
               <p className="white-text" style={{ margin: '5px 0 0 0' }}>{error}</p>
             </div>
           )}
@@ -54,58 +88,24 @@ export const GridRegisterPage: React.FC = () => {
 
           <form onSubmit={handleSubmit}>
             <div style={{ marginBottom: '20px' }}>
-              <label htmlFor="hackr_alias" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
-                HACKR ALIAS
+              <label htmlFor="email" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                EMAIL ADDRESS
               </label>
               <input
-                type="text"
-                id="hackr_alias"
-                value={hackrAlias}
-                onChange={(e) => setHackrAlias(e.target.value)}
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 className="tui-input"
-                placeholder="Choose your alias"
+                placeholder="Enter your email"
                 required
                 autoFocus
                 disabled={loading}
                 style={{ width: '100%' }}
               />
               <small className="gray-text" style={{ display: 'block', marginTop: '5px' }}>
-                This will be your identity in THE PULSE GRID.
+                We'll send you a verification link to complete registration.
               </small>
-            </div>
-
-            <div style={{ marginBottom: '20px' }}>
-              <label htmlFor="password" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
-                PASSWORD
-              </label>
-              <input
-                type="password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="tui-input"
-                placeholder="Enter secure password"
-                required
-                disabled={loading}
-                style={{ width: '100%' }}
-              />
-            </div>
-
-            <div style={{ marginBottom: '20px' }}>
-              <label htmlFor="password_confirmation" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
-                CONFIRM PASSWORD
-              </label>
-              <input
-                type="password"
-                id="password_confirmation"
-                value={passwordConfirmation}
-                onChange={(e) => setPasswordConfirmation(e.target.value)}
-                className="tui-input"
-                placeholder="Re-enter password"
-                required
-                disabled={loading}
-                style={{ width: '100%' }}
-              />
             </div>
 
             <div className="center" style={{ margin: '30px 0' }}>
@@ -115,7 +115,7 @@ export const GridRegisterPage: React.FC = () => {
                 disabled={loading}
                 style={{ fontSize: '1.1em', padding: '10px 30px' }}
               >
-                {loading ? 'JOINING...' : 'JOIN GRID'}
+                {loading ? 'SENDING...' : 'SEND VERIFICATION'}
               </button>
             </div>
           </form>

--- a/app/javascript/components/pages/grid/GridVerifyPage.tsx
+++ b/app/javascript/components/pages/grid/GridVerifyPage.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect } from 'react'
+import { Link, useParams, useNavigate } from 'react-router-dom'
+import { GridLayout } from '~/components/layouts/GridLayout'
+import { useGridAuth } from '~/hooks/useGridAuth'
+
+export const GridVerifyPage: React.FC = () => {
+  const { token } = useParams<{ token: string }>()
+  const navigate = useNavigate()
+  const { verifyToken, completeRegistration } = useGridAuth()
+
+  const [email, setEmail] = useState<string | null>(null)
+  const [hackrAlias, setHackrAlias] = useState('')
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [tokenValid, setTokenValid] = useState(false)
+
+  useEffect(() => {
+    const checkToken = async () => {
+      if (!token) {
+        setError('No verification token provided.')
+        setLoading(false)
+        return
+      }
+
+      const result = await verifyToken(token)
+
+      if (result.valid && result.email) {
+        setTokenValid(true)
+        setEmail(result.email)
+      } else {
+        setError(result.error || 'Invalid verification link.')
+      }
+
+      setLoading(false)
+    }
+
+    checkToken()
+  }, [token, verifyToken])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!token) return
+
+    setError(null)
+    setSubmitting(true)
+
+    const result = await completeRegistration(token, hackrAlias, password, passwordConfirmation)
+
+    if (result.success) {
+      navigate('/grid')
+    } else {
+      setError(result.error || 'Registration failed')
+    }
+
+    setSubmitting(false)
+  }
+
+  if (loading) {
+    return (
+      <GridLayout>
+        <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+          <fieldset className="cyan-168-border">
+            <legend className="center">THE PULSE GRID :: VERIFICATION</legend>
+            <div className="center" style={{ margin: '50px 0' }}>
+              <p style={{ fontSize: '1.2em' }}>VERIFYING TOKEN...</p>
+            </div>
+          </fieldset>
+        </div>
+      </GridLayout>
+    )
+  }
+
+  if (!tokenValid) {
+    return (
+      <GridLayout>
+        <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+          <fieldset className="cyan-168-border">
+            <legend className="center">THE PULSE GRID :: VERIFICATION</legend>
+
+            <div style={{ background: '#330000', border: '2px solid #ff0000', padding: '15px', margin: '20px 0', borderRadius: '4px' }}>
+              <p className="red-255-text" style={{ margin: 0, fontWeight: 'bold' }}>VERIFICATION FAILED</p>
+              <p className="white-text" style={{ margin: '5px 0 0 0' }}>{error}</p>
+            </div>
+
+            <div className="center" style={{ margin: '30px 0' }}>
+              <p style={{ margin: '20px 0', color: '#999' }}>
+                The verification link may have expired or already been used.
+              </p>
+              <Link to="/grid/register" className="tui-button purple-168">
+                REGISTER AGAIN
+              </Link>
+            </div>
+          </fieldset>
+        </div>
+      </GridLayout>
+    )
+  }
+
+  return (
+    <GridLayout>
+      <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+        <fieldset className="cyan-168-border">
+          <legend className="center">THE PULSE GRID :: COMPLETE REGISTRATION</legend>
+
+          {error && (
+            <div style={{ background: '#330000', border: '2px solid #ff0000', padding: '15px', margin: '20px 0', borderRadius: '4px' }}>
+              <p className="red-255-text" style={{ margin: 0, fontWeight: 'bold' }}>ERROR</p>
+              <p className="white-text" style={{ margin: '5px 0 0 0' }}>{error}</p>
+            </div>
+          )}
+
+          <div className="center" style={{ margin: '30px 0' }}>
+            <h1 className="cyan-255-text" style={{ fontSize: '2em', letterSpacing: '0.1em', margin: 0 }}>
+              ALMOST THERE
+            </h1>
+            <p style={{ margin: '10px 0', fontSize: '1.1em' }}>
+              Email verified: <span className="green-255-text">{email}</span>
+            </p>
+            <p style={{ margin: '10px 0', color: '#ccc' }}>
+              Choose your alias and set a password to complete registration.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '20px' }}>
+              <label htmlFor="hackr_alias" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                HACKR ALIAS
+              </label>
+              <input
+                type="text"
+                id="hackr_alias"
+                value={hackrAlias}
+                onChange={(e) => setHackrAlias(e.target.value)}
+                className="tui-input"
+                placeholder="Choose your alias"
+                required
+                autoFocus
+                disabled={submitting}
+                style={{ width: '100%' }}
+              />
+              <small className="gray-text" style={{ display: 'block', marginTop: '5px' }}>
+                This will be your identity in THE PULSE GRID.<br />Minimum 6 characters.
+              </small>
+            </div>
+
+            <div style={{ marginBottom: '20px' }}>
+              <label htmlFor="password" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                PASSWORD
+              </label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="tui-input"
+                placeholder="Enter secure password"
+                required
+                disabled={submitting}
+                style={{ width: '100%' }}
+              />
+            </div>
+
+            <div style={{ marginBottom: '20px' }}>
+              <label htmlFor="password_confirmation" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                CONFIRM PASSWORD
+              </label>
+              <input
+                type="password"
+                id="password_confirmation"
+                value={passwordConfirmation}
+                onChange={(e) => setPasswordConfirmation(e.target.value)}
+                className="tui-input"
+                placeholder="Re-enter password"
+                required
+                disabled={submitting}
+                style={{ width: '100%' }}
+              />
+            </div>
+
+            <div className="center" style={{ margin: '30px 0' }}>
+              <button
+                type="submit"
+                className="tui-button purple-168"
+                disabled={submitting}
+                style={{ fontSize: '1.1em', padding: '10px 30px' }}
+              >
+                {submitting ? 'JOINING...' : 'JOIN GRID'}
+              </button>
+            </div>
+          </form>
+        </fieldset>
+      </div>
+    </GridLayout>
+  )
+}

--- a/app/javascript/components/routing/LowercaseRedirect.test.tsx
+++ b/app/javascript/components/routing/LowercaseRedirect.test.tsx
@@ -63,6 +63,11 @@ describe('LowercaseRedirect', () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
+  it('does not redirect /grid/verify/ paths (case-sensitive tokens)', () => {
+    renderWithRouter('/grid/verify/AbCdEf123XyZ')
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
   it('redirects band profile paths to lowercase', () => {
     renderWithRouter('/System_Rot')
     expect(mockNavigate).toHaveBeenCalledWith('/system_rot', { replace: true })

--- a/app/javascript/components/routing/LowercaseRedirect.tsx
+++ b/app/javascript/components/routing/LowercaseRedirect.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 /**
  * Redirects paths with uppercase letters to their lowercase equivalents.
- * Excludes /shared/ paths which contain case-sensitive tokens.
+ * Excludes paths with case-sensitive tokens.
  */
 export const LowercaseRedirect: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation()
@@ -13,7 +13,7 @@ export const LowercaseRedirect: React.FC<{ children: React.ReactNode }> = ({ chi
     const { pathname, search, hash } = location
 
     // Skip paths with case-sensitive tokens
-    if (pathname.startsWith('/shared/')) {
+    if (pathname.startsWith('/shared/') || pathname.startsWith('/grid/verify/')) {
       return
     }
 

--- a/app/javascript/contexts/GridAuthContext.tsx
+++ b/app/javascript/contexts/GridAuthContext.tsx
@@ -28,6 +28,25 @@ interface RegisterResponse {
   hackr?: GridHackr
 }
 
+interface RequestRegistrationResponse {
+  success: boolean
+  message?: string
+  error?: string
+}
+
+interface VerifyTokenResponse {
+  valid: boolean
+  email?: string
+  error?: string
+}
+
+interface CompleteRegistrationResponse {
+  success: boolean
+  message?: string
+  error?: string
+  hackr?: GridHackr
+}
+
 interface CurrentHackrResponse {
   logged_in: boolean
   hackr?: GridHackr
@@ -40,6 +59,9 @@ interface GridAuthContextType {
   isLoggedIn: boolean
   login: (hackr_alias: string, password: string) => Promise<LoginResponse>
   register: (hackr_alias: string, password: string, password_confirmation: string) => Promise<RegisterResponse>
+  requestRegistration: (email: string) => Promise<RequestRegistrationResponse>
+  verifyToken: (token: string) => Promise<VerifyTokenResponse>
+  completeRegistration: (token: string, hackr_alias: string, password: string, password_confirmation: string) => Promise<CompleteRegistrationResponse>
   disconnect: () => Promise<{ success: boolean; error?: string }>
   checkAuth: () => Promise<void>
 }
@@ -142,6 +164,70 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     }
   }, [])
 
+  const requestRegistration = useCallback(async (email: string): Promise<RequestRegistrationResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<RequestRegistrationResponse>('/api/grid/register', {
+        method: 'POST',
+        body: JSON.stringify({ email })
+      })
+
+      if (!data.success) {
+        setError(data.error || 'Failed to send verification email')
+      }
+      return data
+    } catch (err) {
+      console.error('Registration request failed:', err)
+      const errorMsg = err instanceof Error ? err.message : 'Network error. Please try again.'
+      setError(errorMsg)
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const verifyToken = useCallback(async (token: string): Promise<VerifyTokenResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<VerifyTokenResponse>(`/api/grid/verify/${token}`)
+      if (!data.valid) {
+        setError(data.error || 'Invalid token')
+      }
+      return data
+    } catch (err) {
+      console.error('Token verification failed:', err)
+      const errorMsg = err instanceof Error ? err.message : 'Network error. Please try again.'
+      setError(errorMsg)
+      return { valid: false, error: errorMsg }
+    }
+  }, [])
+
+  const completeRegistration = useCallback(async (
+    token: string,
+    hackr_alias: string,
+    password: string,
+    password_confirmation: string
+  ): Promise<CompleteRegistrationResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<CompleteRegistrationResponse>('/api/grid/complete_registration', {
+        method: 'POST',
+        body: JSON.stringify({ token, hackr_alias, password, password_confirmation })
+      })
+
+      if (data.success && data.hackr) {
+        setHackr(data.hackr)
+        return data
+      }
+
+      setError(data.error || 'Registration failed')
+      return data
+    } catch (err) {
+      console.error('Registration completion failed:', err)
+      const errorMsg = err instanceof Error ? err.message : 'Network error. Please try again.'
+      setError(errorMsg)
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
   const disconnect = useCallback(async () => {
     setError(null)
     try {
@@ -166,6 +252,9 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     isLoggedIn: !!hackr,
     login,
     register,
+    requestRegistration,
+    verifyToken,
+    completeRegistration,
     disconnect,
     checkAuth
   }

--- a/app/mailers/grid_mailer.rb
+++ b/app/mailers/grid_mailer.rb
@@ -1,5 +1,5 @@
 class GridMailer < ApplicationMailer
-  default from: "noreply@hackr.tv"
+  default from: "null@hackr.tv"
 
   def registration_verification(token)
     @token = token

--- a/app/mailers/grid_mailer.rb
+++ b/app/mailers/grid_mailer.rb
@@ -1,0 +1,13 @@
+class GridMailer < ApplicationMailer
+  default from: "noreply@hackr.tv"
+
+  def registration_verification(token)
+    @token = token
+    @verification_url = grid_verify_url(token: token.token)
+
+    mail(
+      to: token.email,
+      subject: "Complete your registration on THE PULSE GRID"
+    )
+  end
+end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -5,6 +5,7 @@
 #
 #  id               :integer          not null, primary key
 #  api_token        :string
+#  email            :string
 #  hackr_alias      :string
 #  last_activity_at :datetime
 #  password_digest  :string
@@ -16,6 +17,7 @@
 # Indexes
 #
 #  index_grid_hackrs_on_api_token    (api_token) UNIQUE
+#  index_grid_hackrs_on_email        (email) UNIQUE
 #  index_grid_hackrs_on_hackr_alias  (hackr_alias) UNIQUE
 #  index_grid_hackrs_on_role         (role)
 #
@@ -75,8 +77,12 @@ class GridHackr < ApplicationRecord
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length
+  validates :email, uniqueness: {case_sensitive: false}, allow_nil: true
+  validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_nil: true
   validates :role, inclusion: {in: %w[operative operator admin], message: "%{value} is not a valid role"}
+  validates :password, length: {minimum: 8, message: "must be at least 8 characters"}, if: -> { password.present? }
   validate :alias_not_reserved
+  validate :password_not_weak
 
   after_initialize :set_default_role, if: :new_record?
 
@@ -130,6 +136,42 @@ class GridHackr < ApplicationRecord
 
   def set_default_role
     self.role ||= "operative"
+  end
+
+  WEAK_PASSWORDS = %w[
+    password asdfasdf qwerty letmein welcome monkey dragon master
+    abc123 admin login trustno1 iloveyou sunshine princess football
+    charlie shadow michael qwerty123 1q2w3e4r baseball
+  ].freeze
+
+  KEYBOARD_WALKS = %w[qwerty asdfgh zxcvbn qwertyuiop asdfghjkl zxcvbnm].freeze
+
+  WEAK_PASSWORD_MESSAGE = " -- Bro, you're a hackr. Don't use a normie password!"
+
+  def password_not_weak
+    return unless password.present?
+
+    pw = password.downcase
+
+    weak =
+      WEAK_PASSWORDS.include?(pw) ||                            # Common passwords (exact match)
+      pw.start_with?("password") ||                             # Starts with "password"
+      KEYBOARD_WALKS.any? { |walk| pw.start_with?(walk) } ||   # Keyboard walks
+      pw.chars.uniq.length == 1 ||                              # All same character
+      (pw.match?(/\A\d+\z/) && sequential_digits?(pw, :asc)) ||  # Sequential ascending digits
+      (pw.match?(/\A\d+\z/) && sequential_digits?(pw, :desc))    # Sequential descending digits
+
+    errors.add(:password, WEAK_PASSWORD_MESSAGE) if weak
+  end
+
+  def sequential_digits?(str, direction)
+    digits = str.chars.map(&:to_i)
+    if direction == :asc
+      # Handle wrap-around: 1234567890 (9 -> 0 counts as ascending)
+      digits.each_cons(2).all? { |a, b| b - a == 1 || (a == 9 && b == 0) }
+    else
+      digits.each_cons(2).all? { |a, b| b - a == -1 || (a == 0 && b == 9) }
+    end
   end
 
   def alias_not_reserved

--- a/app/models/grid_registration_token.rb
+++ b/app/models/grid_registration_token.rb
@@ -1,0 +1,62 @@
+# == Schema Information
+#
+# Table name: grid_registration_tokens
+# Database name: primary
+#
+#  id         :integer          not null, primary key
+#  email      :string           not null
+#  token      :string           not null
+#  expires_at :datetime         not null
+#  used_at    :datetime
+#  ip_address :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_grid_registration_tokens_on_token  (token) UNIQUE
+#  index_grid_registration_tokens_on_email  (email)
+#
+class GridRegistrationToken < ApplicationRecord
+  EXPIRATION_HOURS = 24
+
+  before_validation :normalize_email
+  before_create :generate_token
+  before_create :set_expiration
+
+  validates :email, presence: true, format: {with: URI::MailTo::EMAIL_REGEXP}
+  validates :token, uniqueness: true, allow_nil: true
+
+  scope :valid, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
+  scope :for_email, ->(email) { where(email: email.to_s.downcase.strip) }
+
+  def expired?
+    expires_at < Time.current
+  end
+
+  def used?
+    used_at.present?
+  end
+
+  def valid_for_use?
+    !expired? && !used?
+  end
+
+  def mark_used!
+    update!(used_at: Time.current)
+  end
+
+  private
+
+  def normalize_email
+    self.email = email.to_s.downcase.strip if email.present?
+  end
+
+  def generate_token
+    self.token = SecureRandom.urlsafe_base64(32)
+  end
+
+  def set_expiration
+    self.expires_at = EXPIRATION_HOURS.hours.from_now
+  end
+end

--- a/app/views/grid_mailer/registration_verification.html.erb
+++ b/app/views/grid_mailer/registration_verification.html.erb
@@ -1,0 +1,38 @@
+<div style="font-family: 'Courier New', monospace; max-width: 600px; margin: 0 auto; background-color: #0a0a0a; color: #00ff00; padding: 30px;">
+  <div style="border: 1px solid #00ff00; padding: 20px; margin-bottom: 20px;">
+    <h1 style="color: #00ff00; margin: 0 0 10px 0; font-size: 24px;">THE PULSE GRID</h1>
+    <p style="color: #999; margin: 0; font-size: 12px;">REGISTRATION VERIFICATION</p>
+  </div>
+
+  <div style="padding: 20px 0;">
+    <p style="color: #ccc; line-height: 1.6;">
+      A registration request was initiated for this email address.
+    </p>
+
+    <p style="color: #ccc; line-height: 1.6;">
+      Click the link below to complete your registration and join the Fracture Network:
+    </p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="<%= @verification_url %>" style="display: inline-block; background-color: #00ff00; color: #0a0a0a; padding: 15px 30px; text-decoration: none; font-weight: bold; border: none;">
+        COMPLETE REGISTRATION
+      </a>
+    </div>
+
+    <p style="color: #999; font-size: 12px; line-height: 1.6;">
+      Or copy this link into your browser:<br>
+      <span style="color: #00ff00; word-break: break-all;"><%= @verification_url %></span>
+    </p>
+
+    <p style="color: #999; font-size: 12px; line-height: 1.6; margin-top: 30px;">
+      This link expires in 24 hours.<br>
+      If you didn't request this, you can safely ignore this message.
+    </p>
+  </div>
+
+  <div style="border-top: 1px solid #333; padding-top: 20px; margin-top: 20px;">
+    <p style="color: #777; font-size: 10px; margin: 0;">
+      hackr.tv // THE PULSE GRID
+    </p>
+  </div>
+</div>

--- a/app/views/grid_mailer/registration_verification.text.erb
+++ b/app/views/grid_mailer/registration_verification.text.erb
@@ -1,0 +1,16 @@
+THE PULSE GRID
+===============
+REGISTRATION VERIFICATION
+
+A registration request was initiated for this email address.
+
+Complete your registration by visiting the link below:
+
+<%= @verification_url %>
+
+This link expires in 24 hours.
+
+If you didn't request this, you can safely ignore this message.
+
+--
+hackr.tv // THE PULSE GRID

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -7,7 +7,7 @@
     </style>
   </head>
 
-  <body>
+  <body style="background-color: #0a0a0a; margin: 0; padding: 0;">
     <%= yield %>
   </body>
 </html>

--- a/config/app_settings.yml
+++ b/config/app_settings.yml
@@ -5,7 +5,7 @@ default: &default
 development:
   <<: *default
   prerelease_mode: alpha
-  prerelease_banner_text: "ALPHA BUILD - New user registration is temporarily disabled while we stabilize core systems."
+  prerelease_banner_text: "ALPHA BUILD - Hackr database will be flushed regularly. Please re-register if you cannot log in."
 
 test:
   <<: *default
@@ -13,9 +13,9 @@ test:
 staging:
   <<: *default
   prerelease_mode: alpha
-  prerelease_banner_text: "ALPHA BUILD - New user registration is temporarily disabled while we stabilize core systems."
+  prerelease_banner_text: "ALPHA BUILD - Hackr database will be flushed regularly. Please re-register if you cannot log in."
 
 production:
   <<: *default
   prerelease_mode: alpha
-  prerelease_banner_text: "ALPHA BUILD - New user registration is temporarily disabled while we stabilize core systems."
+  prerelease_banner_text: "ALPHA BUILD - Hackr database will be flushed regularly. Please re-register if you cannot log in."

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,14 +31,18 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Raise delivery errors so we catch issues during development.
+  config.action_mailer.raise_delivery_errors = true
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+
+  # Use Mailpit for local email testing (http://localhost:8025)
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {address: "127.0.0.1", port: 1025}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,26 @@
 # Protects against brute force attacks and abuse
 
 class Rack::Attack
+  # Parse JSON body for POST requests since Rack::Request#params
+  # doesn't include JSON body fields at middleware time
+  def self.json_params(req)
+    return req.env["rack_attack.json_params"] if req.env.key?("rack_attack.json_params")
+
+    parsed = if req.post? && req.content_type&.include?("application/json")
+      begin
+        body = req.body.read
+        req.body.rewind
+        JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+    else
+      {}
+    end
+
+    req.env["rack_attack.json_params"] = parsed
+  end
+
   ### Throttle login attempts ###
 
   # Throttle login attempts by IP address
@@ -17,7 +37,7 @@ class Rack::Attack
   throttle("logins/alias", limit: 5, period: 20.seconds) do |req|
     if req.path == "/api/grid/login" && req.post?
       # Normalize alias to prevent bypass via case variations
-      req.params["hackr_alias"]&.downcase&.strip
+      json_params(req)["hackr_alias"]&.downcase&.strip
     end
   end
 
@@ -34,7 +54,7 @@ class Rack::Attack
   # 3 registration emails per email address per hour
   throttle("registrations/email", limit: 3, period: 1.hour) do |req|
     if req.path == "/api/grid/register" && req.post?
-      req.params["email"]&.downcase&.strip
+      json_params(req)["email"]&.downcase&.strip
     end
   end
 
@@ -52,7 +72,7 @@ class Rack::Attack
   # 5 completion attempts per token per hour
   throttle("complete_registration/token", limit: 5, period: 1.hour) do |req|
     if req.path == "/api/grid/complete_registration" && req.post?
-      req.params["token"]
+      json_params(req)["token"]
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -23,11 +23,36 @@ class Rack::Attack
 
   ### Throttle registration attempts ###
 
-  # Prevent registration spam
-  # 3 registrations per IP per hour
+  # Prevent registration email spam
+  # 3 registration emails per IP per hour
   throttle("registrations/ip", limit: 3, period: 1.hour) do |req|
     if req.path == "/api/grid/register" && req.post?
       req.ip
+    end
+  end
+
+  # 3 registration emails per email address per hour
+  throttle("registrations/email", limit: 3, period: 1.hour) do |req|
+    if req.path == "/api/grid/register" && req.post?
+      req.params["email"]&.downcase&.strip
+    end
+  end
+
+  ### Throttle token verification ###
+
+  # 10 token verifications per IP per minute
+  throttle("verify_token/ip", limit: 10, period: 1.minute) do |req|
+    if req.path.start_with?("/api/grid/verify/") && req.get?
+      req.ip
+    end
+  end
+
+  ### Throttle registration completion ###
+
+  # 5 completion attempts per token per hour
+  throttle("complete_registration/token", limit: 5, period: 1.hour) do |req|
+    if req.path == "/api/grid/complete_registration" && req.post?
+      req.params["token"]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     get "/", to: "pages#spa_root", as: :grid
     get "login", to: "pages#spa_root", as: :grid_login
     get "register", to: "pages#spa_root", as: :grid_register
+    get "verify/:token", to: "pages#spa_root", as: :grid_verify
   end
 
   # hackr.fm routes - SPA
@@ -105,6 +106,8 @@ Rails.application.routes.draw do
     get "grid/current_hackr", to: "grid#current_hackr_info"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
+    get "grid/verify/:token", to: "grid#verify_token"
+    post "grid/complete_registration", to: "grid#complete_registration"
     delete "grid/disconnect", to: "grid#disconnect"
     post "grid/command", to: "grid#command"
 

--- a/data/system/hackrs.yml
+++ b/data/system/hackrs.yml
@@ -3,30 +3,35 @@
 # In development/test, uses defaults for convenience
 hackrs:
   - hackr_alias: XERAEN
+    email: x@hackr.tv
     role: admin
     starting_room: hackr_tv_broadcast_station
     env_password_key: XERAEN_PASSWORD
     default_password: hackthefuture
 
   - hackr_alias: Ryker
+    email: ryker@hackr.tv
     role: admin
     starting_room: hackr_tv_broadcast_station
     env_password_key: RYKER_PASSWORD
     default_password: cyberpulse
 
   - hackr_alias: Cipher
+    email: cipher@hackr.tv
     role: operative
     starting_room: hackr_tv_broadcast_station
     env_password_key: CIPHER_PASSWORD
     default_password: frequency
 
   - hackr_alias: Synthia
+    email: synthia@hackr.tv
     role: operative
     starting_room: xeraen_operations_center
     env_password_key: SYNTHIA_PASSWORD
     default_password: waveform
 
   - hackr_alias: Nyx
+    email: nyx@hackr.tv
     role: operative
     starting_room: hackr_tv_broadcast_station
     env_password_key: NYX_PASSWORD

--- a/db/migrate/20251106032246_create_grid_hackrs.rb
+++ b/db/migrate/20251106032246_create_grid_hackrs.rb
@@ -2,6 +2,7 @@ class CreateGridHackrs < ActiveRecord::Migration[8.0]
   def change
     create_table :grid_hackrs do |t|
       t.string :hackr_alias
+      t.string :email
       t.string :password_digest
       t.integer :current_room_id
       t.string :role
@@ -10,5 +11,6 @@ class CreateGridHackrs < ActiveRecord::Migration[8.0]
     end
     add_index :grid_hackrs, :role
     add_index :grid_hackrs, :hackr_alias, unique: true
+    add_index :grid_hackrs, :email, unique: true
   end
 end

--- a/db/migrate/20260205000001_create_grid_registration_tokens.rb
+++ b/db/migrate/20260205000001_create_grid_registration_tokens.rb
@@ -1,0 +1,16 @@
+class CreateGridRegistrationTokens < ActiveRecord::Migration[8.0]
+  def change
+    create_table :grid_registration_tokens do |t|
+      t.string :email, null: false
+      t.string :token, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+      t.string :ip_address
+
+      t.timestamps
+    end
+
+    add_index :grid_registration_tokens, :token, unique: true
+    add_index :grid_registration_tokens, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_24_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_05_000002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -148,12 +148,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_24_000001) do
     t.string "api_token"
     t.datetime "created_at", null: false
     t.integer "current_room_id"
+    t.string "email"
     t.string "hackr_alias"
     t.datetime "last_activity_at"
     t.string "password_digest"
     t.string "role"
     t.datetime "updated_at", null: false
     t.index ["api_token"], name: "index_grid_hackrs_on_api_token", unique: true
+    t.index ["email"], name: "index_grid_hackrs_on_email", unique: true
     t.index ["hackr_alias"], name: "index_grid_hackrs_on_hackr_alias", unique: true
     t.index ["role"], name: "index_grid_hackrs_on_role"
   end
@@ -188,6 +190,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_24_000001) do
     t.string "mob_type"
     t.string "name"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "grid_registration_tokens", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.datetime "expires_at", null: false
+    t.string "ip_address"
+    t.string "token", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.index ["email"], name: "index_grid_registration_tokens_on_email"
+    t.index ["token"], name: "index_grid_registration_tokens_on_token", unique: true
   end
 
   create_table "grid_rooms", force: :cascade do |t|

--- a/db/seeds/grid_seeds.rb
+++ b/db/seeds/grid_seeds.rb
@@ -312,6 +312,7 @@ end
 
 GridHackr.create!(
   hackr_alias: "XERAEN",
+  email: "x@hackr.tv",
   password: xeraen_password,
   role: "admin",
   current_room: hackr_tv,
@@ -320,6 +321,7 @@ GridHackr.create!(
 
 GridHackr.create!(
   hackr_alias: "Ryker",
+  email: "ryker@hackr.tv",
   password: ryker_password,
   role: "admin",
   current_room: hackr_tv,
@@ -331,6 +333,7 @@ GridHackr.create!(
 cipher_password = Rails.env.production? ? ENV.fetch("CIPHER_PASSWORD") { raise "CIPHER_PASSWORD required in production" } : ENV.fetch("CIPHER_PASSWORD", "frequency")
 GridHackr.create!(
   hackr_alias: "Cipher",
+  email: "cipher@hackr.tv",
   password: cipher_password,
   role: "operative",
   current_room: hackr_tv,
@@ -340,6 +343,7 @@ GridHackr.create!(
 # Synthia - AI consciousness, communicates through frequency modulation
 GridHackr.create!(
   hackr_alias: "Synthia",
+  email: "synthia@hackr.tv",
   password: ENV.fetch("SYNTHIA_PASSWORD", "waveform"),
   role: "operative",
   current_room: xeraen_base,
@@ -349,6 +353,7 @@ GridHackr.create!(
 # Nyx - Newer recruit, still processing the implications
 GridHackr.create!(
   hackr_alias: "Nyx",
+  email: "nyx@hackr.tv",
   password: ENV.fetch("NYX_PASSWORD", "unfiltered"),
   role: "operative",
   current_room: hackr_tv,

--- a/lib/middleware/lowercase_redirect.rb
+++ b/lib/middleware/lowercase_redirect.rb
@@ -40,6 +40,9 @@ class LowercaseRedirect
     return true if path.start_with?("/shared/")
     # Skip /api/shared_playlists/ paths
     return true if path.start_with?("/api/shared_playlists/")
+    # Skip /grid/verify/ paths (case-sensitive registration tokens)
+    return true if path.start_with?("/grid/verify/")
+    return true if path.start_with?("/api/grid/verify/")
     # Skip asset paths
     return true if path.start_with?("/assets/")
     return true if path.start_with?("/vite-dev/")

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -306,6 +306,7 @@ namespace :data do
       end
 
       hackr.assign_attributes(
+        email: attrs["email"],
         role: attrs["role"],
         skip_reserved_check: true
       )

--- a/spec/controllers/api/grid_controller_spec.rb
+++ b/spec/controllers/api/grid_controller_spec.rb
@@ -1,93 +1,263 @@
 require "rails_helper"
 
 RSpec.describe Api::GridController, type: :controller do
-  describe "POST #register" do
-    context "when prerelease mode is active" do
-      before do
-        # Stub APP_SETTINGS to have prerelease_mode set
-        stub_const("APP_SETTINGS", {prerelease_mode: "alpha", prerelease_banner_text: "Test banner"}.freeze)
-      end
+  describe "POST #register (email verification request)" do
+    before do
+      stub_const("APP_SETTINGS", {prerelease_mode: nil}.freeze)
+    end
 
-      it "returns forbidden status" do
-        post :register, params: {
-          hackr_alias: "NewHackr",
-          password: "password123",
-          password_confirmation: "password123"
-        }, format: :json
+    context "with valid email" do
+      it "returns success status" do
+        post :register, params: {email: "test@example.com"}, format: :json
 
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it "returns error message explaining registration is disabled" do
-        post :register, params: {
-          hackr_alias: "NewHackr",
-          password: "password123",
-          password_confirmation: "password123"
-        }, format: :json
-
+        expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
-        expect(json["success"]).to eq(false)
-        expect(json["error"]).to include("Registration is temporarily disabled")
-        expect(json["error"]).to include("alpha")
+        expect(json["success"]).to eq(true)
+        expect(json["message"]).to include("Verification email sent")
       end
 
-      it "does not create a new GridHackr" do
+      it "creates a registration token" do
         expect {
-          post :register, params: {
-            hackr_alias: "NewHackr",
-            password: "password123",
-            password_confirmation: "password123"
-          }, format: :json
-        }.not_to change(GridHackr, :count)
+          post :register, params: {email: "test@example.com"}, format: :json
+        }.to change(GridRegistrationToken, :count).by(1)
+      end
+
+      it "sends a verification email" do
+        expect {
+          post :register, params: {email: "test@example.com"}, format: :json
+        }.to have_enqueued_mail(GridMailer, :registration_verification)
+      end
+
+      it "normalizes email to lowercase" do
+        post :register, params: {email: "TEST@EXAMPLE.COM"}, format: :json
+
+        token = GridRegistrationToken.last
+        expect(token.email).to eq("test@example.com")
+      end
+
+      it "logs the registration email request" do
+        allow(Rails.logger).to receive(:info).and_call_original
+        expect(Rails.logger).to receive(:info).with(/\[AUTH\] Registration email sent: email=test@example.com ip=/)
+
+        post :register, params: {email: "test@example.com"}, format: :json
       end
     end
 
-    context "when prerelease mode is not active" do
+    context "with invalid email" do
+      it "rejects empty email" do
+        post :register, params: {email: ""}, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("Email address is required")
+      end
+
+      it "rejects invalid email format" do
+        post :register, params: {email: "not-an-email"}, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("valid email address")
+      end
+    end
+
+    context "with already registered email" do
       before do
-        # Stub APP_SETTINGS to have no prerelease_mode
-        stub_const("APP_SETTINGS", {prerelease_mode: nil, prerelease_banner_text: nil}.freeze)
-        # Create a starting room for registration
-        zone = create(:grid_zone, slug: "hackr_tv_central")
-        create(:grid_room, grid_zone: zone, room_type: "hub")
+        create(:grid_hackr, email: "taken@example.com")
       end
 
-      it "allows registration" do
-        post :register, params: {
-          hackr_alias: "NewHackr",
-          password: "password123",
-          password_confirmation: "password123"
-        }, format: :json
+      it "returns error for duplicate email" do
+        post :register, params: {email: "taken@example.com"}, format: :json
 
-        expect(response).to have_http_status(:created)
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("already registered")
+      end
+    end
+  end
+
+  describe "GET #verify_token" do
+    context "with valid token" do
+      let!(:token) { GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1") }
+
+      it "returns valid status with email" do
+        get :verify_token, params: {token: token.token}, format: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["valid"]).to eq(true)
+        expect(json["email"]).to eq("test@example.com")
+      end
+    end
+
+    context "with invalid token" do
+      it "returns invalid status" do
+        get :verify_token, params: {token: "nonexistent-token"}, format: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["valid"]).to eq(false)
+        expect(json["error"]).to include("Invalid verification link")
+      end
+    end
+
+    context "with expired token" do
+      let!(:token) { GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1") }
+
+      before do
+        token.update_column(:expires_at, 1.hour.ago)
       end
 
+      it "returns invalid status" do
+        get :verify_token, params: {token: token.token}, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["valid"]).to eq(false)
+        expect(json["error"]).to include("expired")
+      end
+    end
+
+    context "with used token" do
+      let!(:token) { GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1") }
+
+      before do
+        token.update!(used_at: Time.current)
+      end
+
+      it "returns invalid status" do
+        get :verify_token, params: {token: token.token}, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["valid"]).to eq(false)
+        expect(json["error"]).to include("already been used")
+      end
+    end
+  end
+
+  describe "POST #complete_registration" do
+    let!(:zone) { create(:grid_zone, slug: "hackr_tv_central") }
+    let!(:room) { create(:grid_room, grid_zone: zone, room_type: "hub") }
+    let!(:token) { GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1") }
+
+    context "with valid token and valid params" do
       it "creates a new GridHackr" do
         expect {
-          post :register, params: {
+          post :complete_registration, params: {
+            token: token.token,
             hackr_alias: "NewHackr",
-            password: "password123",
-            password_confirmation: "password123"
+            password: "hackthegrid",
+            password_confirmation: "hackthegrid"
           }, format: :json
         }.to change(GridHackr, :count).by(1)
       end
 
-      it "returns success response with hackr data" do
-        post :register, params: {
+      it "returns success with hackr data" do
+        post :complete_registration, params: {
+          token: token.token,
           hackr_alias: "NewHackr",
-          password: "password123",
-          password_confirmation: "password123"
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
         }, format: :json
 
+        expect(response).to have_http_status(:created)
         json = JSON.parse(response.body)
         expect(json["success"]).to eq(true)
         expect(json["hackr"]["hackr_alias"]).to eq("NewHackr")
       end
 
-      it "rejects aliases shorter than minimum length" do
-        post :register, params: {
+      it "sets the email on the hackr" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        hackr = GridHackr.last
+        expect(hackr.email).to eq("test@example.com")
+      end
+
+      it "marks the token as used" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        expect(token.reload.used_at).to be_present
+      end
+
+      it "logs the user in" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        expect(session[:grid_hackr_id]).to eq(GridHackr.last.id)
+      end
+
+      it "logs successful registration" do
+        allow(Rails.logger).to receive(:info).and_call_original
+        expect(Rails.logger).to receive(:info).with(/\[AUTH\] Registration completed: hackr_alias=NewHackr email=test@example.com ip=/)
+
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+      end
+    end
+
+    context "with invalid token" do
+      it "returns error for nonexistent token" do
+        post :complete_registration, params: {
+          token: "bad-token",
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("Invalid verification token")
+      end
+    end
+
+    context "with used token" do
+      before do
+        token.update!(used_at: Time.current)
+      end
+
+      it "returns error" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("already been used")
+      end
+    end
+
+    context "with invalid hackr params" do
+      it "rejects short alias" do
+        post :complete_registration, params: {
+          token: token.token,
           hackr_alias: "ABC",
-          password: "password123",
-          password_confirmation: "password123"
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
         }, format: :json
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -97,10 +267,11 @@ RSpec.describe Api::GridController, type: :controller do
       end
 
       it "rejects reserved aliases" do
-        post :register, params: {
+        post :complete_registration, params: {
+          token: token.token,
           hackr_alias: "administrator",
-          password: "password123",
-          password_confirmation: "password123"
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
         }, format: :json
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -108,11 +279,36 @@ RSpec.describe Api::GridController, type: :controller do
         expect(json["success"]).to eq(false)
         expect(json["error"]).to include("is reserved and cannot be used")
       end
+
+      it "rejects password mismatch" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "NewHackr",
+          password: "hackthegrid",
+          password_confirmation: "differenthackr"
+        }, format: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json["success"]).to eq(false)
+        expect(json["error"]).to include("doesn't match")
+      end
+
+      it "does not mark token as used if registration fails" do
+        post :complete_registration, params: {
+          token: token.token,
+          hackr_alias: "ABC",
+          password: "hackthegrid",
+          password_confirmation: "hackthegrid"
+        }, format: :json
+
+        expect(token.reload.used_at).to be_nil
+      end
     end
   end
 
   describe "POST #login" do
-    let!(:hackr) { create(:grid_hackr, hackr_alias: "TestHackr", password: "password123") }
+    let!(:hackr) { create(:grid_hackr, hackr_alias: "TestHackr", password: "hackthegrid") }
 
     context "when prerelease mode is active" do
       before do
@@ -122,7 +318,7 @@ RSpec.describe Api::GridController, type: :controller do
       it "still allows login for existing users" do
         post :login, params: {
           hackr_alias: "TestHackr",
-          password: "password123"
+          password: "hackthegrid"
         }, format: :json
 
         expect(response).to have_http_status(:ok)
@@ -138,7 +334,7 @@ RSpec.describe Api::GridController, type: :controller do
 
         post :login, params: {
           hackr_alias: "TestHackr",
-          password: "password123"
+          password: "hackthegrid"
         }, format: :json
       end
 
@@ -158,7 +354,7 @@ RSpec.describe Api::GridController, type: :controller do
 
         post :login, params: {
           hackr_alias: "UnknownHackr",
-          password: "password123"
+          password: "hackthegrid"
         }, format: :json
       end
 
@@ -169,39 +365,9 @@ RSpec.describe Api::GridController, type: :controller do
 
         post :login, params: {
           hackr_alias: long_alias,
-          password: "password123"
+          password: "hackthegrid"
         }, format: :json
       end
-    end
-  end
-
-  describe "POST #register auth logging" do
-    before do
-      stub_const("APP_SETTINGS", {prerelease_mode: nil}.freeze)
-      zone = create(:grid_zone, slug: "hackr_tv_central")
-      create(:grid_room, grid_zone: zone, room_type: "hub")
-    end
-
-    it "logs successful registration" do
-      allow(Rails.logger).to receive(:info).and_call_original
-      expect(Rails.logger).to receive(:info).with(/\[AUTH\] Registration success: hackr_alias=NewHackr ip=/)
-
-      post :register, params: {
-        hackr_alias: "NewHackr",
-        password: "password123",
-        password_confirmation: "password123"
-      }, format: :json
-    end
-
-    it "logs failed registration" do
-      allow(Rails.logger).to receive(:warn).and_call_original
-      expect(Rails.logger).to receive(:warn).with(/\[AUTH\] Registration failed: attempted_alias=ABC errors=.*must be at least.*ip=/)
-
-      post :register, params: {
-        hackr_alias: "ABC",
-        password: "password123",
-        password_confirmation: "password123"
-      }, format: :json
     end
   end
 end

--- a/spec/factories/grid_hackrs.rb
+++ b/spec/factories/grid_hackrs.rb
@@ -5,6 +5,7 @@
 #
 #  id               :integer          not null, primary key
 #  api_token        :string
+#  email            :string
 #  hackr_alias      :string
 #  last_activity_at :datetime
 #  password_digest  :string
@@ -16,13 +17,14 @@
 # Indexes
 #
 #  index_grid_hackrs_on_api_token    (api_token) UNIQUE
+#  index_grid_hackrs_on_email        (email) UNIQUE
 #  index_grid_hackrs_on_hackr_alias  (hackr_alias) UNIQUE
 #  index_grid_hackrs_on_role         (role)
 #
 FactoryBot.define do
   factory :grid_hackr do
     sequence(:hackr_alias) { |n| "Hackr#{n}" }
-    password { "password123" }
+    password { "hackthegrid" }
     role { "operative" }
     current_room { nil }
 

--- a/spec/models/grid_hackr_spec.rb
+++ b/spec/models/grid_hackr_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id               :integer          not null, primary key
 #  api_token        :string
+#  email            :string
 #  hackr_alias      :string
 #  last_activity_at :datetime
 #  password_digest  :string
@@ -16,6 +17,7 @@
 # Indexes
 #
 #  index_grid_hackrs_on_api_token    (api_token) UNIQUE
+#  index_grid_hackrs_on_email        (email) UNIQUE
 #  index_grid_hackrs_on_hackr_alias  (hackr_alias) UNIQUE
 #  index_grid_hackrs_on_role         (role)
 #
@@ -122,6 +124,71 @@ RSpec.describe GridHackr, type: :model do
       end
     end
 
+    describe "weak passwords" do
+      let(:weak_error) { "Bro, you're a hackr. Don't use a normie password!" }
+
+      it "rejects common weak passwords" do
+        %w[password asdfasdf qwerty letmein welcome monkey dragon admin trustno1].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects passwords starting with 'password'" do
+        %w[password1 password123 passwordabc PASSWORD99].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects sequential ascending digits" do
+        %w[12345678 123456789 1234567890].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects sequential descending digits" do
+        %w[87654321 987654321 9876543210].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects repeated characters" do
+        %w[aaaaaaaa 11111111 zzzzzzzz].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects keyboard walks" do
+        %w[qwerty123 asdfghjkl zxcvbnm!].each do |weak|
+          hackr = build(:grid_hackr, password: weak)
+          expect(hackr).not_to be_valid, "Expected '#{weak}' to be rejected"
+          expect(hackr.errors[:password]).to include(weak_error)
+        end
+      end
+
+      it "rejects passwords shorter than 8 characters" do
+        hackr = build(:grid_hackr, password: "short")
+        expect(hackr).not_to be_valid
+        expect(hackr.errors[:password]).to include("must be at least 8 characters")
+      end
+
+      it "accepts reasonable passwords" do
+        %w[hackthegrid cyberpulse fr3quency_x n0tf0undh3r3].each do |strong|
+          hackr = build(:grid_hackr, password: strong)
+          expect(hackr).to be_valid, "Expected '#{strong}' to be accepted but got errors: #{hackr.errors.full_messages}"
+        end
+      end
+    end
+
     describe "alias length" do
       context "when enforce_alias_length is true" do
         it "rejects aliases shorter than minimum length" do
@@ -161,12 +228,12 @@ RSpec.describe GridHackr, type: :model do
 
   describe "default values" do
     it "defaults role to 'operative'" do
-      hackr = GridHackr.new(hackr_alias: "TestHackr", password: "password123")
+      hackr = GridHackr.new(hackr_alias: "TestHackr", password: "hackthegrid")
       expect(hackr.role).to eq("operative")
     end
 
     it "does not override explicitly set role" do
-      hackr = GridHackr.new(hackr_alias: "AdminHackr", password: "password123", role: "admin")
+      hackr = GridHackr.new(hackr_alias: "AdminHackr", password: "hackthegrid", role: "admin")
       expect(hackr.role).to eq("admin")
     end
   end

--- a/spec/models/grid_hackr_spec.rb
+++ b/spec/models/grid_hackr_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe GridHackr, type: :model do
     end
 
     describe "weak passwords" do
-      let(:weak_error) { "Bro, you're a hackr. Don't use a normie password!" }
+      let(:weak_error) { " -- Bro, you're a hackr. Don't use a normie password!" }
 
       it "rejects common weak passwords" do
         %w[password asdfasdf qwerty letmein welcome monkey dragon admin trustno1].each do |weak|

--- a/spec/models/grid_registration_token_spec.rb
+++ b/spec/models/grid_registration_token_spec.rb
@@ -1,0 +1,152 @@
+# == Schema Information
+#
+# Table name: grid_registration_tokens
+# Database name: primary
+#
+#  id         :integer          not null, primary key
+#  email      :string           not null
+#  token      :string           not null
+#  expires_at :datetime         not null
+#  used_at    :datetime
+#  ip_address :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_grid_registration_tokens_on_token  (token) UNIQUE
+#  index_grid_registration_tokens_on_email  (email)
+#
+require "rails_helper"
+
+RSpec.describe GridRegistrationToken, type: :model do
+  describe "validations" do
+    it "requires an email" do
+      token = GridRegistrationToken.new(email: nil, ip_address: "127.0.0.1")
+      expect(token).not_to be_valid
+      expect(token.errors[:email]).to include("can't be blank")
+    end
+
+    it "requires a valid email format" do
+      token = GridRegistrationToken.new(email: "not-an-email", ip_address: "127.0.0.1")
+      expect(token).not_to be_valid
+      expect(token.errors[:email]).to include("is invalid")
+    end
+
+    it "accepts valid email format" do
+      token = GridRegistrationToken.new(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token).to be_valid
+    end
+  end
+
+  describe "before_create callbacks" do
+    it "generates a token" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token.token).to be_present
+      expect(token.token.length).to eq(43) # urlsafe_base64(32) produces 43 chars
+    end
+
+    it "sets expiration to 24 hours from now" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token.expires_at).to be_within(1.second).of(24.hours.from_now)
+    end
+  end
+
+  describe "email normalization" do
+    it "normalizes email to lowercase" do
+      token = GridRegistrationToken.create!(email: "TEST@EXAMPLE.COM", ip_address: "127.0.0.1")
+      expect(token.email).to eq("test@example.com")
+    end
+
+    it "strips whitespace from email" do
+      token = GridRegistrationToken.create!(email: "  test@example.com  ", ip_address: "127.0.0.1")
+      expect(token.email).to eq("test@example.com")
+    end
+  end
+
+  describe "#expired?" do
+    it "returns true when expires_at is in the past" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      token.update_column(:expires_at, 1.hour.ago)
+      expect(token.expired?).to be true
+    end
+
+    it "returns false when expires_at is in the future" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token.expired?).to be false
+    end
+  end
+
+  describe "#used?" do
+    it "returns true when used_at is set" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      token.update!(used_at: Time.current)
+      expect(token.used?).to be true
+    end
+
+    it "returns false when used_at is nil" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token.used?).to be false
+    end
+  end
+
+  describe "#valid_for_use?" do
+    it "returns true when not expired and not used" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      expect(token.valid_for_use?).to be true
+    end
+
+    it "returns false when expired" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      token.update_column(:expires_at, 1.hour.ago)
+      expect(token.valid_for_use?).to be false
+    end
+
+    it "returns false when used" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      token.update!(used_at: Time.current)
+      expect(token.valid_for_use?).to be false
+    end
+  end
+
+  describe "#mark_used!" do
+    it "sets used_at to current time" do
+      token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+      token.mark_used!
+      expect(token.used_at).to be_within(1.second).of(Time.current)
+    end
+  end
+
+  describe "scopes" do
+    describe ".valid" do
+      it "returns only non-expired, non-used tokens" do
+        valid_token = GridRegistrationToken.create!(email: "valid@example.com", ip_address: "127.0.0.1")
+
+        expired_token = GridRegistrationToken.create!(email: "expired@example.com", ip_address: "127.0.0.1")
+        expired_token.update_column(:expires_at, 1.hour.ago)
+
+        used_token = GridRegistrationToken.create!(email: "used@example.com", ip_address: "127.0.0.1")
+        used_token.update!(used_at: Time.current)
+
+        expect(GridRegistrationToken.valid).to include(valid_token)
+        expect(GridRegistrationToken.valid).not_to include(expired_token)
+        expect(GridRegistrationToken.valid).not_to include(used_token)
+      end
+    end
+
+    describe ".for_email" do
+      it "returns tokens for the specified email" do
+        token1 = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+        token2 = GridRegistrationToken.create!(email: "other@example.com", ip_address: "127.0.0.1")
+
+        expect(GridRegistrationToken.for_email("test@example.com")).to include(token1)
+        expect(GridRegistrationToken.for_email("test@example.com")).not_to include(token2)
+      end
+
+      it "normalizes the email before searching" do
+        token = GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1")
+        expect(GridRegistrationToken.for_email("TEST@EXAMPLE.COM")).to include(token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  Replaces direct password-based registration with an email verification
  flow. Users submit their email, receive a one-time verification link,
  and complete registration after confirming. Adds GridRegistrationToken
  model, GridMailer, and verify/complete_registration API endpoints.

  Frontend updated with GridVerifyPage, refactored GridRegisterPage, and
  GridAuthContext for managing auth state.

  Also adds password strength validation to GridHackr that rejects common
  passwords, keyboard walks, sequential/repeated characters, and anything
  starting with "password". Minimum length enforced at 8 characters.

  Supporting changes: Rack::Attack rate limiting updates, lowercase
  redirect middleware, mailer layout, seed data, and route additions.