### PR TITLE
Add feature access control for THE PULSE GRID

### DIFF
--- a/app/controllers/admin/grid_controller.rb
+++ b/app/controllers/admin/grid_controller.rb
@@ -2,7 +2,21 @@ class Admin::GridController < Admin::ApplicationController
   def index
     @online_hackrs = GridHackr.online.includes(:current_room).order(:hackr_alias)
     @recent_messages = GridMessage.order(created_at: :desc).includes(:grid_hackr, :room).limit(50)
-    @all_hackrs = GridHackr.order(:hackr_alias)
+    @all_hackrs = GridHackr.includes(:feature_grants).order(:hackr_alias)
+  end
+
+  def grant_feature
+    hackr = GridHackr.find(params[:hackr_id])
+    FeatureGrant.find_or_create_by!(grid_hackr: hackr, feature: params[:feature])
+    set_flash_success("Granted '#{params[:feature]}' access to #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
+  end
+
+  def revoke_feature
+    hackr = GridHackr.find(params[:hackr_id])
+    hackr.feature_grants.where(feature: params[:feature]).destroy_all
+    set_flash_success("Revoked '#{params[:feature]}' access from #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
   end
 
   def broadcast

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -42,7 +42,8 @@ class Api::GridController < ApplicationController
           id: hackr.id,
           hackr_alias: hackr.hackr_alias,
           role: hackr.role,
-          current_room: hackr.current_room ? room_json(hackr.current_room) : nil
+          current_room: hackr.current_room ? room_json(hackr.current_room) : nil,
+          features: hackr.admin? ? [FeatureGrant::PULSE_GRID] : hackr.feature_grants.pluck(:feature)
         }
       }
     else
@@ -177,7 +178,8 @@ class Api::GridController < ApplicationController
             id: @hackr.id,
             hackr_alias: @hackr.hackr_alias,
             role: @hackr.role,
-            current_room: @hackr.current_room ? room_json(@hackr.current_room) : nil
+            current_room: @hackr.current_room ? room_json(@hackr.current_room) : nil,
+            features: @hackr.admin? ? [FeatureGrant::PULSE_GRID] : @hackr.feature_grants.pluck(:feature)
           }
         }, status: :created
       else

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,6 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
 
   before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset]
+  before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
 
   # GET /api/grid/current_hackr - Get current logged-in hackr info
   def current_hackr_info
@@ -11,7 +12,8 @@ class Api::GridController < ApplicationController
         id: current_hackr.id,
         hackr_alias: current_hackr.hackr_alias,
         role: current_hackr.role,
-        current_room: current_hackr.current_room ? room_json(current_hackr.current_room) : nil
+        current_room: current_hackr.current_room ? room_json(current_hackr.current_room) : nil,
+        features: current_hackr.admin? ? [FeatureGrant::PULSE_GRID] : current_hackr.feature_grants.pluck(:feature)
       }
     }
   end

--- a/app/controllers/concerns/grid_authentication.rb
+++ b/app/controllers/concerns/grid_authentication.rb
@@ -79,6 +79,17 @@ module GridAuthentication
     }, status: :unauthorized
   end
 
+  def require_feature_api(feature_name)
+    return unless logged_in?
+    return if current_hackr.has_feature?(feature_name)
+
+    render json: {
+      success: false,
+      error: "Access to this feature has not been granted yet.",
+      feature_locked: true
+    }, status: :forbidden
+  end
+
   def require_admin
     return if admin_hackr?
 

