### PR TITLE
Adds shop and black market system for THE PULSE GRID

### DIFF
--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -1,0 +1,90 @@
+class Admin::GridShopListingsController < Admin::ApplicationController
+  before_action :set_listing, only: [:edit, :update, :destroy, :restock]
+
+  def index
+    @listings = GridShopListing.includes(:grid_mob).order(:grid_mob_id, :name)
+    @listings = @listings.where(grid_mob_id: params[:mob_id]) if params[:mob_id].present?
+    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+  end
+
+  def new
+    @listing = GridShopListing.new(
+      restock_amount: 1,
+      restock_interval_hours: 24,
+      min_clearance: 0,
+      active: true,
+      rotation_pool: false
+    )
+    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+  end
+
+  def create
+    @listing = GridShopListing.new(listing_params)
+    if @listing.save
+      set_flash_success("Listing '#{@listing.name}' created for #{@listing.grid_mob.name}.")
+      redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
+    else
+      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+      flash.now[:error] = @listing.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+  end
+
+  def update
+    if @listing.update(listing_params)
+      set_flash_success("Listing '#{@listing.name}' updated.")
+      redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
+    else
+      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+      flash.now[:error] = @listing.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @listing.name
+    mob_id = @listing.grid_mob_id
+    @listing.destroy!
+    set_flash_success("Listing '#{name}' deleted.")
+    redirect_to admin_grid_shop_listings_path(mob_id: mob_id)
+  end
+
+  def restock
+    if @listing.max_stock.present?
+      @listing.update!(stock: @listing.max_stock, next_restock_at: Time.current + @listing.restock_interval_hours.hours)
+      set_flash_success("'#{@listing.name}' restocked to #{@listing.max_stock}.")
+    else
+      set_flash_error("'#{@listing.name}' has unlimited stock.")
+    end
+    redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
+  end
+
+  private
+
+  def set_listing
+    @listing = GridShopListing.find(params[:id])
+  end
+
+  def listing_params
+    permitted = params.require(:grid_shop_listing).permit(
+      :grid_mob_id, :name, :description, :item_type, :rarity,
+      :base_price, :sell_price, :stock, :max_stock,
+      :restock_amount, :restock_interval_hours,
+      :active, :rotation_pool, :min_clearance
+    )
+    # Parse properties from JSON string
+    if params[:grid_shop_listing][:properties_json].present?
+      permitted[:properties] = JSON.parse(params[:grid_shop_listing][:properties_json])
+    else
+      permitted[:properties] = {}
+    end
+    permitted
+  rescue JSON::ParserError
+    permitted[:properties] = {}
+    permitted
+  end
+end

--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -19,15 +19,22 @@ class Admin::GridShopListingsController < Admin::ApplicationController
   end
 
   def create
-    @listing = GridShopListing.new(listing_params)
-    if @listing.save
+    attrs, json_error = listing_params
+    @listing = GridShopListing.new(attrs)
+
+    if json_error.nil? && @listing.save
       set_flash_success("Listing '#{@listing.name}' created for #{@listing.grid_mob.name}.")
       redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
-    else
-      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
-      flash.now[:error] = @listing.errors.full_messages.join(", ")
-      render :new, status: :unprocessable_entity
+      return
     end
+
+    if json_error
+      @listing.valid? # populate other validation errors
+      @listing.errors.add(:properties, json_error)
+    end
+    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+    flash.now[:error] = @listing.errors.full_messages.join(", ")
+    render :new, status: :unprocessable_entity
   end
 
   def edit
@@ -35,7 +42,17 @@ class Admin::GridShopListingsController < Admin::ApplicationController
   end
 
   def update
-    if @listing.update(listing_params)
+    attrs, json_error = listing_params
+    if json_error
+      @listing.assign_attributes(attrs)
+      @listing.errors.add(:properties, json_error)
+      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+      flash.now[:error] = @listing.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
+    if @listing.update(attrs)
       set_flash_success("Listing '#{@listing.name}' updated.")
       redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
     else
@@ -69,6 +86,9 @@ class Admin::GridShopListingsController < Admin::ApplicationController
     @listing = GridShopListing.find(params[:id])
   end
 
+  # Returns [permitted_attrs, json_error_message_or_nil].
+  # On invalid JSON, :properties is omitted from attrs entirely (preserving
+  # existing values on update) and a human-readable error is returned.
   def listing_params
     permitted = params.require(:grid_shop_listing).permit(
       :grid_mob_id, :name, :description, :item_type, :rarity,
@@ -76,15 +96,21 @@ class Admin::GridShopListingsController < Admin::ApplicationController
       :restock_amount, :restock_interval_hours,
       :active, :rotation_pool, :min_clearance
     )
-    # Parse properties from JSON string
-    permitted[:properties] = if params[:grid_shop_listing][:properties_json].present?
-      JSON.parse(params[:grid_shop_listing][:properties_json])
-    else
-      {}
+
+    json_source = params[:grid_shop_listing][:properties_json]
+    if json_source.blank?
+      permitted[:properties] = {}
+      return [permitted, nil]
     end
-    permitted
-  rescue JSON::ParserError
-    permitted[:properties] = {}
-    permitted
+
+    parsed = JSON.parse(json_source)
+    unless parsed.is_a?(Hash)
+      return [permitted, "must be a JSON object (e.g. {\"slot\": \"gpu\"})"]
+    end
+
+    permitted[:properties] = parsed
+    [permitted, nil]
+  rescue JSON::ParserError => e
+    [permitted, "is not valid JSON: #{e.message}"]
   end
 end

--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -77,10 +77,10 @@ class Admin::GridShopListingsController < Admin::ApplicationController
       :active, :rotation_pool, :min_clearance
     )
     # Parse properties from JSON string
-    if params[:grid_shop_listing][:properties_json].present?
-      permitted[:properties] = JSON.parse(params[:grid_shop_listing][:properties_json])
+    permitted[:properties] = if params[:grid_shop_listing][:properties_json].present?
+      JSON.parse(params[:grid_shop_listing][:properties_json])
     else
-      permitted[:properties] = {}
+      {}
     end
     permitted
   rescue JSON::ParserError

--- a/app/controllers/admin/grid_shop_transactions_controller.rb
+++ b/app/controllers/admin/grid_shop_transactions_controller.rb
@@ -1,0 +1,21 @@
+class Admin::GridShopTransactionsController < Admin::ApplicationController
+  def index
+    @transactions = GridShopTransaction.includes(:grid_hackr, :grid_mob, :grid_shop_listing).recent
+
+    if params[:mob_id].present?
+      @transactions = @transactions.where(grid_mob_id: params[:mob_id])
+    end
+
+    if params[:hackr_alias].present?
+      hackr = GridHackr.find_by("LOWER(hackr_alias) = ?", params[:hackr_alias].downcase)
+      @transactions = @transactions.where(grid_hackr: hackr) if hackr
+    end
+
+    if params[:transaction_type].present?
+      @transactions = @transactions.where(transaction_type: params[:transaction_type])
+    end
+
+    @transactions = @transactions.limit(100)
+    @vendors = GridMob.where(mob_type: "vendor").order(:name)
+  end
+end

--- a/app/controllers/admin/grid_shop_transactions_controller.rb
+++ b/app/controllers/admin/grid_shop_transactions_controller.rb
@@ -8,7 +8,11 @@ class Admin::GridShopTransactionsController < Admin::ApplicationController
 
     if params[:hackr_alias].present?
       hackr = GridHackr.find_by("LOWER(hackr_alias) = ?", params[:hackr_alias].downcase)
-      @transactions = @transactions.where(grid_hackr: hackr) if hackr
+      # Apply the filter even when the alias is unknown — `where(grid_hackr: nil)`
+      # matches transactions from deleted hackrs, which is not what the admin meant.
+      # Force an empty result set instead so the UI clearly shows zero matches.
+      @transactions = hackr ? @transactions.where(grid_hackr: hackr) : @transactions.none
+      @hackr_not_found = hackr.nil?
     end
 
     if params[:transaction_type].present?

--- a/app/jobs/shop_restock_job.rb
+++ b/app/jobs/shop_restock_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ShopRestockJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    GridShopListing
+      .where(active: true)
+      .where.not(max_stock: nil)
+      .where("next_restock_at IS NULL OR next_restock_at <= ?", Time.current)
+      .find_each do |listing|
+        next if listing.stock.present? && listing.stock >= listing.max_stock
+
+        new_stock = [(listing.stock || 0) + listing.restock_amount, listing.max_stock].min
+        listing.update_columns(
+          stock: new_stock,
+          next_restock_at: Time.current + listing.restock_interval_hours.hours
+        )
+      end
+  end
+end

--- a/app/jobs/shop_rotation_job.rb
+++ b/app/jobs/shop_rotation_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ShopRotationJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    mob_ids = GridShopListing.in_rotation_pool.distinct.pluck(:grid_mob_id)
+
+    mob_ids.each do |mob_id|
+      mob = GridMob.find_by(id: mob_id)
+      next unless mob&.vendor?
+
+      Grid::ShopService.rotate!(mob)
+    end
+  end
+end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -86,6 +86,7 @@ class GridHackr < ApplicationRecord
   has_many :feature_grants, dependent: :destroy
   has_many :grid_hackr_achievements, dependent: :destroy
   has_many :grid_achievements, through: :grid_hackr_achievements
+  has_many :grid_shop_transactions, dependent: :destroy
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -86,7 +86,7 @@ class GridHackr < ApplicationRecord
   has_many :feature_grants, dependent: :destroy
   has_many :grid_hackr_achievements, dependent: :destroy
   has_many :grid_achievements, through: :grid_hackr_achievements
-  has_many :grid_shop_transactions, dependent: :destroy
+  has_many :grid_shop_transactions, dependent: :nullify
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -22,6 +22,7 @@
 #  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
 #
 class GridItem < ApplicationRecord
+  ITEM_TYPES = %w[tool consumable data faction collectible component].freeze
   RARITIES = %w[scrap ubiquitous common uncommon rare ultra_rare unicorn].freeze
   RARITY_LABELS = {
     "scrap" => "SCRAP",
@@ -47,7 +48,7 @@ class GridItem < ApplicationRecord
   belongs_to :grid_mining_rig, optional: true
 
   validates :name, presence: true
-  validates :item_type, inclusion: {in: %w[tool consumable data faction collectible component], allow_nil: true}
+  validates :item_type, inclusion: {in: ITEM_TYPES, allow_nil: true}
   validates :rarity, inclusion: {in: RARITIES, allow_nil: true}
   validates :quantity, numericality: {greater_than: 0}, allow_nil: true
   validate :single_location

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -8,6 +8,7 @@
 #  dialogue_tree   :json
 #  mob_type        :string
 #  name            :string
+#  vendor_config   :json
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  grid_faction_id :integer
@@ -16,7 +17,29 @@
 class GridMob < ApplicationRecord
   belongs_to :grid_room
   belongs_to :grid_faction, optional: true
+  has_many :grid_shop_listings, dependent: :destroy
+  has_many :grid_shop_transactions, dependent: :nullify
 
   validates :name, presence: true
   validates :mob_type, inclusion: {in: %w[quest_giver vendor lore special], allow_nil: true}
+
+  def vendor?
+    mob_type == "vendor"
+  end
+
+  def shop_type
+    vendor_config&.dig("shop_type") || "standard"
+  end
+
+  def black_market?
+    shop_type == "black_market"
+  end
+
+  def restock_interval_hours
+    vendor_config&.dig("restock_interval_hours") || 24
+  end
+
+  def rotation_count
+    vendor_config&.dig("rotation_count") || 3
+  end
 end

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string
 #  slug                :string
@@ -38,7 +39,12 @@ class GridRoom < ApplicationRecord
     in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream],
     allow_nil: true
   }
+  validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
   # Delegate to zone for convenience
   delegate :faction, :color_scheme, to: :grid_zone
+
+  def clearance_gated?
+    min_clearance > 0
+  end
 end

