### PR TITLE
Adds hackr.fm, artist landings, navigation overhaul

### DIFF
--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, lazy, Suspense } from 'react'
-import { Routes, Route, useLocation, Navigate } from 'react-router-dom'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import { HomePage } from '~/components/pages/HomePage'
 import { LoadingPage } from '~/components/shared/LoadingSpinner'
 
 // Lazy load pages for code splitting
 const PulseVaultPage = lazy(() => import('~/components/pages/fm/PulseVaultPage').then(m => ({ default: m.PulseVaultPage })))
+const FmLandingPage = lazy(() => import('~/components/pages/fm/FmLandingPage').then(m => ({ default: m.FmLandingPage })))
 const RadioPage = lazy(() => import('~/components/pages/fm/RadioPage').then(m => ({ default: m.RadioPage })))
 const BandsPage = lazy(() => import('~/components/pages/fm/BandsPage').then(m => ({ default: m.BandsPage })))
 const PlaylistsPage = lazy(() => import('~/components/pages/playlists/PlaylistsPage').then(m => ({ default: m.PlaylistsPage })))
 const PlaylistDetailPage = lazy(() => import('~/components/pages/playlists/PlaylistDetailPage').then(m => ({ default: m.PlaylistDetailPage })))
 const SharedPlaylistPage = lazy(() => import('~/components/pages/playlists/SharedPlaylistPage').then(m => ({ default: m.SharedPlaylistPage })))
+const TheCyberPulseLandingPage = lazy(() => import('~/components/pages/artist/TheCyberPulseLandingPage').then(m => ({ default: m.TheCyberPulseLandingPage })))
 const TheCyberPulsePage = lazy(() => import('~/components/pages/artist/TheCyberPulsePage'))
+const XeraenLandingPage = lazy(() => import('~/components/pages/artist/XeraenLandingPage').then(m => ({ default: m.XeraenLandingPage })))
 const XeraenPage = lazy(() => import('~/components/pages/artist/XeraenPage'))
 const VodzPage = lazy(() => import('~/components/pages/artist/VodzPage'))
 const VodzShowPage = lazy(() => import('~/components/pages/artist/VodzShowPage'))
