### PR TITLE
Hackr Handbook: GitBook-style practical docs for GridHackrs

### DIFF
--- a/app/controllers/admin/handbook_articles_controller.rb
+++ b/app/controllers/admin/handbook_articles_controller.rb
@@ -1,0 +1,108 @@
+class Admin::HandbookArticlesController < Admin::ApplicationController
+  before_action :set_article, only: [:edit, :update, :destroy]
+
+  def index
+    @articles = HandbookArticle.includes(:handbook_section).order("handbook_sections.position, handbook_articles.position, handbook_articles.title").references(:handbook_section)
+    @articles = @articles.where(handbook_section_id: params[:section_id]) if params[:section_id].present?
+    @sections = HandbookSection.ordered
+  end
+
+  def new
+    @article = HandbookArticle.new(
+      kind: "reference",
+      published: true,
+      position: next_position(params[:handbook_section_id] || params[:section_id]),
+      handbook_section_id: params[:handbook_section_id] || params[:section_id]
+    )
+    @sections = HandbookSection.ordered
+  end
+
+  def create
+    attrs, json_error = article_params
+    @article = HandbookArticle.new(attrs)
+
+    if json_error.nil? && @article.save
+      set_flash_success("Article '#{@article.title}' created.")
+      redirect_to admin_handbook_articles_path(section_id: @article.handbook_section_id)
+      return
+    end
+
+    if json_error
+      @article.valid?
+      @article.errors.add(:metadata, json_error)
+    end
+    @sections = HandbookSection.ordered
+    flash.now[:error] = @article.errors.full_messages.join(", ")
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit
+    @sections = HandbookSection.ordered
+  end
+
+  def update
+    attrs, json_error = article_params
+    if json_error
+      @article.assign_attributes(attrs)
+      @article.errors.add(:metadata, json_error)
+      @sections = HandbookSection.ordered
+      flash.now[:error] = @article.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
+    if @article.update(attrs)
+      set_flash_success("Article '#{@article.title}' updated.")
+      redirect_to admin_handbook_articles_path(section_id: @article.handbook_section_id)
+    else
+      @sections = HandbookSection.ordered
+      flash.now[:error] = @article.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    title = @article.title
+    section_id = @article.handbook_section_id
+    @article.destroy!
+    set_flash_success("Article '#{title}' deleted.")
+    redirect_to admin_handbook_articles_path(section_id: section_id)
+  end
+
+  private
+
+  def set_article
+    @article = HandbookArticle.find_by!(slug: params[:id])
+  end
+
+  # Returns [permitted_attrs, json_error_or_nil]. On invalid JSON, :metadata
+  # is omitted so existing values are preserved on update, and a readable
+  # error is surfaced.
+  def article_params
+    permitted = params.require(:handbook_article).permit(
+      :handbook_section_id, :title, :slug, :kind, :difficulty,
+      :summary, :body, :position, :published
+    )
+
+    json_source = params[:handbook_article][:metadata_json]
+    if json_source.blank?
+      permitted[:metadata] = {}
+      return [permitted, nil]
+    end
+
+    parsed = JSON.parse(json_source)
+    unless parsed.is_a?(Hash)
+      return [permitted, "must be a JSON object (e.g. {\"search_tags\": [\"cred\", \"mining\"]})"]
+    end
+
+    permitted[:metadata] = parsed
+    [permitted, nil]
+  rescue JSON::ParserError => e
+    [permitted, "is not valid JSON: #{e.message}"]
+  end
+
+  def next_position(section_id)
+    return 0 if section_id.blank?
+    (HandbookArticle.where(handbook_section_id: section_id).maximum(:position) || -1) + 1
+  end
+end

--- a/app/controllers/admin/handbook_sections_controller.rb
+++ b/app/controllers/admin/handbook_sections_controller.rb
@@ -1,0 +1,56 @@
+class Admin::HandbookSectionsController < Admin::ApplicationController
+  before_action :set_section, only: [:edit, :update, :destroy]
+
+  def index
+    @sections = HandbookSection.ordered.includes(:articles)
+  end
+
+  def new
+    @section = HandbookSection.new(published: true, position: next_position)
+  end
+
+  def create
+    @section = HandbookSection.new(section_params)
+    if @section.save
+      set_flash_success("Section '#{@section.name}' created.")
+      redirect_to admin_handbook_sections_path
+    else
+      flash.now[:error] = @section.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @section.update(section_params)
+      set_flash_success("Section '#{@section.name}' updated.")
+      redirect_to admin_handbook_sections_path
+    else
+      flash.now[:error] = @section.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @section.name
+    @section.destroy!
+    set_flash_success("Section '#{name}' deleted.")
+    redirect_to admin_handbook_sections_path
+  end
+
+  private
+
+  def set_section
+    @section = HandbookSection.find_by!(slug: params[:id])
+  end
+
+  def section_params
+    params.require(:handbook_section).permit(:name, :slug, :icon, :summary, :position, :published)
+  end
+
+  def next_position
+    (HandbookSection.maximum(:position) || -1) + 1
+  end
+end

--- a/app/controllers/api/handbook_controller.rb
+++ b/app/controllers/api/handbook_controller.rb
@@ -1,0 +1,108 @@
+module Api
+  class HandbookController < ApplicationController
+    include GridAuthentication
+
+    before_action :require_login_api
+
+    # GET /api/handbook
+    # Full tree payload: sections with their articles. One round-trip powers
+    # both the sidebar and the landing-page TOC. Two queries total (sections,
+    # articles) — grouped in Ruby to avoid N+1 from chained association scopes.
+    def index
+      sections = HandbookSection.published.ordered.to_a
+      articles_by_section = HandbookArticle.published.ordered
+        .where(handbook_section_id: sections.map(&:id))
+        .group_by(&:handbook_section_id)
+
+      render json: {
+        sections: sections.map { |section|
+          {
+            id: section.id,
+            slug: section.slug,
+            name: section.name,
+            icon: section.icon,
+            summary: section.summary,
+            position: section.position,
+            articles: (articles_by_section[section.id] || []).map { |article|
+              serialize_article_summary(article)
+            }
+          }
+        }
+      }
+    end
+
+    # GET /api/handbook/recent
+    # Last N published articles by updated_at. Used by the landing-page
+    # "Recently Updated" panel.
+    def recent
+      limit = [(params[:limit] || 5).to_i, 20].min
+      articles = HandbookArticle.published
+        .includes(:handbook_section)
+        .recently_updated
+        .limit(limit)
+
+      render json: articles.map { |article|
+        serialize_article_summary(article).merge(
+          section: {slug: article.handbook_section.slug, name: article.handbook_section.name}
+        )
+      }
+    end
+
+    # GET /api/handbook/mappings
+    # slug -> title map for any future wiki-link style cross-references.
+    def mappings
+      mapping = HandbookArticle.published.pluck(:slug, :title).to_h
+      render json: mapping
+    end
+
+    # GET /api/handbook/:slug
+    # Full article with section context and prev/next siblings within the
+    # same section for GitBook-style navigation at the bottom of each page.
+    def show
+      article = HandbookArticle.published.find_by!(slug: params[:slug])
+      section = article.handbook_section
+      siblings = section.articles.published.ordered.to_a
+      idx = siblings.index(article)
+      prev_article = idx&.positive? ? siblings[idx - 1] : nil
+      next_article = (idx && idx < siblings.length - 1) ? siblings[idx + 1] : nil
+
+      render json: {
+        id: article.id,
+        slug: article.slug,
+        title: article.title,
+        kind: article.kind,
+        difficulty: article.difficulty,
+        summary: article.summary,
+        body: article.body,
+        metadata: article.metadata,
+        position: article.position,
+        updated_at: article.updated_at,
+        section: {
+          id: section.id,
+          slug: section.slug,
+          name: section.name,
+          icon: section.icon
+        },
+        prev_article: prev_article && {slug: prev_article.slug, title: prev_article.title},
+        next_article: next_article && {slug: next_article.slug, title: next_article.title}
+      }
+    rescue ActiveRecord::RecordNotFound
+      render json: {error: "Handbook article not found"}, status: :not_found
+    end
+
+    private
+
+    def serialize_article_summary(article)
+      {
+        id: article.id,
+        slug: article.slug,
+        title: article.title,
+        kind: article.kind,
+        difficulty: article.difficulty,
+        summary: article.summary,
+        position: article.position,
+        updated_at: article.updated_at
+      }
+    end
+  end
+end

--- a/app/controllers/api/handbook_controller.rb
+++ b/app/controllers/api/handbook_controller.rb
@@ -32,11 +32,12 @@ module Api
     end
 
     # GET /api/handbook/recent
-    # Last N published articles by updated_at. Used by the landing-page
-    # "Recently Updated" panel.
+    # Last N visible articles by updated_at. Used by the landing-page
+    # "Recently Updated" panel. `visible` requires both the article and
+    # its section to be published.
     def recent
       limit = [(params[:limit] || 5).to_i, 20].min
-      articles = HandbookArticle.published
+      articles = HandbookArticle.visible
         .includes(:handbook_section)
         .recently_updated
         .limit(limit)
@@ -50,16 +51,19 @@ module Api
 
     # GET /api/handbook/mappings
     # slug -> title map for any future wiki-link style cross-references.
+    # Scoped to visible articles so unpublished-section content isn't leaked.
     def mappings
-      mapping = HandbookArticle.published.pluck(:slug, :title).to_h
+      mapping = HandbookArticle.visible.pluck(:slug, :title).to_h
       render json: mapping
     end
 
     # GET /api/handbook/:slug
     # Full article with section context and prev/next siblings within the
     # same section for GitBook-style navigation at the bottom of each page.
+    # `visible` ensures articles in unpublished sections 404 here even if
+    # the article itself is marked published.
     def show
-      article = HandbookArticle.published.find_by!(slug: params[:slug])
+      article = HandbookArticle.visible.find_by!(slug: params[:slug])
       section = article.handbook_section
       siblings = section.articles.published.ordered.to_a
       idx = siblings.index(article)
@@ -101,7 +105,11 @@ module Api
         difficulty: article.difficulty,
         summary: article.summary,
         position: article.position,