--- a/app/models/grid_shop_listing.rb
+++ b/app/models/grid_shop_listing.rb
@@ -1,5 +1,40 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_shop_listings
+# Database name: primary
+#
+#  id                     :integer          not null, primary key
+#  active                 :boolean          default(TRUE), not null
+#  base_price             :integer          not null
+#  description            :text
+#  item_type              :string
+#  max_stock              :integer
+#  min_clearance          :integer          default(0), not null
+#  name                   :string           not null
+#  next_restock_at        :datetime
+#  properties             :json
+#  rarity                 :string
+#  restock_amount         :integer          default(1), not null
+#  restock_interval_hours :integer          default(24), not null
+#  rotation_pool          :boolean          default(FALSE), not null
+#  sell_price             :integer          not null
+#  stock                  :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  grid_mob_id            :integer          not null
+#
+# Indexes
+#
+#  index_grid_shop_listings_on_grid_mob_id             (grid_mob_id)
+#  index_grid_shop_listings_on_grid_mob_id_and_active  (grid_mob_id,active)
+#  index_grid_shop_listings_on_next_restock_at         (next_restock_at)
+#
+# Foreign Keys
+#
+#  grid_mob_id  (grid_mob_id => grid_mobs.id)
+#
 class GridShopListing < ApplicationRecord
   belongs_to :grid_mob
   has_many :grid_shop_transactions, dependent: :nullify

--- a/app/models/grid_shop_listing.rb
+++ b/app/models/grid_shop_listing.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class GridShopListing < ApplicationRecord
+  belongs_to :grid_mob
+  has_many :grid_shop_transactions, dependent: :nullify
+
+  validates :name, presence: true
+  validates :item_type, inclusion: {in: GridItem::ITEM_TYPES}, allow_nil: true
+  validates :rarity, inclusion: {in: GridItem::RARITIES}, allow_nil: true
+  validates :base_price, numericality: {only_integer: true, greater_than: 0}
+  validates :sell_price, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :stock, numericality: {only_integer: true, greater_than_or_equal_to: 0}, allow_nil: true
+  validates :max_stock, numericality: {only_integer: true, greater_than: 0}, allow_nil: true
+  validates :restock_amount, numericality: {only_integer: true, greater_than: 0}
+  validates :restock_interval_hours, numericality: {only_integer: true, greater_than: 0}
+  validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :available, -> { where(active: true).where("stock IS NULL OR stock > 0") }
+  scope :in_rotation_pool, -> { where(rotation_pool: true) }
+
+  before_validation :compute_sell_price, if: -> { sell_price.blank? && base_price.present? }
+
+  def unlimited_stock?
+    stock.nil?
+  end
+
+  def out_of_stock?
+    !unlimited_stock? && stock <= 0
+  end
+
+  def in_stock?
+    unlimited_stock? || stock > 0
+  end
+
+  def rarity_color
+    GridItem::RARITY_COLORS[rarity] || "#9ca3af"
+  end
+
+  def rarity_label
+    GridItem::RARITY_LABELS[rarity] || rarity&.upcase
+  end
+
+  private
+
+  def compute_sell_price
+    self.sell_price = (base_price / 2.0).ceil
+  end
+end

--- a/app/models/grid_shop_transaction.rb
+++ b/app/models/grid_shop_transaction.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class GridShopTransaction < ApplicationRecord
+  TRANSACTION_TYPES = %w[buy sell].freeze
+
+  belongs_to :grid_hackr
+  belongs_to :grid_shop_listing, optional: true
+  belongs_to :grid_mob
+
+  validates :transaction_type, inclusion: {in: TRANSACTION_TYPES}
+  validates :quantity, numericality: {only_integer: true, greater_than: 0}
+  validates :price_paid, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :purchases, -> { where(transaction_type: "buy") }
+  scope :sales, -> { where(transaction_type: "sell") }
+
+  # Immutable: prevent updates and deletes
+  before_update { raise ActiveRecord::ReadOnlyRecord, "GridShopTransaction records are immutable" }
+  before_destroy { raise ActiveRecord::ReadOnlyRecord, "GridShopTransaction records cannot be deleted" }
+end

--- a/app/models/grid_shop_transaction.rb
+++ b/app/models/grid_shop_transaction.rb
@@ -1,11 +1,34 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_shop_transactions
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  burn_amount          :integer          default(0), not null
+#  price_paid           :integer          not null
+#  quantity             :integer          default(1), not null
+#  recycle_amount       :integer          default(0), not null
+#  transaction_type     :string           not null
+#  created_at           :datetime         not null
+#  grid_hackr_id        :integer
+#  grid_mob_id          :integer
+#  grid_shop_listing_id :integer
+#
+# Indexes
+#
+#  index_grid_shop_transactions_on_grid_hackr_id                 (grid_hackr_id)
+#  index_grid_shop_transactions_on_grid_hackr_id_and_created_at  (grid_hackr_id,created_at)
+#  index_grid_shop_transactions_on_grid_mob_id                   (grid_mob_id)
+#  index_grid_shop_transactions_on_grid_shop_listing_id          (grid_shop_listing_id)
+#
 class GridShopTransaction < ApplicationRecord
   TRANSACTION_TYPES = %w[buy sell].freeze
 
-  belongs_to :grid_hackr
+  belongs_to :grid_hackr, optional: true
   belongs_to :grid_shop_listing, optional: true
-  belongs_to :grid_mob
+  belongs_to :grid_mob, optional: true
 
   validates :transaction_type, inclusion: {in: TRANSACTION_TYPES}
   validates :quantity, numericality: {only_integer: true, greater_than: 0}

--- a/app/models/grid_transaction.rb
+++ b/app/models/grid_transaction.rb
@@ -22,7 +22,7 @@
 #  index_grid_transactions_on_tx_type        (tx_type)
 #
 class GridTransaction < ApplicationRecord
-  TX_TYPES = %w[transfer mining_reward gameplay_reward burn redemption genesis].freeze
+  TX_TYPES = %w[transfer mining_reward gameplay_reward burn redemption genesis purchase_recycle].freeze
 
   belongs_to :from_cache, class_name: "GridCache"
   belongs_to :to_cache, class_name: "GridCache"

--- a/app/models/grid_zone.rb
+++ b/app/models/grid_zone.rb
@@ -31,7 +31,7 @@ class GridZone < ApplicationRecord
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
   validates :zone_type, inclusion: {
-    in: %w[faction_base govcorp residential transit special],
+    in: %w[faction_base govcorp residential transit special danger_zone],
     allow_nil: true
   }
 end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -301,12 +301,15 @@ module Grid
       item = hackr.grid_items.find_by("LOWER(name) = ?", target.downcase)
       return examine_item(item) if item
 
-      # Check vendor shop listings
+      # Check vendor shop listings (respecting per-listing clearance gate)
       vendor = room.grid_mobs.find_by(mob_type: "vendor")
       if vendor
-        listing = vendor.grid_shop_listings.where(active: true).find_by("LOWER(name) = ?", target.downcase)
+        clearance = hackr.stat("clearance")
+        listing = vendor.grid_shop_listings.where(active: true)
+          .where("min_clearance <= ?", clearance)
+          .find_by("LOWER(name) = ?", target.downcase)
         if listing
-          price = Grid::ShopService.effective_price(listing: listing, mob: vendor, clearance: hackr.stat("clearance"))
+          price = Grid::ShopService.effective_price(listing: listing, mob: vendor, clearance: clearance)
           return examine_listing(listing, price)
         end
       end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -68,6 +68,12 @@ module Grid
         chain_command(args)
       when "rig"
         rig_command(args)
+      when "shop", "browse"
+        shop_command
+      when "buy", "purchase"
+        buy_command(args.join(" "))
+      when "sell"
+        sell_command(args.join(" "))
       when "help", "?"
         help_command
       when "who"
@@ -144,6 +150,14 @@ module Grid
       end
 
       new_room = exit.to_room
+
+      # Clearance gate
+      if new_room.clearance_gated?
+        hackr_clearance = hackr.stat("clearance")
+        if hackr_clearance < new_room.min_clearance
+          return "<span style='color: #f87171;'>ACCESS DENIED. Clearance #{new_room.min_clearance}+ required. You are Clearance #{hackr_clearance}.</span>"
+        end
+      end
       hackr.update!(current_room: new_room)
 
       # Track exploration (unique rooms via visited_rooms array in stats)
@@ -281,11 +295,21 @@ module Grid
 
       # Check items in room
       item = room.grid_items.in_room(room).find_by("LOWER(name) = ?", target.downcase)
-      return "<span style='color: #d0d0d0;'>#{codex_linkify(item.description)}</span>" if item
+      return examine_item(item) if item
 
       # Check items in inventory
       item = hackr.grid_items.find_by("LOWER(name) = ?", target.downcase)
-      return "<span style='color: #d0d0d0;'>#{codex_linkify(item.description)}</span>" if item
+      return examine_item(item) if item
+
+      # Check vendor shop listings
+      vendor = room.grid_mobs.find_by(mob_type: "vendor")
+      if vendor
+        listing = vendor.grid_shop_listings.where(active: true).find_by("LOWER(name) = ?", target.downcase)
+        if listing
+          price = Grid::ShopService.effective_price(listing: listing, mob: vendor, clearance: hackr.stat("clearance"))
+          return examine_listing(listing, price)
+        end
+      end
 
       # Check Mobs
       mob = room.grid_mobs.find_by("LOWER(name) = ?", target.downcase)
@@ -391,6 +415,11 @@ module Grid
         <span style='color: #fbbf24;'>NPCs:</span>
           <span style='color: #34d399;'>talk &lt;npc&gt;</span>              - Talk to an NPC
           <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span> - Ask an NPC about a topic
+
+        <span style='color: #fbbf24;'>Commerce:</span>
+          <span style='color: #34d399;'>shop, browse</span>            - View vendor inventory &amp; prices
+          <span style='color: #34d399;'>buy &lt;item&gt;</span>              - Purchase an item from vendor
+          <span style='color: #34d399;'>sell &lt;item&gt;</span>             - Sell an item to vendor
 
         <span style='color: #fbbf24;'>Economy:</span>
           <span style='color: #34d399;'>cache</span>                   - List your caches
@@ -589,10 +618,164 @@ module Grid
       output.join("\n")
     end
 
+    def examine_item(item)
+      output = "<span style='color: #d0d0d0;'>#{codex_linkify(item.description)}</span>"
+      if item.component? && item.rate_multiplier
+        props = item.properties || {}
+        slot = props["slot"]&.upcase || "UNKNOWN"
+        output += "\n<span style='color: #22d3ee;'>Slot: #{slot}</span>"
+        output += " <span style='color: #fbbf24;'>Multiplier: x#{item.rate_multiplier}</span>"
+        if slot == "MOTHERBOARD"
+          output += "\n<span style='color: #9ca3af;'>Slots: CPU #{props["cpu_slots"] || 0} / GPU #{props["gpu_slots"] || 0} / RAM #{props["ram_slots"] || 0}</span>"
+        end
+      end
+      output
+    end
+
+    def examine_listing(listing, effective_price)
+      color = listing.rarity_color
+      rarity_tag = listing.rarity ? " <span style='color: #{color};'>[#{listing.rarity_label}]</span>" : ""
+      output = "<span style='color: #d0d0d0;'>#{codex_linkify(listing.description)}</span>#{rarity_tag}"
+      output += "\n<span style='color: #6b7280;'>Buy: <span style='color: #34d399;'>#{format_cred(effective_price)} CRED</span> / Sell: #{format_cred(listing.sell_price)} CRED</span>"
+      if listing.item_type == "component"
+        props = listing.properties || {}
+        slot = props["slot"]&.upcase || "UNKNOWN"
+        mult = props["rate_multiplier"] || 1.0
+        output += "\n<span style='color: #22d3ee;'>Slot: #{slot}</span>"
+        output += " <span style='color: #fbbf24;'>Multiplier: x#{mult}</span>"
+        if slot == "MOTHERBOARD"
+          output += "\n<span style='color: #9ca3af;'>Slots: CPU #{props["cpu_slots"] || 0} / GPU #{props["gpu_slots"] || 0} / RAM #{props["ram_slots"] || 0}</span>"
+        end
+      end
+      output
+    end
+
     def dialogue_box(content)
       # Create a thin-bordered box around dialogue content
       # Add blank line before box, strip content to avoid blank lines inside
       "\n<div style='border: 1px solid #666; padding: 10px; margin: 5px 0; background: #0d0d0d;'>#{content.strip}</div>"