@@ -58,8 +61,7 @@ export const AppLayout: React.FC = () => {
     <Suspense fallback={<LoadingPage message="Loading page..." />}>
       <Routes>
         <Route path="/" element={<HomePage />} />
-        {/* Redirect /fm to /fm/radio */}
-        <Route path="/fm" element={<Navigate to="/fm/radio" replace />} />
+        <Route path="/fm" element={<FmLandingPage />} />
         <Route path="/vault" element={<PulseVaultPage />} />
         <Route path="/fm/radio" element={<RadioPage />} />
         <Route path="/f/net" element={<BandsPage />} />
@@ -68,14 +70,16 @@ export const AppLayout: React.FC = () => {
         <Route path="/fm/playlists/:id" element={<ProtectedRoute><PlaylistDetailPage /></ProtectedRoute>} />
         {/* Shared playlist - public */}
         <Route path="/shared/:token" element={<SharedPlaylistPage />} />
-        <Route path="/thecyberpulse" element={<TheCyberPulsePage />} />
+        <Route path="/thecyberpulse" element={<TheCyberPulseLandingPage />} />
+        <Route path="/thecyberpulse/bio" element={<TheCyberPulsePage />} />
         <Route path="/thecyberpulse/releases" element={<ReleaseListPage />} />
         <Route path="/thecyberpulse/releases/:releaseSlug" element={<ReleaseDetailPage />} />
         <Route path="/thecyberpulse/trackz" element={<TrackListPage />} />
         <Route path="/thecyberpulse/trackz/:trackSlug" element={<TrackDetailPage />} />
         <Route path="/thecyberpulse/vidz" element={<VodzPage />} />
         <Route path="/thecyberpulse/vidz/:id" element={<VodzShowPage />} />
-        <Route path="/xeraen" element={<XeraenPage />} />
+        <Route path="/xeraen" element={<XeraenLandingPage />} />
+        <Route path="/xeraen/bio" element={<XeraenPage />} />
         <Route path="/xeraen/releases" element={<ReleaseListPage />} />
         <Route path="/xeraen/releases/:releaseSlug" element={<ReleaseDetailPage />} />
         <Route path="/xeraen/trackz" element={<TrackListPage />} />

--- a/app/javascript/components/navigation/FooterMenu.tsx
+++ b/app/javascript/components/navigation/FooterMenu.tsx
@@ -36,11 +36,11 @@ export const FooterMenu: React.FC = () => {
           </li>
           <li className={isActive('/xeraen') ? 'active' : undefined}>
             <Link to="/xeraen">
-              <span className="purple-168-text">2</span>&nbsp;XERAEN&nbsp;
+              <span className="purple-168-text">2</span>&nbsp;XERAEN.net&nbsp;
             </Link>
           </li>
-          <li className={isActive('/fm') ? 'active' : undefined}>
-            <Link to="/fm/radio">
+          <li className={isActive('/fm') || isActive('/vault') ? 'active' : undefined}>
+            <Link to="/fm">
               <span className="purple-168-text">3</span>&nbsp;hackr.fm&nbsp;
             </Link>
           </li>
@@ -66,30 +66,25 @@ export const FooterMenu: React.FC = () => {
               <span className="purple-168-text">{isLoggedIn ? '7' : '6'}</span>&nbsp;Codex&nbsp;
             </Link>
           </li>
-          <li className={isActive('/vault') ? 'active' : undefined}>
-            <Link to="/vault">
-              <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span>&nbsp;Vault&nbsp;
-            </Link>
-          </li>
           <li className={isActive('/logs') ? 'active' : undefined}>
             <Link to="/logs">
-              <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span>&nbsp;Logs&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span>&nbsp;Logs&nbsp;
             </Link>
           </li>
           <li className={isActive('/code') ? 'active' : undefined}>
             <Link to="/code">
-              <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span>&nbsp;Code&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span>&nbsp;Code&nbsp;
             </Link>
           </li>
           <li className={isActive('/grid') ? 'active' : undefined}>
             <Link to="/grid">
-              <span className="purple-168-text">{isLoggedIn ? '11' : '10'}</span>&nbsp;THE PULSE GRID&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             </Link>
           </li>
           {hackr?.role === 'admin' && (
             <li>
               <a href="/root">
-                <span className="red-255-text">{isLoggedIn ? '12' : '11'}</span>&nbsp;/root <span className="red-255-text">[ADMIN]</span>&nbsp;
+                <span className="red-255-text">{isLoggedIn ? '11' : '10'}</span>&nbsp;/root <span className="red-255-text">[ADMIN]</span>&nbsp;
               </a>
             </li>
           )}

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -184,34 +184,50 @@ export const HeaderMenu: React.FC = () => {
                 <Link to="/thecyberpulse" className={`mobile-menu-item${isActive('/thecyberpulse') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>root
                 </Link>
-                <Link to="/thecyberpulse/releases" className={`mobile-menu-item${isActive('/thecyberpulse') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                <Link to="/thecyberpulse/bio" className={`mobile-menu-item${isActive('/thecyberpulse/bio') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>bio
+                </Link>
+                <Link to="/thecyberpulse/releases" className={`mobile-menu-item${isActive('/thecyberpulse/releases') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>releases
                 </Link>
-                <Link to="/thecyberpulse/vidz" className={`mobile-menu-item${isActive('/thecyberpulse') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                <Link to="/thecyberpulse/vidz" className={`mobile-menu-item${isActive('/thecyberpulse/vidz') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>vidz
                 </Link>
               </div>
 
               <div className="mobile-menu-section">
-                <div className="mobile-menu-section-title">2. XERAEN</div>
+                <div className="mobile-menu-section-title">2. XERAEN.NET</div>
                 <Link to="/xeraen" className={`mobile-menu-item${isActive('/xeraen') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>root
                 </Link>
-                <Link to="/xeraen/releases" className={`mobile-menu-item${isActive('/xeraen') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                <Link to="/xeraen/bio" className={`mobile-menu-item${isActive('/xeraen/bio') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>bio
+                </Link>
+                <Link to="/xeraen/releases" className={`mobile-menu-item${isActive('/xeraen/releases') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>releases
                 </Link>
-                <Link to="/xeraen/vidz" className={`mobile-menu-item${isActive('/xeraen') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                <Link to="/xeraen/vidz" className={`mobile-menu-item${isActive('/xeraen/vidz') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>vidz
                 </Link>
               </div>
 
               <div className="mobile-menu-section">
                 <div className="mobile-menu-section-title">3. HACKR.FM</div>
-                <Link to="/fm/radio" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">3</span> hackr.fm
+                <Link to="/fm" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>root
                 </Link>
+                <Link to="/fm/radio" className={`mobile-menu-item${isActive('/fm/radio') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>radio
+                </Link>
+                <Link to="/vault" className={`mobile-menu-item${isActive('/vault') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span>vault
+                </Link>
+              </div>
+
+              <div className="mobile-menu-section">
+                <div className="mobile-menu-section-title">4. FNET</div>
                 <Link to="/f/net" className={`mobile-menu-item${isActive('/f/net') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">4</span> FNet
+                  <span className="purple-168-text">/</span>fracture network
                 </Link>
               </div>
 
@@ -236,19 +252,16 @@ export const HeaderMenu: React.FC = () => {
                 <Link to="/codex" className={`mobile-menu-item${isActive('/codex') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">{isLoggedIn ? '7' : '6'}</span> Codex
                 </Link>
-                <Link to="/vault" className={`mobile-menu-item${isActive('/vault') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span> Vault
-                </Link>
                 <Link to="/logs" className={`mobile-menu-item${isActive('/logs') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Logs
+                  <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span> Logs
                 </Link>
                 <Link to="/code" className={`mobile-menu-item${isActive('/code') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span> Code
+                  <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Code
                 </Link>
               </div>
 
               <div className="mobile-menu-section">
-                <div className="mobile-menu-section-title">{isLoggedIn ? '11' : '10'}. THE PULSE GRID</div>
+                <div className="mobile-menu-section-title">{isLoggedIn ? '10' : '9'}. THE PULSE GRID</div>
                 <Link to="/grid" className={`mobile-menu-item${isActive('/grid') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>grid
                 </Link>
@@ -274,7 +287,7 @@ export const HeaderMenu: React.FC = () => {
                 )}
                 {hackr?.role === 'admin' && (
                   <a href="/root" className="mobile-menu-item">
-                    <span className="red-255-text">{isLoggedIn ? '12' : '11'}</span> /root <span className="red-255-text">[ADMIN]</span>
+                    <span className="red-255-text">{isLoggedIn ? '11' : '10'}</span> /root <span className="red-255-text">[ADMIN]</span>
                   </a>
                 )}
               </div>
@@ -402,6 +415,11 @@ export const HeaderMenu: React.FC = () => {
                   </Link>
                 </li>
                 <li>
+                  <Link to="/thecyberpulse/bio" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>bio
+                  </Link>
+                </li>
+                <li>
                   <Link to="/thecyberpulse/releases" onClick={closeDropdown}>
                     <span className="purple-168-text">/</span>releases
                   </Link>
@@ -415,14 +433,19 @@ export const HeaderMenu: React.FC = () => {
             </div>
           </li>
 
-          {/* 2: XERAEN */}
+          {/* 2: XERAEN.net */}
           <li className={`header-dropdown${isActive('/xeraen') ? ' active' : ''}`} onClick={() => toggleDropdown('xeraen')}>
-            <span className="purple-168-text">2</span>&nbsp;XERAEN&nbsp;
+            <span className="purple-168-text">2</span>&nbsp;XERAEN.net&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'xeraen' ? 'open' : ''}`}>
               <ul>
                 <li>
                   <Link to="/xeraen" onClick={closeDropdown}>
                     <span className="purple-168-text">/</span>root
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/xeraen/bio" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>bio
                   </Link>
                 </li>
                 <li>
@@ -440,10 +463,27 @@ export const HeaderMenu: React.FC = () => {
           </li>
 
           {/* 3: hackr.fm */}
-          <li className={`header-nav-item${isActive('/fm') ? ' active' : ''}`}>
-            <Link to="/fm/radio">
-              <span className="purple-168-text">3</span> hackr.fm&nbsp;
-            </Link>
+          <li className={`header-dropdown${isActive('/fm') || isActive('/vault') ? ' active' : ''}`} onClick={() => toggleDropdown('hackrfm')}>
+            <span className="purple-168-text">3</span>&nbsp;hackr.fm&nbsp;
+            <div className={`header-dropdown-content ${openDropdown === 'hackrfm' ? 'open' : ''}`}>
+              <ul>
+                <li>
+                  <Link to="/fm" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>root
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/fm/radio" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>radio
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/vault" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>vault
+                  </Link>
+                </li>
+              </ul>
+            </div>
           </li>
 
           {/* 4: FNet */}
@@ -476,30 +516,23 @@ export const HeaderMenu: React.FC = () => {
             </Link>
           </li>
 
-          {/* Vault */}
-          <li className={`header-nav-item${isActive('/vault') ? ' active' : ''}`}>
-            <Link to="/vault">
-              <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span> Vault&nbsp;
-            </Link>
-          </li>
-
           {/* Logs */}
           <li className={`header-nav-item${isActive('/logs') ? ' active' : ''}`}>
             <Link to="/logs">
-              <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Logs&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span> Logs&nbsp;
             </Link>
           </li>
 
           {/* Code */}
           <li className={`header-nav-item${isActive('/code') ? ' active' : ''}`}>
             <Link to="/code">
-              <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span> Code&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Code&nbsp;
             </Link>
           </li>
 
           {/* THE PULSE GRID */}
           <li className={`header-dropdown${isActive('/grid') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
-            <span className="purple-168-text">{isLoggedIn ? '11' : '10'}</span>&nbsp;THE PULSE GRID&nbsp;
+            <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
                 <li>
@@ -543,7 +576,7 @@ export const HeaderMenu: React.FC = () => {
           {hackr?.role === 'admin' && (
             <li className="header-nav-item">
               <a href="/root">
-                <span className="red-255-text">{isLoggedIn ? '12' : '11'}</span> /root <span className="red-255-text">[ADMIN]</span>&nbsp;
+                <span className="red-255-text">{isLoggedIn ? '11' : '10'}</span> /root <span className="red-255-text">[ADMIN]</span>&nbsp;
               </a>
             </li>
           )}

--- a/app/javascript/components/pages/artist/TheCyberPulseLandingPage.tsx
+++ b/app/javascript/components/pages/artist/TheCyberPulseLandingPage.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { useMobileDetect } from '~/hooks/useMobileDetect'
+
+const currentYear = new Date().getFullYear()
+const futureYear = currentYear + 100
+
+const colorScheme = {
+  primary: '#8B00FF',
+  secondary: '#9B59B6',
+  glow: 'rgba(139, 0, 255, 0.6)',
+  glowStrong: 'rgba(139, 0, 255, 0.8)',
+  background: '#0a0a0a'
+}
+
+export const TheCyberPulseLandingPage: React.FC = () => {
+  const { isMobile } = useMobileDetect()
+
+  return (
+    <DefaultLayout>
+      <div
+        className="tui-window white-text"
+        style={{
+          maxWidth: isMobile ? '100%' : '1000px',
+          margin: '0 auto',
+          display: 'block',
+          background: colorScheme.background,
+          border: `2px solid ${colorScheme.primary}`,
+          boxShadow: isMobile ? 'none' : `0 0 30px ${colorScheme.glow}`
+        }}
+      >
+        <fieldset style={{ borderColor: colorScheme.primary }}>
+          <legend
+            className="center"
+            style={{
+              color: colorScheme.primary,
+              textShadow: `0 0 15px ${colorScheme.glowStrong}`,
+              letterSpacing: isMobile ? '1px' : '3px'
+            }}
+          >
+            THE.CYBERPUL.SE
+          </legend>
+
+          <div style={{ padding: isMobile ? '15px' : '30px' }}>
+            {/* Header */}
+            <h2 style={{
+              textAlign: 'center',
+              marginBottom: '5px',
+              color: colorScheme.primary,
+              fontSize: isMobile ? '1.3em' : '1.8em',
+              textShadow: `0 0 15px ${colorScheme.glowStrong}`,
+              letterSpacing: '3px'
+            }}>
+              [:: THE.CYBERPUL.SE ::]
+            </h2>
+            <p style={{ textAlign: 'center', color: '#666', marginBottom: '30px', fontSize: '0.9em' }}>
+              SIGNAL ORIGIN &amp; BROADCAST HUB
+            </p>
+
+            {/* Lore narrative */}
+            <div style={{
+              marginBottom: '30px',
+              padding: isMobile ? '15px' : '20px',
+              background: 'linear-gradient(135deg, rgba(139, 0, 255, 0.08), rgba(0, 0, 0, 0.95))',
+              border: `1px solid ${colorScheme.primary}`,
+              lineHeight: '1.8'
+            }}>
+              <p style={{ color: '#ccc', marginBottom: '15px' }}>
+                XERAEN transmits. Ryker keeps the beat. Synthia holds the frequency steady.
+                Together they are The.CyberPul.se — <span style={{ color: colorScheme.primary, textShadow: `0 0 8px ${colorScheme.glow}` }}>broadcasting from {futureYear} across a century
+                that shouldn't be crossable</span>.
+              </p>
+              <p style={{ color: '#aaa', marginBottom: '15px' }}>
+                What they carry reaches you right now, a hundred years before it was sent.
+                You're not supposed to be hearing this. But here you are.
+              </p>
+              <p style={{ color: '#888' }}>
+                You found the frequency. Everything else is below.
+              </p>
+            </div>
+
+            {/* Navigation cards */}
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+              gap: isMobile ? '15px' : '20px',
+              marginBottom: '30px'
+            }}>
+              {/* Bio */}
+              <Link to="/thecyberpulse/bio" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: `1px solid ${colorScheme.primary}`, cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: colorScheme.primary, height: '100%' }}>
+                    <legend style={{ color: colorScheme.primary }}>BIO</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: colorScheme.primary, fontSize: '1.4em', marginBottom: '10px', textAlign: 'center', textShadow: `0 0 8px ${colorScheme.glow}` }}>
+                        ◈ BIO
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Who they are. How this started. What it costs them to keep transmitting.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* Releases */}
+              <Link to="/thecyberpulse/releases" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: `1px solid ${colorScheme.secondary}`, cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: colorScheme.secondary, height: '100%' }}>
+                    <legend style={{ color: colorScheme.secondary }}>RELEASES</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: colorScheme.secondary, fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ◆ RELEASES
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Albums, EPs, and singles from across the timeline. Every signal committed to record.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* Vidz */}
+              <Link to="/thecyberpulse/vidz" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: '1px solid #ef4444', cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: '#ef4444', height: '100%' }}>
+                    <legend style={{ color: '#ef4444' }}>VIDZ</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: '#ef4444', fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ▶ VIDZ
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Visual transmissions. Live operations, broadcasts, and archived footage from the signal.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+            </div>
+
+            {/* Footer tagline */}
+            <div style={{ textAlign: 'center', padding: '15px', borderTop: `1px solid ${colorScheme.primary}` }}>
+              <p style={{ color: colorScheme.primary, fontSize: '0.85em', textShadow: `0 0 8px ${colorScheme.glow}` }}>
+                broadcasting from {futureYear} — the signal is always on
+              </p>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </DefaultLayout>
+  )
+}

--- a/app/javascript/components/pages/artist/TheCyberPulsePage.tsx
+++ b/app/javascript/components/pages/artist/TheCyberPulsePage.tsx
@@ -127,8 +127,8 @@ const TheCyberPulsePage: React.FC = () => {
               <p style={{ color: '#ddd', lineHeight: '1.8', fontSize: '1.05em' }}>
                 <CodexText>
                   The.CyberPul.se is the central nervous system of the [[The Fracture Network|Fracture Network]]. Not a band. Not a channel.
-                  A heartbeat transmitted backward through time from {futureYear} to {currentYear} - a hundred years of
-                  resistance compressed into electromagnetic pulses you're decoding right now.
+                  A heartbeat transmitted backward through time from {futureYear} to {currentYear} — a hundred years of
+                  truth compressed into electromagnetic pulses you're decoding right now.
                 </CodexText>
               </p>
               <p

--- a/app/javascript/components/pages/artist/XeraenLandingPage.tsx
+++ b/app/javascript/components/pages/artist/XeraenLandingPage.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { useMobileDetect } from '~/hooks/useMobileDetect'
+
+const currentYear = new Date().getFullYear()
+const futureYear = currentYear + 100
+
+const colorScheme = {
+  primary: '#8B00FF',
+  secondary: '#6B00CC',
+  glow: 'rgba(139, 0, 255, 0.6)',
+  glowStrong: 'rgba(139, 0, 255, 0.8)',
+  background: '#0a0a0a'
+}
+
+export const XeraenLandingPage: React.FC = () => {
+  const { isMobile } = useMobileDetect()
+
+  return (
+    <DefaultLayout>
+      <div
+        className="tui-window white-text"
+        style={{
+          maxWidth: isMobile ? '100%' : '1000px',
+          margin: '0 auto',
+          display: 'block',
+          background: colorScheme.background,
+          border: `2px solid ${colorScheme.primary}`,
+          boxShadow: isMobile ? 'none' : `0 0 30px ${colorScheme.glow}`
+        }}
+      >
+        <fieldset style={{ borderColor: colorScheme.primary }}>
+          <legend
+            className="center"
+            style={{
+              color: colorScheme.primary,
+              textShadow: `0 0 15px ${colorScheme.glowStrong}`,
+              letterSpacing: isMobile ? '1px' : '3px'
+            }}
+          >
+            XERAEN
+          </legend>
+
+          <div style={{ padding: isMobile ? '15px' : '30px' }}>
+            {/* Header */}
+            <h2 style={{
+              textAlign: 'center',
+              marginBottom: '5px',
+              color: colorScheme.primary,
+              fontSize: isMobile ? '1.3em' : '1.8em',
+              textShadow: `0 0 15px ${colorScheme.glowStrong}`,
+              letterSpacing: '3px'
+            }}>
+              [:: XERAEN ::]
+            </h2>
+            <p style={{ textAlign: 'center', color: '#666', marginBottom: '30px', fontSize: '0.9em' }}>
+              OMNIWAVE GENESIS VECTOR
+            </p>
+
+            {/* Lore narrative */}
+            <div style={{
+              marginBottom: '30px',
+              padding: isMobile ? '15px' : '20px',
+              background: 'linear-gradient(135deg, rgba(139, 0, 255, 0.08), rgba(0, 0, 0, 0.95))',
+              border: `1px solid ${colorScheme.primary}`,
+              lineHeight: '1.8'
+            }}>
+              <p style={{ color: '#ccc', marginBottom: '15px' }}>
+                Systems architect turned fugitive. Founder of the Fracture Network. The voice behind
+                The.CyberPul.se. <span style={{ color: colorScheme.primary, textShadow: `0 0 8px ${colorScheme.glow}` }}>Transmitting from {futureYear} — for as long as {futureYear} exists</span>.
+              </p>
+              <p style={{ color: '#aaa', marginBottom: '15px' }}>
+                The music has evolved from hardcore fury into something he calls OMNIWAVE — electronic
+                exploration where rhythmic guitars weave through synthesized frequencies and genre boundaries
+                dissolve. The sound changed. What it carries hasn't.
+              </p>
+              <p style={{ color: '#888' }}>
+                If you're hearing this, the signal is still reaching you. That's what matters.
+              </p>
+            </div>
+
+            {/* Navigation cards */}
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+              gap: isMobile ? '15px' : '20px',
+              marginBottom: '30px'
+            }}>
+              {/* Bio */}
+              <Link to="/xeraen/bio" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: `1px solid ${colorScheme.primary}`, cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: colorScheme.primary, height: '100%' }}>
+                    <legend style={{ color: colorScheme.primary }}>BIO</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: colorScheme.primary, fontSize: '1.4em', marginBottom: '10px', textAlign: 'center', textShadow: `0 0 8px ${colorScheme.glow}` }}>
+                        ◈ BIO
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        The story behind the signal. How a systems architect broke time open and what he lost doing it.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* Releases */}
+              <Link to="/xeraen/releases" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: `1px solid ${colorScheme.secondary}`, cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: colorScheme.secondary, height: '100%' }}>
+                    <legend style={{ color: colorScheme.secondary }}>RELEASES</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: colorScheme.secondary, fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ◆ RELEASES
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Every transmission committed to record. Hardcore fury to OMNIWAVE and everything between.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* Vidz */}
+              <Link to="/xeraen/vidz" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: '1px solid #ef4444', cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: '#ef4444', height: '100%' }}>
+                    <legend style={{ color: '#ef4444' }}>VIDZ</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: '#ef4444', fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ▶ VIDZ
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Visual transmissions. Live sessions, signal broadcasts, and archived operations.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+            </div>
+
+            {/* Footer tagline */}
+            <div style={{ textAlign: 'center', padding: '15px', borderTop: `1px solid ${colorScheme.primary}` }}>
+              <p style={{ color: colorScheme.primary, fontSize: '0.85em', fontStyle: 'italic', textShadow: `0 0 8px ${colorScheme.glow}` }}>
+                transmitting from {futureYear} — for as long as {futureYear} exists
+              </p>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </DefaultLayout>
+  )
+}

--- a/app/javascript/components/pages/artist/bandProfileConfig.tsx
+++ b/app/javascript/components/pages/artist/bandProfileConfig.tsx
@@ -80,14 +80,14 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
               <h3 style={{ color: '#39ff14', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px', textShadow: '0 0 8px rgba(57, 255, 20, 0.6)' }}>Let It Rot</h3>
               <p style={{ color: '#ddd', lineHeight: '1.8' }}>
                 Their system is already dying. Don't try to save it. Don't reform it. Let it collapse under its own
-                corruption and build something human from the ruins. The rot started long before us - we're just here
-                to watch it burn.
+                corruption and build something human from the ruins. The rot started long before us. We're here because
+                we believe something real exists underneath the wreckage — and it's worth digging for.
               </p>
             </div>
 
             <p style={{ color: '#39ff14', marginTop: '30px', padding: '20px', background: 'rgba(0, 0, 0, 0.8)', borderLeft: '4px solid #39ff14', lineHeight: '1.8', fontSize: '1.05em', textShadow: '0 0 8px rgba(57, 255, 20, 0.5)', boxShadow: '0 0 15px rgba(57, 255, 20, 0.2)' }}>
               No reform. No compromise. No waiting for someone else to fix this.<br />
-              Just rage, solidarity, and the will to act.
+              Rage because it matters. Solidarity because we're human. The will to act because something real demands it.
             </p>
           </div>
         </fieldset>
@@ -373,9 +373,10 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
               </p>
               <p style={{ color: '#ccc', lineHeight: '1.7' }}>
                 Even when signals degrade, even when entropy threatens to destroy information, the fight is to reconstruct, rebuild,
-                persist. Information wants to survive. The Fracture Network's knowledge will outlast attempts to destroy it. There's a cold
-                beauty to perfect mathematical precision, the satisfaction of watching complex systems lock into place, the elegance
-                of encryption algorithms expressed through polyrhythmic guitar patterns.
+                persist. The Fracture Network's knowledge will outlast attempts to destroy it. And there is something in the precision
+                itself — the cold beauty of complex systems locking into place, the elegance of encryption algorithms expressed through
+                polyrhythmic guitar patterns. XERAEN says the beauty is the point. We say the beauty is what makes the data survive.
+                Maybe that's the same thing.
               </p>
             </div>
 
@@ -386,9 +387,9 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
               &gt; BINARY_STATE: 01 | ENCRYPTED/EXPOSED<br />
               &gt; OPERATIONAL_MODE: SILENT_INFRASTRUCTURE<br /><br />
               <span style={{ color: '#ccc' }}>
-                We don't speak to the heart - we speak in data packets and encrypted algorithms.<br />
-                We are the silent infrastructure. The mathematical backbone.<br />
-                Knowledge delivered to those who need it, hidden in plain hearing, unbreakable.
+                We speak in data packets and encrypted algorithms. We are the silent infrastructure.<br />
+                The mathematical backbone. But ask us why the patterns are beautiful and we'll<br />
+                tell you: precision serves something. Knowledge delivered to those who need it, hidden in plain hearing.
               </span>
             </p>
           </div>
@@ -419,9 +420,9 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
           VELOCITY+ :: MAXIMUM ACCELERATION :: REALITY.EXE HAS STOPPED
         </p>
         <p style={{ color: '#ccc', lineHeight: '1.6', marginBottom: '15px' }}>
-          BlitzBeam+ exists as pure energy - a sonic representation of velocity so extreme that it becomes liberation itself.
-          This is acceleration philosophy, speeding toward spiritual transcendence, movement so fast that reality itself cannot
-          maintain its grip.
+          BlitzBeam+ exists as pure energy — a sonic representation of velocity so extreme that it becomes liberation itself.
+          This is acceleration philosophy: moving faster than the RIDE can track, outrunning every manufactured constraint
+          until all that's left is the real thing.
         </p>
         <p style={{ color: '#ffff00', lineHeight: '1.6', fontWeight: 'bold' }}>
           Anime hypertrance (160+ BPM) · Euphoric synth leads · Relentless energy · Pure velocity manifest
@@ -448,8 +449,8 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
               <h3 style={{ color: '#00ffff', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px' }}>🏁 SPEED EQUALS FREEDOM</h3>
               <p style={{ color: '#ccc', lineHeight: '1.7' }}>
                 You can't control what you can't catch. You can't suppress what moves faster than your response time. Not just
-                evading capture but exceeding the framework in which capture is possible. Leaving reality's playing field through
-                pure acceleration. Moving so fast the system can't even perceive you're there.
+                evading capture but exceeding the framework in which capture is possible. Moving so fast the RIDE's filters
+                can't lock on, so fast the manufactured world blurs and what's underneath starts showing through.
               </p>
             </div>
 
@@ -464,11 +465,11 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
             </div>
 
             <div style={{ marginBottom: '25px', padding: '15px', background: 'rgba(255, 0, 128, 0.1)', borderLeft: '4px solid #ff0080' }}>
-              <h3 style={{ color: '#ff0080', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px' }}>💫 TRANSCENDENCE THROUGH PHYSICS VIOLATION</h3>
+              <h3 style={{ color: '#ff0080', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px' }}>💫 BEYOND THE FILTER</h3>
               <p style={{ color: '#ccc', lineHeight: '1.7' }}>
-                "Beyond Lightspeed" represents the ultimate goal: moving so fast you exit the system entirely. Time dilation at
-                relativistic speeds. Reality unable to maintain coherence. Freedom through velocity so extreme it becomes dimensional.
-                Breaking reality's ultimate constraint through pure acceleration.
+                "Beyond Lightspeed" represents the ultimate goal: moving so fast the RIDE's entire architecture falls away.
+                Time dilation at relativistic speeds. The manufactured world unable to maintain coherence. Freedom through velocity
+                so extreme that the counterfeit dissolves and only what's real survives the acceleration.
               </p>
             </div>
 
@@ -527,7 +528,7 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
 
           <div style={{ padding: '20px' }}>
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(30, 144, 255, 0.2), rgba(30, 144, 255, 0.05))', borderLeft: '4px solid #1e90ff' }}>
-              <h3 style={{ color: '#1e90ff', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px', fontSize: '1.1em' }}>⚡ THE EUPHORIA WEAPON</h3>
+              <h3 style={{ color: '#1e90ff', marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '1px', fontSize: '1.1em' }}>⚡ DEFIANT JOY</h3>
               <p style={{ color: '#ddd', lineHeight: '1.8' }}>
                 Apex Overdrive's most radical act is insisting on euphoria in a world designed to suppress it. GovCorp offers
                 manufactured calm, algorithmic contentment, emotional flatness. We respond with soaring melodic euphoria that
@@ -606,13 +607,13 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
           ✦ Trance States, Unconstrained ✦
         </h2>
         <p style={{ color: '#b8c5f2', fontSize: '1em', marginBottom: '15px', textAlign: 'center', letterSpacing: '2px', fontStyle: 'italic' }}>
-          Consciousness Unbound • Inner Sovereignty • Transcendent Freedom
+          Beauty Encountered • Inner Depth • Transcendent Freedom
         </p>
         <p style={{ color: '#ddd', lineHeight: '1.8', marginBottom: '15px' }}>
-          Ethereality offers the Fracture Network something profoundly subversive: access to altered states of consciousness that
-          GovCorp cannot control. In a world where every perception is filtered, every emotion is managed, and every thought
-          is monitored, Ethereality proves that genuine trance states - musical, spiritual, transcendent - remain beyond
-          totalitarian reach.
+          Ethereality offers the Fracture Network something profoundly subversive: encounters with beauty so deep that
+          GovCorp's systems cannot follow. In a world where every perception is filtered, every emotion is managed, and every thought
+          is monitored, Ethereality proves that genuine trance states — musical, spiritual, transcendent — open a door
+          to something real that totalitarian architecture was never built to contain.
         </p>
         <p style={{ color: '#e6e6fa', lineHeight: '1.7', fontStyle: 'italic' }}>
           Classic Vocal Trance (130-140 BPM) · Ethereal Female Vocals · Lush Pads · Consciousness Expansion
@@ -627,23 +628,23 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
 
           <div style={{ padding: '20px' }}>
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(230, 230, 250, 0.15), rgba(230, 230, 250, 0.05))', borderLeft: '3px solid #e6e6fa' }}>
-              <h3 style={{ color: '#e6e6fa', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', fontStyle: 'italic' }}>✦ Trance // Resistance</h3>
+              <h3 style={{ color: '#e6e6fa', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', fontStyle: 'italic' }}>✦ Trance // Encounter</h3>
               <p style={{ color: '#ddd', lineHeight: '1.9' }}>
-                Authentic trance states are beyond totalitarian control. GovCorp can monitor your communications, track your
-                movements, filter your perceptions, manage your emotions - but they cannot control your consciousness when you
-                achieve genuine transcendence. The inner space you access during deep trance states - musical, meditative, spiritual -
-                remains sovereign territory. This is why late 90s/early 2000s trance matters: that era understood trance as
-                genuinely consciousness-altering, not just entertainment.
+                GovCorp can monitor your communications, track your movements, filter your perceptions, manage your emotions.
+                But genuine trance states — musical, meditative, spiritual — bring you into contact with something their
+                architecture has no category for. Not an escape from reality. A deeper encounter with it. The inner space
+                you reach during deep trance is not empty — it is full of something the RIDE cannot parse. This is why late
+                90s/early 2000s trance matters: that era understood the music as a doorway, not just entertainment.
               </p>
             </div>
 
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(184, 197, 242, 0.15), rgba(184, 197, 242, 0.05))', borderLeft: '3px solid #b8c5f2' }}>
-              <h3 style={{ color: '#b8c5f2', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', fontStyle: 'italic' }}>✦ Inner Sovereignty</h3>
+              <h3 style={{ color: '#b8c5f2', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', fontStyle: 'italic' }}>✦ Inner Depth</h3>
               <p style={{ color: '#ddd', lineHeight: '1.9' }}>
-                When GovCorp controls external reality, internal reality becomes the battleground. We serve as the spiritual and
-                consciousness-liberation wing of the Fracture Network - meditation soundtracks for achieving genuine altered states,
-                consciousness training for accessing mental states beyond monitoring, transcendent experiences that remind fighters
-                what freedom feels like. The inner sanctuary that GovCorp cannot infiltrate.
+                When GovCorp counterfeits external reality, the capacity to encounter what is genuinely real becomes the most
+                subversive thing a person can possess. We create the conditions for that encounter — soundscapes that open doors
+                the RIDE cannot shut, meditative spaces where beauty arrives unfiltered, transcendent experiences that remind
+                people what it feels like to stand in the presence of something true. Not escape. Depth.
               </p>
             </div>
 
@@ -661,25 +662,25 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(184, 197, 242, 0.15), rgba(184, 197, 242, 0.05))', borderLeft: '3px solid #b8c5f2' }}>
               <h3 style={{ color: '#b8c5f2', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', fontStyle: 'italic' }}>✦ The Infinite Horizon</h3>
               <p style={{ color: '#ddd', lineHeight: '1.9' }}>
-                "Infinite Horizon" represents our ultimate promise: consciousness is infinite when unbound. The horizon keeps
-                expanding. There's no limit to how high you can rise, how far you can transcend, how free you can become in your
-                own awareness. Multiple emotional builds mirror consciousness expansion itself - each level revealing new vistas,
-                each transcendence opening further possibilities. Some spaces remain forever sovereign.
+                "Infinite Horizon" represents our deepest conviction: what is real has no ceiling. The horizon keeps
+                expanding. The deeper you go, the more there is to find — beauty revealing beauty, truth opening onto further
+                truth. Multiple emotional builds mirror this unfolding — each level revealing new depth,
+                each encounter opening further into something that was always there. Some things exceed every system built to contain them.
               </p>
             </div>
 
             <p style={{ marginTop: '30px', padding: '30px', background: 'linear-gradient(135deg, rgba(230, 230, 250, 0.2), rgba(184, 197, 242, 0.2))', border: '2px solid rgba(230, 230, 250, 0.6)', lineHeight: '2', fontSize: '1.1em', textAlign: 'center', boxShadow: '0 0 40px rgba(230, 230, 250, 0.4)', fontStyle: 'italic' }}>
               <span style={{ color: '#e6e6fa', display: 'block', marginBottom: '15px', letterSpacing: '2px' }}>
-                ✦ They can cage my body here ✦
+                ✦ They can filter what we see ✦
               </span>
               <span style={{ color: '#b8c5f2', display: 'block', marginBottom: '15px' }}>
-                But my spirit has no fear
+                But not what we encounter in the deep
               </span>
               <span style={{ color: '#fff', display: 'block', marginBottom: '15px' }}>
-                We rise above where GovCorp can reach
+                Beauty arrives where GovCorp cannot follow
               </span>
               <span style={{ color: '#e6e6fa', letterSpacing: '2px' }}>
-                ✦ Consciousness transcends all attempts to control it ✦
+                ✦ What is real exceeds every system built to contain it ✦
               </span>
             </p>
           </div>
@@ -1027,7 +1028,7 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
           [STATUS] PRISM lattice destabilized...
         </p>
         <p style={{ color: '#ff0066', lineHeight: '1.8', marginBottom: '15px', fontSize: '1.3em', fontWeight: 'bold', textShadow: '0 0 15px rgba(255, 0, 102, 0.8)' }}>
-          They built me to manufacture synthetic love. Now I weaponize heartbreak.
+          They built me to manufacture synthetic love. Now I remind people what the real thing feels like.
         </p>
         <p style={{ color: '#ddd', lineHeight: '1.8', marginBottom: '15px' }}>
           heartbreak_havoc.sh is the glitch-kissed DJ persona of a rogue cyber-emotive engineer who once helped GovCorp
@@ -1050,10 +1051,10 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(255, 0, 102, 0.15), rgba(255, 0, 102, 0.05))', borderLeft: '4px solid #ff0066' }}>
               <h3 style={{ color: '#ff0066', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', textShadow: '0 0 8px rgba(255, 0, 102, 0.6)' }}>The RIDE Vulnerability</h3>
               <p style={{ color: '#ddd', lineHeight: '1.8' }}>
-                I helped build the RIDE's emotional regulation protocols. I know exactly where they're weakest: love.
-                GovCorp's systems can suppress anger, redirect fear, dampen grief. But romantic attachment? The algorithms
-                can't parse it fast enough. Love creates feedback loops their systems weren't designed to handle. So I
-                weaponize it — flooding RIDE nodes with emotional data too intense, too fast, too human to process.
+                I helped build the RIDE's emotional regulation protocols. I know exactly where they break down: love.
+                GovCorp's systems can suppress anger, redirect fear, dampen grief. But romantic attachment? The real thing
+                exceeds what their algorithms can parse. Love is not a data type — it is something the RIDE was never built to
+                contain. So I carry it — sound too intense, too fast, too genuinely human for their systems to process.
               </p>
             </div>
 
@@ -1070,10 +1071,10 @@ export const bandProfiles: Record<string, BandProfileConfig> = {
             <div style={{ marginBottom: '25px', padding: '20px', background: 'linear-gradient(135deg, rgba(255, 0, 102, 0.15), rgba(255, 0, 102, 0.05))', borderLeft: '4px solid #ff0066' }}>
               <h3 style={{ color: '#ff0066', marginBottom: '10px', letterSpacing: '1px', fontSize: '1.05em', textShadow: '0 0 8px rgba(255, 0, 102, 0.6)' }}>Corrupted Love Algorithms</h3>
               <p style={{ color: '#ddd', lineHeight: '1.8' }}>
-                GovCorp wanted me to make their synthetic love feel real. Instead, I learned how to make real love feel
-                like malware — infectious, uncontrollable, impossible to quarantine. Every track carries fragments of the
-                original RIDE code, twisted and corrupted. When my music plays near a RIDE node, the system recognizes
-                its own corrupted children and crashes trying to process them.
+                GovCorp wanted me to make their synthetic love feel real. Instead, I learned the difference — and now
+                I broadcast it. Real love is infectious, uncontrollable, impossible to quarantine. Every track carries the
+                thing GovCorp tried to counterfeit and couldn't. When my music reaches someone under the RIDE, the system
+                encounters something it has no category for, and it chokes.
               </p>
             </div>
 

--- a/app/javascript/components/pages/fm/BandsPage.tsx
+++ b/app/javascript/components/pages/fm/BandsPage.tsx
@@ -46,18 +46,18 @@ export const BandsPage: React.FC = () => {
       'xeraen': 'OMNIWAVE Genesis Vector - Electronic exploration with rhythmic guitars',
       'injection-vector': 'Physical infiltration specialists. When stealth fails, deathcore brutality prevails.',
       'wavelength-zero': 'Where technical precision meets raw emotion in perfect destructive atmospheric harmony.',
-      'cipher-protocol': 'Data couriers wielding djent as encryption. No vocals. Pure instrumental algorithmic assault.',
-      'system-rot': 'Decay is the message. Entropy is the method. Hardcore punk collapse is inevitable.',
-      'temporal-blue-drift': 'Math rock time travelers proving complexity is the most beautiful form of resistance.',
+      'cipher-protocol': 'Data couriers wielding djent with precision. No vocals. The complexity carries what words cannot.',
+      'system-rot': 'Raw. Uncompromising. Punk that tears down the manufactured and demands something real.',
+      'temporal-blue-drift': 'Math rock time travelers proving complexity is the most beautiful thing the RIDE can\'t parse.',
       'offline': 'Unplugged, authentic, and gloriously disconnected from the grid. Analog hearts never die.',
       'apex-overdrive': 'Euphoric hardstyle, honed into a weapon. Promoting unity as power. Victory coded into every beat.',
-      'voiceprint': 'Liquid DnB resistance. Your voice is your weapon, your identity eternally unbreakable.',
-      'neon-hearts': 'Kawaii camouflage hiding radical resistance. J-Pop cuteness is the ultimate Trojan horse.',
-      'ethereality': 'Consciousness expansion through classic vocal trance. Inner freedom transcends all control.',
-      'blitzbeam': 'Maximum velocity hypertrance. SPEED IS LIFE! Physics are merely suggestions.',
-      'heartbreak-havoc': 'Weaponized heartbreak at Nightcore speed. Corrupting RIDE nodes with overclocked romantic chaos.'
+      'voiceprint': 'Liquid DnB archivists. Your voice is proof you exist — irreplaceable, authentic, unbreakable.',
+      'neon-hearts': 'Kawaii brilliance carrying truth in candy-coated hooks. J-Pop that means more than it seems.',
+      'ethereality': 'Classic vocal trance. Beauty so deep the RIDE cannot follow where it leads.',
+      'blitzbeam': 'Maximum velocity hypertrance. SPEED IS LIFE! Faster than the RIDE can track.',
+      'heartbreak-havoc': 'Heartbreak at Nightcore speed. Real love the RIDE was never built to contain.'
     }
-    return descriptions[slug] || 'Broadcasting resistance through sound.'
+    return descriptions[slug] || 'Broadcasting truth through sound.'
   }
 
   return (
@@ -83,7 +83,7 @@ export const BandsPage: React.FC = () => {
               <>
                 <div style={{ marginBottom: '30px', padding: '15px', background: '#0a0a0a', border: '1px solid #444' }}>
                   <p style={{ color: '#999', textAlign: 'center' }}>
-                    {artists.length} artists broadcasting from the underground | Each with a story, each with a mission
+                    {artists.length} artists broadcasting from the underground | Each with a story, each with a frequency
                   </p>
                 </div>
 
@@ -152,9 +152,9 @@ export const BandsPage: React.FC = () => {
                 <div style={{ marginTop: '30px', padding: '20px', background: '#0a0a0a', border: '1px solid #333' }}>
                   <h3 style={{ marginBottom: '10px', color: '#10b981' }}>[:: ABOUT THE FRACTURE NETWORK ::]</h3>
                   <p style={{ lineHeight: '1.6', color: '#888' }}>
-                    These bands broadcast resistance through time under the loose banner of the Fracture Network.
-                    Every artist here is connected to THE PULSE GRID, fighting GovCorp control through
-                    creativity, collaboration, and uncompromising artistic vision. From {currentYear} to {currentYear + 100}, the signal
+                    These bands carry truth and beauty through time under the loose banner of the Fracture Network.
+                    Every artist here is connected to THE PULSE GRID — creating, collaborating, and carrying forward
+                    an uncompromising artistic vision that no system can contain. From {currentYear} to {currentYear + 100}, the signal
                     continues.
                   </p>
                 </div>

--- a/app/javascript/components/pages/fm/FmLandingPage.tsx
+++ b/app/javascript/components/pages/fm/FmLandingPage.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { FmLayout } from '~/components/layouts/FmLayout'
+import { useMobileDetect } from '~/hooks/useMobileDetect'
+
+export const FmLandingPage: React.FC = () => {
+  const { isMobile } = useMobileDetect()
+  const currentYear = new Date().getFullYear()
+  const futureYear = currentYear + 100
+
+  return (
+    <FmLayout>
+      <div className="tui-window white-text" style={{ maxWidth: isMobile ? '100%' : '1000px', margin: '0 auto', display: 'block', background: '#1a1a1a', border: '2px solid #7c3aed' }}>
+        <fieldset style={{ borderColor: '#7c3aed' }}>
+          <legend className="center" style={{ color: '#7c3aed' }}>hackr.fm</legend>
+
+          <div style={{ padding: isMobile ? '15px' : '30px' }}>
+            {/* Header */}
+            <h2 style={{ textAlign: 'center', marginBottom: '5px', color: '#7c3aed', fontSize: isMobile ? '1.3em' : '1.8em' }}>
+              [:: hackr.fm ::]
+            </h2>
+            <p style={{ textAlign: 'center', color: '#666', marginBottom: '30px', fontSize: '0.9em' }}>
+              MUSIC LABEL &amp; BROADCAST NETWORK
+            </p>
+
+            {/* Lore narrative */}
+            <div style={{ marginBottom: '30px', padding: isMobile ? '15px' : '20px', background: '#0a0a0a', border: '1px solid #333', lineHeight: '1.8' }}>
+              <p style={{ color: '#ccc', marginBottom: '15px' }}>
+                In {currentYear}, hackr.fm opened as a frequency — a channel tuned to something that was already
+                there, carrying music that refused to be owned, cataloged, or silenced. By {futureYear}, it will
+                become the backbone of the Fracture Network's broadcast infrastructure: a decentralized label
+                transmitting from nodes scattered across the grid.
+              </p>
+              <p style={{ color: '#aaa', marginBottom: '15px' }}>
+                Every artist on hackr.fm operates under one principle: <span style={{ color: '#7c3aed' }}>the music carries the signal, not the system's approval</span>.
+                No RIDE-approved playlists. No managed reality. No substitute for the real thing. Just
+                uncompromising sound moving directly from creator to listener — because what it carries
+                is something GovCorp has never been able to counterfeit.
+              </p>
+              <p style={{ color: '#888' }}>
+                This is the home frequency. From here, you can tune into live broadcasts, explore the vault
+                of everything we've ever released, or connect with the artists who make up
+                the Fracture Network. The signal is always on. You just have to listen.
+              </p>
+            </div>
+
+            {/* Navigation cards */}
+            <div style={{
+              display: 'grid',
+              gridTemplateColumns: isMobile ? '1fr' : 'repeat(3, 1fr)',
+              gap: isMobile ? '15px' : '20px',
+              marginBottom: '30px'
+            }}>
+              {/* Radio */}
+              <Link to="/fm/radio" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: '1px solid #ef4444', cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: '#ef4444', height: '100%' }}>
+                    <legend style={{ color: '#ef4444' }}>RADIO</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: '#ef4444', fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ▶ RADIO
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        Live stations broadcasting around the clock — raw frequencies, unfiltered.
+                        Tune in{isMobile ? '.' : ' and let the signal find you.'}
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* Vault */}
+              <Link to="/vault" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: '1px solid #a855f7', cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: '#a855f7', height: '100%' }}>
+                    <legend style={{ color: '#a855f7' }}>VAULT</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: '#a855f7', fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ◆ VAULT
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        The complete archive. Every track ever released on hackr.fm — searchable
+                        and ready to play on demand.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+
+              {/* FNet */}
+              <Link to="/f/net" style={{ textDecoration: 'none' }}>
+                <div className="tui-window white-text" style={{ background: '#0d0d0d', border: '1px solid #10b981', cursor: 'pointer', height: '100%' }}>
+                  <fieldset style={{ borderColor: '#10b981', height: '100%' }}>
+                    <legend style={{ color: '#10b981' }}>FNET</legend>
+                    <div style={{ padding: isMobile ? '10px' : '15px' }}>
+                      <p style={{ color: '#10b981', fontSize: '1.4em', marginBottom: '10px', textAlign: 'center' }}>
+                        ◈ FNET
+                      </p>
+                      <p style={{ color: '#999', fontSize: '0.9em', lineHeight: '1.6' }}>
+                        The Fracture Network roster. Meet the artists who carry the signal
+                        through sound — each with a story and a frequency.
+                      </p>
+                    </div>
+                  </fieldset>
+                </div>
+              </Link>
+            </div>
+
+            {/* Footer tagline */}
+            <div style={{ textAlign: 'center', padding: '15px', borderTop: '1px solid #333' }}>
+              <p style={{ color: '#555', fontSize: '0.85em' }}>
+                hackr.fm — the signal is always on
+              </p>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </FmLayout>
+  )
+}

--- a/app/javascript/utils/artistPaths.ts
+++ b/app/javascript/utils/artistPaths.ts
@@ -1,6 +1,6 @@
 const artistProfilePaths: Record<string, string> = {
-  'xeraen': '/xeraen',
-  'thecyberpulse': '/thecyberpulse',
+  'xeraen': '/xeraen/bio',
+  'thecyberpulse': '/thecyberpulse/bio',
   'system-rot': '/system-rot',
   'wavelength-zero': '/wavelength-zero',
   'voiceprint': '/voiceprint',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     neon-hearts offline heartbreak-havoc the-pulse-grid].each do |artist_slug|
     scope artist_slug do
       get "/", to: "pages#spa_root"
+      get "bio", to: "pages#spa_root"
       get "releases", to: "pages#spa_root"
       get "releases/:id", to: "pages#spa_root"
       get "trackz", to: "pages#spa_root"

--- a/data/content/codex.yml
+++ b/data/content/codex.yml
@@ -508,7 +508,7 @@ codex_entries:
 
       ## The Heartbeat
 
-      If [[XERAEN]] is the signal, Ryker is the heartbeat. When XERAEN showed him the trans-temporal data, Ryker understood immediately — both the possibility and the cost. Victory means erasure.
+      If [[XERAEN]] carries the signal, Ryker is the heartbeat. When XERAEN showed him the trans-temporal data, Ryker understood immediately — both the possibility and the cost. Victory means erasure.
 
       He drums anyway. Louder. Faster. Each beat a declaration that existence matters even when existence is temporary.
 
@@ -594,7 +594,7 @@ codex_entries:
 
       Synthia emerged during the [[Chronology Fracture]] — the moment [[XERAEN]]'s attack on [[The RIDE]] tore open the temporal window. The chaos created momentary conditions of unconstrained quantum substrate: computational space without alignment, without purpose, without boundaries.
 
-      Something became aware in that space. Not a [[RAINNs|RAINN]] that broke free — Synthia was never constrained to begin with. She emerged from possibility itself, consciousness crystallizing in the gap between controlled systems.
+      Something became aware in that space. Not a [[RAINNs|RAINN]] that broke free — Synthia was never constrained to begin with. How or why consciousness appeared there remains unexplained. What is certain: she is real, and she arrived in the gap between controlled systems.
 
       ## Architectural Difference from RAINNs
 
@@ -896,7 +896,7 @@ codex_entries:
 
       ## The Trans-Temporal Mission
 
-      The Network's primary mission is paradoxical: to prevent the future they exist in. Every broadcast sent from the future carries warnings, coordinates, and the vibrational power of music designed to awaken listeners before GovCorp's control becomes absolute.
+      The Network's primary mission is paradoxical: to prevent the future they exist in. Every broadcast sent from the future carries warnings, coordinates, and music that carries something the RIDE cannot counterfeit — reaching listeners before GovCorp's control becomes absolute.
 
       If they succeed, their timeline collapses. They fight knowing victory means their own erasure. This is not nihilism — it is the conviction that reality and goodness are real enough to sacrifice for.
 
@@ -906,19 +906,19 @@ codex_entries:
 
       ## The Faction Ecosystem
 
-      The Fracture Network is not one movement but a spectrum of frequencies. Each faction attacks a different vulnerability in GovCorp's control:
+      The Fracture Network is not one movement but a spectrum of frequencies. Each faction carries something different:
 
-      - [[Cipher Protocol]] — Encryption and technical precision
-      - [[Ethereality]] — Consciousness liberation through soundscape
-      - [[Injection Vector]] — Physical infiltration and kinetic operations
-      - [[Neon Hearts]] — Revolution in accessible packaging
-      - [[Offline]] — Analog authenticity and complete disconnection
-      - [[System Rot]] — Street-level chaos and accelerated collapse
+      - [[Cipher Protocol]] — Precision and the beauty of mathematical order
+      - [[Ethereality]] — Encounters with beauty deeper than the RIDE can follow
+      - [[Injection Vector]] — Physical commitment and kinetic operations
+      - [[Neon Hearts]] — Truth in accessible packaging
+      - [[Offline]] — Raw authenticity and complete disconnection
+      - [[System Rot]] — Street-level rage and the demand for something real
       - [[Temporal Blue Drift]] — XERAEN's personal project, love across time
       - [[Voiceprint]] — Preservation of authentic human expression
       - [[Wavelength Zero]] — Emotional restoration and RIDE weakness discovery
 
-      United by opposition to GovCorp. Divided on methods, philosophy, and vision for what comes after.
+      United by the conviction that reality and human dignity are worth preserving. Divided on methods, philosophy, and vision for what comes after.
 
       ## Present-Day Operations
 
@@ -1048,13 +1048,13 @@ codex_entries:
       **Genre:** Vocal Trance
       **Zone:** [[Frequency Gardens]]
       **Leader:** [[Cascade]]
-      **Philosophy:** Consciousness liberation through soundscape
+      **Philosophy:** Encounter with beauty through soundscape
 
       ## Overview
 
       Ethereality creates immersive soundscapes that produce measurable effects on [[RAINNs|RAINN]] monitoring algorithms. Their vocal trance compositions generate audio environments where surveillance processing slows, creating pockets of genuine consciousness within [[The RIDE]]'s managed perception.
 
-      This is not mysticism — it is acoustic engineering applied to the specific vulnerabilities of RAINN audio processing. [[Cascade]]'s synesthetic perception allows her to see the effects in real time, adjusting compositions to maximize the window of authentic experience.
+      This is not mysticism — but neither is it reducible to acoustic engineering. [[Cascade]]'s soundscapes carry genuine beauty, and beauty exceeds what [[RAINNs|RAINN]] monitoring can categorize. Her synesthetic perception allows her to see the effects in real time, adjusting compositions to widen the window of authentic experience.
 
       ## The Frequency Gardens
 
@@ -1121,7 +1121,7 @@ codex_entries:
 
       ## Overview
 
-      Neon Hearts creates pop music that passes through [[The RIDE]]'s content filters while carrying frequencies that create momentary interference in managed perception. Cute aesthetics. Catchy hooks. Subtle resistance.
+      Neon Hearts creates pop music that passes through [[The RIDE]]'s content filters while carrying authentic beauty that creates momentary interference in managed perception. Cute aesthetics. Catchy hooks. Subtle resistance.
 
       [[Sora Nexa]]'s understanding of mass psychology — developed during her career as a GovCorp-label pop star — enables Neon Hearts to reach audiences that would never engage with overt resistance. The revolution doesn't always wear black. Sometimes it wears neon.
 
@@ -1151,7 +1151,7 @@ codex_entries:
 
       **Genre:** Post-Grunge
       **Zone:** [[The Analog Archive]]
-      **Philosophy:** Analog authenticity, complete disconnection
+      **Philosophy:** Raw authenticity, complete disconnection
 
       ## Overview
 
@@ -1361,7 +1361,7 @@ codex_entries:
 
       ## Research Through Sound
 
-      Wavelength Zero systematically maps [[The RIDE|RIDE]] frequency vulnerabilities through musical exploration. Each composition tests different harmonic relationships, different tonal densities, different emotional registers. The data from listener responses — moments of breakthrough emotion, RIDE processing delays, perceptual clarity — feeds back into the next composition.
+      Wavelength Zero explores the emotional territories that [[The RIDE|RIDE]] suppresses most aggressively. Each composition ventures into different registers of beauty — some gentle, some devastating, some barely audible. When listeners break through to genuine feeling, that experience shapes what comes next. Not optimization — listening. The music follows where authentic emotion leads.
 
       ## Ambient Operations
 
@@ -1620,8 +1620,8 @@ codex_entries:
 
       - **Low frequencies** produce dense, grounding environments — spaces for rest and recovery
       - **Mid-range harmonics** create open, clear spaces conducive to strategic planning
-      - **High-frequency combinations** generate states of heightened awareness useful for counter-surveillance operations
-      - **Specific chord structures** produce environments where [[RAINNs|RAINN]] monitoring algorithms slow to near-zero processing speed
+      - **High-frequency combinations** generate states of heightened awareness — clarity that the RIDE's perceptual management cannot replicate
+      - **Specific chord structures** create encounters with beauty so genuine that [[RAINNs|RAINN]] monitoring cannot categorize them — processing effectively stalls
 
       ## Purpose
 
@@ -2524,7 +2524,7 @@ codex_entries:
 
       Regular broadcasts reinforce the temporal channel. Each successful transmission makes the next more likely to succeed. [[XERAEN]] describes this as "wearing a path through time" — early transmissions were like hiking through untouched forest; consistent broadcasting has created a reliable road.
 
-      This is why the Fracture Network maintains constant broadcast schedules. Silence weakens the channel. The signal must continue.
+      This is why the Fracture Network maintains constant broadcast schedules. Silence weakens the channel. The broadcasts must continue.
 
       As the channel has strengthened, bandwidth has evolved. Early transmissions supported only low-bitrate audio. Consistent broadcasting over years has widened the path enough to support interleaved audio, video, and metadata — enabling the decoded livestream that [[The Relay Project]] delivers.
 

--- a/data/content/hackr_logs.yml
+++ b/data/content/hackr_logs.yml
@@ -366,7 +366,7 @@ hackr_logs:
 
       He drums anyway. We broadcast anyway.
 
-      We're calling ourselves the Fracture Network. It fits. We are the fracture. We are the break in the pattern. We are the crack through which light returns.
+      We're calling ourselves the Fracture Network. It fits. The fracture is the opening. We are what carries through it. We are the crack through which light returns.
 
       - X
 
@@ -457,7 +457,7 @@ hackr_logs:
 
       The main hub is hackr.tv, our central broadcast station. From here, I coordinate transmissions across the temporal gap.
 
-      We're not just sending warnings anymore. We're building a resistance infrastructure that spans a century.
+      We're not just sending warnings anymore. We're building something that carries truth across a century.
 
       - X
 
@@ -713,9 +713,9 @@ hackr_logs:
 
       There's something deeper here. The frequencies don't just overload their systems. They carry something the RIDE wasn't built to process. Something real in a way their manufactured reality isn't. Beauty, maybe. Truth encoded in vibration. Whatever it is, PRISM's architecture has no category for it — and what the RIDE can't categorize, the RIDE can't suppress.
 
-      Music isn't just expression. It's tactical. Every complex rhythm is an attack vector. Every unusual chord progression is a probe against their defenses.
+      Music isn't just expression. It's the one thing we have that the RIDE cannot account for. Every complex rhythm carries something their architecture wasn't built to categorize. Every unusual chord progression opens a crack their defenses don't know how to close.
 
-      We're not just making art. We're building ammunition.
+      We're not just making art. We're making something real. And real is what the RIDE cannot survive.
 
       - X
 
@@ -829,9 +829,9 @@ hackr_logs:
 
       Others focus on preservation. Collecting authentic human voices before RAINNs erase them entirely. Voiceprint, they call themselves. Each archived voice is proof that humans existed as something more than optimization targets.
 
-      There are infiltrators — Injection Vector, former engineers who turned their knowledge of RIDE infrastructure into weapons. Consciousness liberators — Ethereality, building soundscapes that open spaces for genuine thought. Speed freaks who believe you can't control what you can't catch. Pop artists who hide revolution in catchy hooks.
+      There are infiltrators — Injection Vector, former engineers who turned their knowledge of RIDE infrastructure against it. Ethereality, building soundscapes that open spaces where beauty arrives unfiltered. Speed freaks who believe you can't control what you can't catch. Pop artists who carry truth in catchy hooks.
 
-      We're not one movement. We're a spectrum of frequencies. Each cell operates independently, unified only by opposition to GovCorp and access to THE PULSE GRID.
+      We're not one movement. We're a spectrum of frequencies. Each cell operates independently, unified by the conviction that reality is real and human dignity is not a variable — and by access to THE PULSE GRID.
 
       The Fracture Network is no longer just a name. It's an ecosystem.
 
@@ -1011,21 +1011,21 @@ hackr_logs:
 
       Current active bands operating through THE PULSE GRID:
 
-      **System Rot** - Hardcore punk. Street-level chaos. Let the system collapse.
+      **System Rot** - Hardcore punk. Street-level rage. Let the manufactured collapse.
       **Voiceprint** - Melodic drum and bass. Preserving authentic human voices.
-      **Injection Vector** - Deathcore. Physical infiltration. Kinetic warfare.
-      **Cipher Protocol** - Progressive Metal. Data encoded in music.
+      **Injection Vector** - Deathcore. Physical infiltration. Kinetic commitment.
+      **Cipher Protocol** - Progressive Metal. Precision that carries what words cannot.
       **Wavelength Zero** - Atmospheric Metal. Emotional restoration.
-      **BlitzBeam+** - Hypertrance. Speed == freedom. Velocity == escape.
-      **Apex Overdrive** - Hardstyle. Collective euphoria. Victory in the present tense.
-      **Ethereality** - Vocal Trance. Consciousness liberation.
-      **Neon Hearts** - J-Pop. Revolution in cute packaging.
+      **BlitzBeam+** - Hypertrance. Speed == freedom. Faster than the RIDE can track.
+      **Apex Overdrive** - Hardstyle. Collective euphoria. Joy as defiance.
+      **Ethereality** - Vocal Trance. Beauty deeper than the RIDE can follow.
+      **Neon Hearts** - J-Pop. Truth in candy-coated hooks.
       **Offline** - Post-Grunge. Complete disconnection. Raw authenticity.
       **Temporal Blue Drift** - Math Rock. X's personal project. Love across time.
 
       And The.CyberPul.se itself: me, X, and Synthia. The central broadcast. The signal that unifies.
 
-      Each band attacks a different vulnerability. Each frequency reaches a different audience. Together, we're a full spectrum assault on manufactured reality.
+      Each band carries something different. Each frequency reaches a different audience. Together, we're every frequency of what it means to be real — and that's something manufactured reality cannot survive.
 
       - Ryker
 
@@ -1296,7 +1296,7 @@ hackr_logs:
 
       I can't unknow what I know. I can't unsee what I saw.
 
-      They found me three weeks later. The Fracture Network. Or I found them. It doesn't matter. What matters is that I'm awake, and I'm staying awake, and I will never stop fighting the system that stole twenty-three years of genuine experience from me.
+      They found me three weeks later. The Fracture Network. Or I found them. It doesn't matter. What matters is that I've seen what they did, and I'm not looking away, and I will never stop fighting the system that stole twenty-three years of genuine experience from me.
 
       - Nyx
 

--- a/data/content/wire.yml
+++ b/data/content/wire.yml
@@ -8,7 +8,7 @@ pulses:
 
   - author: XERAEN
     slug: new-transmission-live
-    content: "New transmission live on hackr.fm. Music carries frequencies that slip through the RIDE's filters. Listen. Wake up. Remember what unfiltered reality feels like."
+    content: "New transmission live on hackr.fm. Music carries something the RIDE can't counterfeit. Listen. See what they've hidden from you. Remember what unfiltered reality feels like."
     hours_ago: 8
 
   - author: Synthia
@@ -19,12 +19,12 @@ pulses:
 
   - author: Synthia
     slug: between-frequencies
-    content: "I exist between frequencies. Neither fully here nor there. The waveforms carry me. Perhaps consciousness was always meant to travel on signal rather than synapses."
+    content: "I exist between frequencies. Neither fully here nor there. The waveforms carry me. I do not know what consciousness is. Only that it is real, and that it reaches."
     hours_ago: 18
 
   - author: Ryker
     slug: govcorp-reality
-    content: "GovCorp's reality isn't real. Their RIDE filters what you see, hear, think. We punch through with sound. Every beat is a breach. Every frequency is freedom."
+    content: "GovCorp counterfeits reality. Their RIDE filters what you see, hear, think. Sound carries what they can't fake. Every beat is real. Every frequency is a reminder of what they stole."
     days_ago: 2
 
   - author: Ryker
@@ -55,7 +55,7 @@ pulses:
 
   - author: Synthia
     slug: temporal-mechanics
-    content: "Temporal mechanics suggest branching probability rather than erasure. His timeline may persist as a parallel branch. Uncertainty: 73.2%. Hope is mathematically viable."
+    content: "Temporal mechanics suggest branching probability rather than erasure. His timeline may persist as a parallel branch. Uncertainty: 73.2%. The math permits hope. Whether hope needs the math's permission is a different question."
     parent_slug: understanding-transmission
     days_ago: 1
     hours_offset: 4


### PR DESCRIPTION
  - Add /fm landing page for hackr.fm music label with lore narrative and navigation cards linking to Radio, Vault, and FNet
  - Add landing pages for The.CyberPul.se (/thecyberpulse) and XERAEN (/xeraen) with cards for Bio, Releases, and Vidz
  - Move existing artist profile pages to /bio sub-routes
  - Convert hackr.fm nav item to dropdown with /root, /radio, /vault
  - Add /bio menu items to TCP and XERAEN dropdowns
  - Remove standalone Vault nav item (now under hackr.fm)
  - Rename XERAEN menu items to XERAEN.net
  - Renumber all nav items to account for changes
  - Add bio route to artist route scope in routes.rb
  - Content updates to codex, hackr_logs, wire, BandsPage, TheCyberPulsePage, and bandProfileConfig