-        updated_at: article.updated_at
+        updated_at: article.updated_at,
+        # Required for sidebar tag search to match against `search_tags`.
+        # Mirrors the `metadata` field returned by #show so the payload
+        # shape is consistent between summary and detail.
+        metadata: article.metadata || {}
       }
     end
   end

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -36,6 +36,8 @@ const LogsIndexPage = lazy(() => import('~/components/pages/logs/LogsIndexPage')
 const LogDetailPage = lazy(() => import('~/components/pages/logs/LogDetailPage').then(m => ({ default: m.LogDetailPage })))
 const CodexIndexPage = lazy(() => import('~/components/pages/codex/CodexIndexPage').then(m => ({ default: m.CodexIndexPage })))
 const CodexEntryPage = lazy(() => import('~/components/pages/codex/CodexEntryPage').then(m => ({ default: m.CodexEntryPage })))
+const HandbookIndexPage = lazy(() => import('~/components/pages/handbook/HandbookIndexPage').then(m => ({ default: m.HandbookIndexPage })))
+const HandbookArticlePage = lazy(() => import('~/components/pages/handbook/HandbookArticlePage').then(m => ({ default: m.HandbookArticlePage })))
 const TimelinePage = lazy(() => import('~/components/pages/timeline/TimelinePage').then(m => ({ default: m.TimelinePage })))
 const HotwirePage = lazy(() => import('~/components/pulsewire/HotwirePage').then(m => ({ default: m.HotwirePage })))
 const UserPulsesPage = lazy(() => import('~/components/pulsewire/UserPulsesPage').then(m => ({ default: m.UserPulsesPage })))
@@ -109,6 +111,9 @@ export const AppLayout: React.FC = () => {
         {/* Codex routes */}
         <Route path="/codex" element={<CodexIndexPage />} />
         <Route path="/codex/:slug" element={<CodexEntryPage />} />
+        {/* Handbook routes - login required */}
+        <Route path="/handbook" element={<ProtectedRoute><HandbookIndexPage /></ProtectedRoute>} />
+        <Route path="/handbook/:slug" element={<ProtectedRoute><HandbookArticlePage /></ProtectedRoute>} />
         {/* Timeline route */}
         <Route path="/timeline" element={<TimelinePage />} />
         {/* PulseWire routes */}

--- a/app/javascript/components/navigation/FooterMenu.tsx
+++ b/app/javascript/components/navigation/FooterMenu.tsx
@@ -84,7 +84,7 @@ export const FooterMenu: React.FC = () => {
           {hackr?.role === 'admin' && (
             <li>
               <a href="/root">
-                <span className="red-255-text">11</span>&nbsp;/root <span className="red-255-text">[ADMIN]</span>&nbsp;
+                <span className="red-255-text">11</span>&nbsp;/root
               </a>
             </li>
           )}

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -255,13 +255,18 @@ export const HeaderMenu: React.FC = () => {
                 <Link to="/codex" className={`mobile-menu-item${isActive('/codex') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">{isLoggedIn ? '8' : '7'}</span> Codex
                 </Link>
+                {isLoggedIn && (
+                  <Link to="/handbook" className={`mobile-menu-item${isActive('/handbook') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                    <span className="purple-168-text">9</span> Handbook
+                  </Link>
+                )}
                 <Link to="/logs" className={`mobile-menu-item${isActive('/logs') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
-                  <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Logs
+                  <span className="purple-168-text">{isLoggedIn ? '10' : '8'}</span> Logs
                 </Link>
               </div>
 
               <div className="mobile-menu-section">
-                <div className="mobile-menu-section-title">{isLoggedIn ? '9' : '8'}. THE PULSE GRID</div>
+                <div className="mobile-menu-section-title">{isLoggedIn ? '11' : '9'}. THE PULSE GRID</div>
                 <Link to="/grid" className={`mobile-menu-item${isActive('/grid') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span>grid
                 </Link>
@@ -290,7 +295,7 @@ export const HeaderMenu: React.FC = () => {
                 )}
                 {hackr?.role === 'admin' && (
                   <a href="/root" className="mobile-menu-item">
-                    <span className="red-255-text">10</span> /root <span className="red-255-text">[ADMIN]</span>
+                    <span className="red-255-text">12</span> /root
                   </a>
                 )}
               </div>
@@ -301,12 +306,14 @@ export const HeaderMenu: React.FC = () => {
                     href="#"
                     className="mobile-menu-item"
                     style={{ color: '#dc2626' }}
+                    title="Disconnect"
+                    aria-label="Disconnect"
                     onClick={(e) => {
                       handleDisconnect(e)
                       setMobileMenuOpen(false)
                     }}
                   >
-                    × Disconnect
+                    × DC
                   </a>
                 )}
               </div>
@@ -526,16 +533,25 @@ export const HeaderMenu: React.FC = () => {
             </Link>
           </li>
 
+          {/* Handbook (logged in only) */}
+          {isLoggedIn && (
+            <li className={`header-nav-item${isActive('/handbook') ? ' active' : ''}`}>
+              <Link to="/handbook">
+                <span className="purple-168-text">9</span> Handbook&nbsp;
+              </Link>
+            </li>
+          )}
+
           {/* Logs */}
           <li className={`header-nav-item${isActive('/logs') ? ' active' : ''}`}>
             <Link to="/logs">
-              <span className="purple-168-text">{isLoggedIn ? '9' : '8'}</span> Logs&nbsp;
+              <span className="purple-168-text">{isLoggedIn ? '10' : '8'}</span> Logs&nbsp;
             </Link>
           </li>
 
           {/* THE PULSE GRID */}
           <li className={`header-dropdown${isActive('/grid') || isActive('/code') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
-            <span className="purple-168-text">{isLoggedIn ? '10' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
+            <span className="purple-168-text">{isLoggedIn ? '11' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
                 <li>
@@ -584,7 +600,7 @@ export const HeaderMenu: React.FC = () => {
           {hackr?.role === 'admin' && (
             <li className="header-nav-item">
               <a href="/root">
-                <span className="red-255-text">11</span> /root <span className="red-255-text">[ADMIN]</span>&nbsp;
+                <span className="red-255-text">12</span> /root
               </a>
             </li>
           )}
@@ -592,8 +608,8 @@ export const HeaderMenu: React.FC = () => {
           {/* Disconnect (only show if logged in) */}
           {isLoggedIn && (
             <li className="header-nav-item">
-              <a href="#" onClick={handleDisconnect} style={{ color: '#dc2626' }}>
-                <span>×</span> Disconnect&nbsp;
+              <a href="#" onClick={handleDisconnect} style={{ color: '#dc2626' }} title="Disconnect" aria-label="Disconnect">
+                <span>×</span> DC&nbsp;
               </a>
             </li>
           )}

--- a/app/javascript/components/pages/handbook/HandbookArticlePage.tsx
+++ b/app/javascript/components/pages/handbook/HandbookArticlePage.tsx
@@ -19,32 +19,39 @@ export const HandbookArticlePage: React.FC = () => {
   const { slug } = useParams<{ slug: string }>()
   const { tree, loading: treeLoading } = useHandbookTree()
   const [article, setArticle] = useState<HandbookArticle | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [fetchedSlug, setFetchedSlug] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
 
+  // Derived during render: when `slug` changes, `fetchedSlug` lags until
+  // the effect resolves. Avoids the anti-pattern of calling setLoading()
+  // synchronously inside the effect body, which triggers cascading renders.
+  const loading = slug !== undefined && slug !== fetchedSlug
+
   useEffect(() => {
     if (!slug) return
-    setLoading(true)
-    setError(null)
-
     let mounted = true
     apiJson<HandbookArticle>(`/api/handbook/${slug}`)
       .then(data => {
         if (mounted) {
           setArticle(data)
-          setLoading(false)
+          setError(null)
+          setFetchedSlug(slug)
         }
       })
       .catch(err => {
         if (mounted) {
           console.error('Failed to load handbook article:', err)
           setError(err?.message || 'Failed to load article')
-          setLoading(false)
+          setFetchedSlug(slug)
         }
       })
     return () => { mounted = false }
   }, [slug])
+
+  // When the URL slug changes, hide any stale error from the previous
+  // fetch. Derived, not effect-driven.
+  const activeError = slug === fetchedSlug ? error : null
 
   const sections = tree?.sections || []
 
@@ -61,7 +68,7 @@ export const HandbookArticlePage: React.FC = () => {
     )
   }
 
-  if (error || !article) {
+  if (activeError || !article) {
     return (
       <HandbookLayout
         sections={sections}
@@ -73,7 +80,7 @@ export const HandbookArticlePage: React.FC = () => {
           <fieldset className="red-168-border">
             <legend className="center">ERROR</legend>
             <div style={{ padding: '30px', textAlign: 'center' }}>
-              <p>{error || 'Article not found.'}</p>
+              <p>{activeError || 'Article not found.'}</p>
               <Link to="/handbook" className="tui-button cyan-168" style={{ marginTop: '16px', display: 'inline-block' }}>
                 ← Back to Handbook
               </Link>

--- a/app/javascript/components/pages/handbook/HandbookArticlePage.tsx
+++ b/app/javascript/components/pages/handbook/HandbookArticlePage.tsx
@@ -1,0 +1,233 @@
+import React, { useState, useEffect } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { MarkdownContent } from '~/components/shared/MarkdownContent'
+import { apiJson } from '~/utils/apiClient'
+import { formatFutureDate } from '~/utils/dateUtils'
+import { useHandbookTree } from '~/hooks/useHandbookTree'
+import { HandbookLayout } from './HandbookLayout'
+import type { HandbookArticle } from '~/types/handbook'
+
+const ACCENT = '#22d3ee'
+
+const KIND_COLORS: Record<string, string> = {
+  tutorial: '#fbbf24',
+  reference: ACCENT
+}
+
+export const HandbookArticlePage: React.FC = () => {
+  const { slug } = useParams<{ slug: string }>()
+  const { tree, loading: treeLoading } = useHandbookTree()
+  const [article, setArticle] = useState<HandbookArticle | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  useEffect(() => {
+    if (!slug) return
+    setLoading(true)
+    setError(null)
+
+    let mounted = true
+    apiJson<HandbookArticle>(`/api/handbook/${slug}`)
+      .then(data => {
+        if (mounted) {
+          setArticle(data)
+          setLoading(false)
+        }
+      })
+      .catch(err => {
+        if (mounted) {
+          console.error('Failed to load handbook article:', err)
+          setError(err?.message || 'Failed to load article')
+          setLoading(false)
+        }
+      })
+    return () => { mounted = false }
+  }, [slug])
+
+  const sections = tree?.sections || []
+
+  if (loading || treeLoading) {
+    return (
+      <HandbookLayout
+        sections={sections}
+        currentArticleSlug={slug}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+      >
+        <LoadingSpinner message="Loading article..." color="cyan-168-text" size="large" />
+      </HandbookLayout>
+    )
+  }
+
+  if (error || !article) {
+    return (
+      <HandbookLayout
+        sections={sections}
+        currentArticleSlug={slug}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+      >
+        <div className="tui-window red-168 white-text">
+          <fieldset className="red-168-border">
+            <legend className="center">ERROR</legend>
+            <div style={{ padding: '30px', textAlign: 'center' }}>
+              <p>{error || 'Article not found.'}</p>
+              <Link to="/handbook" className="tui-button cyan-168" style={{ marginTop: '16px', display: 'inline-block' }}>
+                ← Back to Handbook
+              </Link>
+            </div>
+          </fieldset>
+        </div>
+      </HandbookLayout>
+    )
+  }
+
+  const kindColor = KIND_COLORS[article.kind] || ACCENT
+
+  return (
+    <HandbookLayout
+      sections={sections}
+      currentSectionSlug={article.section.slug}
+      currentArticleSlug={article.slug}
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+    >
+      <div className="tui-window cyan-168 white-text">
+        <fieldset className="cyan-168-border">
+          <legend className="center">{article.section.name.toUpperCase()}</legend>
+          <div style={{ padding: '30px', background: '#1a1a1a' }}>
+            {/* Breadcrumb */}
+            <div style={{ fontSize: '0.85em', marginBottom: '16px', color: '#666' }}>
+              <Link to="/handbook" style={{ color: '#60a5fa', textDecoration: 'none' }}>Handbook</Link>
+              <span style={{ margin: '0 8px' }}>/</span>
+              <span style={{ color: '#a0a0a0' }}>{article.section.name}</span>
+              <span style={{ margin: '0 8px' }}>/</span>
+              <span style={{ color: '#d0d0d0' }}>{article.title}</span>
+            </div>
+
+            {/* Kind / difficulty badges */}
+            <div style={{ marginBottom: '12px', display: 'flex', gap: '8px', alignItems: 'center' }}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  padding: '3px 10px',
+                  background: kindColor,
+                  color: '#000',
+                  fontSize: '0.75em',
+                  fontWeight: 'bold',
+                  textTransform: 'uppercase',
+                  borderRadius: '2px'
+                }}
+              >
+                {article.kind}
+              </span>
+              {article.difficulty && (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    padding: '3px 10px',
+                    background: '#333',
+                    color: '#d0d0d0',
+                    fontSize: '0.75em',
+                    fontWeight: 'bold',
+                    textTransform: 'uppercase',
+                    borderRadius: '2px'
+                  }}
+                >
+                  {article.difficulty}
+                </span>
+              )}
+            </div>
+
+            <h1 style={{ margin: '0 0 18px 0', color: kindColor, fontSize: '2.2em', fontFamily: 'monospace' }}>
+              {article.title}
+            </h1>
+
+            {article.summary && (
+              <div
+                style={{
+                  padding: '14px 18px',
+                  background: '#0a0a0a',
+                  border: `2px solid ${kindColor}`,
+                  marginBottom: '26px',
+                  borderRadius: '2px'
+                }}
+              >
+                <p style={{ margin: 0, color: '#e5e5e5', fontSize: '1.05em', lineHeight: 1.6, fontStyle: 'italic' }}>
+                  {article.summary}
+                </p>
+              </div>
+            )}
+
+            {article.body && <MarkdownContent content={article.body} accentColor={kindColor} />}
+
+            {/* Prev / next nav */}
+            {(article.prev_article || article.next_article) && (
+              <div
+                style={{
+                  marginTop: '40px',
+                  paddingTop: '20px',
+                  borderTop: '1px solid #333',
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: '12px'
+                }}
+              >
+                <div>
+                  {article.prev_article && (
+                    <Link
+                      to={`/handbook/${article.prev_article.slug}`}
+                      style={{
+                        display: 'block',
+                        padding: '12px 14px',
+                        background: '#0a0a0a',
+                        border: '1px solid #333',
+                        textDecoration: 'none',
+                        color: '#d0d0d0'
+                      }}
+                    >
+                      <div style={{ color: '#666', fontSize: '0.78em', marginBottom: '4px' }}>← PREVIOUS</div>
+                      <div style={{ color: '#60a5fa' }}>{article.prev_article.title}</div>
+                    </Link>
+                  )}
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  {article.next_article && (
+                    <Link
+                      to={`/handbook/${article.next_article.slug}`}
+                      style={{
+                        display: 'block',
+                        padding: '12px 14px',
+                        background: '#0a0a0a',
+                        border: '1px solid #333',
+                        textDecoration: 'none',
+                        color: '#d0d0d0'
+                      }}
+                    >
+                      <div style={{ color: '#666', fontSize: '0.78em', marginBottom: '4px' }}>NEXT →</div>
+                      <div style={{ color: '#60a5fa' }}>{article.next_article.title}</div>
+                    </Link>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div
+              style={{
+                marginTop: '32px',
+                paddingTop: '16px',
+                borderTop: '1px solid #333',
+                color: '#666',
+                fontSize: '0.82em'
+              }}
+            >
+              Last updated: {formatFutureDate(article.updated_at)}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </HandbookLayout>
+  )
+}

--- a/app/javascript/components/pages/handbook/HandbookIndexPage.tsx
+++ b/app/javascript/components/pages/handbook/HandbookIndexPage.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+import { formatFutureDate } from '~/utils/dateUtils'
+import { useHandbookTree } from '~/hooks/useHandbookTree'
+import { HandbookLayout } from './HandbookLayout'
+import type { HandbookArticleSummary } from '~/types/handbook'
+
+const ACCENT = '#22d3ee'
+
+export const HandbookIndexPage: React.FC = () => {
+  const { tree, loading, error } = useHandbookTree()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [recent, setRecent] = useState<HandbookArticleSummary[]>([])
+
+  useEffect(() => {
+    apiJson<HandbookArticleSummary[]>('/api/handbook/recent?limit=5')
+      .then(setRecent)
+      .catch(err => console.error('Failed to load recent handbook articles:', err))
+  }, [])
+
+  if (loading) {
+    return (
+      <HandbookLayout
+        sections={[]}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+      >
+        <LoadingSpinner message="Loading handbook..." color="cyan-168-text" size="large" />
+      </HandbookLayout>
+    )
+  }
+
+  if (error || !tree) {
+    return (
+      <HandbookLayout
+        sections={[]}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+      >
+        <div className="tui-window red-168 white-text">
+          <fieldset className="red-168-border">
+            <legend className="center">ERROR</legend>
+            <div style={{ padding: '30px', textAlign: 'center' }}>
+              <p>{error || 'Failed to load handbook.'}</p>
+            </div>
+          </fieldset>
+        </div>
+      </HandbookLayout>
+    )
+  }
+
+  const totalArticles = tree.sections.reduce((sum, s) => sum + s.articles.length, 0)
+
+  return (
+    <HandbookLayout
+      sections={tree.sections}
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+    >
+      <div className="tui-window cyan-168 white-text">
+        <fieldset className="cyan-168-border">
+          <legend className="center">HACKR HANDBOOK</legend>
+          <div style={{ padding: '30px', background: '#1a1a1a' }}>
+            <h1 style={{ margin: '0 0 12px 0', color: ACCENT, fontSize: '2em', fontFamily: 'monospace' }}>
+              Operator's Field Manual
+            </h1>
+            <p style={{ color: '#d0d0d0', marginBottom: '24px', lineHeight: 1.6 }}>
+              Practical documentation for using hackr.tv — THE PULSE GRID, WIRE, Uplink, Vault,
+              the terminal interface, and everything in between.{' '}
+              {totalArticles > 0 && (
+                <span style={{ color: '#888' }}>
+                  {tree.sections.length} sections · {totalArticles} articles
+                </span>
+              )}
+            </p>
+
+            {recent.length > 0 && (
+              <div
+                style={{
+                  background: '#0a0a0a',
+                  border: '1px solid #333',
+                  padding: '18px 20px',
+                  marginBottom: '32px'
+                }}
+              >
+                <h2 style={{ color: ACCENT, margin: '0 0 12px 0', fontSize: '0.95em', letterSpacing: '1px' }}>
+                  :: RECENTLY UPDATED ::
+                </h2>
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                  {recent.map(article => (
+                    <li key={article.slug} style={{ marginBottom: '6px' }}>
+                      <Link
+                        to={`/handbook/${article.slug}`}
+                        style={{ color: '#d0d0d0', textDecoration: 'none' }}
+                      >
+                        <span style={{ color: '#60a5fa' }}>{article.title}</span>
+                        {article.section && (
+                          <span style={{ color: '#666', fontSize: '0.85em' }}>
+                            {' '}— {article.section.name}
+                          </span>
+                        )}
+                        <span style={{ color: '#555', fontSize: '0.8em', marginLeft: '8px' }}>
+                          {formatFutureDate(article.updated_at)}
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <h2 style={{ color: ACCENT, margin: '0 0 16px 0', fontSize: '1em', letterSpacing: '1px' }}>
+              :: TABLE OF CONTENTS ::
+            </h2>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '18px' }}>
+              {tree.sections.map(section => (
+                <div
+                  key={section.slug}
+                  style={{ background: '#0a0a0a', border: '1px solid #333', padding: '16px 18px' }}
+                >
+                  <h3 style={{ margin: '0 0 6px 0', color: '#fff', fontSize: '1.1em' }}>
+                    {section.icon && (
+                      <span style={{ color: '#fbbf24', marginRight: '8px', fontFamily: 'monospace' }}>
+                        {section.icon}
+                      </span>
+                    )}
+                    {section.name}
+                  </h3>
+                  {section.summary && (
+                    <p style={{ color: '#888', fontSize: '0.88em', margin: '0 0 10px 0', lineHeight: 1.5 }}>
+                      {section.summary}
+                    </p>
+                  )}
+                  <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                    {section.articles.map(article => (
+                      <li key={article.slug} style={{ margin: '4px 0' }}>
+                        <Link
+                          to={`/handbook/${article.slug}`}
+                          style={{
+                            color: '#a0a0a0',
+                            textDecoration: 'none',
+                            fontSize: '0.9em',
+                            display: 'inline-block',
+                            padding: '2px 0'
+                          }}
+                        >
+                          {article.kind === 'tutorial' && (
+                            <span style={{ color: '#fbbf24', marginRight: '6px' }}>▶</span>
+                          )}
+                          <span style={{ color: '#60a5fa' }}>{article.title}</span>
+                          {article.difficulty && (
+                            <span
+                              style={{
+                                color: '#666',
+                                fontSize: '0.82em',
+                                marginLeft: '6px',
+                                textTransform: 'uppercase'
+                              }}
+                            >
+                              [{article.difficulty}]
+                            </span>
+                          )}
+                        </Link>
+                      </li>
+                    ))}
+                    {section.articles.length === 0 && (
+                      <li style={{ color: '#555', fontSize: '0.85em', fontStyle: 'italic' }}>
+                        No articles yet.
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </HandbookLayout>
+  )
+}

--- a/app/javascript/components/pages/handbook/HandbookLayout.tsx
+++ b/app/javascript/components/pages/handbook/HandbookLayout.tsx
@@ -1,0 +1,107 @@
+import React, { type ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { useMobileDetect } from '~/hooks/useMobileDetect'
+import { HandbookSidebar } from './HandbookSidebar'
+import type { HandbookSection } from '~/types/handbook'
+
+interface HandbookLayoutProps {
+  sections: HandbookSection[]
+  currentSectionSlug?: string
+  currentArticleSlug?: string
+  searchQuery: string
+  onSearchChange: (q: string) => void
+  children: ReactNode
+}
+
+export const HandbookLayout: React.FC<HandbookLayoutProps> = ({
+  sections,
+  currentSectionSlug,
+  currentArticleSlug,
+  searchQuery,
+  onSearchChange,
+  children
+}) => {
+  const { isDesktop } = useMobileDetect()
+
+  return (
+    <DefaultLayout showAsciiArt={false}>
+      <div
+        style={{
+          maxWidth: '1280px',
+          margin: '24px auto',
+          padding: '0 16px',
+          display: 'grid',
+          gridTemplateColumns: isDesktop ? '280px 1fr' : '1fr',
+          gap: '20px',
+          alignItems: 'start'
+        }}
+      >
+        {/* Sidebar: persistent left rail on desktop, top dropdown on mobile */}
+        <aside style={{ position: isDesktop ? 'sticky' : 'static', top: isDesktop ? '16px' : undefined }}>
+          {isDesktop ? (
+            <HandbookSidebar
+              sections={sections}
+              currentSectionSlug={currentSectionSlug}
+              currentArticleSlug={currentArticleSlug}
+              searchQuery={searchQuery}
+              onSearchChange={onSearchChange}
+            />
+          ) : (
+            <MobileSectionSelector
+              sections={sections}
+              currentSectionSlug={currentSectionSlug}
+              currentArticleSlug={currentArticleSlug}
+            />
+          )}
+        </aside>
+
+        <main>{children}</main>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+interface MobileSectionSelectorProps {
+  sections: HandbookSection[]
+  currentSectionSlug?: string
+  currentArticleSlug?: string
+}
+
+const MobileSectionSelector: React.FC<MobileSectionSelectorProps> = ({
+  sections,
+  currentArticleSlug
+}) => {
+  const navigate = useNavigate()
+  return (
+    <div style={{ background: '#0d0d0d', border: '1px solid #333', padding: '12px' }}>
+      <label
+        htmlFor="handbook-mobile-jump"
+        style={{ display: 'block', color: '#22d3ee', fontSize: '0.85em', fontWeight: 'bold', marginBottom: '6px' }}
+      >
+        JUMP TO ARTICLE
+      </label>
+      <select
+        id="handbook-mobile-jump"
+        value={currentArticleSlug || ''}
+        onChange={(e) => {
+          const slug = e.target.value
+          navigate(slug ? `/handbook/${slug}` : '/handbook')
+        }}
+        className="tui-input"
+        style={{ width: '100%', padding: '6px 8px', background: '#0a0a0a', color: '#d0d0d0', border: '1px solid #333' }}
+      >
+        <option value="">— Handbook Home —</option>
+        {sections.map(section => (
+          <optgroup key={section.slug} label={section.name}>
+            {section.articles.map(article => (
+              <option key={article.slug} value={article.slug}>
+                {article.kind === 'tutorial' ? '▶ ' : ''}{article.title}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/app/javascript/components/pages/handbook/HandbookSidebar.tsx
+++ b/app/javascript/components/pages/handbook/HandbookSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { HandbookSection } from '~/types/handbook'
 
@@ -20,29 +20,26 @@ export const HandbookSidebar: React.FC<HandbookSidebarProps> = ({
   searchQuery = '',
   onSearchChange
 }) => {
-  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() => {
-    const initial: Record<string, boolean> = {}
-    sections.forEach(s => {
-      initial[s.slug] = currentSectionSlug ? s.slug === currentSectionSlug : true
-    })
-    return initial
-  })
+  // Tracks ONLY explicit user toggles. Default open/closed state is derived
+  // during render from `currentSectionSlug`, so navigation between articles
+  // no longer needs an effect to "sync" the sidebar state.
+  const [userToggles, setUserToggles] = useState<Record<string, boolean>>({})
 
-  // Expand the section containing the current article whenever it changes
-  useEffect(() => {
-    if (!currentSectionSlug) return
-    setOpenSections(prev => ({ ...prev, [currentSectionSlug]: true }))
-  }, [currentSectionSlug])
+  const defaultOpen = (slug: string) =>
+    !currentSectionSlug || slug === currentSectionSlug
+
+  const isOpen = (slug: string) => userToggles[slug] ?? defaultOpen(slug)
 
   const toggle = (slug: string) => {
-    setOpenSections(prev => ({ ...prev, [slug]: !prev[slug] }))
+    setUserToggles(prev => ({ ...prev, [slug]: !(prev[slug] ?? defaultOpen(slug)) }))
   }
 
   const q = searchQuery.trim().toLowerCase()
   const hasQuery = q.length > 0
 
   const articleMatches = (section: HandbookSection, a: HandbookSection['articles'][number]) => {
-    const tags = (((a as unknown) as { metadata?: { search_tags?: string[] } }).metadata?.search_tags) || []
+    const rawTags = (a.metadata as { search_tags?: unknown })?.search_tags
+    const tags = Array.isArray(rawTags) ? rawTags.filter((t): t is string => typeof t === 'string') : []
     return (
       a.title.toLowerCase().includes(q) ||
       (a.summary || '').toLowerCase().includes(q) ||
@@ -108,7 +105,7 @@ export const HandbookSidebar: React.FC<HandbookSidebarProps> = ({
 
       <div>
         {filteredSections.map(({ section, matchingArticles }) => {
-          const isOpen = hasQuery ? true : (openSections[section.slug] ?? false)
+          const sectionOpen = hasQuery ? true : isOpen(section.slug)
           const isActiveSection = section.slug === currentSectionSlug
 
           return (
@@ -132,7 +129,7 @@ export const HandbookSidebar: React.FC<HandbookSidebarProps> = ({
                 }}
               >
                 <span style={{ color: MUTED, width: '10px', display: 'inline-block' }}>
-                  {isOpen ? '▾' : '▸'}
+                  {sectionOpen ? '▾' : '▸'}
                 </span>
                 {section.icon && (
                   <span style={{ color: '#fbbf24', fontFamily: 'monospace' }}>{section.icon}</span>
@@ -140,7 +137,7 @@ export const HandbookSidebar: React.FC<HandbookSidebarProps> = ({
                 <span>{section.name}</span>
               </button>
 
-              {isOpen && (
+              {sectionOpen && (
                 <ul style={{ listStyle: 'none', margin: 0, padding: '2px 0 2px 28px' }}>
                   {matchingArticles.map(article => {
                     const isActive = article.slug === currentArticleSlug

--- a/app/javascript/components/pages/handbook/HandbookSidebar.tsx
+++ b/app/javascript/components/pages/handbook/HandbookSidebar.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import type { HandbookSection } from '~/types/handbook'
+
+interface HandbookSidebarProps {
+  sections: HandbookSection[]
+  currentSectionSlug?: string
+  currentArticleSlug?: string
+  searchQuery?: string
+  onSearchChange?: (q: string) => void
+}
+
+const ACCENT = '#22d3ee'
+const MUTED = '#6b7280'
+
+export const HandbookSidebar: React.FC<HandbookSidebarProps> = ({
+  sections,
+  currentSectionSlug,
+  currentArticleSlug,
+  searchQuery = '',
+  onSearchChange
+}) => {
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {}
+    sections.forEach(s => {
+      initial[s.slug] = currentSectionSlug ? s.slug === currentSectionSlug : true
+    })
+    return initial
+  })
+
+  // Expand the section containing the current article whenever it changes
+  useEffect(() => {
+    if (!currentSectionSlug) return
+    setOpenSections(prev => ({ ...prev, [currentSectionSlug]: true }))
+  }, [currentSectionSlug])
+
+  const toggle = (slug: string) => {
+    setOpenSections(prev => ({ ...prev, [slug]: !prev[slug] }))
+  }
+
+  const q = searchQuery.trim().toLowerCase()
+  const hasQuery = q.length > 0
+
+  const articleMatches = (section: HandbookSection, a: HandbookSection['articles'][number]) => {
+    const tags = (((a as unknown) as { metadata?: { search_tags?: string[] } }).metadata?.search_tags) || []
+    return (
+      a.title.toLowerCase().includes(q) ||
+      (a.summary || '').toLowerCase().includes(q) ||
+      section.name.toLowerCase().includes(q) ||
+      tags.some(t => t.toLowerCase().includes(q))
+    )
+  }
+
+  const filteredSections = sections
+    .map(section => ({
+      section,
+      matchingArticles: hasQuery
+        ? section.articles.filter(a => articleMatches(section, a))
+        : section.articles
+    }))
+    .filter(({ matchingArticles }) => !hasQuery || matchingArticles.length > 0)
+
+  return (
+    <nav
+      aria-label="Handbook navigation"
+      style={{
+        background: '#0d0d0d',
+        border: '1px solid #333',
+        padding: '16px',
+        color: '#d0d0d0'
+      }}
+    >
+      <div style={{ marginBottom: '14px' }}>
+        <Link
+          to="/handbook"
+          style={{
+            display: 'block',
+            color: ACCENT,
+            textDecoration: 'none',
+            fontWeight: 'bold',
+            fontSize: '1.1em',
+            marginBottom: '4px'
+          }}
+        >
+          HACKR HANDBOOK
+        </Link>
+        <div style={{ color: MUTED, fontSize: '0.8em' }}>Operator's field manual</div>
+      </div>
+
+      {onSearchChange && (
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search articles..."
+          className="tui-input"
+          style={{
+            width: '100%',
+            padding: '6px 8px',
+            marginBottom: '14px',
+            background: '#0a0a0a',
+            color: '#d0d0d0',
+            border: '1px solid #333',
+            fontSize: '0.9em'
+          }}
+        />
+      )}
+
+      <div>
+        {filteredSections.map(({ section, matchingArticles }) => {
+          const isOpen = hasQuery ? true : (openSections[section.slug] ?? false)
+          const isActiveSection = section.slug === currentSectionSlug
+
+          return (
+            <div key={section.slug} style={{ marginBottom: '6px' }}>
+              <button
+                onClick={() => toggle(section.slug)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: '6px 4px',
+                  width: '100%',
+                  textAlign: 'left',
+                  color: isActiveSection ? ACCENT : '#d0d0d0',
+                  fontFamily: 'inherit',
+                  fontSize: '0.95em',
+                  fontWeight: 'bold',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px'
+                }}
+              >
+                <span style={{ color: MUTED, width: '10px', display: 'inline-block' }}>
+                  {isOpen ? '▾' : '▸'}
+                </span>
+                {section.icon && (
+                  <span style={{ color: '#fbbf24', fontFamily: 'monospace' }}>{section.icon}</span>
+                )}
+                <span>{section.name}</span>
+              </button>
+
+              {isOpen && (
+                <ul style={{ listStyle: 'none', margin: 0, padding: '2px 0 2px 28px' }}>
+                  {matchingArticles.map(article => {
+                    const isActive = article.slug === currentArticleSlug
+                    return (
+                      <li key={article.slug} style={{ margin: '2px 0' }}>
+                        <Link
+                          to={`/handbook/${article.slug}`}
+                          style={{
+                            display: 'block',
+                            padding: '4px 8px',
+                            textDecoration: 'none',
+                            color: isActive ? '#fff' : '#a0a0a0',
+                            background: isActive ? 'rgba(34, 211, 238, 0.15)' : 'transparent',
+                            borderLeft: isActive ? `3px solid ${ACCENT}` : '3px solid transparent',
+                            fontSize: '0.88em',
+                            lineHeight: '1.4'
+                          }}
+                        >
+                          {article.kind === 'tutorial' && (
+                            <span style={{ color: '#fbbf24', fontSize: '0.75em', marginRight: '6px' }}>
+                              ▶
+                            </span>
+                          )}
+                          {article.title}
+                        </Link>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+          )
+        })}
+
+        {hasQuery && filteredSections.length === 0 && (
+          <div style={{ color: MUTED, padding: '10px 4px', fontSize: '0.85em', fontStyle: 'italic' }}>
+            No articles match "{searchQuery}".
+          </div>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/app/javascript/components/shared/MarkdownContent.tsx
+++ b/app/javascript/components/shared/MarkdownContent.tsx
@@ -1,0 +1,149 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import { transformMarkdownLinks } from '~/utils/codexLinks'
+import { useCodexMappings } from '~/hooks/useCodexMappings'
+
+// Paths that are served directly by Rails (not by the React SPA) and must
+// trigger a full-page navigation rather than a client-side route change.
+// Keep this list small — it exists only for cross-boundary links from
+// markdown content. Add a path here if an article needs to link to it and
+// the SPA would otherwise 404.
+const RAILS_ONLY_PATHS = [
+  '/terminal',
+  '/root'
+]
+
+const isRailsOnlyPath = (href: string) =>
+  RAILS_ONLY_PATHS.some(p => href === p || href.startsWith(p + '/') || href.startsWith(p + '?'))
+
+interface MarkdownContentProps {
+  content: string
+  accentColor?: string
+}
+
+export const MarkdownContent: React.FC<MarkdownContentProps> = ({
+  content,
+  accentColor = '#22d3ee'
+}) => {
+  const { mappings } = useCodexMappings()
+
+  return (
+    <div style={{ color: '#e5e5e5', lineHeight: '1.8', fontSize: '1.05em' }}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeSanitize]}
+        components={{
+          h1: (props) => <h1 style={{ color: accentColor, marginTop: '30px', marginBottom: '15px', fontSize: '1.8em' }} {...props} />,
+          h2: (props) => <h2 style={{ color: accentColor, marginTop: '25px', marginBottom: '12px', fontSize: '1.5em' }} {...props} />,
+          h3: (props) => <h3 style={{ color: accentColor, marginTop: '20px', marginBottom: '10px', fontSize: '1.3em' }} {...props} />,
+          p: (props) => <p style={{ marginBottom: '15px' }} {...props} />,
+          a: ({ href, children, ...props }) => {
+            const linkStyle = {
+              display: 'inline' as const,
+              color: '#60a5fa',
+              textDecoration: 'none',
+              borderBottom: '1px solid #60a5fa',
+              transition: 'color 0.2s'
+            }
+            if (href && href.startsWith('/') && !isRailsOnlyPath(href)) {
+              return (
+                <Link
+                  to={href}
+                  style={linkStyle}
+                  onMouseEnter={(e) => e.currentTarget.style.color = '#93c5fd'}
+                  onMouseLeave={(e) => e.currentTarget.style.color = '#60a5fa'}
+                >
+                  {children}
+                </Link>
+              )
+            }
+            return (
+              <a
+                href={href}
+                style={linkStyle}
+                onMouseEnter={(e) => e.currentTarget.style.color = '#93c5fd'}
+                onMouseLeave={(e) => e.currentTarget.style.color = '#60a5fa'}
+                {...props}
+              >
+                {children}
+              </a>
+            )
+          },
+          ul: (props) => <ul style={{ marginLeft: '20px', marginBottom: '15px' }} {...props} />,
+          ol: (props) => <ol style={{ marginLeft: '20px', marginBottom: '15px' }} {...props} />,
+          li: (props) => <li style={{ marginBottom: '8px' }} {...props} />,
+          strong: (props) => <strong style={{ color: '#fff' }} {...props} />,
+          code: (props) => (
+            <code
+              style={{
+                background: '#0a0a0a',
+                padding: '2px 6px',
+                borderRadius: '3px',
+                fontFamily: 'monospace',
+                fontSize: '0.9em',
+                color: '#fbbf24'
+              }}
+              {...props}
+            />
+          ),
+          pre: (props) => (
+            <pre
+              style={{
+                background: '#0a0a0a',
+                padding: '15px',
+                borderRadius: '3px',
+                overflow: 'auto',
+                marginBottom: '15px',
+                border: '1px solid #333'
+              }}
+              {...props}
+            />
+          ),
+          table: (props) => (
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                marginBottom: '20px',
+                background: '#0a0a0a',
+                border: `1px solid ${accentColor}`
+              }}
+              {...props}
+            />
+          ),
+          thead: (props) => (
+            <thead style={{ background: accentColor, color: '#000' }} {...props} />
+          ),
+          th: (props) => (
+            <th
+              style={{
+                padding: '12px 15px',
+                textAlign: 'left',
+                fontWeight: 'bold',
+                borderBottom: `2px solid ${accentColor}`
+              }}
+              {...props}
+            />
+          ),
+          td: (props) => (
+            <td style={{ padding: '10px 15px', borderBottom: '1px solid #333' }} {...props} />
+          ),
+          tr: (props) => (
+            <tr
+              style={{ transition: 'background 0.2s' }}
+              onMouseEnter={(e) => e.currentTarget.style.background = '#1a1a1a'}
+              onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+              {...props}
+            />
+          )
+        }}
+      >
+        {transformMarkdownLinks(content, mappings)}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/app/javascript/hooks/useHandbookTree.ts
+++ b/app/javascript/hooks/useHandbookTree.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import type { HandbookTree } from '~/types/handbook'
+
+let cachedTree: HandbookTree | null = null
+let fetchPromise: Promise<HandbookTree> | null = null
+
+async function fetchHandbookTree (): Promise<HandbookTree> {
+  if (cachedTree !== null) return cachedTree
+  if (fetchPromise !== null) return fetchPromise
+
+  fetchPromise = apiJson<HandbookTree>('/api/handbook')
+    .then(data => {
+      cachedTree = data
+      fetchPromise = null
+      return data
+    })
+    .catch(err => {
+      fetchPromise = null
+      throw err
+    })
+
+  return fetchPromise
+}
+
+export function useHandbookTree () {
+  const [tree, setTree] = useState<HandbookTree | null>(() => cachedTree)
+  const [loading, setLoading] = useState(() => !cachedTree)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (cachedTree !== null) return
+
+    let mounted = true
+    fetchHandbookTree()
+      .then(data => {
+        if (mounted) {
+          setTree(data)
+          setLoading(false)
+        }
+      })
+      .catch(err => {
+        if (mounted) {
+          console.error('Failed to load handbook tree:', err)
+          setError(err?.message || 'Failed to load handbook')
+          setLoading(false)
+        }
+      })
+    return () => { mounted = false }
+  }, [])
+
+  return { tree, loading, error }
+}
+
+export function invalidateHandbookTree (): void {
+  cachedTree = null
+}

--- a/app/javascript/types/handbook.ts
+++ b/app/javascript/types/handbook.ts
@@ -10,6 +10,7 @@ export interface HandbookArticleSummary {
   summary: string | null
   position: number
   updated_at: string
+  metadata: Record<string, unknown>
   section?: { slug: string; name: string }
 }
 

--- a/app/javascript/types/handbook.ts
+++ b/app/javascript/types/handbook.ts
@@ -1,0 +1,49 @@
+export type HandbookKind = 'reference' | 'tutorial'
+export type HandbookDifficulty = 'beginner' | 'intermediate' | 'advanced'
+
+export interface HandbookArticleSummary {
+  id: number
+  slug: string
+  title: string
+  kind: HandbookKind
+  difficulty: HandbookDifficulty | null
+  summary: string | null
+  position: number
+  updated_at: string
+  section?: { slug: string; name: string }
+}
+
+export interface HandbookSection {
+  id: number
+  slug: string
+  name: string
+  icon: string | null
+  summary: string | null
+  position: number
+  articles: HandbookArticleSummary[]
+}
+
+export interface HandbookTree {
+  sections: HandbookSection[]
+}
+
+export interface HandbookArticle {
+  id: number
+  slug: string
+  title: string
+  kind: HandbookKind
+  difficulty: HandbookDifficulty | null
+  summary: string | null
+  body: string
+  metadata: Record<string, unknown>
+  position: number
+  updated_at: string
+  section: {
+    id: number
+    slug: string
+    name: string
+    icon: string | null
+  }
+  prev_article: { slug: string; title: string } | null
+  next_article: { slug: string; title: string } | null
+}

--- a/app/models/handbook_article.rb
+++ b/app/models/handbook_article.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: handbook_articles
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  body                :text
+#  difficulty          :string
+#  kind                :string           default("reference"), not null
+#  metadata            :json
+#  position            :integer          default(0), not null
+#  published           :boolean          default(TRUE), not null
+#  slug                :string           not null
+#  summary             :text
+#  title               :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  handbook_section_id :integer          not null
+#
+# Indexes
+#
+#  index_handbook_articles_on_handbook_section_id               (handbook_section_id)
+#  index_handbook_articles_on_handbook_section_id_and_position  (handbook_section_id,position)
+#  index_handbook_articles_on_kind                              (kind)
+#  index_handbook_articles_on_published                         (published)
+#  index_handbook_articles_on_slug                              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  handbook_section_id  (handbook_section_id => handbook_sections.id)
+#
+class HandbookArticle < ApplicationRecord
+  has_paper_trail
+
+  KINDS = %w[reference tutorial].freeze
+  DIFFICULTIES = %w[beginner intermediate advanced].freeze
+
+  belongs_to :handbook_section
+
+  validates :title, presence: true
+  validates :slug, presence: true, uniqueness: true,
+    format: {with: /\A[a-z0-9-]+\z/, message: "must be lowercase alphanumeric with hyphens"}
+  validates :kind, presence: true, inclusion: {in: KINDS}
+  validates :difficulty, inclusion: {in: DIFFICULTIES}, allow_blank: true
+  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  before_validation :generate_slug, if: -> { slug.blank? && title.present? }
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(position: :asc, title: :asc) }
+  scope :tutorials, -> { where(kind: "tutorial") }
+  scope :reference_kind, -> { where(kind: "reference") }
+  scope :recently_updated, -> { order(updated_at: :desc) }
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def generate_slug
+    self.slug = title.downcase.gsub(/[^a-z0-9\s-]/, "").gsub(/\s+/, "-").squeeze("-").strip
+  end
+end

--- a/app/models/handbook_article.rb
+++ b/app/models/handbook_article.rb
@@ -47,6 +47,12 @@ class HandbookArticle < ApplicationRecord
   before_validation :generate_slug, if: -> { slug.blank? && title.present? }
 
   scope :published, -> { where(published: true) }
+  # Visible to end users: article AND its section are both published. Use
+  # this for any reader-facing lookup; use `published` alone only when the
+  # section's visibility has already been enforced separately.
+  scope :visible, -> {
+    published.joins(:handbook_section).where(handbook_sections: {published: true})
+  }
   scope :ordered, -> { order(position: :asc, title: :asc) }
   scope :tutorials, -> { where(kind: "tutorial") }
   scope :reference_kind, -> { where(kind: "reference") }

--- a/app/models/handbook_section.rb
+++ b/app/models/handbook_section.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: handbook_sections
+# Database name: primary
+#
+#  id         :integer          not null, primary key
+#  icon       :string
+#  name       :string           not null
+#  position   :integer          default(0), not null
+#  published  :boolean          default(TRUE), not null
+#  slug       :string           not null
+#  summary    :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_handbook_sections_on_published               (published)
+#  index_handbook_sections_on_published_and_position  (published,position)
+#  index_handbook_sections_on_slug                    (slug) UNIQUE
+#
+class HandbookSection < ApplicationRecord
+  has_paper_trail
+
+  has_many :articles,
+    -> { ordered },
+    class_name: "HandbookArticle",
+    dependent: :destroy
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true,
+    format: {with: /\A[a-z0-9-]+\z/, message: "must be lowercase alphanumeric with hyphens"}
+  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  before_validation :generate_slug, if: -> { slug.blank? && name.present? }
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(position: :asc, name: :asc) }
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def generate_slug
+    self.slug = name.downcase.gsub(/[^a-z0-9\s-]/, "").gsub(/\s+/, "-").squeeze("-").strip
+  end
+end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -401,60 +401,60 @@ module Grid
         <span style='color: #22d3ee; font-weight: bold;'>Available Commands:</span>
 
         <span style='color: #fbbf24;'>Navigation:</span>
-          <span style='color: #34d399;'>look, l</span>                 - Look around the room
-          <span style='color: #34d399;'>go &lt;direction&gt;</span>          - Move in a direction
-          <span style='color: #34d399;'>north, n / south, s</span>     - Move north/south
-          <span style='color: #34d399;'>east, e / west, w</span>       - Move east/west
-          <span style='color: #34d399;'>up, u / down, d</span>         - Move up/down
+          <span style='color: #34d399;'>look, l</span>                   - Look around the room
+          <span style='color: #34d399;'>go &lt;direction&gt;</span>            - Move in a direction
+          <span style='color: #34d399;'>north, n / south, s</span>       - Move north/south
+          <span style='color: #34d399;'>east, e / west, w</span>         - Move east/west
+          <span style='color: #34d399;'>up, u / down, d</span>           - Move up/down
 
         <span style='color: #fbbf24;'>Items:</span>
-          <span style='color: #34d399;'>inventory, inv, i</span>       - View your inventory
-          <span style='color: #34d399;'>take &lt;item&gt;</span>             - Pick up an item
-          <span style='color: #34d399;'>drop &lt;item&gt;</span>             - Drop an item
-          <span style='color: #34d399;'>use &lt;item&gt;</span>              - Use an item
-          <span style='color: #34d399;'>salvage &lt;item&gt;</span>          - Break down an item for XP
-          <span style='color: #34d399;'>examine &lt;target&gt;, x</span>     - Examine item, NPC, or hackr
+          <span style='color: #34d399;'>inventory, inv, i</span>         - View your inventory
+          <span style='color: #34d399;'>take &lt;item&gt;</span>               - Pick up an item
+          <span style='color: #34d399;'>drop &lt;item&gt;</span>               - Drop an item
+          <span style='color: #34d399;'>use &lt;item&gt;</span>                - Use an item
+          <span style='color: #34d399;'>salvage &lt;item&gt;</span>            - Break down an item for XP
+          <span style='color: #34d399;'>examine &lt;target&gt;, x</span>       - Examine item, NPC, or hackr
 
         <span style='color: #fbbf24;'>NPCs:</span>
-          <span style='color: #34d399;'>talk &lt;npc&gt;</span>              - Talk to an NPC
-          <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span> - Ask an NPC about a topic
+          <span style='color: #34d399;'>talk &lt;npc&gt;</span>                - Talk to an NPC
+          <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>   - Ask an NPC about a topic
 
         <span style='color: #fbbf24;'>Commerce:</span>
-          <span style='color: #34d399;'>shop, browse</span>            - View vendor inventory &amp; prices
-          <span style='color: #34d399;'>buy &lt;item&gt;</span>              - Purchase an item from vendor
-          <span style='color: #34d399;'>sell &lt;item&gt;</span>             - Sell an item to vendor
+          <span style='color: #34d399;'>shop, browse</span>              - View vendor inventory &amp; prices
+          <span style='color: #34d399;'>buy &lt;item&gt;</span>                - Purchase an item from vendor
+          <span style='color: #34d399;'>sell &lt;item&gt;</span>               - Sell an item to vendor
 
         <span style='color: #fbbf24;'>Economy:</span>
-          <span style='color: #34d399;'>cache</span>                   - List your caches
-          <span style='color: #34d399;'>cache create</span>            - Create a new cache
-          <span style='color: #34d399;'>cache balance [addr]</span>    - Check balance
-          <span style='color: #34d399;'>cache history [addr]</span>    - Transaction history
-          <span style='color: #34d399;'>cache send &lt;amt&gt; &lt;to&gt; [from &lt;src&gt;] [memo &lt;text&gt;]</span> - Send CRED
-          <span style='color: #34d399;'>cache default &lt;addr&gt;</span>   - Set default cache
-          <span style='color: #34d399;'>cache name &lt;addr&gt; &lt;nick&gt;</span> - Nickname a cache
-          <span style='color: #34d399;'>cache abandon &lt;addr&gt;</span>   - Abandon a cache
+          <span style='color: #34d399;'>cache</span>                     - List your caches
+          <span style='color: #34d399;'>cache create</span>              - Create a new cache
+          <span style='color: #34d399;'>cache balance [addr]</span>      - Check balance
+          <span style='color: #34d399;'>cache history [addr]</span>      - Transaction history
+          <span style='color: #34d399;'>cache send &lt;amt&gt; &lt;to&gt;</span>     - Send CRED (opts: from &lt;src&gt;, memo &lt;text&gt;)
+          <span style='color: #34d399;'>cache default &lt;addr&gt;</span>      - Set default cache
+          <span style='color: #34d399;'>cache name &lt;addr&gt; &lt;nick&gt;</span>  - Nickname a cache
+          <span style='color: #34d399;'>cache abandon &lt;addr&gt;</span>      - Abandon a cache (WARNING: This is irreversible)
 
         <span style='color: #fbbf24;'>Ledger:</span>
-          <span style='color: #34d399;'>chain latest</span>            - Recent global transactions
-          <span style='color: #34d399;'>chain tx &lt;hash&gt;</span>         - Look up a transaction
-          <span style='color: #34d399;'>chain cache &lt;addr&gt;</span>     - Public history for a cache
-          <span style='color: #34d399;'>chain supply</span>            - CRED supply overview
+          <span style='color: #34d399;'>chain latest</span>              - Recent global transactions
+          <span style='color: #34d399;'>chain tx &lt;hash&gt;</span>           - Look up a transaction
+          <span style='color: #34d399;'>chain cache &lt;addr&gt;</span>        - Public history for a cache
+          <span style='color: #34d399;'>chain supply</span>              - CRED supply overview
 
         <span style='color: #fbbf24;'>Mining:</span>
-          <span style='color: #34d399;'>rig</span>                     - Mining rig status
-          <span style='color: #34d399;'>rig on / rig off</span>        - Toggle mining
-          <span style='color: #34d399;'>rig install &lt;item&gt;</span>     - Install component (rig must be off)
-          <span style='color: #34d399;'>rig uninstall &lt;item&gt;</span>   - Remove component (rig must be off)
-          <span style='color: #34d399;'>rig inspect</span>             - Detailed rig view
+          <span style='color: #34d399;'>rig</span>                       - Mining rig status
+          <span style='color: #34d399;'>rig on / rig off</span>          - Toggle mining
+          <span style='color: #34d399;'>rig install &lt;item&gt;</span>        - Install component (rig must be off)
+          <span style='color: #34d399;'>rig uninstall &lt;item&gt;</span>      - Remove component (rig must be off)
+          <span style='color: #34d399;'>rig inspect</span>               - Detailed rig view
 
         <span style='color: #fbbf24;'>Social:</span>
-          <span style='color: #34d399;'>say &lt;message&gt;</span>           - Say something in the room
-          <span style='color: #34d399;'>who</span>                     - See who's online
+          <span style='color: #34d399;'>say &lt;message&gt;</span>             - Say something in the room
+          <span style='color: #34d399;'>who</span>                       - See who's online
 
         <span style='color: #fbbf24;'>Operative:</span>
-          <span style='color: #34d399;'>stat, stats</span>             - View your operative profile
-          <span style='color: #34d399;'>clear, cls</span>              - Clear the screen
-          <span style='color: #34d399;'>help, ?</span>                 - Show this help message
+          <span style='color: #34d399;'>stat, stats</span>               - View your operative profile
+          <span style='color: #34d399;'>clear, cls</span>                - Clear the screen
+          <span style='color: #34d399;'>help, ?</span>                   - Show this help message
       HELP
     end
 

--- a/app/views/admin/handbook_articles/_form.html.erb
+++ b/app/views/admin/handbook_articles/_form.html.erb
@@ -1,0 +1,86 @@
+<%= form_with model: [:admin, article], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 0 0 15px 0;">[:: ARTICLE INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :handbook_section_id, "SECTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :handbook_section_id,
+          @sections.map { |s| [s.name, s.id] },
+          {}, class: "tui-input", style: "width: 100%;" %>
+    </div>
+
+    <div>
+      <%= f.label :title, "TITLE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :title, class: "tui-input", style: "width: 100%;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    <small style="color: #666;">Auto-generated from title if left blank. Globally unique across the handbook.</small>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :kind, "KIND", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :kind,
+          HandbookArticle::KINDS.map { |k| [k.titleize, k] },
+          {}, class: "tui-input", style: "width: 100%;" %>
+    </div>
+
+    <div>
+      <%= f.label :difficulty, "DIFFICULTY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :difficulty,
+          HandbookArticle::DIFFICULTIES.map { |d| [d.titleize, d] },
+          {include_blank: "—"}, class: "tui-input", style: "width: 100%;" %>
+      <small style="color: #666;">Optional. Useful for tutorials.</small>
+    </div>
+
+    <div>
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%;", min: 0 %>
+      <small style="color: #666;">Order within section.</small>
+    </div>
+
+    <div>
+      <%= f.label :published, class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" do %>
+        <%= f.check_box :published, style: "margin-right: 8px;" %> PUBLISHED
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :summary, "SUMMARY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :summary, class: "tui-input", style: "width: 100%; min-height: 60px;" %>
+    <small style="color: #666;">One-sentence hook shown in sidebar/landing.</small>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: BODY (MARKDOWN) ::]</h3>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.text_area :body, class: "tui-input", style: "width: 100%; min-height: 400px; font-family: monospace; font-size: 0.95em;" %>
+    <small style="color: #666;">
+      GFM markdown. Raw HTML allowed (sanitized on render). Use <code>[[Codex Entry]]</code> for Codex cross-references,
+      and <code>[link text](/handbook/other-slug)</code> for internal handbook links.
+    </small>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: METADATA (JSON) ::]</h3>
+
+  <div style="margin-bottom: 20px;">
+    <%= text_area_tag "handbook_article[metadata_json]",
+        (article.metadata.present? ? JSON.pretty_generate(article.metadata) : "{}"),
+        class: "tui-input", style: "width: 100%; font-family: monospace; min-height: 100px;" %>
+    <small style="color: #666;">JSON object. <code>search_tags</code> array is searched client-side (hidden from display). Example: <code>{"search_tags": ["cred", "mining", "rigs"]}</code></small>
+  </div>
+
+  <div style="margin-top: 30px; display: flex; gap: 10px;">
+    <%= f.submit article.persisted? ? "Save Article" : "Create Article",
+        class: "tui-button purple-168",
+        style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <%= link_to "Cancel", admin_handbook_articles_path,
+        class: "tui-button grey-168",
+        style: "padding: 10px 30px; font-size: 1.1em;" %>
+  </div>
+<% end %>

--- a/app/views/admin/handbook_articles/edit.html.erb
+++ b/app/views/admin/handbook_articles/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/articles :: EDIT "<%= @article.title %>"</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", article: @article %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_articles/index.html.erb
+++ b/app/views/admin/handbook_articles/index.html.erb
@@ -1,0 +1,89 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/articles :: ARTICLES</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
+        <%= link_to "+ New Article", new_admin_handbook_article_path(section_id: params[:section_id]), class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "← Sections", admin_handbook_sections_path, class: "tui-button cyan-168", style: "padding: 8px 20px;" %>
+        <span style="color: #666; margin: 0 5px;">|</span>
+        <%= link_to "All Sections", admin_handbook_articles_path, class: "tui-button", style: "padding: 6px 14px; font-size: 0.85em;" %>
+        <% @sections.each do |section| %>
+          <% active = params[:section_id].to_s == section.id.to_s %>
+          <%= link_to section.name,
+              admin_handbook_articles_path(section_id: section.id),
+              class: "tui-button #{active ? "cyan-168" : ""}",
+              style: "padding: 6px 14px; font-size: 0.85em;" %>
+        <% end %>
+      </div>
+
+      <% if @articles.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Section</th>
+                <th style="text-align: center;">Pos</th>
+                <th style="text-align: left;">Title</th>
+                <th style="text-align: left;">Slug</th>
+                <th style="text-align: center;">Kind</th>
+                <th style="text-align: center;">Difficulty</th>
+                <th style="text-align: center;">Published</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @articles.each do |article| %>
+                <tr>
+                  <td style="color: #c084fc;"><%= article.handbook_section.name %></td>
+                  <td style="text-align: center; color: #888;"><%= article.position %></td>
+                  <td class="cyan-255-text"><%= article.title %></td>
+                  <td style="color: #666; font-family: monospace;"><%= article.slug %></td>
+                  <td style="text-align: center;">
+                    <% if article.kind == "tutorial" %>
+                      <span class="yellow-168-text">TUTORIAL</span>
+                    <% else %>
+                      <span style="color: #888;">REFERENCE</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center; color: #888;"><%= article.difficulty.presence || "-" %></td>
+                  <td style="text-align: center;">
+                    <% if article.published? %>
+                      <span class="green-255-text">YES</span>
+                    <% else %>
+                      <span style="color: #444;">-</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_handbook_article_path(article), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= button_to "Delete", admin_handbook_article_path(article), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete article '#{article.title}'?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No handbook articles yet.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Admin Dashboard", admin_root_path, class: "tui-button cyan-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_articles/new.html.erb
+++ b/app/views/admin/handbook_articles/new.html.erb
@@ -1,0 +1,15 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/articles :: NEW ARTICLE</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", article: @article %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_sections/_form.html.erb
+++ b/app/views/admin/handbook_sections/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_with model: [:admin, section], local: true do |f| %>
+  <div style="margin-bottom: 15px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+    <small style="color: #666;">Auto-generated from name if left blank. Lowercase, hyphens only.</small>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :icon, "ICON", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :icon, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Short text/emoji (e.g. &gt;&gt;, %%, F, ⚡)</small>
+    </div>
+
+    <div style="flex: 1;">
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+    </div>
+
+    <div style="flex: 1;">
+      <%= f.label :published, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :published, style: "margin-right: 8px;" %> PUBLISHED
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :summary, "SUMMARY", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_area :summary, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+    <small style="color: #666;">Short description for the section landing/header.</small>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit section.persisted? ? "Save Section" : "Create Section", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_handbook_sections_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  </div>
+<% end %>

--- a/app/views/admin/handbook_sections/edit.html.erb
+++ b/app/views/admin/handbook_sections/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/sections :: EDIT "<%= @section.name %>"</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", section: @section %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_sections/index.html.erb
+++ b/app/views/admin/handbook_sections/index.html.erb
@@ -1,0 +1,73 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/sections :: SECTIONS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
+        <%= link_to "+ New Section", new_admin_handbook_section_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "Articles →", admin_handbook_articles_path, class: "tui-button cyan-168", style: "padding: 8px 20px;" %>
+      </div>
+
+      <% if @sections.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Pos</th>
+                <th style="text-align: left;">Icon</th>
+                <th style="text-align: left;">Name</th>
+                <th style="text-align: left;">Slug</th>
+                <th style="text-align: center;">Articles</th>
+                <th style="text-align: center;">Published</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @sections.each do |section| %>
+                <tr>
+                  <td style="text-align: center; color: #888;"><%= section.position %></td>
+                  <td style="color: #fbbf24; font-family: monospace;"><%= section.icon %></td>
+                  <td class="cyan-255-text"><%= section.name %></td>
+                  <td style="color: #666; font-family: monospace;"><%= section.slug %></td>
+                  <td style="text-align: center; color: #888;"><%= section.articles.size %></td>
+                  <td style="text-align: center;">
+                    <% if section.published? %>
+                      <span class="green-255-text">YES</span>
+                    <% else %>
+                      <span style="color: #444;">-</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Articles", admin_handbook_articles_path(section_id: section.id), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "Edit", edit_admin_handbook_section_path(section), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_handbook_section_path(section), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete section '#{section.name}' and all #{section.articles.size} articles?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No handbook sections yet.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Admin Dashboard", admin_root_path, class: "tui-button cyan-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_sections/new.html.erb
+++ b/app/views/admin/handbook_sections/new.html.erb
@@ -1,0 +1,15 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/handbook/sections :: NEW SECTION</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", section: @section %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -52,9 +52,6 @@
       <% if current_hackr %>
         <span style="color: #888;">Logged in as:</span>
         <span class="purple-168-text"><%= current_hackr.hackr_alias %></span>
-        <% if current_hackr.admin? %>
-          <span class="red-255-text">[ADMIN]</span>
-        <% end %>
       <% end %>
     </div>
 
@@ -71,6 +68,13 @@
       </div>
       <%= link_to "Logs", admin_hackr_logs_path, class: "cyan-168-text", style: "text-decoration: none;" %>
       <%= link_to "Codex", admin_codex_entries_path, class: "cyan-168-text", style: "text-decoration: none;" %>
+      <div class="admin-nav-dropdown">
+        <span class="admin-nav-dropdown-trigger cyan-168-text">Handbook</span>
+        <div class="admin-nav-dropdown-menu">
+          <%= link_to "Sections", admin_handbook_sections_path, class: "cyan-168-text" %>
+          <%= link_to "Articles", admin_handbook_articles_path, class: "cyan-168-text" %>
+        </div>
+      </div>
       <%= link_to "Streams", admin_hackr_streams_path, class: "green-255-text", style: "text-decoration: none;" %>
       <%= link_to "PulseWire", admin_pulse_wire_index_path, class: "purple-168-text", style: "text-decoration: none;" %>
       <%= link_to "Uplink", admin_uplink_index_path, class: "purple-168-text", style: "text-decoration: none;" %>
@@ -86,7 +90,7 @@
       </div>
       <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text", style: "text-decoration: none;" %>
       <span style="color: #333;">|</span>
-      <%= link_to "← Exit Admin", root_path, class: "red-168-text", style: "text-decoration: none;" %>
+      <%= link_to "← Exit", root_path, class: "red-168-text", style: "text-decoration: none;" %>
     </nav>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,12 @@ Rails.application.routes.draw do
     get ":slug", to: "pages#spa_root", as: :codex_entry
   end
 
+  # Handbook (practical docs for GridHackr users) - SPA
+  scope "handbook" do
+    get "/", to: "pages#spa_root", as: :handbook
+    get ":slug", to: "pages#spa_root", as: :handbook_article
+  end
+
   # PulseWire routes - SPA
   scope "wire" do
     get "/", to: "pages#spa_root", as: :wire
@@ -119,6 +125,11 @@ Rails.application.routes.draw do
     get "codex/mappings", to: "codex#mappings"
     get "codex", to: "codex#index"
     get "codex/:slug", to: "codex#show"
+
+    get "handbook/mappings", to: "handbook#mappings"
+    get "handbook/recent", to: "handbook#recent"
+    get "handbook", to: "handbook#index"
+    get "handbook/:slug", to: "handbook#show"
     get "radio_stations", to: "radio#index"
     get "radio_stations/:id/playlists", to: "radio#station_playlists"
     get "hackr_stream", to: "hackr_streams#show"
@@ -264,6 +275,10 @@ Rails.application.routes.draw do
       end
     end
     resources :grid_shop_transactions, only: [:index]
+
+    # Hackr Handbook (docs — full CRUD, YAML-seedable)
+    resources :handbook_sections
+    resources :handbook_articles
 
     # PulseWire moderation (still functional - runtime operations)
     resources :pulse_wire, only: %i[index destroy] do

--- a/data/content/handbook.yml
+++ b/data/content/handbook.yml
@@ -1,0 +1,430 @@
+# Hackr Handbook - practical docs for GridHackr users.
+# Two-level hierarchy: sections contain articles.
+# Markdown body. [[Codex Slug]] links to Codex entries. Internal
+# links: [link text](/handbook/other-slug).
+# Re-running `rails data:handbook` upserts by slug (YAML wins). Admin-
+# created articles/sections not present here are preserved.
+handbook_sections:
+  - slug: getting-started
+    name: Getting Started
+    icon: ">>"
+    position: 0
+    published: true
+    summary: "Orientation for new operatives — what the Grid is, how to log in, and where to go first."
+    articles:
+      - slug: welcome-to-the-handbook
+        title: Welcome to the Handbook
+        kind: reference
+        position: 0
+        published: true
+        summary: "What the Hackr Handbook is and how to use it."
+        metadata:
+          search_tags:
+            - welcome
+            - intro
+            - handbook
+        body: |
+          # Welcome to the Hackr Handbook
+
+          The Handbook is the operator's field manual for hackr.tv. It covers the
+          tools you'll use day-to-day: **THE PULSE GRID**, **WIRE**, **Uplink**,
+          the **Vault**, the **Terminal interface**, and everything in between.
+
+          ## How it's organized
+
+          - **Reference** pages describe a system — what it is, what the commands do, how the rules work.
+          - **Tutorials** walk you through doing something end-to-end. Follow them in order.
+
+          Use the sidebar on the left to browse by section. Use the search box at
+          the top to jump straight to an article by title or tag.
+
+          ## Where to start
+
+          - New to the Grid? Read [Your First Connection](/handbook/first-connection).
+          - Looking up a command? Start with [GRID Terminal Basics](/handbook/grid-terminal-basics).
+          - Hunting for context instead of mechanics? That's the [Codex](/codex), not the Handbook.
+      - slug: first-connection
+        title: Your First Connection
+        kind: tutorial
+        difficulty: beginner
+        position: 1
+        published: true
+        summary: "What to do in your first session in-Grid — orientation, core commands, finding your bearings."
+        metadata:
+          search_tags:
+            - onboarding
+            - first session
+            - orientation
+        body: |
+          # Your First Connection
+
+          You're in. Now what?
+
+          This walkthrough gets a brand-new operative oriented in their first
+          session on the Grid.
+
+          ## 1. Get your bearings
+
+          Type `look` to see a description of your current room — where you
+          are, what's around you, who else is here, and which directions you
+          can go.
+
+          ## 2. See the command list
+
+          Type `help`. The terminal will list the commands available to you.
+          Most take simple arguments. For example, `go north`, `examine Codec`,
+          `take card`.
+
+          ## 3. Check your profile
+
+          Type `stat` (or `st`). This shows your XP, clearance, vitals, and
+          your CRED balance. You won't have much yet - it's in your hands to change that.
+
+          ## 4. Move through an exit
+
+          Pick one of the exits from your `look` output and type
+          `go <direction>`. Keep exploring. Unfamiliar rooms are the point.
+
+          ## 5. Talk to people
+
+          If there's a character (mob) in the room, `talk <name>` will start a
+          conversation. Some of them have useful things to tell you. Some of
+          them don't.
+
+          ## Next step
+
+          Read [What is THE PULSE GRID?](/handbook/pulse-grid-overview) for a
+          high-level tour of the systems you'll be interacting with from here
+          on.
+
+  - slug: pulse-grid
+    name: THE PULSE GRID
+    icon: "#"
+    position: 1
+    published: true
+    summary: "The MUD. Rooms, items, commands, clearance, CRED, and everything the operative does in the Grid."
+    articles:
+      - slug: pulse-grid-overview
+        title: What is THE PULSE GRID?
+        kind: reference
+        position: 0
+        published: true
+        summary: "High-level tour of the MUD and its core loops."
+        metadata:
+          search_tags:
+            - grid
+            - mud
+            - overview
+        body: |
+          # THE PULSE GRID
+
+          THE PULSE GRID is the text-based MUD at the heart of hackr.tv.
+          Operatives move between rooms, interact with mobs, collect items,
+          mine [[CRED]], and unlock progression.
+
+          ## Core loops
+
+          - **Explore** — move through zones and rooms with `go`, `look`, `examine`.
+          - **Interact** — `talk`, `take`, `use`, `salvage`.
+          - **Progress** — earn XP, raise your clearance, unlock new zones and commands.
+          - **Trade** — `shop` at vendors, `buy` and `sell` items.
+
+          Read the individual articles in this section for detail on each loop.
+      - slug: clearance-levels
+        title: Clearance Levels
+        kind: reference
+        position: 1
+        published: true
+        summary: "How clearance works and what higher tiers unlock."
+        metadata:
+          search_tags:
+            - clearance
+            - xp
+            - leveling
+        body: |
+          # Clearance Levels
+
+          Your **clearance level** (CL) is your standing in the Grid. It rises
+          as you earn XP. Higher clearance opens doors — literally and
+          figuratively.
+
+          ## What clearance gates
+
+          - **Zones and rooms.** Some parts of the Grid refuse entry until
+            you've earned your way in. If you get bounced at a threshold,
+            you're not cleared yet — come back later.
+          - **Vendors and listings.** Certain shops, and certain items within
+            shops, require a minimum clearance.
+          - **Commands.** A handful of commands only become available once
+            you've climbed high enough.
+
+          ## Pacing
+
+          Early levels come fast. Later ones don't. Don't expect the curve to
+          feel the same at CL3 as it does at CL30.
+
+          Check your current CL any time with `stat`.
+
+  - slug: wire
+    name: WIRE
+    icon: "~"
+    position: 2
+    published: true
+    summary: "Asynchronous broadcast feed — post pulses, echo what you agree with, signal drops."
+    articles:
+      - slug: wire-overview
+        title: WIRE — Broadcast Feed
+        kind: reference
+        position: 0
+        published: true
+        summary: "What WIRE is and how the pulse/echo model works."
+        metadata:
+          search_tags:
+            - wire
+            - pulses
+            - echoes
+            - social
+        body: |
+          # WIRE
+
+          WIRE is the asynchronous broadcast feed at `/wire`. Think of it as the
+          operative bulletin board: short messages (**pulses**) and their
+          amplifications (**echoes**).
+
+          ## Pulses
+
+          A pulse is a short broadcast — markdown-friendly, visible to all
+          operatives. Post from the web UI or via terminal command.
+
+          ## Echoes
+
+          An echo amplifies someone else's pulse onto your timeline. Similar to
+          a repost, but with optional commentary.
+
+          ## Signal drops
+
+          Moderators can **signal drop** a pulse to remove it from public
+          view. If your own pulse gets dropped, you'll be notified.
+
+  - slug: uplink
+    name: Uplink
+    icon: "@"
+    position: 3
+    published: true
+    summary: "Real-time operative chat channels. Use during livestreams and for coordination."
+    articles:
+      - slug: uplink-overview
+        title: Uplink — Real-Time Channels
+        kind: reference
+        position: 0
+        published: true
+        summary: "Channel model, moderation, livestream integration."
+        metadata:
+          search_tags:
+            - uplink
+            - chat
+            - livestream
+        body: |
+          # Uplink
+
+          Uplink is the real-time chat layer at `/uplink`. Operatives join
+          channels, send packets (messages), and coordinate in the moment —
+          especially during livestreams.
+
+          ## Channels
+
+          Channels are organized around topics or streams. Some are open, some
+          are clearance-gated.
+
+          ## Livestream popout
+
+          `/uplink/popout` gives a chromeless chat overlay for use on stream —
+          the only Uplink route that's publicly viewable.
+
+  - slug: vault
+    name: Vault
+    icon: "$"
+    position: 4
+    published: true
+    summary: "Your personal music repository — releases you've unlocked and tracks you can play anywhere."
+    articles:
+      - slug: vault-overview
+        title: Vault — Your Music Repository
+        kind: reference
+        position: 0
+        published: true
+        summary: "What lives in the Vault, how unlocks work, where to find it."
+        metadata:
+          search_tags:
+            - vault
+            - music
+            - releases
+        body: |
+          # Vault
+
+          The Vault (at [`/vault`](/vault)) is the personal music archive for operatives
+          — releases and tracks you've collected, bookmarked, or had granted
+          to you.
+
+          Access the Vault any time from the `hackr.fm` nav dropdown.
+
+  - slug: terminal
+    name: Terminal Interfaces
+    icon: "%"
+    position: 5
+    published: true
+    summary: "Command syntax reference for the in-Grid terminal."
+    articles:
+      - slug: grid-terminal-basics
+        title: GRID Terminal Basics
+        kind: reference
+        position: 0
+        published: true
+        summary: "Common commands: look, go, take, examine, help."
+        metadata:
+          search_tags:
+            - commands
+            - terminal
+            - help
+        body: |
+          # GRID Terminal Basics
+
+          Inside THE PULSE GRID, you interact by typing commands. The terminal
+          parses the first word as the command and the rest as arguments.
+
+          ## Core commands
+
+          | Command | Purpose |
+          |---------|---------|
+          | `look` | Describe the current room |
+          | `go <dir>` | Move through an exit |
+          | `examine <target>` | Inspect a mob, item, or operative |
+          | `take <item>` | Pick up an item |
+          | `inventory` / `inv` | Show your carried items |
+          | `stat` | Show XP, clearance, vitals, CRED |
+          | `help` | List available commands |
+
+          Commands are case-insensitive. Most have short aliases — `inv` for
+          `inventory`, `st` for `stat`.
+
+          ## Not using the web client?
+
+          If you prefer a native terminal, see
+          [SSH Terminal Access](/handbook/ssh-terminal-access) — same command
+          parser, different front door.
+      - slug: ssh-terminal-access
+        title: SSH Terminal Access
+        kind: reference
+        position: 1
+        published: true
+        summary: "Connect to hackr.tv from a native terminal over SSH. Rotating credentials at /terminal."
+        metadata:
+          search_tags:
+            - ssh
+            - terminal
+            - access
+            - credentials
+            - mudlet
+        body: |
+          # SSH Terminal Access
+
+          hackr.tv can be accessed from a native terminal over SSH, separate
+          from the web client. Some operatives prefer it — native keybinds,
+          tmux/screen sessions, scrollback, and no browser chrome.
+
+          ## Get the Network credentials
+
+          Visit [`/terminal`](/terminal) to see the current connection
+          command and password. Credentials rotate daily, so check back when
+          your session expires.
+
+          ## Connect
+
+          From any terminal:
+
+          ```
+          ssh access@terminal.hackr.tv -p 9915
+          ```
+
+          Enter the password from the `/terminal` page when prompted.
+
+          ## Compatible clients
+
+          Anything that speaks SSH will work. Common choices:
+
+          - **Linux / BSD** — your shell of choice (bash, zsh, fish, ksh, sh) in any emulator
+          - **macOS** — Terminal.app, Kitty, Ghostty, iTerm2
+          - **Windows** — Windows Terminal, Tabby, mRemoteNG, PuTTY
+          - **Mobile** — Termux (Android), a-Shell or Blink (iOS)
+          - **MUD-aware** — Mudlet, TinTin++, MUSHclient
+
+          MUD clients give you the nicest experience for the in-Grid
+          interface — triggers, aliases, logging, and highlighted output.
+
+          ## Inside the session
+
+          Once connected, you will have general hackr access. To connect to THE
+          PULSE GRID, you'll need to log in with your operative credentials. At
+          that point, you can access THE PULSE GRID where you will be at the
+          same command parser described in
+          [GRID Terminal Basics](/handbook/grid-terminal-basics). All the  same
+          commands work.
+
+          ## Why rotating credentials?
+
+          The daily rotation is a soft barrier, not a secret. The purpose is
+          to keep the endpoint public-ish (anyone who visits the web can
+          connect) without giving bots a permanent handle.
+
+  - slug: tutorials
+    name: Tutorials
+    icon: ">"
+    position: 6
+    published: true
+    summary: "Step-by-step walkthroughs. Follow them in order to learn a full subsystem end-to-end."
+    articles:
+      - slug: tutorial-mine-your-first-cred
+        title: Mine Your First CRED
+        kind: tutorial
+        difficulty: beginner
+        position: 0
+        published: true
+        summary: "Provision a mining rig, install components, and earn your first CRED."
+        metadata:
+          search_tags:
+            - cred
+            - mining
+            - tutorial
+            - rigs
+        body: |
+          # Mine Your First CRED
+
+          CRED is the currency of THE PULSE GRID. You earn it by running a
+          mining rig. This tutorial gets you from zero to mining.
+
+          ## 1. Check your provisioning
+
+          Log in and run `rig`. If you see a rig, you're already provisioned.
+          If not, check `help` for the provisioning command.
+
+          ## 2. Inspect your rig
+
+          `rig inspect` shows your motherboard slots and what's installed.
+
+          ## 3. Turn the rig on
+
+          `rig on` — your rig starts working and will accrue CRED over time.
+
+          ## 4. Check your cache
+
+          `cache` lists your wallets. The default one receives mining rewards.
+
+          ## 5. Boost while streaming
+
+          Watching `#live` during an active stream boosts your mining rate
+          and earns a chat bonus on top. Showing up pays off.
+
+          ## Next step
+
+          Read [Clearance Levels](/handbook/clearance-levels) to understand
+          how progression works.

--- a/db/migrate/20260412120001_create_handbook_sections.rb
+++ b/db/migrate/20260412120001_create_handbook_sections.rb
@@ -1,0 +1,18 @@
+class CreateHandbookSections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :handbook_sections do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :icon
+      t.text :summary
+      t.integer :position, default: 0, null: false
+      t.boolean :published, default: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :handbook_sections, :slug, unique: true
+    add_index :handbook_sections, :published
+    add_index :handbook_sections, [:published, :position]
+  end
+end

--- a/db/migrate/20260412120002_create_handbook_articles.rb
+++ b/db/migrate/20260412120002_create_handbook_articles.rb
@@ -1,0 +1,23 @@
+class CreateHandbookArticles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :handbook_articles do |t|
+      t.references :handbook_section, null: false, foreign_key: true, index: true
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.string :kind, default: "reference", null: false
+      t.string :difficulty
+      t.text :summary
+      t.text :body
+      t.integer :position, default: 0, null: false
+      t.boolean :published, default: true, null: false
+      t.json :metadata, default: {}
+
+      t.timestamps
+    end
+
+    add_index :handbook_articles, :slug, unique: true
+    add_index :handbook_articles, :kind
+    add_index :handbook_articles, :published
+    add_index :handbook_articles, [:handbook_section_id, :position]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -420,6 +420,40 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_000002) do
     t.index ["artist_id"], name: "index_hackr_streams_on_artist_id"
   end
 
+  create_table "handbook_articles", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "difficulty"
+    t.integer "handbook_section_id", null: false
+    t.string "kind", default: "reference", null: false
+    t.json "metadata", default: {}
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: true, null: false
+    t.string "slug", null: false
+    t.text "summary"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["handbook_section_id", "position"], name: "index_handbook_articles_on_handbook_section_id_and_position"
+    t.index ["handbook_section_id"], name: "index_handbook_articles_on_handbook_section_id"
+    t.index ["kind"], name: "index_handbook_articles_on_kind"
+    t.index ["published"], name: "index_handbook_articles_on_published"
+    t.index ["slug"], name: "index_handbook_articles_on_slug", unique: true
+  end
+
+  create_table "handbook_sections", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "icon"
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: true, null: false
+    t.string "slug", null: false
+    t.text "summary"
+    t.datetime "updated_at", null: false
+    t.index ["published", "position"], name: "index_handbook_sections_on_published_and_position"
+    t.index ["published"], name: "index_handbook_sections_on_published"
+    t.index ["slug"], name: "index_handbook_sections_on_slug", unique: true
+  end
+
   create_table "moderation_logs", force: :cascade do |t|
     t.string "action", null: false
     t.integer "actor_id", null: false
@@ -783,6 +817,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_000002) do
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "hackr_logs", "grid_hackrs"
   add_foreign_key "hackr_streams", "artists"
+  add_foreign_key "handbook_articles", "handbook_sections"
   add_foreign_key "moderation_logs", "chat_messages"
   add_foreign_key "moderation_logs", "grid_hackrs", column: "actor_id"
   add_foreign_key "moderation_logs", "grid_hackrs", column: "target_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -197,8 +197,8 @@ namespace :data do
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
 
-  desc "Load content (codex, hackr_logs, wire)"
-  task content: [:codex, :hackr_logs, :wire]
+  desc "Load content (codex, hackr_logs, wire, handbook)"
+  task content: [:codex, :hackr_logs, :wire, :handbook]
 
   desc "Load overlays"
   task overlays: [
@@ -932,7 +932,7 @@ namespace :data do
         metadata: attrs["metadata"]
       )
 
-      if entry.changed? || attrs["metadata"].present?
+      if entry.changed?
         entry.save!
         was_new ? (created += 1) : (updated += 1)
         puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{entry.name} (#{entry.entry_type})"
@@ -940,6 +940,68 @@ namespace :data do
     end
 
     puts "Codex Entries: #{created} created, #{updated} updated, #{CodexEntry.count} total"
+  end
+
+  desc "Load handbook sections and articles from YAML"
+  task handbook: :environment do
+    puts "\n--- Loading Handbook ---"
+    yaml_file = Rails.root.join("data", "content", "handbook.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    sections_data = data["handbook_sections"] || []
+
+    sections_created = sections_updated = 0
+    articles_created = articles_updated = 0
+
+    sections_data.each do |section_attrs|
+      section = HandbookSection.find_or_initialize_by(slug: section_attrs["slug"])
+      was_new = section.new_record?
+
+      section.assign_attributes(
+        name: section_attrs["name"],
+        icon: section_attrs["icon"],
+        summary: section_attrs["summary"],
+        position: section_attrs["position"] || 0,
+        published: section_attrs.fetch("published", true)
+      )
+
+      if section.changed?
+        section.save!
+        was_new ? (sections_created += 1) : (sections_updated += 1)
+        puts "  #{was_new ? "✓ Created" : "↻ Updated"} section: #{section.name}"
+      end
+
+      (section_attrs["articles"] || []).each do |article_attrs|
+        article = HandbookArticle.find_or_initialize_by(slug: article_attrs["slug"])
+        article_was_new = article.new_record?
+
+        article.assign_attributes(
+          handbook_section: section,
+          title: article_attrs["title"],
+          kind: article_attrs["kind"] || "reference",
+          difficulty: article_attrs["difficulty"],
+          summary: article_attrs["summary"],
+          body: article_attrs["body"],
+          position: article_attrs["position"] || 0,
+          published: article_attrs.fetch("published", true),
+          metadata: article_attrs["metadata"] || {}
+        )
+
+        if article.changed?
+          article.save!
+          article_was_new ? (articles_created += 1) : (articles_updated += 1)
+          puts "    #{article_was_new ? "✓ Created" : "↻ Updated"} article: #{article.title}"
+        end
+      end
+    end
+
+    puts "Handbook Sections: #{sections_created} created, #{sections_updated} updated, #{HandbookSection.count} total"
+    puts "Handbook Articles: #{articles_created} created, #{articles_updated} updated, #{HandbookArticle.count} total"
   end
 
   desc "Load hackr logs from YAML"

--- a/spec/controllers/api/handbook_controller_spec.rb
+++ b/spec/controllers/api/handbook_controller_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Api::HandbookController, type: :controller do
       expect(section_payload["articles"].map { |a| a["slug"] }).not_to include(unpublished.slug)
     end
 
+    it "includes metadata in article summaries so tag search can match" do
+      section = create(:handbook_section)
+      create(:handbook_article,
+        handbook_section: section,
+        metadata: {"search_tags" => ["cred", "mining"]})
+
+      get :index, format: :json
+      article_payload = JSON.parse(response.body)["sections"].first["articles"].first
+      expect(article_payload["metadata"]).to eq("search_tags" => ["cred", "mining"])
+    end
+
     it "orders sections by position then name" do
       later = create(:handbook_section, name: "Zeta", position: 5)
       earlier = create(:handbook_section, name: "Alpha", position: 1)
@@ -108,6 +119,13 @@ RSpec.describe Api::HandbookController, type: :controller do
       get :show, params: {slug: hidden.slug}, format: :json
       expect(response).to have_http_status(:not_found)
     end
+
+    it "returns 404 for a published article in an unpublished section" do
+      hidden_section = create(:handbook_section, :unpublished)
+      orphaned = create(:handbook_article, handbook_section: hidden_section)
+      get :show, params: {slug: orphaned.slug}, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "GET #recent (authenticated)" do
@@ -142,6 +160,14 @@ RSpec.describe Api::HandbookController, type: :controller do
       get :recent, format: :json
       expect(JSON.parse(response.body)).to be_empty
     end
+
+    it "excludes published articles whose section is unpublished" do
+      hidden_section = create(:handbook_section, :unpublished)
+      create(:handbook_article, handbook_section: hidden_section)
+
+      get :recent, format: :json
+      expect(JSON.parse(response.body)).to be_empty
+    end
   end
 
   describe "GET #mappings (authenticated)" do
@@ -155,6 +181,14 @@ RSpec.describe Api::HandbookController, type: :controller do
       get :mappings, format: :json
       body = JSON.parse(response.body)
       expect(body).to eq({published.slug => published.title})
+    end
+
+    it "excludes published articles whose section is unpublished" do
+      hidden_section = create(:handbook_section, :unpublished)
+      create(:handbook_article, handbook_section: hidden_section, slug: "hidden-article", title: "Hidden")
+
+      get :mappings, format: :json
+      expect(JSON.parse(response.body)).to be_empty
     end
   end
 end

--- a/spec/controllers/api/handbook_controller_spec.rb
+++ b/spec/controllers/api/handbook_controller_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe Api::HandbookController, type: :controller do
+  let(:hackr) { create(:grid_hackr) }
+
+  describe "authentication" do
+    it "returns 401 for unauthenticated requests to #index" do
+      get :index, format: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 for unauthenticated requests to #show" do
+      article = create(:handbook_article)
+      get :show, params: {slug: article.slug}, format: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 for unauthenticated requests to #recent" do
+      get :recent, format: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 401 for unauthenticated requests to #mappings" do
+      get :mappings, format: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET #index (authenticated)" do
+    before { session[:grid_hackr_id] = hackr.id }
+
+    it "returns the published section tree" do
+      section = create(:handbook_section, name: "THE PULSE GRID", position: 0)
+      published = create(:handbook_article, handbook_section: section, title: "Clearance", position: 0)
+      unpublished = create(:handbook_article, :unpublished, handbook_section: section)
+      hidden_section = create(:handbook_section, :unpublished)
+      create(:handbook_article, handbook_section: hidden_section)
+
+      get :index, format: :json
+      expect(response).to have_http_status(:ok)
+      payload = JSON.parse(response.body)
+
+      expect(payload["sections"].length).to eq(1)
+      section_payload = payload["sections"].first
+      expect(section_payload["slug"]).to eq(section.slug)
+      expect(section_payload["articles"].length).to eq(1)
+      expect(section_payload["articles"].first["slug"]).to eq(published.slug)
+      expect(section_payload["articles"].map { |a| a["slug"] }).not_to include(unpublished.slug)
+    end
+
+    it "orders sections by position then name" do
+      later = create(:handbook_section, name: "Zeta", position: 5)
+      earlier = create(:handbook_section, name: "Alpha", position: 1)
+
+      get :index, format: :json
+      slugs = JSON.parse(response.body)["sections"].map { |s| s["slug"] }
+      expect(slugs).to eq([earlier.slug, later.slug])
+    end
+  end
+
+  describe "GET #show (authenticated)" do
+    before { session[:grid_hackr_id] = hackr.id }
+
+    let(:section) { create(:handbook_section) }
+    let!(:article_a) { create(:handbook_article, handbook_section: section, title: "A", position: 0) }
+    let!(:article_b) { create(:handbook_article, handbook_section: section, title: "B", position: 1) }
+    let!(:article_c) { create(:handbook_article, handbook_section: section, title: "C", position: 2) }
+
+    it "returns the article with section context" do
+      get :show, params: {slug: article_b.slug}, format: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body["slug"]).to eq(article_b.slug)
+      expect(body["body"]).to be_present
+      expect(body["section"]["slug"]).to eq(section.slug)
+    end
+
+    it "includes prev/next siblings within the section" do
+      get :show, params: {slug: article_b.slug}, format: :json
+      body = JSON.parse(response.body)
+
+      expect(body["prev_article"]["slug"]).to eq(article_a.slug)
+      expect(body["next_article"]["slug"]).to eq(article_c.slug)
+    end
+
+    it "returns nil prev for the first article" do
+      get :show, params: {slug: article_a.slug}, format: :json
+      body = JSON.parse(response.body)
+      expect(body["prev_article"]).to be_nil
+      expect(body["next_article"]["slug"]).to eq(article_b.slug)
+    end
+
+    it "returns nil next for the last article" do
+      get :show, params: {slug: article_c.slug}, format: :json
+      body = JSON.parse(response.body)
+      expect(body["prev_article"]["slug"]).to eq(article_b.slug)
+      expect(body["next_article"]).to be_nil
+    end
+
+    it "returns 404 for unknown slug" do
+      get :show, params: {slug: "nope"}, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 for unpublished articles" do
+      hidden = create(:handbook_article, :unpublished, handbook_section: section)
+      get :show, params: {slug: hidden.slug}, format: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET #recent (authenticated)" do
+    before { session[:grid_hackr_id] = hackr.id }
+
+    it "returns the most recently updated published articles" do
+      section = create(:handbook_section)
+      old = create(:handbook_article, handbook_section: section, title: "Old")
+      old.update_column(:updated_at, 2.days.ago)
+      recent = create(:handbook_article, handbook_section: section, title: "Recent")
+
+      get :recent, format: :json
+      body = JSON.parse(response.body)
+      expect(body.first["slug"]).to eq(recent.slug)
+      expect(body.map { |a| a["slug"] }).to include(old.slug)
+      expect(body.first["section"]["slug"]).to eq(section.slug)
+    end
+
+    it "honors the limit param, capped at 20" do
+      section = create(:handbook_section)
+      create_list(:handbook_article, 3, handbook_section: section)
+
+      get :recent, params: {limit: 2}, format: :json
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(2)
+    end
+
+    it "excludes unpublished articles" do
+      section = create(:handbook_section)
+      create(:handbook_article, :unpublished, handbook_section: section)
+
+      get :recent, format: :json
+      expect(JSON.parse(response.body)).to be_empty
+    end
+  end
+
+  describe "GET #mappings (authenticated)" do
+    before { session[:grid_hackr_id] = hackr.id }
+
+    it "returns a slug->title hash for published articles only" do
+      section = create(:handbook_section)
+      published = create(:handbook_article, handbook_section: section, slug: "mining", title: "Mining")
+      create(:handbook_article, :unpublished, handbook_section: section, slug: "secret", title: "Secret")
+
+      get :mappings, format: :json
+      body = JSON.parse(response.body)
+      expect(body).to eq({published.slug => published.title})
+    end
+  end
+end

--- a/spec/factories/handbook_articles.rb
+++ b/spec/factories/handbook_articles.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: handbook_articles
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  body                :text
+#  difficulty          :string
+#  kind                :string           default("reference"), not null
+#  metadata            :json
+#  position            :integer          default(0), not null
+#  published           :boolean          default(TRUE), not null
+#  slug                :string           not null
+#  summary             :text
+#  title               :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  handbook_section_id :integer          not null
+#
+# Indexes
+#
+#  index_handbook_articles_on_handbook_section_id               (handbook_section_id)
+#  index_handbook_articles_on_handbook_section_id_and_position  (handbook_section_id,position)
+#  index_handbook_articles_on_kind                              (kind)
+#  index_handbook_articles_on_published                         (published)
+#  index_handbook_articles_on_slug                              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  handbook_section_id  (handbook_section_id => handbook_sections.id)
+#
+FactoryBot.define do
+  factory :handbook_article do
+    handbook_section
+    sequence(:title) { |n| "Article #{n}" }
+    sequence(:slug) { |n| "article-#{n}" }
+    kind { "reference" }
+    summary { "Article summary" }
+    body { "# Article body\n\nMarkdown content." }
+    position { 0 }
+    published { true }
+    metadata { {} }
+
+    trait :tutorial do
+      kind { "tutorial" }
+      difficulty { "beginner" }
+    end
+
+    trait :unpublished do
+      published { false }
+    end
+  end
+end

--- a/spec/factories/handbook_sections.rb
+++ b/spec/factories/handbook_sections.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: handbook_sections
+# Database name: primary
+#
+#  id         :integer          not null, primary key
+#  icon       :string
+#  name       :string           not null
+#  position   :integer          default(0), not null
+#  published  :boolean          default(TRUE), not null
+#  slug       :string           not null
+#  summary    :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_handbook_sections_on_published               (published)
+#  index_handbook_sections_on_published_and_position  (published,position)
+#  index_handbook_sections_on_slug                    (slug) UNIQUE
+#
+FactoryBot.define do
+  factory :handbook_section do
+    sequence(:name) { |n| "Section #{n}" }
+    sequence(:slug) { |n| "section-#{n}" }
+    icon { ">>" }
+    summary { "Section summary" }
+    position { 0 }
+    published { true }
+
+    trait :unpublished do
+      published { false }
+    end
+  end
+end

--- a/spec/models/handbook_article_spec.rb
+++ b/spec/models/handbook_article_spec.rb
@@ -1,0 +1,100 @@
+# == Schema Information
+#
+# Table name: handbook_articles
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  body                :text
+#  difficulty          :string
+#  kind                :string           default("reference"), not null
+#  metadata            :json
+#  position            :integer          default(0), not null
+#  published           :boolean          default(TRUE), not null
+#  slug                :string           not null
+#  summary             :text
+#  title               :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  handbook_section_id :integer          not null
+#
+# Indexes
+#
+#  index_handbook_articles_on_handbook_section_id               (handbook_section_id)
+#  index_handbook_articles_on_handbook_section_id_and_position  (handbook_section_id,position)
+#  index_handbook_articles_on_kind                              (kind)
+#  index_handbook_articles_on_published                         (published)
+#  index_handbook_articles_on_slug                              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  handbook_section_id  (handbook_section_id => handbook_sections.id)
+#
+require "rails_helper"
+
+RSpec.describe HandbookArticle, type: :model do
+  describe "validations" do
+    it "requires a title" do
+      article = build(:handbook_article, title: nil)
+      expect(article).not_to be_valid
+    end
+
+    it "requires a unique slug globally" do
+      create(:handbook_article, slug: "foo")
+      duplicate = build(:handbook_article, slug: "foo")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:slug]).to be_present
+    end
+
+    it "auto-generates a slug from the title when blank" do
+      article = build(:handbook_article, title: "Mine Your First CRED", slug: nil)
+      article.valid?
+      expect(article.slug).to eq("mine-your-first-cred")
+    end
+
+    it "restricts kind to the allowed set" do
+      article = build(:handbook_article, kind: "whatever")
+      expect(article).not_to be_valid
+      expect(article.errors[:kind]).to be_present
+    end
+
+    it "allows a blank difficulty" do
+      article = build(:handbook_article, difficulty: nil)
+      expect(article).to be_valid
+    end
+
+    it "restricts difficulty to the allowed set when present" do
+      article = build(:handbook_article, difficulty: "impossible")
+      expect(article).not_to be_valid
+      expect(article.errors[:difficulty]).to be_present
+    end
+
+    it "requires a handbook_section" do
+      article = build(:handbook_article, handbook_section: nil)
+      expect(article).not_to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let(:section) { create(:handbook_section) }
+    let!(:published_ref) { create(:handbook_article, handbook_section: section, kind: "reference", position: 0) }
+    let!(:published_tut) { create(:handbook_article, :tutorial, handbook_section: section, position: 1) }
+    let!(:hidden) { create(:handbook_article, :unpublished, handbook_section: section, position: 2) }
+
+    it ".published filters unpublished" do
+      expect(HandbookArticle.published).to match_array([published_ref, published_tut])
+    end
+
+    it ".tutorials returns only tutorials" do
+      expect(HandbookArticle.tutorials).to eq([published_tut])
+    end
+
+    it ".reference_kind returns only reference articles" do
+      expect(HandbookArticle.reference_kind).to match_array([published_ref, hidden])
+    end
+
+    it ".recently_updated orders by updated_at desc" do
+      hidden.touch
+      expect(HandbookArticle.recently_updated.first).to eq(hidden)
+    end
+  end
+end

--- a/spec/models/handbook_section_spec.rb
+++ b/spec/models/handbook_section_spec.rb
@@ -1,0 +1,85 @@
+# == Schema Information
+#
+# Table name: handbook_sections
+# Database name: primary
+#
+#  id         :integer          not null, primary key
+#  icon       :string
+#  name       :string           not null
+#  position   :integer          default(0), not null
+#  published  :boolean          default(TRUE), not null
+#  slug       :string           not null
+#  summary    :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_handbook_sections_on_published               (published)
+#  index_handbook_sections_on_published_and_position  (published,position)
+#  index_handbook_sections_on_slug                    (slug) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe HandbookSection, type: :model do
+  describe "validations" do
+    it "requires a name" do
+      section = build(:handbook_section, name: nil)
+      expect(section).not_to be_valid
+      expect(section.errors[:name]).to be_present
+    end
+
+    it "requires a unique slug" do
+      create(:handbook_section, slug: "getting-started")
+      duplicate = build(:handbook_section, slug: "getting-started")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:slug]).to be_present
+    end
+
+    it "rejects slugs with invalid characters" do
+      section = build(:handbook_section, slug: "Has Spaces")
+      expect(section).not_to be_valid
+      expect(section.errors[:slug]).to be_present
+    end
+
+    it "auto-generates a slug from the name when blank" do
+      section = build(:handbook_section, name: "Getting Started", slug: nil)
+      section.valid?
+      expect(section.slug).to eq("getting-started")
+    end
+
+    it "rejects negative positions" do
+      section = build(:handbook_section, position: -1)
+      expect(section).not_to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let!(:published_b) { create(:handbook_section, name: "Bravo", position: 1) }
+    let!(:published_a) { create(:handbook_section, name: "Alpha", position: 0) }
+    let!(:hidden) { create(:handbook_section, :unpublished, name: "Hidden", position: 2) }
+
+    it ".published returns only published sections" do
+      expect(HandbookSection.published).to match_array([published_a, published_b])
+    end
+
+    it ".ordered sorts by position then name" do
+      expect(HandbookSection.ordered).to eq([published_a, published_b, hidden])
+    end
+  end
+
+  describe "#to_param" do
+    it "returns the slug" do
+      section = build(:handbook_section, slug: "pulse-grid")
+      expect(section.to_param).to eq("pulse-grid")
+    end
+  end
+
+  describe "article association" do
+    it "destroys dependent articles when the section is destroyed" do
+      section = create(:handbook_section)
+      create(:handbook_article, handbook_section: section)
+      expect { section.destroy }.to change(HandbookArticle, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
  Parallel to the in-world Codex (which remains lore-only), the Handbook
  is a login-gated, GitBook-style docs portal at /handbook covering the
  practical use of hackr.tv subsystems: THE PULSE GRID, WIRE, Uplink,
  Vault, and the Terminal Interfaces (both the in-Grid command parser
  and the SSH terminal). Two-level hierarchy (sections → articles) with
  YAML-seeded content (data/content/handbook.yml) and full admin CRUD
  at /root/handbook_{sections,articles}. YAML wins on reseed.

  New:
  - Models: HandbookSection, HandbookArticle (slug-keyed, has_paper_trail)
  - API: Api::HandbookController — tree, show (with prev/next), recent, mappings. Login-gated via require_login_api. Two-query index avoids N+1 by grouping articles in Ruby.
  - SPA: /handbook + /handbook/:slug, wrapped in ProtectedRoute. Sidebar tree with collapsible sections, client-side search (title + summary + tags), landing TOC + Recently Updated panel, prev/next nav, kind + difficulty badges. Mobile falls back to an article-jump `<select>`.
  - Shared MarkdownContent extracted from Codex pipeline (react-markdown
    + remark-gfm + rehype-raw + rehype-sanitize). Routes Rails-only paths (/terminal, /root) via full-page navigation instead of React Router Link so they don't 404 inside the SPA.
  - Seeded sections: Getting Started, THE PULSE GRID, WIRE, Uplink, Vault, Terminal Interfaces, Tutorials (10 starter articles).
  - Rake task data:handbook added to data:content composite.
  - Specs: 36 passing (model validations, scopes, dependent destroy; API auth gate, tree shape, prev/next, recent limit, publish scoping).

  Secondary cleanups:
  - Removes `|| attrs["metadata"].present?` fallback from both the Codex and Handbook seed tasks. It was a legacy guard against stale AR JSON dirty-tracking; Rails 8 handles JSON change detection correctly. Without it, no-op reseeds are truly idempotent instead of logging spurious updates for every row with a metadata block.
  - Realigns the in-Grid `help` command output in Grid::CommandParser so every command description starts at the same column. Shortens the `cache send` syntax inline and moves optional args to the description to keep the grid intact.
  - Adds Handbook dropdown to the admin /root nav.
  - Admin nav: drops redundant "[ADMIN]" label and shortens "Exit Admin" to "Exit".
  - Header nav: adds Handbook link (logged-in only), renumbers trailing items, shortens "Disconnect" to "DC" with title/aria-label tooltip.
  - FooterMenu updated in step with header changes.