+    end
+
+    # --- Shop commands ---
+
+    def shop_command
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      vendor = room.grid_mobs.find_by(mob_type: "vendor")
+      return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
+
+      items = Grid::ShopService.listing_display(mob: vendor, hackr: hackr)
+
+      if items.empty?
+        return dialogue_box(
+          "<span style='color: #c084fc;'>#{h(vendor.name)}</span>: <span style='color: #60a5fa;'>\"Nothing for you right now.\"</span>"
+        )
+      end
+
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+
+      if vendor.black_market?
+        clearance = hackr.stat("clearance")
+        output << "<span style='color: #f87171; font-weight: bold;'>⚠ BLACK MARKET</span> <span style='color: #9ca3af;'>:: #{h(vendor.name)}</span>"
+        output << "<span style='color: #6b7280;'>Prices adjusted for CLEARANCE #{clearance}. Higher clearance = better rates.</span>"
+      else
+        output << "<span style='color: #22d3ee; font-weight: bold;'>VENDOR :: #{h(vendor.name)}</span>"
+      end
+
+      output << ""
+
+      # Table
+      rows = items.map do |entry|
+        listing = entry[:listing]
+        price = entry[:effective_price]
+        color = listing.rarity_color
+        name_display = "<span style='color: #{color};'>#{h(listing.name)}</span>"
+        rarity_display = "<span style='color: #{color};'>[#{listing.rarity_label}]</span>"
+
+        price_color = entry[:affordable] ? "#34d399" : "#f87171"
+        price_display = "<span style='color: #{price_color};'>#{format_cred(price)}</span>"
+
+        stock_display = if listing.unlimited_stock?
+          "<span style='color: #34d399;'>∞</span>"
+        elsif listing.out_of_stock?
+          "<span style='color: #f87171;'>OUT</span>"
+        else
+          "<span style='color: #fbbf24;'>#{listing.stock}</span>"
+        end
+
+        "<tr><td style='padding: 2px 12px 2px 0;'>#{name_display}</td>" \
+        "<td style='padding: 2px 12px 2px 0;'>#{rarity_display}</td>" \
+        "<td style='padding: 2px 12px 2px 0; text-align: right;'>#{price_display}</td>" \
+        "<td style='padding: 2px 0; text-align: center;'>#{stock_display}</td></tr>"
+      end
+
+      table = "<table style='border-collapse: collapse; margin: 0 8px;'>" \
+        "<tr style='color: #6b7280;'>" \
+        "<th style='text-align: left; padding: 2px 12px 2px 0; border-bottom: 1px solid #333;'>Item</th>" \
+        "<th style='text-align: left; padding: 2px 12px 2px 0; border-bottom: 1px solid #333;'>Rarity</th>" \
+        "<th style='text-align: right; padding: 2px 12px 2px 0; border-bottom: 1px solid #333;'>Price</th>" \
+        "<th style='text-align: center; padding: 2px 0; border-bottom: 1px solid #333;'>Stock</th>" \
+        "</tr>#{rows.join}</table>"
+      output << table
+
+      output << ""
+      balance = hackr.default_cache&.balance || 0
+      output << "<span style='color: #6b7280;'>Your CRED: #{format_cred(balance)}. Use 'buy &lt;item&gt;' to purchase, 'sell &lt;item&gt;' to sell.</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+
+      output.join("\n")
+    end
+
+    def buy_command(item_name)
+      return "<span style='color: #fbbf24;'>Buy what? Usage: buy &lt;item&gt;</span>" if item_name.empty?
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      vendor = room.grid_mobs.find_by(mob_type: "vendor")
+      return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
+
+      result = Grid::ShopService.buy!(hackr: hackr, mob: vendor, item_name: item_name)
+
+      item = result[:item]
+      color = item.rarity_color
+      name_display = item.unicorn? ? item.rainbow_name_html : "<span style='color: #{color};'>#{h(item.name)}</span>"
+
+      output = "<span style='color: #34d399;'>Purchased </span>#{name_display}<span style='color: #34d399;'> for <span style='color: #fbbf24;'>#{format_cred(result[:price_paid])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
+
+      notifications = achievement_checker.check(:purchase_item, item_name: item.name)
+      output = append_notifications(output, notifications)
+      {output: output, event: nil}
+    rescue Grid::ShopService::AccessDenied => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::ItemNotFound => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::InsufficientStock => e
+      "<span style='color: #fbbf24;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::InsufficientBalance => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def sell_command(item_name)
+      return "<span style='color: #fbbf24;'>Sell what? Usage: sell &lt;item&gt;</span>" if item_name.empty?
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      vendor = room.grid_mobs.find_by(mob_type: "vendor")
+      return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
+
+      result = Grid::ShopService.sell!(hackr: hackr, mob: vendor, item_name: item_name)
+
+      "<span style='color: #34d399;'>Sold </span><span style='color: #d0d0d0;'>#{h(result[:item_name])}</span><span style='color: #34d399;'> for <span style='color: #fbbf24;'>#{format_cred(result[:sell_price])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
+    rescue Grid::ShopService::AccessDenied => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::ItemNotFound => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::TransactionService::InsufficientBalance
+      "<span style='color: #f87171;'>The vendor can't afford to buy that right now.</span>"
     end
 
     # --- Economy commands ---

--- a/app/services/grid/economy_config.rb
+++ b/app/services/grid/economy_config.rb
@@ -11,6 +11,16 @@ module Grid
     PRESENCE_TTL = 10.minutes
     CHAT_BONUS = 1     # flat CRED per tick for chatting during live stream
 
+    # Shop economy
+    SHOP_BURN_RATIO = 0.70       # 70% of purchase price burned
+    SHOP_RECYCLE_RATIO = 0.30    # 30% recycled to gameplay pool
+    SELL_PRICE_RATIO = 0.50      # Players sell items at 50% of base price
+
+    # Black market
+    BLACK_MARKET_MIN_CLEARANCE = 10
+    BLACK_MARKET_BASE_MULTIPLIER = 5.0
+    BLACK_MARKET_CLEARANCE_REDUCTION = 0.04  # per clearance level above minimum
+
     MINING_POOL_TOTAL = (TOTAL_SUPPLY * MINING_POOL_SHARE).to_i
     GAMEPLAY_POOL_TOTAL = (TOTAL_SUPPLY * GAMEPLAY_POOL_SHARE).to_i
 

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -143,7 +143,7 @@ module Grid
       if mob.black_market?
         multiplier = [1.0, EconomyConfig::BLACK_MARKET_BASE_MULTIPLIER -
           (clearance - EconomyConfig::BLACK_MARKET_MIN_CLEARANCE) *
-          EconomyConfig::BLACK_MARKET_CLEARANCE_REDUCTION].max
+            EconomyConfig::BLACK_MARKET_CLEARANCE_REDUCTION].max
         (listing.base_price * multiplier).ceil
       else
         listing.base_price
@@ -185,17 +185,21 @@ module Grid
       burn_amt = burn_amount(amount)
       recycle_amt = amount - burn_amt
 
-      Grid::TransactionService.burn!(
-        from_cache: hackr_cache,
-        amount: burn_amt,
-        memo: "Shop purchase: #{item_name}"
-      ) if burn_amt > 0
+      if burn_amt > 0
+        Grid::TransactionService.burn!(
+          from_cache: hackr_cache,
+          amount: burn_amt,
+          memo: "Shop purchase: #{item_name}"
+        )
+      end
 
-      Grid::TransactionService.recycle!(
-        from_cache: hackr_cache,
-        amount: recycle_amt,
-        memo: "Shop recycle: #{item_name}"
-      ) if recycle_amt > 0
+      if recycle_amt > 0
+        Grid::TransactionService.recycle!(
+          from_cache: hackr_cache,
+          amount: recycle_amt,
+          memo: "Shop recycle: #{item_name}"
+        )
+      end
     end
     private_class_method :split_purchase!
   end

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+module Grid
+  class ShopService
+    class InsufficientBalance < StandardError; end
+    class InsufficientStock < StandardError; end
+    class AccessDenied < StandardError; end
+    class ItemNotFound < StandardError; end
+
+    # Returns visible listings with effective prices for a given hackr
+    def self.listing_display(mob:, hackr:)
+      clearance = hackr.stat("clearance")
+      cache = hackr.default_cache
+
+      mob.grid_shop_listings.where(active: true).order(:rarity, :name).map do |listing|
+        next if listing.min_clearance > clearance
+
+        price = effective_price(listing: listing, mob: mob, clearance: clearance)
+        balance = cache&.balance || 0
+
+        {
+          listing: listing,
+          effective_price: price,
+          affordable: balance >= price,
+          out_of_stock: listing.out_of_stock?
+        }
+      end.compact
+    end
+
+    # Buy an item from a vendor
+    def self.buy!(hackr:, mob:, item_name:)
+      raise AccessDenied, "This vendor doesn't sell anything" unless mob.vendor?
+
+      clearance = hackr.stat("clearance")
+      listing = mob.grid_shop_listings.where(active: true)
+        .find_by("LOWER(name) = ?", item_name.downcase)
+
+      raise ItemNotFound, "This vendor doesn't sell '#{item_name}'" unless listing
+      raise AccessDenied, "CLEARANCE #{listing.min_clearance}+ required" if clearance < listing.min_clearance
+      raise InsufficientStock, "'#{listing.name}' is out of stock" if listing.out_of_stock?
+
+      price = effective_price(listing: listing, mob: mob, clearance: clearance)
+      cache = hackr.default_cache
+      raise InsufficientBalance, "Insufficient CRED (need #{price}, have #{cache&.balance || 0})" unless cache && cache.balance >= price
+
+      item = nil
+
+      ActiveRecord::Base.transaction do
+        # Optimistic stock decrement — prevents race condition
+        unless listing.unlimited_stock?
+          updated = GridShopListing.where(id: listing.id).where("stock > 0")
+            .update_all("stock = stock - 1")
+          raise InsufficientStock, "'#{listing.name}' is out of stock" if updated == 0
+        end
+
+        # Split CRED: burn 70%, recycle 30% to gameplay pool
+        split_purchase!(hackr_cache: cache, amount: price, item_name: listing.name)
+
+        # Create item in hackr's inventory
+        item = GridItem.create!(
+          grid_hackr: hackr,
+          name: listing.name,
+          description: listing.description,
+          item_type: listing.item_type,
+          rarity: listing.rarity,
+          value: listing.base_price,
+          quantity: 1,
+          properties: listing.properties
+        )
+
+        # Record the shop transaction
+        GridShopTransaction.create!(
+          grid_hackr: hackr,
+          grid_shop_listing: listing,
+          grid_mob: mob,
+          transaction_type: "buy",
+          quantity: 1,
+          price_paid: price,
+          burn_amount: burn_amount(price),
+          recycle_amount: price - burn_amount(price),
+          created_at: Time.current
+        )
+      end
+
+      {listing: listing, item: item, price_paid: price, new_balance: cache.reload.balance}
+    end
+
+    # Sell an item to a vendor
+    def self.sell!(hackr:, mob:, item_name:)
+      raise AccessDenied, "This vendor doesn't buy anything" unless mob.vendor?
+
+      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      raise ItemNotFound, "You don't have '#{item_name}'" unless item
+
+      # Find matching listing for sell price, or use item.value * SELL_PRICE_RATIO
+      listing = mob.grid_shop_listings.find_by("LOWER(name) = ?", item_name.downcase)
+      sell_price = if listing
+        listing.sell_price
+      else
+        (item.value * EconomyConfig::SELL_PRICE_RATIO).ceil
+      end
+      sell_price = [sell_price, 1].max # minimum 1 CRED
+
+      cache = hackr.default_cache
+      raise AccessDenied, "You need a cache to receive CRED" unless cache
+
+      item_name_saved = item.name
+
+      ActiveRecord::Base.transaction do
+        # Pay the hackr from gameplay pool
+        Grid::TransactionService.mint_gameplay!(
+          to_cache: cache,
+          amount: sell_price,
+          memo: "Sell: #{item.name}"
+        )
+
+        # Remove the item
+        if item.quantity > 1
+          item.update!(quantity: item.quantity - 1)
+        else
+          item.destroy!
+        end
+
+        # Record the shop transaction
+        GridShopTransaction.create!(
+          grid_hackr: hackr,
+          grid_shop_listing: listing,
+          grid_mob: mob,
+          transaction_type: "sell",
+          quantity: 1,
+          price_paid: sell_price,
+          burn_amount: 0,
+          recycle_amount: 0,
+          created_at: Time.current
+        )
+      end
+
+      {item_name: item_name_saved, sell_price: sell_price, new_balance: cache.reload.balance}
+    end
+
+    # Compute effective price for a listing
+    def self.effective_price(listing:, mob:, clearance: 0)
+      if mob.black_market?
+        multiplier = [1.0, EconomyConfig::BLACK_MARKET_BASE_MULTIPLIER -
+          (clearance - EconomyConfig::BLACK_MARKET_MIN_CLEARANCE) *
+          EconomyConfig::BLACK_MARKET_CLEARANCE_REDUCTION].max
+        (listing.base_price * multiplier).ceil
+      else
+        listing.base_price
+      end
+    end
+
+    # Restock a vendor's limited-stock listings
+    def self.restock!(mob)
+      mob.grid_shop_listings.where(active: true).where.not(max_stock: nil).find_each do |listing|
+        next if listing.stock >= listing.max_stock
+
+        new_stock = [listing.stock + listing.restock_amount, listing.max_stock].min
+        listing.update_columns(
+          stock: new_stock,
+          next_restock_at: Time.current + listing.restock_interval_hours.hours
+        )
+      end
+    end
+
+    # Rotate a vendor's rotation pool listings
+    def self.rotate!(mob)
+      pool = mob.grid_shop_listings.in_rotation_pool
+      return if pool.empty?
+      return if mob.rotation_count < 1
+
+      ActiveRecord::Base.transaction do
+        pool.update_all(active: false)
+        selected_ids = pool.pluck(:id).sample(mob.rotation_count)
+        GridShopListing.where(id: selected_ids).update_all(active: true)
+      end
+    end
+
+    def self.burn_amount(price)
+      (price * EconomyConfig::SHOP_BURN_RATIO).floor
+    end
+    private_class_method :burn_amount
+
+    def self.split_purchase!(hackr_cache:, amount:, item_name:)
+      burn_amt = burn_amount(amount)
+      recycle_amt = amount - burn_amt
+
+      Grid::TransactionService.burn!(
+        from_cache: hackr_cache,
+        amount: burn_amt,
+        memo: "Shop purchase: #{item_name}"
+      ) if burn_amt > 0
+
+      Grid::TransactionService.recycle!(
+        from_cache: hackr_cache,
+        amount: recycle_amt,
+        memo: "Shop recycle: #{item_name}"
+      ) if recycle_amt > 0
+    end
+    private_class_method :split_purchase!
+  end
+end

