### PR TITLE
Adds forgot password flow for logged-out users

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -42,6 +42,7 @@ class Api::GridController < ApplicationController
         hackr: {
           id: hackr.id,
           hackr_alias: hackr.hackr_alias,
+          email: hackr.email,
           role: hackr.role,
           current_room: hackr.current_room ? room_json(hackr.current_room) : nil,
           features: hackr.admin? ? [FeatureGrant::PULSE_GRID] : hackr.feature_grants.pluck(:feature)
@@ -203,8 +204,41 @@ class Api::GridController < ApplicationController
     }
   end
 
+  # POST /api/grid/forgot_password - Send password reset email (unauthenticated)
+  def forgot_password
+    email = params[:email].to_s.downcase.strip
+
+    # Always return success to prevent email enumeration
+    hackr = GridHackr.find_by(email: email)
+
+    if hackr
+      token = GridVerificationToken.create!(
+        grid_hackr: hackr,
+        purpose: "password_reset",
+        ip_address: request.remote_ip
+      )
+
+      GridMailer.password_reset(token).deliver_later
+      Rails.logger.info("[AUTH] Forgot password email sent: email=#{email} ip=#{request.remote_ip}")
+    else
+      Rails.logger.info("[AUTH] Forgot password attempt for unknown email: ip=#{request.remote_ip}")
+    end
+
+    render json: {
+      success: true,
+      message: "If an account exists with that email, a reset link has been sent."
+    }
+  end
+
   # POST /api/grid/request_password_reset - Send password reset email
   def request_password_reset