--- a/app/javascript/components/auth/FeatureGate.tsx
+++ b/app/javascript/components/auth/FeatureGate.tsx
@@ -1,0 +1,23 @@
+import React, { type ReactNode } from 'react'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { GridComingSoonPage } from '~/components/pages/grid/GridComingSoonPage'
+
+interface FeatureGateProps {
+  feature: string
+  children: ReactNode
+}
+
+export const FeatureGate: React.FC<FeatureGateProps> = ({ feature, children }) => {
+  const { isLoggedIn, loading, hasFeature } = useGridAuth()
+
+  if (loading) {
+    return <LoadingSpinner message="Checking access..." />
+  }
+
+  if (isLoggedIn && !hasFeature(feature)) {
+    return <GridComingSoonPage />
+  }
+
+  return <>{children}</>
+}

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -38,6 +38,7 @@ const NotFoundPage = lazy(() => import('~/components/errors/NotFoundPage').then(
 
 // Auth components
 import { ProtectedRoute } from '~/components/auth/ProtectedRoute'
+import { FeatureGate } from '~/components/auth/FeatureGate'
 
 export const AppLayout: React.FC = () => {
   const location = useLocation()
@@ -85,7 +86,7 @@ export const AppLayout: React.FC = () => {
         <Route path="/heartbreak_havoc" element={<BandProfilePage />} />
         <Route path="/wavelength_zero" element={<WavelengthZeroPage />} />
         {/* THE PULSE GRID routes */}
-        <Route path="/grid" element={<GridGamePage />} />
+        <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
         <Route path="/grid/login" element={<GridLoginPage />} />
         <Route path="/grid/register" element={<GridRegisterPage />} />
         <Route path="/grid/verify/:token" element={<GridVerifyPage />} />

--- a/app/javascript/components/pages/grid/GridComingSoonPage.tsx
+++ b/app/javascript/components/pages/grid/GridComingSoonPage.tsx
@@ -42,7 +42,7 @@ export const GridComingSoonPage: React.FC = () => {
         color: '#666',
         marginBottom: '30px'
       }}>
-        // access pending
+        {'// access pending'}
       </p>
 
       <div style={{ marginBottom: '30px', fontSize: '0.9em', color: '#444', letterSpacing: '2px' }}>

--- a/app/javascript/components/pages/grid/GridComingSoonPage.tsx
+++ b/app/javascript/components/pages/grid/GridComingSoonPage.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+export const GridComingSoonPage: React.FC = () => {
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: '#0a0a0a',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontFamily: 'monospace',
+      color: '#a78bfa',
+      padding: '20px',
+      textAlign: 'center'
+    }}>
+      <div style={{ marginBottom: '30px', fontSize: '0.9em', color: '#444', letterSpacing: '2px' }}>
+        ╔══════════════════════════════════════╗
+      </div>
+
+      <h1 style={{
+        fontSize: '1.8em',
+        fontWeight: 'bold',
+        color: '#a78bfa',
+        marginBottom: '16px',
+        letterSpacing: '3px',
+        textTransform: 'uppercase'
+      }}>
+        THE PULSE GRID
+      </h1>
+
+      <p style={{
+        fontSize: '1.1em',
+        color: '#c084fc',
+        marginBottom: '8px'
+      }}>
+        will open soon
+      </p>
+
+      <p style={{
+        fontSize: '0.85em',
+        color: '#666',
+        marginBottom: '30px'
+      }}>
+        // access pending
+      </p>
+
+      <div style={{ marginBottom: '30px', fontSize: '0.9em', color: '#444', letterSpacing: '2px' }}>
+        ╚══════════════════════════════════════╝
+      </div>
+
+      <a
+        href="/"
+        style={{
+          color: '#4ade80',
+          textDecoration: 'none',
+          fontSize: '0.85em',
+          letterSpacing: '1px',
+          padding: '8px 16px',
+          border: '1px solid #333',
+          borderRadius: '2px'
+        }}
+      >
+        ← hackr.tv
+      </a>
+    </div>
+  )
+}
+
+export default GridComingSoonPage

--- a/app/javascript/contexts/GridAuthContext.tsx
+++ b/app/javascript/contexts/GridAuthContext.tsx
@@ -6,6 +6,7 @@ export interface GridHackr {
   hackr_alias: string
   role: string
   current_room: GridRoom | null
+  features: string[]
 }
 
 export interface GridRoom {
@@ -78,6 +79,7 @@ interface GridAuthContextType {
   resetPassword: (token: string, password: string, password_confirmation: string) => Promise<ResetPasswordResponse>
   disconnect: () => Promise<{ success: boolean; error?: string }>
   checkAuth: () => Promise<void>
+  hasFeature: (feature: string) => boolean
 }
 
 const GridAuthContext = createContext<GridAuthContextType | null>(null)
@@ -285,6 +287,12 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     }
   }, [])
 