--- a/app/services/grid/transaction_service.rb
+++ b/app/services/grid/transaction_service.rb
@@ -42,6 +42,11 @@ module Grid
       execute!(from_cache: from_cache, to_cache: GridCache.redemption, amount: amount, tx_type: "redemption", memo: memo)
     end
 
+    # Purchase recycle (player cache → gameplay pool)
+    def self.recycle!(from_cache:, amount:, memo: nil)
+      execute!(from_cache: from_cache, to_cache: GridCache.gameplay_pool, amount: amount, tx_type: "purchase_recycle", memo: memo)
+    end
+
     # Genesis mint (genesis cache → genesis cache, then distribute)
     def self.genesis!(to_cache:, amount:, memo:)
       execute!(from_cache: GridCache.genesis, to_cache: to_cache, amount: amount, tx_type: "genesis", memo: memo)

--- a/app/views/admin/grid_shop_listings/_form.html.erb
+++ b/app/views/admin/grid_shop_listings/_form.html.erb
@@ -1,0 +1,123 @@
+<%# Flash Messages %>
+<% if flash[:error] %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+    <p class="red-255-text"><%= flash[:error] %></p>
+  </div>
+<% end %>
+
+<%= form_with model: [:admin, listing], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: LISTING INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :grid_mob_id, "VENDOR", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_mob_id,
+          @vendors.map { |v| ["#{v.name} (#{v.grid_room.name})", v.id] },
+          {}, class: "tui-input", style: "width: 100%;" %>
+    </div>
+
+    <div>
+      <%= f.label :name, "ITEM NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if listing.errors[:name].any? %>
+        <br><small class="red-255-text"><%= listing.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :item_type, "ITEM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :item_type,
+          GridItem::ITEM_TYPES.map { |t| [t.titleize, t] },
+          { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
+    </div>
+
+    <div>
+      <%= f.label :rarity, "RARITY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :rarity,
+          GridItem::RARITIES.map { |r| [r.titleize.gsub("_", "-"), r] },
+          { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
+    </div>
+
+    <div>
+      <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%;", min: 0 %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: PRICING ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :base_price, "BUY PRICE (CRED)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :base_price, class: "tui-input", style: "width: 100%;", min: 1 %>
+    </div>
+
+    <div>
+      <%= f.label :sell_price, "SELL PRICE (CRED)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :sell_price, class: "tui-input", style: "width: 100%;", min: 0 %>
+      <small style="color: #888;">Leave blank for auto (50% of buy price)</small>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: STOCK ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :stock, "CURRENT STOCK", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :stock, class: "tui-input", style: "width: 100%;", min: 0 %>
+      <small style="color: #888;">Blank = unlimited</small>
+    </div>
+
+    <div>
+      <%= f.label :max_stock, "MAX STOCK", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :max_stock, class: "tui-input", style: "width: 100%;", min: 1 %>
+      <small style="color: #888;">Blank = unlimited</small>
+    </div>
+
+    <div>
+      <%= f.label :restock_amount, "RESTOCK AMT", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :restock_amount, class: "tui-input", style: "width: 100%;", min: 1 %>
+    </div>
+
+    <div>
+      <%= f.label :restock_interval_hours, "RESTOCK (hrs)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :restock_interval_hours, class: "tui-input", style: "width: 100%;", min: 1 %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: FLAGS ::]</h3>
+
+  <div style="display: flex; gap: 30px;">
+    <label class="white-text" style="display: flex; align-items: center; gap: 8px;">
+      <%= f.check_box :active, style: "width: auto;" %> Active
+    </label>
+    <label class="white-text" style="display: flex; align-items: center; gap: 8px;">
+      <%= f.check_box :rotation_pool, style: "width: auto;" %> Rotation Pool
+    </label>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: PROPERTIES (JSON) ::]</h3>
+
+  <div style="margin-bottom: 20px;">
+    <%= text_area_tag "grid_shop_listing[properties_json]",
+        (listing.properties.present? ? JSON.pretty_generate(listing.properties) : "{}"),
+        class: "tui-input", style: "width: 100%; font-family: monospace; height: 120px;" %>
+    <small style="color: #888;">JSON object. For components: {"slot": "gpu", "rate_multiplier": 1.5}. For consumables: {"effect_type": "heal", "amount": 30}</small>
+  </div>
+
+  <div style="margin-top: 30px; display: flex; gap: 10px;">
+    <%= f.submit listing.persisted? ? "Save Listing" : "Create Listing",
+        class: "tui-button purple-168",
+        style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <%= link_to "Cancel", admin_grid_shop_listings_path,
+        class: "tui-button grey-168",
+        style: "padding: 10px 30px; font-size: 1.1em;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_shop_listings/edit.html.erb
+++ b/app/views/admin/grid_shop_listings/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/shops :: EDIT LISTING</legend>
+    <div style="padding: 20px;">
+      <%= render "form", listing: @listing %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_shop_listings/index.html.erb
+++ b/app/views/admin/grid_shop_listings/index.html.erb
@@ -1,0 +1,111 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/shops :: SHOP LISTINGS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <!-- Navigation & Filters -->
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
+        <%= link_to "+ New Listing", new_admin_grid_shop_listing_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "Transactions", admin_grid_shop_transactions_path, class: "tui-button purple-168", style: "padding: 8px 20px;" %>
+        <span style="color: #666; margin: 0 5px;">|</span>
+        <%= link_to "All Vendors", admin_grid_shop_listings_path, class: "tui-button", style: "padding: 6px 14px; font-size: 0.85em;" %>
+        <% @vendors.each do |vendor| %>
+          <% active = params[:mob_id].to_s == vendor.id.to_s %>
+          <%= link_to vendor.name,
+              admin_grid_shop_listings_path(mob_id: vendor.id),
+              class: "tui-button #{active ? "cyan-168" : ""}",
+              style: "padding: 6px 14px; font-size: 0.85em;" %>
+        <% end %>
+      </div>
+
+      <% if @listings.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Vendor</th>
+                <th style="text-align: left;">Item</th>
+                <th style="text-align: left;">Rarity</th>
+                <th style="text-align: right;">Buy</th>
+                <th style="text-align: right;">Sell</th>
+                <th style="text-align: center;">Stock</th>
+                <th style="text-align: center;">Active</th>
+                <th style="text-align: center;">Rot.</th>
+                <th style="text-align: center;">CL</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @listings.each do |listing| %>
+                <tr>
+                  <td style="color: #c084fc;"><%= listing.grid_mob.name %></td>
+                  <td class="cyan-255-text"><%= listing.name %></td>
+                  <td>
+                    <% if listing.rarity %>
+                      <span style="color: <%= listing.rarity_color %>;"><%= listing.rarity_label %></span>
+                    <% else %>
+                      <span style="color: #444;">-</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: right;" class="green-255-text"><%= number_with_delimiter(listing.base_price) %></td>
+                  <td style="text-align: right; color: #888;"><%= number_with_delimiter(listing.sell_price) %></td>
+                  <td style="text-align: center;">
+                    <% if listing.unlimited_stock? %>
+                      <span style="color: #34d399;">&infin;</span>
+                    <% elsif listing.out_of_stock? %>
+                      <span class="red-255-text">0/<%= listing.max_stock %></span>
+                    <% else %>
+                      <span class="yellow-168-text"><%= listing.stock %>/<%= listing.max_stock %></span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% if listing.active? %>
+                      <span class="green-255-text">ON</span>
+                    <% else %>
+                      <span style="color: #444;">OFF</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% if listing.rotation_pool? %>
+                      <span class="yellow-168-text">YES</span>
+                    <% else %>
+                      <span style="color: #444;">-</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center; color: #888;"><%= listing.min_clearance > 0 ? listing.min_clearance : "-" %></td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_shop_listing_path(listing), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <% if listing.max_stock.present? %>
+                      <%= button_to "Restock", restock_admin_grid_shop_listing_path(listing), method: :post, form: { style: "display: inline;" }, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <% end %>
+                    <%= button_to "Delete", admin_grid_shop_listing_path(listing), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete listing '#{listing.name}'?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No shop listings found.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Grid Admin", admin_grid_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_shop_listings/new.html.erb
+++ b/app/views/admin/grid_shop_listings/new.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/shops :: NEW LISTING</legend>
+    <div style="padding: 20px;">
+      <%= render "form", listing: @listing %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_shop_transactions/index.html.erb
+++ b/app/views/admin/grid_shop_transactions/index.html.erb
@@ -38,7 +38,7 @@
               <% @transactions.each do |tx| %>
                 <tr>
                   <td style="color: #666; font-family: monospace; font-size: 0.85em;"><%= tx.created_at.strftime("%Y-%m-%d %H:%M") %></td>
-                  <td class="purple-168-text"><%= tx.grid_hackr.hackr_alias %></td>
+                  <td class="purple-168-text"><%= tx.grid_hackr&.hackr_alias || "<span style='color: #666;'>(deleted)</span>".html_safe %></td>
                   <td style="text-align: center;">
                     <% if tx.transaction_type == "buy" %>
                       <span class="green-255-text">BUY</span>
@@ -46,7 +46,7 @@
                       <span class="yellow-168-text">SELL</span>
                     <% end %>
                   </td>
-                  <td style="color: #c084fc;"><%= tx.grid_mob.name %></td>
+                  <td style="color: #c084fc;"><%= tx.grid_mob&.name || "<span style='color: #666;'>(deleted)</span>".html_safe %></td>
                   <td class="cyan-255-text"><%= tx.grid_shop_listing&.name || "(deleted)" %></td>
                   <td style="text-align: right;" class="green-255-text"><%= number_with_delimiter(tx.price_paid) %></td>
                   <td style="text-align: right; color: #f87171;"><%= tx.burn_amount > 0 ? number_with_delimiter(tx.burn_amount) : "-" %></td>
@@ -58,7 +58,11 @@
         </div>
       <% else %>
         <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
-          <p style="color: #666; font-size: 1.2em;">No shop transactions recorded yet.</p>
+          <% if @hackr_not_found %>
+            <p class="yellow-168-text" style="font-size: 1.2em;">No hackr found with alias '<%= h(params[:hackr_alias]) %>'.</p>
+          <% else %>
+            <p style="color: #666; font-size: 1.2em;">No shop transactions match the current filters.</p>
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/admin/grid_shop_transactions/index.html.erb
+++ b/app/views/admin/grid_shop_transactions/index.html.erb
@@ -1,0 +1,70 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/shops :: TRANSACTION LOG</legend>
+
+    <div style="padding: 20px;">
+      <!-- Filters -->
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
+        <%= link_to "<- Listings", admin_grid_shop_listings_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+
+        <%= form_tag admin_grid_shop_transactions_path, method: :get, style: "display: flex; gap: 10px; align-items: center;" do %>
+          <%= text_field_tag :hackr_alias, params[:hackr_alias], placeholder: "Hackr alias", class: "tui-input", style: "width: 150px; padding: 6px 10px;" %>
+          <%= select_tag :mob_id,
+              options_from_collection_for_select(@vendors, :id, :name, params[:mob_id]),
+              include_blank: "All Vendors", class: "tui-input", style: "padding: 6px 10px;" %>
+          <%= select_tag :transaction_type,
+              options_for_select([["All Types", ""], ["Purchases", "buy"], ["Sales", "sell"]], params[:transaction_type]),
+              class: "tui-input", style: "padding: 6px 10px;" %>
+          <%= submit_tag "Filter", class: "tui-button cyan-168", style: "padding: 6px 16px;" %>
+        <% end %>
+      </div>
+
+      <% if @transactions.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Time</th>
+                <th style="text-align: left;">Hackr</th>
+                <th style="text-align: center;">Type</th>
+                <th style="text-align: left;">Vendor</th>
+                <th style="text-align: left;">Item</th>
+                <th style="text-align: right;">Price</th>
+                <th style="text-align: right;">Burn</th>
+                <th style="text-align: right;">Recycle</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @transactions.each do |tx| %>
+                <tr>
+                  <td style="color: #666; font-family: monospace; font-size: 0.85em;"><%= tx.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+                  <td class="purple-168-text"><%= tx.grid_hackr.hackr_alias %></td>
+                  <td style="text-align: center;">
+                    <% if tx.transaction_type == "buy" %>
+                      <span class="green-255-text">BUY</span>
+                    <% else %>
+                      <span class="yellow-168-text">SELL</span>
+                    <% end %>
+                  </td>
+                  <td style="color: #c084fc;"><%= tx.grid_mob.name %></td>
+                  <td class="cyan-255-text"><%= tx.grid_shop_listing&.name || "(deleted)" %></td>
+                  <td style="text-align: right;" class="green-255-text"><%= number_with_delimiter(tx.price_paid) %></td>
+                  <td style="text-align: right; color: #f87171;"><%= tx.burn_amount > 0 ? number_with_delimiter(tx.burn_amount) : "-" %></td>
+                  <td style="text-align: right; color: #34d399;"><%= tx.recycle_amount > 0 ? number_with_delimiter(tx.recycle_amount) : "-" %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No shop transactions recorded yet.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Grid Admin", admin_grid_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -80,6 +80,7 @@
         <div class="admin-nav-dropdown-menu">
           <%= link_to "Dashboard", admin_grid_path, class: "green-168-text" %>
           <%= link_to "Economy", admin_grid_economy_path, class: "green-168-text" %>
+          <%= link_to "Shops", admin_grid_shop_listings_path, class: "green-168-text" %>
           <%= link_to "Achievements", admin_grid_achievements_path, class: "green-168-text" %>
         </div>
       </div>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -21,3 +21,11 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+  shop_restock:
+    class: ShopRestockJob
+    schedule: every hour
+
+  shop_rotation:
+    class: ShopRotationJob
+    schedule: every Monday at midnight

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,6 +257,14 @@ Rails.application.routes.draw do
       end
     end
 
+    # Grid shops (runtime CRUD + stock management)
+    resources :grid_shop_listings do
+      member do
+        post :restock
+      end
+    end
+    resources :grid_shop_transactions, only: [:index]
+
     # PulseWire moderation (still functional - runtime operations)
     resources :pulse_wire, only: %i[index destroy] do
       collection do

--- a/data/world/exits.yml
+++ b/data/world/exits.yml
@@ -31,6 +31,28 @@ exits:
     direction: west
     locked: false
 
+  # Signal Bazaar (shop) — accessible from Transit Corridor
+  - from_room_slug: transit-corridor-alpha
+    to_room_slug: the-signal-bazaar
+    direction: north
+    locked: false
+
+  - from_room_slug: the-signal-bazaar
+    to_room_slug: transit-corridor-alpha
+    direction: south
+    locked: false
+
+  # The Blacksite (black market) — hidden passage from Transit Corridor
+  - from_room_slug: transit-corridor-alpha
+    to_room_slug: the-blacksite
+    direction: down
+    locked: false
+
+  - from_room_slug: the-blacksite
+    to_room_slug: transit-corridor-alpha
+    direction: up
+    locked: false
+
   - from_room_slug: hackr-tv-broadcast-station
     to_room_slug: the-rhythm-nexus
     direction: west

--- a/data/world/mobs.yml
+++ b/data/world/mobs.yml
@@ -17,6 +17,37 @@ mobs:
         ride: "The RIDE - Reality Interference and Dictation Environment. GovCorp's worldwide reality manipulation system. Most citizens live inside it without knowing. We breach it. We fight it."
         prism: "PRISM was the precursor - reality manipulation tech from 2050. The RIDE is what it became. Global. Pervasive. Inescapable. Unless you know where to look."
 
+  - name: Codec
+    room_slug: the-signal-bazaar
+    faction_slug: null
+    description: "A wiry trader with augmented eyes that cycle through spectrums, tracking every item in the bazaar simultaneously. Their fingers are stained with solder and their coat is lined with pockets full of components."
+    mob_type: vendor
+    vendor_config:
+      shop_type: standard
+      restock_interval_hours: 24
+    dialogue_tree:
+      greeting: "Welcome to The Signal Bazaar. I got tools, patches, components — you name it. You got CRED, we can make something work."
+      topics:
+        prices: "Everything at fair market rate. No haggling, no drama. Take it or leave it."
+        stock: "I restock daily from my supply chains. If I'm out of something, check back tomorrow."
+        components: "I carry standard-grade components. Nothing fancy, but they'll keep your rig running. For the exotic stuff... you'll have to look elsewhere."
+
+  - name: GHOST
+    room_slug: the-blacksite
+    faction_slug: null
+    description: "You can't quite make out GHOST's face — the shadows seem to actively avoid illuminating it. They speak in a low monotone that somehow cuts through any background noise. A faint smell of burnt circuitry follows them."
+    mob_type: vendor
+    vendor_config:
+      shop_type: black_market
+      restock_interval_hours: 168
+      rotation_count: 4
+    dialogue_tree:
+      greeting: "You're either very brave or very stupid to come here. Either works for me. What do you need?"
+      topics:
+        clearance: "The higher your clearance, the better I treat you. Prove you're worth the risk and the prices get... friendlier."
+        stock: "Stock rotates weekly. What's here today won't be here next week. If you see something you want, don't hesitate."
+        trust: "Trust is earned in the Underbelly. Every clearance level you gain means less risk for me, which means better rates for you."
+
   - name: Temporal Theorist
     room_slug: xeraen-operations-center
     faction_slug: xeraen

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -24,6 +24,19 @@ rooms:
     zone_slug: govcorp-surveillance
     room_type: govcorp
 
+  - name: The Signal Bazaar
+    slug: the-signal-bazaar
+    description: "A cramped market corridor lit by flickering neon signs advertising firmware patches and bootleg components. Salvaged tech lines makeshift shelves behind reinforced glass. The air smells like solder and ozone. A vendor tracks your movements from behind a jury-rigged counter."
+    zone_slug: transit-network
+    room_type: shop
+
+  - name: The Blacksite
+    slug: the-blacksite
+    description: "No signs. No light except a single red strip running along the baseboards. The air tastes like ozone and bad decisions. The walls are lined with signal-dampening mesh — nothing broadcasts in or out. If you found this place, you were meant to."
+    zone_slug: the-underbelly
+    room_type: shop
+    min_clearance: 10
+
   - name: The Rhythm Nexus
     slug: the-rhythm-nexus
     description: "Ryker's domain. A cavernous space converted into a combination recording studio, performance venue, and resistance headquarters. Drum kits and recording equipment share space with server racks. Vintage analog gear - tape machines, tube amplifiers, physical mixing boards - stands alongside digital systems. Purple and cyan neon cuts through the darkness. The air vibrates with potential energy even when no one's playing."

--- a/data/world/shop_listings.yml
+++ b/data/world/shop_listings.yml
@@ -1,0 +1,322 @@
+# Shop Listings — vendor inventory definitions
+# Loaded by: rails data:shop_listings (after mobs)
+shop_listings:
+
+  # ══════════════════════════════════════════
+  # THE SIGNAL BAZAAR — Standard shop (Codec)
+  # ══════════════════════════════════════════
+
+  # Consumables
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: MedPatch
+    description: "A standard-issue dermal adhesive infused with nanite healing agents. Slap it on, feel the burn, feel better."
+    item_type: consumable
+    rarity: common
+    base_price: 50
+    max_stock: 10
+    restock_amount: 3
+    properties:
+      effect_type: heal
+      amount: 30
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Stim Shot
+    description: "A cocktail of synthetic adrenaline and nootropics. Your hands will shake, but you'll get things done."
+    item_type: consumable
+    rarity: common
+    base_price: 50
+    max_stock: 10
+    restock_amount: 3
+    properties:
+      effect_type: energize
+      amount: 30
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Neural Patch
+    description: "Firmware patch that temporarily boosts cognitive throughput. Side effects include vivid dreams and a mild taste of copper."
+    item_type: consumable
+    rarity: uncommon
+    base_price: 150
+    max_stock: 5
+    restock_amount: 2
+    properties:
+      effect_type: psyche_boost
+      amount: 40
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Muse Chip
+    description: "A micro-implant that stimulates the creative cortex. Popular among artists, musicians, and the dangerously unhinged."
+    item_type: consumable
+    rarity: uncommon
+    base_price: 150
+    max_stock: 5
+    restock_amount: 2
+    properties:
+      effect_type: inspire
+      amount: 40
+
+  # Tools
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Basic Decryption Key
+    description: "Opens standard-grade encrypted containers. Disposable — one use, then it fries itself."
+    item_type: tool
+    rarity: common
+    base_price: 75
+    max_stock: 20
+    restock_amount: 5
+    properties: {}
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Signal Analyzer
+    description: "Portable frequency scanner. Useful for detecting hidden transmissions and anomalies."
+    item_type: tool
+    rarity: uncommon
+    base_price: 200
+    max_stock: 3
+    restock_amount: 1
+    properties: {}
+
+  # Components (up to uncommon, rarely rare)
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Enhanced GPU
+    description: "A mid-tier graphics processor. Decent hash rate, reasonable power draw."
+    item_type: component
+    rarity: uncommon
+    base_price: 300
+    max_stock: 3
+    restock_amount: 1
+    properties:
+      slot: gpu
+      rate_multiplier: 1.3
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Enhanced CPU
+    description: "Dual-core processor salvaged from decommissioned GovCorp terminals. Still kicks."
+    item_type: component
+    rarity: uncommon
+    base_price: 300
+    max_stock: 3
+    restock_amount: 1
+    properties:
+      slot: cpu
+      rate_multiplier: 1.3
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Enhanced RAM Module
+    description: "High-bandwidth memory module. Makes everything snappier."
+    item_type: component
+    rarity: uncommon
+    base_price: 250
+    max_stock: 3
+    restock_amount: 1
+    properties:
+      slot: ram
+      rate_multiplier: 1.25
+
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Hardened PSU
+    description: "Surge-protected power supply. Won't fry when the grid spikes."
+    item_type: component
+    rarity: uncommon
+    base_price: 200
+    max_stock: 4
+    restock_amount: 1
+    properties:
+      slot: psu
+      rate_multiplier: 1.2
+
+  # Data
+  - vendor_name: Codec
+    room_slug: the-signal-bazaar
+    name: Faction Data Shard
+    description: "A data fragment of unknown origin. The encryption is beyond standard tools. Someone will want this."
+    item_type: data
+    rarity: uncommon
+    base_price: 200
+    max_stock: 3
+    restock_amount: 1
+    properties: {}
+
+  # ══════════════════════════════════════════
+  # THE BLACKSITE — Black market (GHOST)
+  # All items in rotation pool, activated weekly
+  # ══════════════════════════════════════════
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Milspec GPU
+    description: "Military-specification graphics processor. Stolen from a GovCorp mining facility. The serial numbers have been... removed."
+    item_type: component
+    rarity: rare
+    base_price: 800
+    max_stock: 2
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties:
+      slot: gpu
+      rate_multiplier: 1.8
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Milspec CPU
+    description: "Quad-core processor with hardened encryption coprocessor. Falls off a GovCorp truck every now and then."
+    item_type: component
+    rarity: rare
+    base_price: 800
+    max_stock: 2
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties:
+      slot: cpu
+      rate_multiplier: 1.8
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Overclocked RAM Array
+    description: "Eight high-density modules wired in parallel. Runs hot. Runs fast. Don't ask where it came from."
+    item_type: component
+    rarity: rare
+    base_price: 650
+    max_stock: 2
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties:
+      slot: ram
+      rate_multiplier: 1.7
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Quantum Flux Capacitor
+    description: "Experimental power supply that harnesses quantum fluctuations. Theoretically impossible. Practically devastating."
+    item_type: component
+    rarity: ultra_rare
+    base_price: 2500
+    max_stock: 1
+    restock_amount: 1
+    restock_interval_hours: 336
+    rotation_pool: true
+    min_clearance: 15
+    properties:
+      slot: psu
+      rate_multiplier: 2.5
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Neural Cortex Board
+    description: "A motherboard that interfaces directly with neural tissue. Three times the slots of anything on the market. The installation process is... unpleasant."
+    item_type: component
+    rarity: ultra_rare
+    base_price: 5000
+    max_stock: 1
+    restock_amount: 1
+    restock_interval_hours: 336
+    rotation_pool: true
+    min_clearance: 20
+    properties:
+      slot: motherboard
+      cpu_slots: 2
+      gpu_slots: 4
+      ram_slots: 4
+      rate_multiplier: 2.0
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Deep Scan Array
+    description: "Military-grade network scanner. Reads encrypted traffic, identifies hidden nodes, maps surveillance blind spots."
+    item_type: tool
+    rarity: rare
+    base_price: 1000
+    max_stock: 2
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties: {}
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: GovCorp Access Spoofcard
+    description: "Spoofs GovCorp network credentials. Burns out after a single use. Don't get caught with one."
+    item_type: tool
+    rarity: rare
+    base_price: 1200
+    max_stock: 1
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties: {}
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Temporal Resonance Crystal
+    description: "A byproduct of Chronology Fracture research. It hums at a frequency that shouldn't exist. Collectors pay a fortune for these."
+    item_type: collectible
+    rarity: ultra_rare
+    base_price: 3000
+    max_stock: 1
+    restock_amount: 1
+    restock_interval_hours: 336
+    rotation_pool: true
+    min_clearance: 10
+    properties: {}
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Fracture Beacon
+    description: "Emits a signal recognizable only to Fracture Network operatives across temporal boundaries. Possession alone is a statement."
+    item_type: faction
+    rarity: ultra_rare
+    base_price: 5000
+    max_stock: 1
+    restock_amount: 1
+    restock_interval_hours: 336
+    rotation_pool: true
+    min_clearance: 25
+    properties: {}
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Phantom Drive
+    description: "Untraceable storage device with quantum-encrypted partitions. What's stored on it is between you and the universe."
+    item_type: data
+    rarity: rare
+    base_price: 900
+    max_stock: 3
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties: {}
+
+  - vendor_name: GHOST
+    room_slug: the-blacksite
+    name: Black ICE Injector
+    description: "Military-grade psyche stimulant. Sharpens the mind to a razor edge. The comedown is legendary. Handle with extreme care."
+    item_type: consumable
+    rarity: rare
+    base_price: 500
+    max_stock: 2
+    restock_amount: 1
+    restock_interval_hours: 168
+    rotation_pool: true
+    min_clearance: 10
+    properties:
+      effect_type: psyche_boost
+      amount: 80

--- a/data/world/shop_listings.yml
+++ b/data/world/shop_listings.yml
@@ -149,7 +149,9 @@ shop_listings:
 
   # ══════════════════════════════════════════
   # THE BLACKSITE — Black market (GHOST)
-  # All items in rotation pool, activated weekly
+  # All items in rotation pool. Seeded as inactive;
+  # ShopRotationJob activates N per week (vendor_config.rotation_count).
+  # Initial rotation triggered at first seed time.
   # ══════════════════════════════════════════
 
   - vendor_name: GHOST

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -32,6 +32,14 @@ zones:
     faction_slug: govcorp
     ambient_playlist_slug: govcorp-surveillance-ambience
 
+  - name: The Underbelly
+    slug: the-underbelly
+    description: "A network of unregistered passages beneath the Transit Network. Surveillance dead zone. If you know, you know."
+    zone_type: danger_zone
+    color_scheme: red/black
+    faction_slug: null
+    ambient_playlist_slug: null
+
   - name: The Hackr Hangar
     slug: hackr-hangar
     description: "Ryker M. Pulse's headquarters and primary broadcast facility. Where the raw signal is created before transmission to Sector X."

--- a/db/migrate/20260409000001_create_grid_shop_tables.rb
+++ b/db/migrate/20260409000001_create_grid_shop_tables.rb
@@ -1,0 +1,40 @@
+class CreateGridShopTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_shop_listings do |t|
+      t.references :grid_mob, null: false, foreign_key: true, index: true
+      t.string :name, null: false
+      t.text :description
+      t.string :item_type
+      t.string :rarity
+      t.json :properties, default: {}
+      t.integer :base_price, null: false
+      t.integer :sell_price, null: false
+      t.integer :stock           # nil = unlimited
+      t.integer :max_stock       # nil = unlimited
+      t.integer :restock_amount, default: 1, null: false
+      t.integer :restock_interval_hours, default: 24, null: false
+      t.datetime :next_restock_at
+      t.boolean :active, default: true, null: false
+      t.boolean :rotation_pool, default: false, null: false
+      t.integer :min_clearance, default: 0, null: false
+      t.timestamps
+    end
+
+    add_index :grid_shop_listings, [:grid_mob_id, :active]
+    add_index :grid_shop_listings, :next_restock_at
+
+    create_table :grid_shop_transactions do |t|
+      t.references :grid_hackr, null: false, index: true
+      t.references :grid_shop_listing, null: true, index: true
+      t.references :grid_mob, null: false, index: true
+      t.string :transaction_type, null: false
+      t.integer :quantity, default: 1, null: false
+      t.integer :price_paid, null: false
+      t.integer :burn_amount, null: false, default: 0
+      t.integer :recycle_amount, null: false, default: 0
+      t.datetime :created_at, null: false
+    end
+
+    add_index :grid_shop_transactions, [:grid_hackr_id, :created_at]
+  end
+end

--- a/db/migrate/20260409000001_create_grid_shop_tables.rb
+++ b/db/migrate/20260409000001_create_grid_shop_tables.rb
@@ -24,9 +24,9 @@ class CreateGridShopTables < ActiveRecord::Migration[8.1]
     add_index :grid_shop_listings, :next_restock_at
 
     create_table :grid_shop_transactions do |t|
-      t.references :grid_hackr, null: false, index: true
+      t.references :grid_hackr, null: true, index: true
       t.references :grid_shop_listing, null: true, index: true
-      t.references :grid_mob, null: false, index: true
+      t.references :grid_mob, null: true, index: true
       t.string :transaction_type, null: false
       t.integer :quantity, default: 1, null: false
       t.integer :price_paid, null: false

--- a/db/migrate/20260409000002_add_shop_columns_to_rooms_and_mobs.rb
+++ b/db/migrate/20260409000002_add_shop_columns_to_rooms_and_mobs.rb
@@ -1,0 +1,6 @@
+class AddShopColumnsToRoomsAndMobs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_rooms, :min_clearance, :integer, default: 0, null: false
+    add_column :grid_mobs, :vendor_config, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_000002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -269,6 +269,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_000001) do
     t.string "mob_type"
     t.string "name"
     t.datetime "updated_at", null: false