+    if current_hackr.email.blank?
+      return render json: {
+        success: false,
+        error: "No email address on file. Set an email first to enable password reset."
+      }, status: :unprocessable_entity
+    end
+
     token = GridVerificationToken.create!(
       grid_hackr: current_hackr,
       purpose: "password_reset",

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -25,6 +25,7 @@ const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').t
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
+const ForgotPasswordPage = lazy(() => import('~/components/pages/grid/ForgotPasswordPage').then(m => ({ default: m.ForgotPasswordPage })))
 const IdentityPage = lazy(() => import('~/components/pages/grid/IdentityPage').then(m => ({ default: m.IdentityPage })))
 const ResetPasswordPage = lazy(() => import('~/components/pages/grid/ResetPasswordPage').then(m => ({ default: m.ResetPasswordPage })))
 const GridConfirmEmailChangePage = lazy(() => import('~/components/pages/grid/GridConfirmEmailChangePage').then(m => ({ default: m.GridConfirmEmailChangePage })))
@@ -101,6 +102,7 @@ export const AppLayout: React.FC = () => {
         <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
         <Route path="/grid/login" element={<GridLoginPage />} />
         <Route path="/grid/register" element={<GridRegisterPage />} />
+        <Route path="/grid/forgot_password" element={<ForgotPasswordPage />} />
         <Route path="/grid/verify/:token" element={<GridVerifyPage />} />
         <Route path="/grid/identity" element={<ProtectedRoute><IdentityPage /></ProtectedRoute>} />
         <Route path="/grid/reset_password/:token" element={<ResetPasswordPage />} />

--- a/app/javascript/components/pages/grid/ForgotPasswordPage.tsx
+++ b/app/javascript/components/pages/grid/ForgotPasswordPage.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { GridLayout } from '~/components/layouts/GridLayout'
+import { useGridAuthContext } from '~/contexts/GridAuthContext'
+
+export const ForgotPasswordPage: React.FC = () => {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const { forgotPassword } = useGridAuthContext()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const result = await forgotPassword(email)
+
+    if (result.success) {
+      setSuccess(true)
+    } else {
+      setError(result.error || 'Failed to send reset email')
+    }
+
+    setLoading(false)
+  }
+
+  if (success) {
+    return (
+      <GridLayout>
+        <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+          <fieldset className="cyan-168-border">
+            <legend className="center">THE PULSE GRID :: RECOVERY</legend>
+
+            <div className="center" style={{ margin: '30px 0' }}>
+              <h1 className="green-255-text" style={{ fontSize: '2.5em', letterSpacing: '0.1em', margin: 0 }}>
+                CHECK YOUR INBOX
+              </h1>
+              <p style={{ margin: '20px 0', fontSize: '1.2em', lineHeight: '1.6' }}>
+                If an account exists for<br />
+                <span className="cyan-255-text" style={{ fontWeight: 'bold' }}>{email}</span>
+              </p>
+              <p style={{ margin: '20px 0', color: '#ccc' }}>
+                a password reset link has been sent. Click it to set a new password.
+              </p>
+              <p style={{ margin: '20px 0', color: '#bbb', fontSize: '0.9em' }}>
+                The link expires in 24 hours.
+              </p>
+            </div>
+
+            <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
+
+            <div className="center" style={{ margin: '20px 0' }}>
+              <p className="white-text" style={{ marginBottom: '10px' }}>DIDN'T RECEIVE IT?</p>
+              <button
+                onClick={() => setSuccess(false)}
+                className="tui-button purple-168"
+              >
+                TRY AGAIN
+              </button>
+            </div>
+
+            <div className="center" style={{ margin: '20px 0' }}>
+              <Link to="/grid/login" className="tui-button green-168">BACK TO LOGIN</Link>
+            </div>
+          </fieldset>
+        </div>
+      </GridLayout>
+    )
+  }
+
+  return (
+    <GridLayout>
+      <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
+        <fieldset className="cyan-168-border">
+          <legend className="center">THE PULSE GRID :: RECOVERY</legend>
+
+          {error && (
+            <div style={{ background: '#330000', border: '2px solid #ff0000', padding: '15px', margin: '20px 0', borderRadius: '4px' }}>
+              <p className="red-255-text" style={{ margin: 0, fontWeight: 'bold' }}>ERROR</p>
+              <p className="white-text" style={{ margin: '5px 0 0 0' }}>{error}</p>
+            </div>
+          )}
+
+          <div className="center" style={{ margin: '30px 0' }}>
+            <h1 className="cyan-255-text" style={{ fontSize: '2.5em', letterSpacing: '0.1em', margin: 0 }}>
+              RECOVER ACCESS
+            </h1>
+            <p style={{ margin: '10px 0', fontSize: '1.2em' }}>RESET YOUR CREDENTIALS</p>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '20px' }}>
+              <label htmlFor="email" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                EMAIL ADDRESS
+              </label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="tui-input"
+                placeholder="Enter your registered email"
+                required
+                autoFocus
+                disabled={loading}
+                style={{ width: '100%' }}
+              />
+              <small className="gray-text" style={{ display: 'block', marginTop: '5px' }}>
+                We'll send you a link to reset your password.
+              </small>
+            </div>
+
+            <div className="center" style={{ margin: '30px 0' }}>
+              <button
+                type="submit"
+                className="tui-button purple-168"
+                disabled={loading}
+                style={{ fontSize: '1.1em', padding: '10px 30px' }}
+              >
+                {loading ? 'SENDING...' : 'SEND RESET LINK'}
+              </button>
+            </div>
+          </form>
+
+          <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
+
+          <div className="center" style={{ margin: '20px 0' }}>
+            <p className="white-text" style={{ marginBottom: '10px' }}>REMEMBER YOUR CREDENTIALS?</p>
+            <Link to="/grid/login" className="tui-button green-168">BACK TO LOGIN</Link>
+          </div>
+        </fieldset>
+      </div>
+    </GridLayout>
+  )
+}