+  const hasFeature = useCallback((feature: string): boolean => {
+    if (!hackr) return false
+    if (hackr.role === 'admin') return true
+    return hackr.features?.includes(feature) ?? false
+  }, [hackr])
+
   const disconnect = useCallback(async () => {
     setError(null)
     try {
@@ -315,7 +323,8 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     requestPasswordReset,
     resetPassword,
     disconnect,
-    checkAuth
+    checkAuth,
+    hasFeature
   }
 
   return (

--- a/app/models/feature_grant.rb
+++ b/app/models/feature_grant.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: feature_grants
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  feature       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#
+# Indexes
+#
+#  index_feature_grants_on_feature                    (feature)
+#  index_feature_grants_on_grid_hackr_id              (grid_hackr_id)
+#  index_feature_grants_on_grid_hackr_id_and_feature  (grid_hackr_id,feature) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+class FeatureGrant < ApplicationRecord
+  PULSE_GRID = "pulse_grid"
+
+  belongs_to :grid_hackr
+
+  validates :feature, presence: true, uniqueness: {scope: :grid_hackr_id}
+end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -74,6 +74,7 @@ class GridHackr < ApplicationRecord
   has_many :user_punishments, dependent: :destroy
   has_many :moderation_logs_as_actor, class_name: "ModerationLog", foreign_key: :actor_id, dependent: :nullify
   has_many :moderation_logs_as_target, class_name: "ModerationLog", foreign_key: :target_id, dependent: :nullify
+  has_many :feature_grants, dependent: :destroy
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length
@@ -120,6 +121,10 @@ class GridHackr < ApplicationRecord
 
   def at_least_admin?
     role_level >= ROLE_LEVELS["admin"]
+  end
+
+  def has_feature?(feature_name)
+    admin? || feature_grants.exists?(feature: feature_name)
   end
 
   # Update last activity timestamp without triggering callbacks

--- a/app/views/admin/grid/index.html.erb
+++ b/app/views/admin/grid/index.html.erb
@@ -116,6 +116,7 @@
                 <th style="text-align: left;">ID</th>
                 <th style="text-align: left;">Hackr Alias</th>
                 <th style="text-align: left;">Role</th>
+                <th style="text-align: center;">Grid Access</th>
                 <th style="text-align: center;">Status</th>
                 <th style="text-align: center;">Created</th>
               </tr>
@@ -130,6 +131,17 @@
                       <span class="red-255-text">[ADMIN]</span>
                     <% else %>
                       <span style="color: #888;">operative</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% if hackr.admin? %>
+                      <span class="red-255-text">ADMIN</span>
+                    <% elsif hackr.feature_grants.any? { |fg| fg.feature == FeatureGrant::PULSE_GRID } %>
+                      <span class="green-255-text">GRANTED</span>
+                      <%= button_to "Revoke", admin_grid_revoke_feature_path(hackr_id: hackr.id, feature: FeatureGrant::PULSE_GRID), method: :delete, class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 5px;", data: { confirm: "Revoke grid access from #{hackr.hackr_alias}?" } %>
+                    <% else %>
+                      <span style="color: #666;">NONE</span>
+                      <%= button_to "Grant", admin_grid_grant_feature_path(hackr_id: hackr.id, feature: FeatureGrant::PULSE_GRID), method: :post, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 5px;", data: { confirm: "Grant grid access to #{hackr.hackr_alias}?" } %>
                     <% end %>
                   </td>
                   <td style="text-align: center;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,8 @@ Rails.application.routes.draw do
     # Grid management (still functional - runtime operations)
     get "grid", to: "grid#index", as: :grid
     post "grid/broadcast", to: "grid#broadcast", as: :grid_broadcast
+    post "grid/grant_feature", to: "grid#grant_feature", as: :grid_grant_feature
+    delete "grid/revoke_feature", to: "grid#revoke_feature", as: :grid_revoke_feature
 
     # PulseWire moderation (still functional - runtime operations)
     resources :pulse_wire, only: %i[index destroy] do

--- a/db/migrate/20260206000001_create_feature_grants.rb
+++ b/db/migrate/20260206000001_create_feature_grants.rb
@@ -1,0 +1,13 @@
+class CreateFeatureGrants < ActiveRecord::Migration[8.0]
+  def change
+    create_table :feature_grants do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.string :feature, null: false
+
+      t.timestamps
+    end
+
+    add_index :feature_grants, [:grid_hackr_id, :feature], unique: true
+    add_index :feature_grants, :feature
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_05_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_06_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -120,6 +120,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_05_000002) do
     t.index ["is_seed"], name: "index_echoes_on_is_seed"
     t.index ["pulse_id", "grid_hackr_id"], name: "index_echoes_on_pulse_id_and_grid_hackr_id", unique: true
     t.index ["pulse_id"], name: "index_echoes_on_pulse_id"
+  end
+
+  create_table "feature_grants", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "feature", null: false
+    t.integer "grid_hackr_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature"], name: "index_feature_grants_on_feature"
+    t.index ["grid_hackr_id", "feature"], name: "index_feature_grants_on_grid_hackr_id_and_feature", unique: true
+    t.index ["grid_hackr_id"], name: "index_feature_grants_on_grid_hackr_id"
   end
 
   create_table "grid_exits", force: :cascade do |t|
@@ -553,6 +563,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_05_000002) do
   add_foreign_key "chat_messages", "hackr_streams"
   add_foreign_key "echoes", "grid_hackrs"
   add_foreign_key "echoes", "pulses"
+  add_foreign_key "feature_grants", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"

--- a/spec/models/grid_verification_token_spec.rb
+++ b/spec/models/grid_verification_token_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: grid_verification_tokens
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  expires_at    :datetime         not null
+#  ip_address    :string
+#  purpose       :string           not null
+#  token         :string           not null
+#  used_at       :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_verification_tokens_on_grid_hackr_id              (grid_hackr_id)
+#  index_grid_verification_tokens_on_grid_hackr_id_and_purpose  (grid_hackr_id,purpose)
+#  index_grid_verification_tokens_on_token                      (token) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
 require "rails_helper"
 
 RSpec.describe GridVerificationToken, type: :model do


### PR DESCRIPTION
  Introduce a generic FeatureGrant model (join table) so admins can
  grant/revoke per-user access to gated features. The first gated
  feature is `pulse_grid` — new users see a "coming soon" page instead
  of the game, and the command API returns 403 with `feature_locked`.
  Admins bypass all gates automatically. Includes admin UI with
  grant/revoke buttons on the /root/grid dashboard.