+    t.json "vendor_config"
   end
 
   create_table "grid_registration_tokens", force: :cascade do |t|
@@ -288,6 +289,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_000001) do
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "grid_zone_id", null: false
+    t.integer "min_clearance", default: 0, null: false
     t.string "name"
     t.string "room_type"
     t.string "slug"
@@ -295,6 +297,46 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_000001) do
     t.index ["ambient_playlist_id"], name: "index_grid_rooms_on_ambient_playlist_id"
     t.index ["grid_zone_id"], name: "index_grid_rooms_on_grid_zone_id"
     t.index ["slug"], name: "index_grid_rooms_on_slug", unique: true
+  end
+
+  create_table "grid_shop_listings", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.integer "base_price", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "grid_mob_id", null: false
+    t.string "item_type"
+    t.integer "max_stock"
+    t.integer "min_clearance", default: 0, null: false
+    t.string "name", null: false
+    t.datetime "next_restock_at"
+    t.json "properties", default: {}
+    t.string "rarity"
+    t.integer "restock_amount", default: 1, null: false
+    t.integer "restock_interval_hours", default: 24, null: false
+    t.boolean "rotation_pool", default: false, null: false
+    t.integer "sell_price", null: false
+    t.integer "stock"
+    t.datetime "updated_at", null: false
+    t.index ["grid_mob_id", "active"], name: "index_grid_shop_listings_on_grid_mob_id_and_active"
+    t.index ["grid_mob_id"], name: "index_grid_shop_listings_on_grid_mob_id"
+    t.index ["next_restock_at"], name: "index_grid_shop_listings_on_next_restock_at"
+  end
+
+  create_table "grid_shop_transactions", force: :cascade do |t|
+    t.integer "burn_amount", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "grid_mob_id", null: false
+    t.integer "grid_shop_listing_id"
+    t.integer "price_paid", null: false
+    t.integer "quantity", default: 1, null: false
+    t.integer "recycle_amount", default: 0, null: false
+    t.string "transaction_type", null: false
+    t.index ["grid_hackr_id", "created_at"], name: "index_grid_shop_transactions_on_grid_hackr_id_and_created_at"
+    t.index ["grid_hackr_id"], name: "index_grid_shop_transactions_on_grid_hackr_id"
+    t.index ["grid_mob_id"], name: "index_grid_shop_transactions_on_grid_mob_id"
+    t.index ["grid_shop_listing_id"], name: "index_grid_shop_transactions_on_grid_shop_listing_id"
   end
 
   create_table "grid_transactions", force: :cascade do |t|