--- a/app/javascript/components/pages/grid/GridLoginPage.tsx
+++ b/app/javascript/components/pages/grid/GridLoginPage.tsx
@@ -98,6 +98,13 @@ export const GridLoginPage: React.FC = () => {
           <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
 
           <div className="center" style={{ margin: '20px 0' }}>
+            <p className="white-text" style={{ marginBottom: '10px' }}>LOST YOUR CREDENTIALS?</p>
+            <Link to="/grid/forgot_password" className="tui-button orange-168">RECOVER ACCESS</Link>
+          </div>
+
+          <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
+
+          <div className="center" style={{ margin: '20px 0' }}>
             <p className="white-text" style={{ marginBottom: '10px' }}>NEW TO THE FRACTURE NETWORK?</p>
             <Link to="/grid/register" className="tui-button green-168">REGISTER AS HACKR</Link>
           </div>

--- a/app/javascript/components/pages/grid/IdentityPage.tsx
+++ b/app/javascript/components/pages/grid/IdentityPage.tsx
@@ -140,7 +140,7 @@ export const IdentityPage: React.FC = () => {
                 opacity: loading ? 0.6 : 1
               }}
             >
-              {loading ? 'SENDING...' : 'CHANGE PASSWORD'}
+              {loading ? 'SENDING...' : 'RESET CREDENTIALS'}
             </button>
 
             {message && (

--- a/app/javascript/contexts/GridAuthContext.tsx
+++ b/app/javascript/contexts/GridAuthContext.tsx
@@ -49,6 +49,12 @@ interface CompleteRegistrationResponse {
   hackr?: GridHackr
 }
 
+interface ForgotPasswordResponse {
+  success: boolean
+  message?: string
+  error?: string
+}
+
 interface RequestPasswordResetResponse {
   success: boolean
   message?: string
@@ -88,6 +94,7 @@ interface GridAuthContextType {
   requestRegistration: (email: string) => Promise<RequestRegistrationResponse>
   verifyToken: (token: string) => Promise<VerifyTokenResponse>
   completeRegistration: (token: string, hackr_alias: string, password: string, password_confirmation: string) => Promise<CompleteRegistrationResponse>
+  forgotPassword: (email: string) => Promise<ForgotPasswordResponse>
   requestPasswordReset: () => Promise<RequestPasswordResetResponse>
   resetPassword: (token: string, password: string, password_confirmation: string) => Promise<ResetPasswordResponse>
   requestEmailChange: (new_email: string) => Promise<RequestEmailChangeResponse>
@@ -259,6 +266,26 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     }
   }, [])
 
+  const forgotPassword = useCallback(async (email: string): Promise<ForgotPasswordResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<ForgotPasswordResponse>('/api/grid/forgot_password', {
+        method: 'POST',
+        body: JSON.stringify({ email })
+      })
+
+      if (!data.success) {
+        setError(data.error || 'Failed to send password reset email')
+      }
+      return data
+    } catch (err) {
+      console.error('Forgot password request failed:', err)
+      const errorMsg = err instanceof Error ? err.message : 'Network error. Please try again.'
+      setError(errorMsg)
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
   const requestPasswordReset = useCallback(async (): Promise<RequestPasswordResetResponse> => {
     setError(null)
     try {
@@ -375,6 +402,7 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     requestRegistration,
     verifyToken,
     completeRegistration,
+    forgotPassword,
     requestPasswordReset,
     resetPassword,
     requestEmailChange,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -58,6 +58,22 @@ class Rack::Attack
     end
   end
 
+  ### Throttle forgot password attempts ###
+
+  # 3 forgot password requests per IP per hour
+  throttle("forgot_password/ip", limit: 3, period: 1.hour) do |req|
+    if req.path == "/api/grid/forgot_password" && req.post?
+      req.ip
+    end
+  end
+
+  # 3 forgot password requests per email per hour
+  throttle("forgot_password/email", limit: 3, period: 1.hour) do |req|
+    if req.path == "/api/grid/forgot_password" && req.post?
+      json_params(req)["email"]&.downcase&.strip
+    end
+  end
+
   ### Throttle token verification ###
 
   # 10 token verifications per IP per minute

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -22,6 +22,14 @@ class Rack::Attack
     req.env["rack_attack.json_params"] = parsed
   end
 
+  # Safely extract a string value from parsed JSON params.
+  # Returns nil for non-string values (arrays, hashes, numbers)
+  # to avoid NoMethodError/TypeError in throttle key blocks.
+  def self.json_string_param(req, key)
+    value = json_params(req)[key]
+    value.is_a?(String) ? value.downcase.strip : nil
+  end
+
   ### Throttle login attempts ###
 
   # Throttle login attempts by IP address
@@ -36,8 +44,7 @@ class Rack::Attack
   # 5 requests per 20 seconds per alias
   throttle("logins/alias", limit: 5, period: 20.seconds) do |req|
     if req.path == "/api/grid/login" && req.post?
-      # Normalize alias to prevent bypass via case variations
-      json_params(req)["hackr_alias"]&.downcase&.strip
+      json_string_param(req, "hackr_alias")
     end
   end
 
@@ -54,7 +61,7 @@ class Rack::Attack
   # 3 registration emails per email address per hour
   throttle("registrations/email", limit: 3, period: 1.hour) do |req|
     if req.path == "/api/grid/register" && req.post?
-      json_params(req)["email"]&.downcase&.strip
+      json_string_param(req, "email")
     end
   end
 
@@ -70,7 +77,7 @@ class Rack::Attack
   # 3 forgot password requests per email per hour
   throttle("forgot_password/email", limit: 3, period: 1.hour) do |req|
     if req.path == "/api/grid/forgot_password" && req.post?
-      json_params(req)["email"]&.downcase&.strip
+      json_string_param(req, "email")
     end
   end
 
@@ -88,7 +95,7 @@ class Rack::Attack
   # 5 completion attempts per token per hour
   throttle("complete_registration/token", limit: 5, period: 1.hour) do |req|
     if req.path == "/api/grid/complete_registration" && req.post?
-      json_params(req)["token"]
+      json_string_param(req, "token")
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     get "login", to: "pages#spa_root", as: :grid_login
     get "register", to: "pages#spa_root", as: :grid_register
     get "verify/:token", to: "pages#spa_root", as: :grid_verify
+    get "forgot_password", to: "pages#spa_root", as: :grid_forgot_password
     get "identity", to: "pages#spa_root", as: :grid_identity
     get "reset_password/:token", to: "pages#spa_root", as: :grid_password_reset
     get "confirm_email_change/:token", to: "pages#spa_root", as: :grid_confirm_email_change
@@ -109,6 +110,7 @@ Rails.application.routes.draw do
     post "grid/complete_registration", to: "grid#complete_registration"
     delete "grid/disconnect", to: "grid#disconnect"
     post "grid/command", to: "grid#command"
+    post "grid/forgot_password", to: "grid#forgot_password"
     post "grid/request_password_reset", to: "grid#request_password_reset"
     post "grid/reset_password", to: "grid#reset_password"
     post "grid/request_email_change", to: "grid#request_email_change"


### PR DESCRIPTION
  - Add unauthenticated POST /api/grid/forgot_password endpoint that looks up GridHackr by email, creates password_reset token, and sends GridMailer.password_reset. Always returns success to prevent email enumeration.
  - Add ForgotPasswordPage with TUI aesthetic matching registration flow, including email form and "CHECK YOUR INBOX" success state.
  - Add "RECOVER ACCESS" link to GridLoginPage between form and register section.
  - Add forgotPassword(email) method to GridAuthContext.
  - Add Rack::Attack rate limits for forgot_password (3/ip/hr, 3/email/hr).
  - Fix: Add email field to login response JSON (was missing, causing IdentityPage to show "N/A").
  - Fix: Guard request_password_reset against hackrs with no email on file.
  - Change IdentityPage button text from "CHANGE PASSWORD" to "RESET CREDENTIALS".