@@ -736,6 +778,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_000001) do
   add_foreign_key "grid_hackr_achievements", "grid_achievements"
   add_foreign_key "grid_hackr_achievements", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
+  add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "hackr_logs", "grid_hackrs"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,8 +326,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_000002) do
   create_table "grid_shop_transactions", force: :cascade do |t|
     t.integer "burn_amount", default: 0, null: false
     t.datetime "created_at", null: false
-    t.integer "grid_hackr_id", null: false
-    t.integer "grid_mob_id", null: false
+    t.integer "grid_hackr_id"
+    t.integer "grid_mob_id"
     t.integer "grid_shop_listing_id"
     t.integer "price_paid", null: false
     t.integer "quantity", default: 1, null: false

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -192,7 +192,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, zones, rooms, etc.)"
-  task world: [:factions, :zones, :rooms, :exits, :mobs, :items, :achievements]
+  task world: [:factions, :zones, :rooms, :exits, :mobs, :items, :achievements, :shop_listings]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -553,7 +553,8 @@ namespace :data do
         name: attrs["name"],
         description: attrs["description"],
         grid_zone: zone,
-        room_type: attrs["room_type"]
+        room_type: attrs["room_type"],
+        min_clearance: attrs["min_clearance"] || 0
       )
 
       if room.changed?
@@ -638,7 +639,8 @@ namespace :data do
         description: attrs["description"],
         mob_type: attrs["mob_type"],
         grid_faction: faction,
-        dialogue_tree: attrs["dialogue_tree"]
+        dialogue_tree: attrs["dialogue_tree"],
+        vendor_config: attrs["vendor_config"]
       )
 
       if mob.changed?
@@ -730,6 +732,66 @@ namespace :data do
     end
 
     puts "Achievements: #{created} created, #{updated} updated, #{GridAchievement.count} total"
+  end
+
+  desc "Load shop listings from YAML"
+  task shop_listings: :environment do
+    puts "\n--- Loading Shop Listings ---"
+    yaml_file = Rails.root.join("data", "world", "shop_listings.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    listings_data = data["shop_listings"]
+    created = updated = 0
+
+    listings_data.each do |attrs|
+      room = GridRoom.find_by(slug: attrs["room_slug"])
+      unless room
+        puts "  ✗ Room not found: #{attrs["room_slug"]}"
+        next
+      end
+
+      mob = GridMob.find_by(name: attrs["vendor_name"], grid_room: room)
+      unless mob
+        puts "  ✗ Vendor not found: #{attrs["vendor_name"]} in #{attrs["room_slug"]}"
+        next
+      end
+
+      listing = GridShopListing.find_or_initialize_by(name: attrs["name"], grid_mob: mob)
+      was_new = listing.new_record?
+
+      base_price = attrs["base_price"]
+      sell_price = attrs["sell_price"] || (base_price / 2.0).ceil
+
+      listing.assign_attributes(
+        description: attrs["description"],
+        item_type: attrs["item_type"],
+        rarity: attrs["rarity"],
+        base_price: base_price,
+        sell_price: sell_price,
+        stock: attrs["max_stock"],
+        max_stock: attrs["max_stock"],
+        restock_amount: attrs["restock_amount"] || 1,
+        restock_interval_hours: attrs["restock_interval_hours"] || mob.restock_interval_hours,
+        next_restock_at: Time.current + (attrs["restock_interval_hours"] || mob.restock_interval_hours).hours,
+        active: attrs.fetch("active", true),
+        rotation_pool: attrs.fetch("rotation_pool", false),
+        min_clearance: attrs["min_clearance"] || 0,
+        properties: attrs["properties"] || {}
+      )
+
+      if listing.changed?
+        listing.save!
+        was_new ? (created += 1) : (updated += 1)
+        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{listing.name} (#{mob.name})"
+      end
+    end
+
+    puts "Shop Listings: #{created} created, #{updated} updated, #{GridShopListing.count} total"
   end
 
   desc "Load key playlists from YAML"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -748,6 +748,9 @@ namespace :data do
     listings_data = data["shop_listings"]
     created = updated = 0
 
+    # Vendors that need initial rotation seeding (first-time black market creation).
+    vendors_needing_rotation = Set.new
+
     listings_data.each do |attrs|
       room = GridRoom.find_by(slug: attrs["room_slug"])
       unless room
@@ -766,29 +769,48 @@ namespace :data do
 
       base_price = attrs["base_price"]
       sell_price = attrs["sell_price"] || (base_price / 2.0).ceil
+      rotation_pool = attrs.fetch("rotation_pool", false)
+      restock_hours = attrs["restock_interval_hours"] || mob.restock_interval_hours
 
+      # Definition fields — always updated from YAML (source of truth)
       listing.assign_attributes(
         description: attrs["description"],
         item_type: attrs["item_type"],
         rarity: attrs["rarity"],
         base_price: base_price,
         sell_price: sell_price,
-        stock: attrs["max_stock"],
         max_stock: attrs["max_stock"],
         restock_amount: attrs["restock_amount"] || 1,
-        restock_interval_hours: attrs["restock_interval_hours"] || mob.restock_interval_hours,
-        next_restock_at: Time.current + (attrs["restock_interval_hours"] || mob.restock_interval_hours).hours,
-        active: attrs.fetch("active", true),
-        rotation_pool: attrs.fetch("rotation_pool", false),
+        restock_interval_hours: restock_hours,
+        rotation_pool: rotation_pool,
         min_clearance: attrs["min_clearance"] || 0,
         properties: attrs["properties"] || {}
       )
+
+      # Runtime state — only set on creation. Preserves live stock, active flag,
+      # and restock timer on re-import. Rotation pool items start inactive so the
+      # rotation job (or the initial seed below) controls which are visible.
+      if was_new
+        listing.stock = attrs["max_stock"]
+        listing.next_restock_at = Time.current + restock_hours.hours
+        listing.active = attrs.fetch("active", !rotation_pool)
+        vendors_needing_rotation << mob if rotation_pool
+      end
 
       if listing.changed?
         listing.save!
         was_new ? (created += 1) : (updated += 1)
         puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{listing.name} (#{mob.name})"
       end
+    end
+
+    # Seed initial rotation for any vendor with a freshly-created rotation pool
+    # and no currently-active rotation items. This ensures players don't see an
+    # empty black market until the next weekly rotation job runs.
+    vendors_needing_rotation.each do |mob|
+      next if mob.grid_shop_listings.in_rotation_pool.where(active: true).exists?
+      Grid::ShopService.rotate!(mob)
+      puts "  ⟳ Seeded initial rotation: #{mob.name}"
     end
 
     puts "Shop Listings: #{created} created, #{updated} updated, #{GridShopListing.count} total"

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -1,33 +1,29 @@
-# == Schema Information
-#
-# Table name: grid_items
-# Database name: primary
-#
-#  id                 :integer          not null, primary key
-#  description        :text
-#  item_type          :string
-#  name               :string
-#  properties         :json
-#  quantity           :integer          default(1), not null
-#  rarity             :string
-#  value              :integer          default(0), not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  grid_hackr_id      :integer
-#  grid_mining_rig_id :integer
-#  room_id            :integer
-#
-# Indexes
-#
-#  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
-#
 FactoryBot.define do
   factory :grid_item do
-    name { "MyString" }
-    description { "MyText" }
-    item_type { "MyString" }
-    room_id { 1 }
-    grid_player_id { 1 }
-    properties { "" }
+    sequence(:name) { |n| "Item #{n}" }
+    description { "A grid item" }
+    item_type { "tool" }
+    rarity { "common" }
+    value { 10 }
+    quantity { 1 }
+    properties { {} }
+
+    # By default, items are in a room
+    association :room, factory: :grid_room
+
+    trait :in_inventory do
+      room { nil }
+      association :grid_hackr
+    end
+
+    trait :component do
+      item_type { "component" }
+      properties { {"slot" => "gpu", "rate_multiplier" => 1.0} }
+    end
+
+    trait :consumable do
+      item_type { "consumable" }
+      properties { {"effect_type" => "heal", "amount" => 25} }
+    end
   end
 end

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_items
+# Database name: primary
+#
+#  id                 :integer          not null, primary key
+#  description        :text
+#  item_type          :string
+#  name               :string
+#  properties         :json
+#  quantity           :integer          default(1), not null
+#  rarity             :string
+#  value              :integer          default(0), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  grid_hackr_id      :integer
+#  grid_mining_rig_id :integer
+#  room_id            :integer
+#
+# Indexes
+#
+#  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
+#
 FactoryBot.define do
   factory :grid_item do
     sequence(:name) { |n| "Item #{n}" }

--- a/spec/factories/grid_mobs.rb
+++ b/spec/factories/grid_mobs.rb
@@ -8,6 +8,7 @@
 #  dialogue_tree   :json
 #  mob_type        :string
 #  name            :string
+#  vendor_config   :json
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  grid_faction_id :integer

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string
 #  slug                :string

--- a/spec/factories/grid_shop_listings.rb
+++ b/spec/factories/grid_shop_listings.rb
@@ -1,0 +1,50 @@
+FactoryBot.define do
+  factory :grid_shop_listing do
+    sequence(:name) { |n| "Shop Item #{n}" }
+    description { "An item for sale" }
+    association :grid_mob, :vendor
+    item_type { "consumable" }
+    rarity { "common" }
+    base_price { 100 }
+    sell_price { 50 }
+    stock { 10 }
+    max_stock { 10 }
+    restock_amount { 1 }
+    restock_interval_hours { 24 }
+    active { true }
+    rotation_pool { false }
+    min_clearance { 0 }
+    properties { {} }
+
+    trait :unlimited do
+      stock { nil }
+      max_stock { nil }
+    end
+
+    trait :out_of_stock do
+      stock { 0 }
+    end
+
+    trait :rotation do
+      rotation_pool { true }
+    end
+
+    trait :black_market do
+      min_clearance { 10 }
+      rarity { "rare" }
+      base_price { 800 }
+      sell_price { 400 }
+      association :grid_mob, :vendor, vendor_config: {"shop_type" => "black_market"}
+    end
+
+    trait :component do
+      item_type { "component" }
+      properties { {"slot" => "gpu", "rate_multiplier" => 1.5} }
+    end
+
+    trait :consumable do
+      item_type { "consumable" }
+      properties { {"effect_type" => "heal", "amount" => 30} }
+    end
+  end
+end

--- a/spec/factories/grid_shop_listings.rb
+++ b/spec/factories/grid_shop_listings.rb
@@ -1,3 +1,38 @@
+# == Schema Information
+#
+# Table name: grid_shop_listings
+# Database name: primary
+#
+#  id                     :integer          not null, primary key
+#  active                 :boolean          default(TRUE), not null
+#  base_price             :integer          not null
+#  description            :text
+#  item_type              :string
+#  max_stock              :integer
+#  min_clearance          :integer          default(0), not null
+#  name                   :string           not null
+#  next_restock_at        :datetime
+#  properties             :json
+#  rarity                 :string
+#  restock_amount         :integer          default(1), not null
+#  restock_interval_hours :integer          default(24), not null
+#  rotation_pool          :boolean          default(FALSE), not null
+#  sell_price             :integer          not null
+#  stock                  :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  grid_mob_id            :integer          not null
+#
+# Indexes
+#
+#  index_grid_shop_listings_on_grid_mob_id             (grid_mob_id)
+#  index_grid_shop_listings_on_grid_mob_id_and_active  (grid_mob_id,active)
+#  index_grid_shop_listings_on_next_restock_at         (next_restock_at)
+#
+# Foreign Keys
+#
+#  grid_mob_id  (grid_mob_id => grid_mobs.id)
+#
 FactoryBot.define do
   factory :grid_shop_listing do
     sequence(:name) { |n| "Shop Item #{n}" }

--- a/spec/models/grid_mob_spec.rb
+++ b/spec/models/grid_mob_spec.rb
@@ -8,6 +8,7 @@
 #  dialogue_tree   :json
 #  mob_type        :string
 #  name            :string
+#  vendor_config   :json
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  grid_faction_id :integer

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string
 #  slug                :string

--- a/spec/services/grid/shop_service_spec.rb
+++ b/spec/services/grid/shop_service_spec.rb
@@ -78,7 +78,11 @@ RSpec.describe Grid::ShopService do
     end
 
     it "raises InsufficientBalance when hackr can't afford it" do
-      fund_cache(cache, -950) rescue nil # drain to 50
+      begin
+        fund_cache(cache, -950)
+      rescue
+        nil
+      end # drain to 50
       hackr_cache = create(:grid_cache, :default, grid_hackr: create(:grid_hackr))
       poor_hackr = hackr_cache.grid_hackr
       fund_cache(hackr_cache, 10)

--- a/spec/services/grid/shop_service_spec.rb
+++ b/spec/services/grid/shop_service_spec.rb
@@ -1,0 +1,308 @@
+require "rails_helper"
+
+RSpec.describe Grid::ShopService do
+  let(:zone) { create(:grid_zone) }
+  let(:shop_room) { create(:grid_room, :shop, grid_zone: zone) }
+  let(:vendor) { create(:grid_mob, :vendor, grid_room: shop_room) }
+  let(:hackr) { create(:grid_hackr, current_room: shop_room) }
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+  let(:burn_cache) { create(:grid_cache, :burn) }
+
+  let!(:listing) do
+    create(:grid_shop_listing, :consumable,
+      grid_mob: vendor,
+      name: "MedPatch",
+      base_price: 100,
+      sell_price: 50,
+      stock: 5,
+      max_stock: 5)
+  end
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  before do
+    cache
+    gameplay_pool
+    burn_cache
+  end
+
+  describe ".buy!" do
+    before { fund_cache(cache, 1000) }
+
+    it "creates an item in the hackr's inventory" do
+      expect {
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      }.to change { hackr.grid_items.count }.by(1)
+    end
+
+    it "returns purchase receipt" do
+      result = described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      expect(result[:price_paid]).to eq(100)
+      expect(result[:item].name).to eq("MedPatch")
+      expect(result[:item].grid_hackr).to eq(hackr)
+    end
+
+    it "burns 70% and recycles 30% of the price" do
+      described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      expect(burn_cache.balance).to eq(70)
+      expect(gameplay_pool.balance).to eq(30)
+    end
+
+    it "decrements stock" do
+      described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      expect(listing.reload.stock).to eq(4)
+    end
+
+    it "creates a shop transaction record" do
+      expect {
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      }.to change(GridShopTransaction, :count).by(1)
+
+      tx = GridShopTransaction.last
+      expect(tx.transaction_type).to eq("buy")
+      expect(tx.price_paid).to eq(100)
+      expect(tx.burn_amount).to eq(70)
+      expect(tx.recycle_amount).to eq(30)
+    end
+
+    it "is case-insensitive for item names" do
+      result = described_class.buy!(hackr: hackr, mob: vendor, item_name: "medpatch")
+      expect(result[:item].name).to eq("MedPatch")
+    end
+
+    it "raises InsufficientBalance when hackr can't afford it" do
+      fund_cache(cache, -950) rescue nil # drain to 50
+      hackr_cache = create(:grid_cache, :default, grid_hackr: create(:grid_hackr))
+      poor_hackr = hackr_cache.grid_hackr
+      fund_cache(hackr_cache, 10)
+
+      expect {
+        described_class.buy!(hackr: poor_hackr, mob: vendor, item_name: "MedPatch")
+      }.to raise_error(described_class::InsufficientBalance)
+    end
+
+    it "raises InsufficientStock when out of stock" do
+      listing.update_columns(stock: 0)
+      expect {
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      }.to raise_error(described_class::InsufficientStock)
+    end
+
+    it "raises ItemNotFound for unknown items" do
+      expect {
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "Nonexistent")
+      }.to raise_error(described_class::ItemNotFound)
+    end
+
+    it "raises AccessDenied for non-vendor mobs" do
+      lore_mob = create(:grid_mob, grid_room: shop_room, mob_type: "lore")
+      expect {
+        described_class.buy!(hackr: hackr, mob: lore_mob, item_name: "MedPatch")
+      }.to raise_error(described_class::AccessDenied)
+    end
+
+    context "with unlimited stock" do
+      before { listing.update_columns(stock: nil, max_stock: nil) }
+
+      it "does not decrement stock" do
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+        expect(listing.reload.stock).to be_nil
+      end
+    end
+
+    context "with concurrent purchases (race condition)" do
+      it "prevents double-purchase of last stock" do
+        listing.update_columns(stock: 1)
+        fund_cache(cache, 10000)
+
+        # First buy succeeds
+        described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+
+        # Second buy fails — stock is now 0
+        expect {
+          described_class.buy!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+        }.to raise_error(described_class::InsufficientStock)
+      end
+    end
+  end
+
+  describe ".sell!" do
+    before do
+      gameplay_pool
+      fund_cache(gameplay_pool, 100_000)
+    end
+
+    let!(:item) do
+      create(:grid_item,
+        grid_hackr: hackr,
+        room: nil,
+        name: "MedPatch",
+        item_type: "consumable",
+        rarity: "common",
+        value: 100)
+    end
+
+    it "destroys the item" do
+      expect {
+        described_class.sell!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      }.to change { hackr.grid_items.count }.by(-1)
+    end
+
+    it "pays the hackr sell price from gameplay pool" do
+      result = described_class.sell!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      expect(result[:sell_price]).to eq(50)
+      expect(cache.reload.balance).to eq(50)
+    end
+
+    it "creates a sell transaction record" do
+      expect {
+        described_class.sell!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+      }.to change(GridShopTransaction, :count).by(1)
+
+      tx = GridShopTransaction.last
+      expect(tx.transaction_type).to eq("sell")
+      expect(tx.price_paid).to eq(50)
+    end
+
+    it "raises ItemNotFound when hackr doesn't have the item" do
+      expect {
+        described_class.sell!(hackr: hackr, mob: vendor, item_name: "Nonexistent")
+      }.to raise_error(described_class::ItemNotFound)
+    end
+
+    context "with quantity > 1" do
+      before { item.update!(quantity: 3) }
+
+      it "decrements quantity instead of destroying" do
+        described_class.sell!(hackr: hackr, mob: vendor, item_name: "MedPatch")
+        expect(item.reload.quantity).to eq(2)
+      end
+    end
+
+    context "without matching listing" do
+      it "uses item value * 50% as sell price" do
+        item.update!(name: "Random Loot", value: 200)
+        result = described_class.sell!(hackr: hackr, mob: vendor, item_name: "Random Loot")
+        expect(result[:sell_price]).to eq(100)
+      end
+    end
+  end
+
+  describe ".effective_price" do
+    let(:bm_vendor) do
+      create(:grid_mob, :vendor, grid_room: shop_room,
+        vendor_config: {"shop_type" => "black_market"})
+    end
+
+    let(:bm_listing) do
+      create(:grid_shop_listing, grid_mob: bm_vendor, base_price: 1000)
+    end
+
+    it "returns base_price for standard vendors" do
+      price = described_class.effective_price(listing: listing, mob: vendor, clearance: 50)
+      expect(price).to eq(100)
+    end
+
+    it "applies 5x multiplier at clearance 10 for black market" do
+      price = described_class.effective_price(listing: bm_listing, mob: bm_vendor, clearance: 10)
+      expect(price).to eq(5000)
+    end
+
+    it "applies reduced multiplier at higher clearance" do
+      # At clearance 50: max(1.0, 5.0 - (50-10)*0.04) = max(1.0, 3.4) = 3.4
+      price = described_class.effective_price(listing: bm_listing, mob: bm_vendor, clearance: 50)
+      expect(price).to eq(3400)
+    end
+
+    it "floors at 1x multiplier (base price)" do
+      # At clearance 99: max(1.0, 5.0 - (99-10)*0.04) = max(1.0, 1.44) = 1.44
+      price = described_class.effective_price(listing: bm_listing, mob: bm_vendor, clearance: 99)
+      expect(price).to eq(1440)
+    end
+
+    it "never goes below base price" do
+      # Even at absurdly high clearance, min is 1.0x
+      price = described_class.effective_price(listing: bm_listing, mob: bm_vendor, clearance: 200)
+      expect(price).to eq(1000)
+    end
+  end
+
+  describe ".listing_display" do
+    it "returns visible listings with prices" do
+      items = described_class.listing_display(mob: vendor, hackr: hackr)
+      expect(items.length).to eq(1)
+      expect(items.first[:listing]).to eq(listing)
+      expect(items.first[:effective_price]).to eq(100)
+    end
+
+    it "filters listings by clearance" do
+      listing.update!(min_clearance: 50)
+      hackr.set_stat!("clearance", 10)
+      items = described_class.listing_display(mob: vendor, hackr: hackr)
+      expect(items).to be_empty
+    end
+
+    it "excludes inactive listings" do
+      listing.update!(active: false)
+      items = described_class.listing_display(mob: vendor, hackr: hackr)
+      expect(items).to be_empty
+    end
+  end
+
+  describe ".restock!" do
+    it "restocks items below max" do
+      listing.update_columns(stock: 2, next_restock_at: 1.hour.ago)
+      described_class.restock!(vendor)
+      expect(listing.reload.stock).to eq(3)
+    end
+
+    it "does not exceed max_stock" do
+      listing.update_columns(stock: 4, max_stock: 5, restock_amount: 5)
+      described_class.restock!(vendor)
+      expect(listing.reload.stock).to eq(5)
+    end
+
+    it "skips items already at max" do
+      listing.update_columns(stock: 5, max_stock: 5)
+      expect { described_class.restock!(vendor) }.not_to change { listing.reload.stock }
+    end
+  end
+
+  describe ".rotate!" do
+    let(:bm_vendor) do
+      create(:grid_mob, :vendor, grid_room: shop_room,
+        vendor_config: {"shop_type" => "black_market", "rotation_count" => 2})
+    end
+
+    let!(:rot_listings) do
+      5.times.map do |i|
+        create(:grid_shop_listing,
+          grid_mob: bm_vendor,
+          name: "Rotation Item #{i}",
+          rotation_pool: true,
+          active: false)
+      end
+    end
+
+    it "activates rotation_count items from the pool" do
+      described_class.rotate!(bm_vendor)
+      active_count = bm_vendor.grid_shop_listings.in_rotation_pool.where(active: true).count
+      expect(active_count).to eq(2)
+    end
+
+    it "deactivates all rotation items before selecting" do
+      rot_listings.first.update!(active: true)
+      described_class.rotate!(bm_vendor)
+      # Exactly rotation_count should be active
+      active_count = bm_vendor.grid_shop_listings.in_rotation_pool.where(active: true).count
+      expect(active_count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
  Introduces a commerce layer for the CRED economy with vendor shops and
  a clearance-gated black market. Players can buy items with CRED (70%
  burned, 30% recycled to gameplay pool) and sell items back at 50% of
  base price from the gameplay pool.

## Models:
  - GridShopListing: catalog template (not GridItem) with stock, pricing, restock config, rotation pool flag, per-listing clearance gates
  - GridShopTransaction: immutable audit log for all buys/sells
  - GridMob: vendor_config JSON column + vendor/black_market helpers
  - GridRoom: min_clearance column + clearance_gated? predicate
  - GridZone: added danger_zone to enum

## Economy:
  - Grid::ShopService: buy!/sell!/listing_display/restock!/rotate!
  - TransactionService.recycle!: new purchase_recycle tx_type
  - EconomyConfig: SHOP_BURN_RATIO, SHOP_RECYCLE_RATIO, black market pricing constants

  Black market pricing formula:
    price = base_price * max(1.0, 5.0 - (clearance - 10) * 0.04) At CL10: 5x. At CL50: 3.4x. At CL99: 1.44x. Never below base.

## Commands
  - `shop/browse`, `buy <item>`, `sell <item>`
  - Clearance gate added to go_command for gated rooms
  - examine extended to show rig component multipliers and shop listings (with buy/sell prices and component stats)
  - Shop browse uses HTML `<table>` for proper column alignment

## Jobs (Solid Queue recurring)
- ShopRestockJob: hourly, restocks listings past next_restock_at
- ShopRotationJob: weekly Monday, swaps active rotation pool items

## Admin
  - Full CRUD at /root/grid_shop_listings with vendor filter + restock action
  - Transaction log at /root/grid_shop_transactions with filters
  - Nav link under Grid dropdown

## World data
  - New zone: The Underbelly (danger_zone)
  - New rooms: The Signal Bazaar (standard shop), The Blacksite (black market, min_clearance: 10)
  - New vendors: Codec (11 standard listings), GHOST (11 rotation-pool black market listings)
  - Exits connecting both to Transit Corridor Alpha
  - data/world/shop_listings.yml + data:shop_listings rake task

## Tests
  - 31 new specs in shop_service_spec covering buy/sell/pricing/stock/ rotation/restock, including race condition on last-stock decrement
  - Fixed stale grid_items factory (grid_player_id b proper associations)
  - All 234 Grid specs passing