### PR TITLE
[TPG] Faction Reputation System

### DIFF
--- a/app/controllers/admin/grid_factions_controller.rb
+++ b/app/controllers/admin/grid_factions_controller.rb
@@ -1,0 +1,97 @@
+class Admin::GridFactionsController < Admin::ApplicationController
+  before_action :set_faction, only: [:edit, :update, :destroy]
+
+  def index
+    @factions = GridFaction.ordered.includes(:parent, :incoming_rep_links, :outgoing_rep_links).to_a
+    @rep_links = GridFactionRepLink.includes(:source_faction, :target_faction).to_a
+  end
+
+  def new
+    @faction = GridFaction.new(kind: "collective", position: 0)
+  end
+
+  def create
+    @faction = GridFaction.new(faction_params)
+    if @faction.save
+      set_flash_success("Faction '#{@faction.name}' created.")
+      redirect_to admin_grid_factions_path
+    else
+      flash.now[:error] = @faction.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @faction.update(faction_params)
+      set_flash_success("Faction '#{@faction.name}' updated.")
+      redirect_to admin_grid_factions_path
+    else
+      flash.now[:error] = @faction.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @faction.name
+    if @faction.grid_zones.any? || @faction.grid_mobs.any?
+      set_flash_error("Can't delete '#{name}' — zones or mobs still reference it.")
+    else
+      @faction.destroy!
+      set_flash_success("Faction '#{name}' deleted.")
+    end
+    redirect_to admin_grid_factions_path
+  end
+
+  # Bulk-replace rep links from a single form submission. Simpler than
+  # per-row REST for a small graph that's edited holistically.
+  def update_rep_links
+    raw = params[:rep_links] || []
+    raw = raw.values if raw.is_a?(ActionController::Parameters)
+    desired = []
+    raw.each do |attrs|
+      attrs = attrs.permit(:source_slug, :target_slug, :weight) if attrs.is_a?(ActionController::Parameters)
+      next if attrs["source_slug"].blank? || attrs["target_slug"].blank?
+      next if attrs["weight"].blank? || attrs["weight"].to_f.zero?
+
+      source = GridFaction.find_by(slug: attrs["source_slug"])
+      target = GridFaction.find_by(slug: attrs["target_slug"])
+      next unless source && target
+      next if source.id == target.id
+
+      desired << {source: source, target: target, weight: attrs["weight"].to_f}
+    end
+
+    GridFactionRepLink.transaction do
+      desired_keys = desired.map { |d| [d[:source].id, d[:target].id] }.to_set
+      GridFactionRepLink.find_each do |link|
+        link.destroy! unless desired_keys.include?([link.source_faction_id, link.target_faction_id])
+      end
+      desired.each do |d|
+        link = GridFactionRepLink.find_or_initialize_by(source_faction_id: d[:source].id, target_faction_id: d[:target].id)
+        link.weight = d[:weight]
+        link.save! if link.changed? || link.new_record?
+      end
+    end
+
+    set_flash_success("Rep-link graph updated (#{desired.size} link#{"s" unless desired.size == 1}).")
+    redirect_to admin_grid_factions_path
+  rescue ActiveRecord::RecordInvalid => e
+    set_flash_error("Rep-link update rejected: #{e.record.errors.full_messages.join(", ")}")
+    redirect_to admin_grid_factions_path
+  end
+
+  private
+
+  def set_faction
+    @faction = GridFaction.find(params[:id])
+  end
+
+  def faction_params
+    params.require(:grid_faction).permit(
+      :name, :slug, :description, :color_scheme, :kind, :position, :parent_id, :artist_id
+    )
+  end
+end

--- a/app/controllers/admin/grid_hackr_reputations_controller.rb
+++ b/app/controllers/admin/grid_hackr_reputations_controller.rb
@@ -1,0 +1,53 @@
+class Admin::GridHackrReputationsController < Admin::ApplicationController
+  def index
+    @hackrs = GridHackr.order(:hackr_alias)
+    @factions = GridFaction.ordered.includes(:incoming_rep_links).to_a
+    # Only leaf factions accept direct rep writes; aggregates are derived on
+    # read from their incoming rep-links, so adjusting them silently no-ops.
+    @adjustable_factions = @factions.reject(&:aggregate?)
+
+    scope = GridHackrReputation.includes(:grid_hackr).where(subject_type: "GridFaction")
+
+    if params[:hackr_alias].present?
+      hackr = GridHackr.find_by("LOWER(hackr_alias) = ?", params[:hackr_alias].downcase)
+      scope = hackr ? scope.where(grid_hackr: hackr) : scope.none
+      @hackr_filter_missing = hackr.nil?
+    end
+
+    if params[:faction_slug].present?
+      faction = GridFaction.find_by(slug: params[:faction_slug])
+      scope = faction ? scope.where(subject_id: faction.id) : scope.none
+    end
+
+    @reputations = scope.order("grid_hackrs.hackr_alias, subject_id").to_a
+
+    # Preload factions once to avoid N+1 on .subject lookup.
+    faction_ids = @reputations.map(&:subject_id).uniq
+    @faction_map = GridFaction.where(id: faction_ids).index_by(&:id)
+  end
+
+  def adjust
+    hackr = GridHackr.find(params[:grid_hackr_id])
+    faction = GridFaction.find(params[:grid_faction_id])
+    delta = params[:delta].to_i
+    reason = params[:reason].presence || "admin:manual"
+    note = params[:note].presence
+
+    if delta.zero?
+      set_flash_error("Delta must be non-zero.")
+      redirect_to admin_grid_hackr_reputations_path and return
+    end
+
+    service = Grid::ReputationService.new(hackr)
+    result = service.adjust!(faction, delta, reason: reason, source: current_hackr, note: note)
+
+    set_flash_success("#{hackr.hackr_alias} :: #{faction.display_name} #{"+" if result[:applied_delta].positive?}#{result[:applied_delta]} → #{result[:new_value]} (#{result[:tier_after][:label]}).")
+    redirect_to admin_grid_hackr_reputations_path
+  rescue Grid::ReputationService::SubjectMissing
+    set_flash_error("Faction not found.")
+    redirect_to admin_grid_hackr_reputations_path
+  rescue Grid::ReputationService::AggregateSubjectNotAdjustable => e
+    set_flash_error(e.message)
+    redirect_to admin_grid_hackr_reputations_path
+  end
+end

--- a/app/controllers/admin/grid_reputation_events_controller.rb
+++ b/app/controllers/admin/grid_reputation_events_controller.rb
@@ -1,0 +1,30 @@
+class Admin::GridReputationEventsController < Admin::ApplicationController
+  PAGE_SIZE = 100
+
+  def index
+    @hackrs = GridHackr.order(:hackr_alias)
+    @factions = GridFaction.ordered.to_a
+
+    scope = GridReputationEvent.includes(:grid_hackr)
+
+    if params[:hackr_alias].present?
+      hackr = GridHackr.find_by("LOWER(hackr_alias) = ?", params[:hackr_alias].downcase)
+      scope = hackr ? scope.where(grid_hackr: hackr) : scope.none
+      @hackr_filter_missing = hackr.nil?
+    end
+
+    if params[:faction_slug].present?
+      faction = GridFaction.find_by(slug: params[:faction_slug])
+      scope = faction ? scope.where(subject_type: "GridFaction", subject_id: faction.id) : scope.none
+    end
+
+    if params[:reason].present?
+      scope = scope.where("reason LIKE ?", "#{params[:reason]}%")
+    end
+
+    @events = scope.recent.limit(PAGE_SIZE).to_a
+
+    subject_ids = @events.select { |e| e.subject_type == "GridFaction" }.map(&:subject_id).uniq
+    @faction_map = GridFaction.where(id: subject_ids).index_by(&:id)
+  end
+end

--- a/app/models/grid_faction.rb
+++ b/app/models/grid_faction.rb
@@ -6,19 +6,107 @@
 #  id           :integer          not null, primary key
 #  color_scheme :string
 #  description  :text
+#  kind         :string           default("collective"), not null
 #  name         :string
+#  position     :integer          default(0), not null
 #  slug         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  artist_id    :integer
+#  parent_id    :integer
+#
+# Indexes
+#
+#  index_grid_factions_on_kind       (kind)
+#  index_grid_factions_on_parent_id  (parent_id)
+#  index_grid_factions_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  parent_id  (parent_id => grid_factions.id)
 #
 class GridFaction < ApplicationRecord
+  KINDS = %w[collective individual system].freeze
+
   belongs_to :artist, optional: true
+  belongs_to :parent, class_name: "GridFaction", optional: true
+  has_many :children, class_name: "GridFaction", foreign_key: :parent_id, dependent: :nullify
 
   has_many :grid_zones
   has_many :grid_rooms, through: :grid_zones
   has_many :grid_mobs
 
+  has_many :outgoing_rep_links,
+    class_name: "GridFactionRepLink",
+    foreign_key: :source_faction_id,
+    dependent: :destroy,
+    inverse_of: :source_faction
+
+  has_many :incoming_rep_links,
+    class_name: "GridFactionRepLink",
+    foreign_key: :target_faction_id,
+    dependent: :destroy,
+    inverse_of: :target_faction
+
+  has_many :rep_targets, through: :outgoing_rep_links, source: :target_faction
+  has_many :rep_sources, through: :incoming_rep_links, source: :source_faction
+
+  has_many :grid_hackr_reputations,
+    as: :subject,
+    dependent: :destroy
+
+  # Polymorphic `subject` has no FK, so deletions must cascade explicitly to
+  # avoid orphan audit rows whose `subject` association dangles. Source
+  # pointers (mobs, admin hackrs, etc.) are intentionally left alone on those
+  # models' destroy paths — historical audit is preserved even when the source
+  # record is gone.
+  has_many :grid_reputation_events,
+    as: :subject,
+    dependent: :destroy
+
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
+  validates :kind, inclusion: {in: KINDS}
+  validate :parent_not_self
+  validate :parent_chain_has_no_cycle
+
+  scope :ordered, -> { order(:position, :name) }
+  scope :roots, -> { where(parent_id: nil) }
+
+  def leaf?
+    incoming_rep_links.none?
+  end
+
+  # True if other factions contribute rep to this faction via links.
+  def aggregate?
+    incoming_rep_links.any?
+  end
+
+  def display_name
+    name.presence || slug
+  end
+
+  private
+
+  def parent_not_self
+    errors.add(:parent_id, "cannot be self") if parent_id.present? && parent_id == id
+  end
+
+  # Walk the parent chain; if we loop back to this record, reject the write.
+  # Display hierarchy is authoritatively a DAG.
+  def parent_chain_has_no_cycle
+    return if parent_id.blank?
+
+    current_id = parent_id
+    visited = Set.new
+    visited << id if persisted?
+    while current_id
+      if visited.include?(current_id)
+        errors.add(:parent_id, "would create a hierarchy cycle")
+        return
+      end
+      visited << current_id
+      current_id = self.class.where(id: current_id).pick(:parent_id)
+    end
+  end
 end

--- a/app/models/grid_faction_rep_link.rb
+++ b/app/models/grid_faction_rep_link.rb
@@ -1,0 +1,64 @@
+# == Schema Information
+#
+# Table name: grid_faction_rep_links
+# Database name: primary
+#
+#  id                :integer          not null, primary key
+#  weight            :decimal(6, 3)    not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  source_faction_id :integer          not null
+#  target_faction_id :integer          not null
+#
+# Indexes
+#
+#  index_faction_rep_links_unique                     (source_faction_id,target_faction_id) UNIQUE
+#  index_grid_faction_rep_links_on_source_faction_id  (source_faction_id)
+#  index_grid_faction_rep_links_on_target_faction_id  (target_faction_id)
+#
+# Foreign Keys
+#
+#  source_faction_id  (source_faction_id => grid_factions.id)
+#  target_faction_id  (target_faction_id => grid_factions.id)
+#
+class GridFactionRepLink < ApplicationRecord
+  belongs_to :source_faction, class_name: "GridFaction", inverse_of: :outgoing_rep_links
+  belongs_to :target_faction, class_name: "GridFaction", inverse_of: :incoming_rep_links
+
+  validates :weight, presence: true, numericality: true
+  validates :source_faction_id,
+    uniqueness: {scope: :target_faction_id, message: "already has a link to this target"}
+  validate :no_self_link
+  validate :no_cycle
+
+  private
+
+  def no_self_link
+    errors.add(:target_faction_id, "cannot equal source") if source_faction_id == target_faction_id
+  end
+
+  # Reject links that would close a cycle: DFS from `target` following outgoing
+  # links; if we can reach `source`, the new edge would complete a loop. The
+  # faction graph is small (≤ ~20 nodes), so no BFS/indexing optimisation needed.
+  def no_cycle
+    return if source_faction_id.blank? || target_faction_id.blank?
+    return if source_faction_id == target_faction_id # caught by no_self_link
+
+    stack = [target_faction_id]
+    visited = Set.new
+    until stack.empty?
+      current = stack.pop
+      next if visited.include?(current)
+      visited << current
+
+      if current == source_faction_id
+        errors.add(:base, "link would create a cycle in the rep-link graph")
+        return
+      end
+
+      outgoing = self.class.where(source_faction_id: current)
+      outgoing = outgoing.where.not(id: id) if persisted?
+      stack.concat(outgoing.pluck(:target_faction_id))
+    end
+  end
+end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -87,6 +87,8 @@ class GridHackr < ApplicationRecord
   has_many :grid_hackr_achievements, dependent: :destroy
   has_many :grid_achievements, through: :grid_hackr_achievements
   has_many :grid_shop_transactions, dependent: :nullify
+  has_many :grid_hackr_reputations, dependent: :destroy
+  has_many :grid_reputation_events, dependent: :destroy
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length

--- a/app/models/grid_hackr_reputation.rb
+++ b/app/models/grid_hackr_reputation.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: grid_hackr_reputations
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  subject_type  :string           not null
+#  value         :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  subject_id    :bigint           not null
+#
+# Indexes
+#
+#  index_grid_hackr_reputations_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_reputations_on_subject             (subject_type,subject_id)
+#  index_hackr_reputations_unique                 (grid_hackr_id,subject_type,subject_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+class GridHackrReputation < ApplicationRecord
+  MIN_VALUE = -1000
+  MAX_VALUE = 1000
+
+  belongs_to :grid_hackr
+  belongs_to :subject, polymorphic: true
+
+  validates :subject_type, presence: true
+  validates :subject_id, presence: true
+  validates :value,
+    numericality: {only_integer: true, greater_than_or_equal_to: MIN_VALUE, less_than_or_equal_to: MAX_VALUE}
+  validates :grid_hackr_id, uniqueness: {scope: [:subject_type, :subject_id]}
+
+  scope :for_subject_type, ->(type) { where(subject_type: type.to_s) }
+  scope :nonzero, -> { where.not(value: 0) }
+end

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -22,6 +22,7 @@ class GridMob < ApplicationRecord
 
   validates :name, presence: true
   validates :mob_type, inclusion: {in: %w[quest_giver vendor lore special], allow_nil: true}
+  validate :faction_not_aggregate
 
   def vendor?
     mob_type == "vendor"
@@ -41,5 +42,18 @@ class GridMob < ApplicationRecord
 
   def rotation_count
     vendor_config&.dig("rotation_count") || 3
+  end
+
+  private
+
+  # NPC/vendor rep hooks call ReputationService#adjust! on the mob's faction;
+  # aggregate factions refuse direct writes. Block the misconfiguration at
+  # write time so bad YAML seeds or admin edits surface immediately instead
+  # of silently skipping rep in the command path.
+  def faction_not_aggregate
+    return unless grid_faction&.aggregate?
+    errors.add(:grid_faction,
+      "'#{grid_faction.display_name}' is an aggregate (derived from rep-links); " \
+      "assign a source faction instead")
   end
 end

--- a/app/models/grid_reputation_event.rb
+++ b/app/models/grid_reputation_event.rb
@@ -1,0 +1,54 @@
+# == Schema Information
+#
+# Table name: grid_reputation_events
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  delta         :integer          not null
+#  note          :text
+#  reason        :string
+#  source_type   :string
+#  subject_type  :string           not null
+#  value_after   :integer          not null
+#  created_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  source_id     :bigint
+#  subject_id    :bigint           not null
+#
+# Indexes
+#
+#  index_grid_reputation_events_on_grid_hackr_id  (grid_hackr_id)
+#  index_rep_events_on_hackr_and_time             (grid_hackr_id,created_at DESC)
+#  index_rep_events_on_source                     (source_type,source_id)
+#  index_rep_events_on_subject_and_time           (subject_type,subject_id,created_at DESC)
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+class GridReputationEvent < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :subject, polymorphic: true
+  belongs_to :source, polymorphic: true, optional: true
+
+  validates :delta, presence: true, numericality: {only_integer: true}
+  validates :value_after, presence: true, numericality: {only_integer: true}
+
+  # Append-only: no updates in app code (enforced by convention — the service
+  # layer only inserts, the admin UI is read-only). Destroy is allowed so the
+  # hackr `dependent: :destroy` cascade can succeed when a hackr is deleted.
+  def readonly?
+    persisted? && !@allow_destroy && !destroyed?
+  end
+
+  def destroy
+    @allow_destroy = true
+    super
+  ensure
+    @allow_destroy = false
+  end
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_hackr, ->(hackr) { where(grid_hackr: hackr) }
+  scope :for_subject, ->(subject) { where(subject_type: subject.class.name, subject_id: subject.id) }
+end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -56,6 +56,8 @@ module Grid
         ask_command(args)
       when "stat", "stats", "st"
         stat_command
+      when "rep", "reputation", "standing"
+        rep_command
       when "use"
         use_command(args.join(" "))
       when "salvage"
@@ -353,7 +355,9 @@ module Grid
       increment_stat!("npcs_talked")
 
       output = dialogue_box(content.join("\n"))
+      rep_notif = grant_faction_rep(mob.grid_faction, 1, reason: "talk:#{slugify(mob.name)}", source: mob)
       notifications = achievement_checker.check(:talk_npc, npc_name: mob.name)
+      notifications.unshift(rep_notif) if rep_notif
       append_notifications(output, notifications)
     end
 
@@ -453,6 +457,7 @@ module Grid
 
         <span style='color: #fbbf24;'>Operative:</span>
           <span style='color: #34d399;'>stat, stats</span>               - View your operative profile
+          <span style='color: #34d399;'>rep, reputation</span>           - View faction standings in detail
           <span style='color: #34d399;'>clear, cls</span>                - Clear the screen
           <span style='color: #34d399;'>help, ?</span>                   - Show this help message
       HELP
@@ -514,6 +519,59 @@ module Grid
           icon = a.badge_icon.present? ? "#{a.badge_icon} " : ""
           output << "  #{icon}<span style='color: #d0d0d0;'>#{h(a.name)}</span> <span style='color: #6b7280;'>(+#{a.xp_reward}xp)</span>"
         end
+      end
+
+      standings = reputation_service.faction_standings
+      if standings.any?
+        output << ""
+        output << "<span style='color: #fbbf24;'>STANDING:</span>"
+        max_name = standings.map { |s| s[:faction].display_name.length }.max || 0
+        standings.each do |s|
+          output << "  #{format_rep_row(s, name_width: max_name, compact: true)}"
+        end
+        output << "  <span style='color: #6b7280;'>(use 'rep' for the full standing report)</span>"
+      end
+
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      output.join("\n")
+    end
+
+    def rep_command
+      standings = reputation_service.faction_standings(include_zero: true)
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      output << "<span style='color: #22d3ee; font-weight: bold;'>STANDING REPORT :: #{h(hackr.hackr_alias)}</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+
+      if standings.empty?
+        output << "<span style='color: #9ca3af;'>No factions on file. The Grid doesn't know you yet.</span>"
+        output << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+        return output.join("\n")
+      end
+
+      # Walk the parent→child hierarchy recursively so arbitrary depth renders.
+      # Orphan rows (parent_id set but parent not in the standings list, e.g.,
+      # filtered out or deleted) are promoted to roots. Cycle guard defends
+      # against pathological data — real prevention is at the model validator.
+      children_by_parent = standings.group_by { |s| s[:faction].parent_id }
+      standing_ids = standings.map { |s| s[:faction].id }.to_set
+      roots = standings.select { |s| s[:faction].parent_id.nil? || !standing_ids.include?(s[:faction].parent_id) }
+
+      ordered = []
+      max_name = 0
+      walk = lambda do |standing, depth, visited|
+        fid = standing[:faction].id
+        next if visited.include?(fid)
+        visited = visited + [fid]
+        ordered << [standing, depth]
+        indent_len = (depth > 0) ? (2 * (depth - 1) + 3) : 0
+        max_name = [max_name, indent_len + standing[:faction].display_name.length].max
+        (children_by_parent[fid] || []).each { |child| walk.call(child, depth + 1, visited) }
+      end
+      roots.each { |s| walk.call(s, 0, []) }
+
+      ordered.each do |(standing, depth)|
+        output << format_rep_row(standing, name_width: max_name, depth: depth)
       end
 
       output << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
@@ -748,7 +806,9 @@ module Grid
 
       output = "<span style='color: #34d399;'>Purchased </span>#{name_display}<span style='color: #34d399;'> for <span style='color: #fbbf24;'>#{format_cred(result[:price_paid])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
 
+      rep_notif = grant_faction_rep(vendor.grid_faction, 2, reason: "buy:#{slugify(item.name)}", source: vendor)
       notifications = achievement_checker.check(:purchase_item, item_name: item.name)
+      notifications.unshift(rep_notif) if rep_notif
       output = append_notifications(output, notifications)
       {output: output, event: nil}
     rescue Grid::ShopService::AccessDenied => e
@@ -1321,6 +1381,10 @@ module Grid
       @achievement_checker ||= Grid::AchievementChecker.new(hackr)
     end
 
+    def reputation_service
+      @reputation_service ||= Grid::ReputationService.new(hackr)
+    end
+
     def increment_stat!(key, amount = 1)
       current = hackr.stat(key) || 0
       hackr.set_stat!(key, current + amount)
@@ -1329,6 +1393,121 @@ module Grid
     def append_notifications(output, notifications)
       return output if notifications.empty?
       [output, *notifications].compact.join("\n")
+    end
+
+    # --- Reputation helpers ---
+
+    # Apply rep and return a short inline notification for the command output,
+    # or nil if the subject is missing/misconfigured or the delta clamped to zero.
+    # Aggregate-faction misconfiguration (NPC/vendor assigned to a faction with
+    # incoming rep-links) is swallowed silently — gameplay should never crash
+    # because world data has a bad edge; it just skips the rep award.
+    def grant_faction_rep(faction, delta, reason:, source: nil)
+      return nil unless faction
+      result = reputation_service.adjust!(faction, delta, reason: reason, source: source)
+      return nil if result.nil? || result[:applied_delta].zero?
+      build_rep_notification(result)
+    rescue Grid::ReputationService::SubjectMissing,
+      Grid::ReputationService::AggregateSubjectNotAdjustable
+      nil
+    end
+
+    def build_rep_notification(result)
+      subject = result[:subject]
+      delta = result[:applied_delta]
+      sign = delta.positive? ? "+" : ""
+      delta_color = delta.positive? ? "#34d399" : "#ef4444"
+      tier_transition = (result[:tier_before][:key] != result[:tier_after][:key])
+
+      parts = [
+        "<span style='color: #fbbf24;'>▲ REP</span>",
+        "<span style='color: #{delta_color};'>#{sign}#{delta}</span>",
+        "<span style='color: #9ca3af;'>::</span>",
+        "<span style='color: #a78bfa;'>#{h(subject.display_name)}</span>",
+        tier_label_span(result[:tier_after])
+      ]
+      lines = [parts.join(" ")]
+
+      if tier_transition
+        lines << "  <span style='color: #fbbf24;'>▲▲ #{h(subject.display_name)}: #{result[:tier_before][:label]} → #{result[:tier_after][:label]}</span>"
+      end
+
+      result[:rollups].each do |rollup|
+        rollup_transition = rollup[:tier_before][:key] != rollup[:tier_after][:key]
+        next unless rollup_transition
+        lines << "  <span style='color: #a78bfa;'>▲ #{h(rollup[:faction].display_name)}: #{rollup[:tier_before][:label]} → #{rollup[:tier_after][:label]}</span>"
+      end
+
+      lines.join("\n")
+    end
+
+    # Longest tier label — used to pad the tier badge column so bars align.
+    TIER_BADGE_WIDTH = Grid::Reputation::TIERS.map { |t| t[:label].length }.max + 2 # brackets
+    # Widest numeric value: sign + up to 4 digits = 5 chars (e.g. "+1000", "-1000").
+    REP_VALUE_WIDTH = 5
+
+    def tier_label_span(tier, pad_to: TIER_BADGE_WIDTH)
+      padded = "[#{tier[:label]}]".ljust(pad_to)
+      "<span style='color: #{tier[:color]};'>#{padded}</span>"
+    end
+
+    # Render a single standing line.
+    # `compact: true` → short form for the `stat` STANDING block (no bar, no next-tier).
+    # `compact: false` → full form for `rep` (bar, next-tier hint, rollup contribution footnote).
+    def format_rep_row(standing, name_width:, depth: 0, compact: false)
+      faction = standing[:faction]
+      tier = standing[:tier]
+      effective = standing[:effective]
+      # depth 0 → no prefix; depth 1 → "└─ "; each deeper level adds 2 leading
+      # spaces so grandchildren stack visibly under their parent's "└─".
+      indent = (depth > 0) ? ("  " * (depth - 1)) + "└─ " : ""
+      label_padded = "#{indent}#{faction.display_name}".ljust(name_width)
+      value_padded = format_rep_value(effective).rjust(REP_VALUE_WIDTH)
+
+      if compact
+        tag = standing[:aggregate] ? " <span style='color: #6b7280;'>(rollup)</span>" : ""
+        return "<span style='color: #d0d0d0;'>#{h(label_padded)}</span>  #{tier_label_span(tier)} <span style='color: #9ca3af;'>#{value_padded}</span>#{tag}"
+      end
+
+      bar = rep_bar(effective)
+      next_tier_str = if standing[:next_tier]
+        diff = standing[:next_tier][:min] - effective
+        "<span style='color: #6b7280;'>#{diff} to #{standing[:next_tier][:label]}</span>"
+      else
+        "<span style='color: #fbbf24;'>[MAX]</span>"
+      end
+
+      "  <span style='color: #d0d0d0;'>#{h(label_padded)}</span>  #{tier_label_span(tier)}  #{bar}  <span style='color: #9ca3af;'>#{value_padded}</span>  #{next_tier_str}"
+    end
+
+    # 20-cell bar spanning -1000..+1000, centered on zero. Color reflects tier.
+    def rep_bar(value)
+      width = 20
+      half = width / 2
+      clamped = value.clamp(Grid::Reputation::MIN_VALUE, Grid::Reputation::MAX_VALUE)
+      fill_cells = (clamped.abs * half / Grid::Reputation::MAX_VALUE.to_f).round
+      tier = Grid::Reputation.tier_for(value)
+
+      left = if value < 0
+        ("░" * (half - fill_cells)) + ("█" * fill_cells)
+      else
+        "░" * half
+      end
+      right = if value > 0
+        ("█" * fill_cells) + ("░" * (half - fill_cells))
+      else
+        "░" * half
+      end
+      "<span style='color: #{tier[:color]};'>#{left}│#{right}</span>"
+    end
+
+    def format_rep_value(value)
+      sign = value.positive? ? "+" : ""
+      "#{sign}#{value}"
+    end
+
+    def slugify(text)
+      text.to_s.downcase.gsub(/[^a-z0-9]+/, "_").gsub(/^_|_$/, "")
     end
   end
 end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -562,7 +562,7 @@ module Grid
       walk = lambda do |standing, depth, visited|
         fid = standing[:faction].id
         next if visited.include?(fid)
-        visited = visited + [fid]
+        visited += [fid]
         ordered << [standing, depth]
         indent_len = (depth > 0) ? (2 * (depth - 1) + 3) : 0
         max_name = [max_name, indent_len + standing[:faction].display_name.length].max

--- a/app/services/grid/reputation.rb
+++ b/app/services/grid/reputation.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Grid
+  # Tier ladder and thresholds for reputation display.
+  #
+  # Thresholds are inclusive lower bounds. Ordered ascending so Reputation.tier_for
+  # can pick via reverse-scan.
+  module Reputation
+    TIERS = [
+      {key: :blacklisted, label: "BLACKLISTED", min: -1000, color: "#dc2626"},
+      {key: :hostile, label: "HOSTILE", min: -599, color: "#ef4444"},
+      {key: :flagged, label: "FLAGGED", min: -199, color: "#f97316"},
+      {key: :unknown, label: "UNKNOWN", min: -49, color: "#9ca3af"},
+      {key: :trusted, label: "TRUSTED", min: 50, color: "#34d399"},
+      {key: :operative, label: "OPERATIVE", min: 200, color: "#22d3ee"},
+      {key: :specialist, label: "SPECIALIST", min: 500, color: "#a78bfa"},
+      {key: :architect, label: "ARCHITECT", min: 800, color: "#fbbf24"}
+    ].freeze
+
+    MIN_VALUE = GridHackrReputation::MIN_VALUE
+    MAX_VALUE = GridHackrReputation::MAX_VALUE
+
+    def self.tier_for(value)
+      v = value.to_i
+      TIERS.reverse_each { |t| return t if v >= t[:min] }
+      TIERS.first
+    end
+
+    def self.next_tier_for(value)
+      current = tier_for(value)
+      idx = TIERS.index(current)
+      return nil if idx.nil? || idx == TIERS.length - 1
+      TIERS[idx + 1]
+    end
+  end
+end

--- a/app/services/grid/reputation_service.rb
+++ b/app/services/grid/reputation_service.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+module Grid
+  # Per-hackr reputation service. Handles leaf rep writes, event logging, and
+  # derived rollup computation via the faction rep-link graph.
+  #
+  # Only LEAF values persist to grid_hackr_reputations. Aggregate subjects
+  # (e.g. Fracture Network) are computed on read from weighted links.
+  class ReputationService
+    SubjectMissing = Class.new(StandardError)
+    # Raised when a caller tries to adjust a subject whose effective rep is
+    # computed from incoming rep-links. Stored leaf values on such subjects are
+    # ignored by effective_rep, so allowing the write would silently diverge the
+    # audit log from what players see.
+    AggregateSubjectNotAdjustable = Class.new(StandardError)
+
+    # Class of acceptable polymorphic subjects. `GridZone` is here because a
+    # future regional-rep feature will reuse the same storage; all current call
+    # sites pass GridFactions.
+    VALID_SUBJECT_CLASSES = [GridFaction, GridZone].freeze
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Adjust rep for a subject (faction or future region).
+    # Clamps final stored value to [MIN_VALUE, MAX_VALUE]; delta applied is the
+    # actual change after clamping, which may be smaller than requested.
+    #
+    # Returns a hash describing the change plus any aggregate standings that
+    # transitioned tiers so the UI can surface them.
+    def adjust!(subject, delta, reason: nil, source: nil, note: nil)
+      subject = resolve_subject(subject)
+      raise SubjectMissing, "reputation subject not found" unless subject
+      if subject.respond_to?(:aggregate?) && subject.aggregate?
+        raise AggregateSubjectNotAdjustable,
+          "'#{subject.display_name}' is an aggregate — its rep is derived from incoming rep-links. Adjust a source faction instead."
+      end
+
+      result = nil
+      attempts = 0
+      begin
+        attempts += 1
+        ActiveRecord::Base.transaction do
+          # Ensure the row exists BEFORE taking the pessimistic lock so the lock
+          # is meaningful (SELECT FOR UPDATE only locks extant rows). If the row
+          # is created between find_or_create_by! and .lock by another worker,
+          # we'll still see the latest value under FOR UPDATE.
+          GridHackrReputation.find_or_create_by!(
+            grid_hackr: @hackr, subject_type: subject.class.name, subject_id: subject.id
+          ) { |r| r.value = 0 }
+
+          rep = GridHackrReputation.lock.find_by!(
+            grid_hackr: @hackr, subject_type: subject.class.name, subject_id: subject.id
+          )
+
+          old_value = rep.value
+          rollup_before = rollup_snapshot_for_sources(subject)
+
+          new_value = (old_value + delta.to_i).clamp(Reputation::MIN_VALUE, Reputation::MAX_VALUE)
+          applied_delta = new_value - old_value
+
+          rep.value = new_value
+          rep.save!
+
+          event = GridReputationEvent.create!(
+            grid_hackr: @hackr,
+            subject: subject,
+            delta: applied_delta,
+            value_after: new_value,
+            reason: reason,
+            source: source,
+            note: note
+          )
+
+          rollup_after = rollup_snapshot_for_sources(subject)
+          rollups = diff_rollups(rollup_before, rollup_after)
+
+          result = {
+            subject: subject,
+            old_value: old_value,
+            new_value: new_value,
+            applied_delta: applied_delta,
+            requested_delta: delta.to_i,
+            tier_before: Reputation.tier_for(old_value),
+            tier_after: Reputation.tier_for(new_value),
+            rollups: rollups,
+            event: event
+          }
+        end
+      rescue ActiveRecord::RecordNotUnique
+        # Two concurrent callers raced on initial create. Retry once; the second
+        # attempt will find the row existing and proceed under the lock.
+        retry if attempts < 2
+        raise
+      end
+
+      result
+    end
+
+    # Effective (displayable) reputation for a subject.
+    # - Leaf (no incoming rep-links): returns stored leaf value.
+    # - Aggregate: recursively sums weighted EFFECTIVE rep of each source so
+    #   chains of aggregates propagate correctly (A → B → C works).
+    #   `visited` is a cycle guard; if the graph somehow contains a cycle
+    #   (the model validates against this, but defensive anyway), a revisited
+    #   node contributes 0. Clamps to [MIN, MAX].
+    def effective_rep(subject, visited: nil)
+      subject = resolve_subject(subject)
+      return 0 unless subject
+
+      visited ||= Set.new
+      return 0 if visited.include?(subject.id)
+
+      links = subject.respond_to?(:incoming_rep_links) ? subject.incoming_rep_links : []
+      return leaf_value(subject) if links.empty?
+
+      next_visited = visited + [subject.id]
+      sum = links.sum { |link| link.weight * effective_rep(link.source_faction, visited: next_visited) }
+      sum.round.clamp(Reputation::MIN_VALUE, Reputation::MAX_VALUE)
+    end
+
+    # Raw stored leaf value. Returns 0 if no row exists yet. Uses the per-call
+    # preload cache (populated by faction_standings) when available.
+    def leaf_value(subject)
+      subject = resolve_subject(subject)
+      return 0 unless subject
+
+      if @preload
+        return @preload.dig(subject.class.name, subject.id) || 0
+      end
+
+      rep = GridHackrReputation.find_by(
+        grid_hackr: @hackr, subject_type: subject.class.name, subject_id: subject.id
+      )
+      rep&.value || 0
+    end
+
+    # All faction standings as a display-ready list. Returns every faction that
+    # either has a stored leaf value for this hackr OR is an aggregate whose
+    # computed value is nonzero. Always includes factions passed in `always`.
+    def faction_standings(include_zero: false, always: [])
+      factions = GridFaction.ordered
+        .includes(incoming_rep_links: :source_faction, outgoing_rep_links: :target_faction)
+        .to_a
+      always_ids = Array(always).map { |f| resolve_subject(f)&.id }.compact.to_set
+
+      prime_preload!
+
+      factions.filter_map do |f|
+        leaf = leaf_value(f)
+        effective = effective_rep(f)
+        has_activity = leaf != 0 || always_ids.include?(f.id)
+        next nil unless include_zero || has_activity || effective != 0
+
+        {
+          faction: f,
+          leaf: leaf,
+          effective: effective,
+          aggregate: f.aggregate?,
+          tier: Reputation.tier_for(effective),
+          next_tier: Reputation.next_tier_for(effective)
+        }
+      end
+    ensure
+      reset_preload!
+    end
+
+    private
+
+    def resolve_subject(subject)
+      case subject
+      when *VALID_SUBJECT_CLASSES
+        subject
+      when String, Symbol
+        GridFaction.find_by(slug: subject.to_s)
+      end
+    end
+
+    # Build a {class_name => {id => value}} hash of all this hackr's rep rows
+    # so repeated lookups during rendering are O(1) instead of O(1 query each).
+    def prime_preload!
+      @preload = Hash.new { |h, k| h[k] = {} }
+      GridHackrReputation.where(grid_hackr: @hackr).find_each do |rep|
+        @preload[rep.subject_type][rep.subject_id] = rep.value
+      end
+    end
+
+    def reset_preload!
+      @preload = nil
+    end
+
+    # For every faction whose rep this subject CONTRIBUTES to (outgoing links),
+    # snapshot the hackr's effective rep so we can diff before/after an adjust!.
+    def rollup_snapshot_for_sources(subject)
+      return {} unless subject.is_a?(GridFaction)
+      subject.outgoing_rep_links.includes(:target_faction).each_with_object({}) do |link, memo|
+        target = link.target_faction
+        memo[target.id] = {faction: target, value: effective_rep(target)}
+      end
+    end
+
+    def diff_rollups(before, after)
+      after.filter_map do |faction_id, after_snap|
+        before_snap = before[faction_id]
+        next nil unless before_snap
+        next nil if before_snap[:value] == after_snap[:value]
+        {
+          faction: after_snap[:faction],
+          old_value: before_snap[:value],
+          new_value: after_snap[:value],
+          tier_before: Reputation.tier_for(before_snap[:value]),
+          tier_after: Reputation.tier_for(after_snap[:value])
+        }
+      end
+    end
+  end
+end

--- a/app/views/admin/grid_factions/_form.html.erb
+++ b/app/views/admin/grid_factions/_form.html.erb
@@ -1,0 +1,54 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @faction.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @faction.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 60px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :kind, "KIND", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :kind, GridFaction::KINDS.map { |k| [k, k] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :color_scheme, "COLOR", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :color_scheme, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :parent_id, "PARENT FACTION (display hierarchy only)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.collection_select :parent_id, GridFaction.ordered.where.not(id: @faction.id), :id, :display_name, {include_blank: "(none)"}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    <small style="color: #666;">Rep math is controlled by the Rep Link Graph on the index page, NOT by this field.</small>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :artist_id, "LINKED ARTIST", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.collection_select :artist_id, Artist.order(:name), :id, :name, {include_blank: "(none)"}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @faction.new_record? ? "Create Faction" : "Update Faction", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_grid_factions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  </div>
+</div>

--- a/app/views/admin/grid_factions/edit.html.erb
+++ b/app/views/admin/grid_factions/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/factions/<%= @faction.slug %> :: EDIT FACTION</legend>
+
+    <div style="padding: 20px;">
+      <%= form_with model: @faction, url: admin_grid_faction_path(@faction), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_factions/index.html.erb
+++ b/app/views/admin/grid_factions/index.html.erb
@@ -1,0 +1,108 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/factions :: FACTION DEFINITIONS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="margin-bottom: 20px;">
+        <%= link_to "+ New Faction", new_admin_grid_faction_path, class: "tui-button green-168" %>
+        <%= link_to "Rep Log →", admin_grid_reputation_events_path, class: "tui-button", style: "margin-left: 8px;" %>
+        <%= link_to "Hackr Reps →", admin_grid_hackr_reputations_path, class: "tui-button", style: "margin-left: 8px;" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Kind</th>
+              <th style="text-align: left;">Parent</th>
+              <th style="text-align: center;">Position</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @factions.each do |faction| %>
+              <tr>
+                <td>
+                  <span class="cyan-255-text"><%= faction.display_name %></span>
+                </td>
+                <td style="color: #666; font-family: monospace;"><%= faction.slug %></td>
+                <td style="color: #888;"><%= faction.kind %></td>
+                <td style="color: #888;"><%= faction.parent&.display_name || "—" %></td>
+                <td style="text-align: center; color: #888;"><%= faction.position %></td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_faction_path(faction), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= button_to "Delete", admin_grid_faction_path(faction), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete faction '#{faction.name}'?" } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Rep Link Graph -->
+      <div style="margin-top: 40px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: REP LINK GRAPH ::]</h3>
+        <p style="color: #888; margin-bottom: 15px;">Directed edges: adjusting <b>source</b> rep shifts computed rep for <b>target</b> by <code>weight × source_value</code>. Leave a row blank to delete it on save.</p>
+
+        <%= form_with url: update_rep_links_admin_grid_factions_path, method: :post, local: true do %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Source</th>
+                  <th style="text-align: left;">Target</th>
+                  <th style="text-align: center;">Weight</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% slots = @rep_links.size + 3 %>
+                <% slots.times do |i| %>
+                  <% link = @rep_links[i] %>
+                  <tr>
+                    <td>
+                      <%= select_tag "rep_links[#{i}][source_slug]",
+                        options_from_collection_for_select(@factions, :slug, :display_name, link&.source_faction&.slug),
+                        include_blank: "(none)",
+                        class: "tui-input", style: "padding: 4px 8px; width: 100%;" %>
+                    </td>
+                    <td>
+                      <%= select_tag "rep_links[#{i}][target_slug]",
+                        options_from_collection_for_select(@factions, :slug, :display_name, link&.target_faction&.slug),
+                        include_blank: "(none)",
+                        class: "tui-input", style: "padding: 4px 8px; width: 100%;" %>
+                    </td>
+                    <td style="text-align: center;">
+                      <%= number_field_tag "rep_links[#{i}][weight]", link&.weight, step: 0.01, class: "tui-input", style: "padding: 4px 8px; width: 100px; text-align: right;" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+
+            <div style="margin-top: 15px;">
+              <%= submit_tag "Save Rep Links", class: "tui-button green-168", style: "padding: 8px 16px; font-weight: bold;" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Grid Admin", admin_grid_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_factions/new.html.erb
+++ b/app/views/admin/grid_factions/new.html.erb
@@ -1,0 +1,11 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/factions/new :: NEW FACTION</legend>
+
+    <div style="padding: 20px;">
+      <%= form_with model: @faction, url: admin_grid_factions_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_hackr_reputations/index.html.erb
+++ b/app/views/admin/grid_hackr_reputations/index.html.erb
@@ -1,0 +1,106 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/reputations :: HACKR STANDINGS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <!-- Filters -->
+      <%= form_with url: admin_grid_hackr_reputations_path, method: :get, local: true, style: "margin-bottom: 20px;" do %>
+        <div style="display: flex; gap: 10px; align-items: flex-end;">
+          <div>
+            <label class="white-text" style="display: block; margin-bottom: 5px;">Hackr alias</label>
+            <%= text_field_tag :hackr_alias, params[:hackr_alias], class: "tui-input", style: "padding: 6px 10px;" %>
+          </div>
+          <div>
+            <label class="white-text" style="display: block; margin-bottom: 5px;">Faction</label>
+            <%= select_tag :faction_slug, options_from_collection_for_select(@factions, :slug, :display_name, params[:faction_slug]), include_blank: "(any)", class: "tui-input", style: "padding: 6px 10px;" %>
+          </div>
+          <%= submit_tag "Filter", class: "tui-button green-168", style: "padding: 6px 16px;" %>
+          <%= link_to "Clear", admin_grid_hackr_reputations_path, class: "tui-button", style: "padding: 6px 16px;" %>
+        </div>
+      <% end %>
+
+      <% if @hackr_filter_missing %>
+        <p class="yellow-168-text" style="margin-bottom: 15px;">No hackr found with alias '<%= params[:hackr_alias] %>'.</p>
+      <% end %>
+
+      <!-- Listing -->
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Hackr</th>
+              <th style="text-align: left;">Faction</th>
+              <th style="text-align: right;">Value</th>
+              <th style="text-align: left;">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @reputations.each do |rep| %>
+              <tr>
+                <td><span class="cyan-255-text"><%= rep.grid_hackr.hackr_alias %></span></td>
+                <td style="color: #a78bfa;"><%= @faction_map[rep.subject_id]&.display_name %></td>
+                <td style="text-align: right; font-family: monospace;" class="<%= rep.value.positive? ? "green-255-text" : (rep.value.negative? ? "red-255-text" : "") %>">
+                  <%= rep.value.positive? ? "+" : "" %><%= rep.value %>
+                </td>
+                <td style="color: #888;"><%= rep.updated_at.strftime("%Y-%m-%d %H:%M") %></td>
+              </tr>
+            <% end %>
+            <% if @reputations.empty? %>
+              <tr><td colspan="4" style="text-align: center; color: #666; padding: 20px;">No reputation records match.</td></tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Manual Adjust -->
+      <div style="margin-top: 40px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: MANUAL ADJUST ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+          <%= form_with url: adjust_admin_grid_hackr_reputations_path, method: :post, local: true do %>
+            <div style="display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;">
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 5px;">Hackr</label>
+                <%= select_tag :grid_hackr_id, options_from_collection_for_select(@hackrs, :id, :hackr_alias), class: "tui-input", style: "padding: 6px 10px; min-width: 180px;" %>
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 5px;">Faction</label>
+                <%= select_tag :grid_faction_id, options_from_collection_for_select(@adjustable_factions, :id, :display_name), class: "tui-input", style: "padding: 6px 10px; min-width: 180px;" %>
+                <small style="color: #666; display: block; margin-top: 4px;">Aggregate factions (derived from rep-links) are hidden.</small>
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 5px;">Delta</label>
+                <%= number_field_tag :delta, 0, class: "tui-input", style: "padding: 6px 10px; width: 90px;" %>
+              </div>
+              <div style="flex: 1; min-width: 200px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px;">Reason tag</label>
+                <%= text_field_tag :reason, "admin:manual", class: "tui-input", style: "padding: 6px 10px; width: 100%;" %>
+              </div>
+              <div style="flex: 2; min-width: 260px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px;">Note (optional)</label>
+                <%= text_field_tag :note, "", class: "tui-input", style: "padding: 6px 10px; width: 100%;" %>
+              </div>
+              <%= submit_tag "Apply", class: "tui-button green-168", style: "padding: 6px 16px;" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Factions", admin_grid_factions_path, class: "tui-button green-168" %>
+        <%= link_to "Rep Log →", admin_grid_reputation_events_path, class: "tui-button", style: "margin-left: 8px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_reputation_events/index.html.erb
+++ b/app/views/admin/grid_reputation_events/index.html.erb
@@ -1,0 +1,76 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/reputation_events :: REP LOG</legend>
+
+    <div style="padding: 20px;">
+      <!-- Filters -->
+      <%= form_with url: admin_grid_reputation_events_path, method: :get, local: true, style: "margin-bottom: 20px;" do %>
+        <div style="display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;">
+          <div>
+            <label class="white-text" style="display: block; margin-bottom: 5px;">Hackr alias</label>
+            <%= text_field_tag :hackr_alias, params[:hackr_alias], class: "tui-input", style: "padding: 6px 10px;" %>
+          </div>
+          <div>
+            <label class="white-text" style="display: block; margin-bottom: 5px;">Faction</label>
+            <%= select_tag :faction_slug, options_from_collection_for_select(@factions, :slug, :display_name, params[:faction_slug]), include_blank: "(any)", class: "tui-input", style: "padding: 6px 10px;" %>
+          </div>
+          <div>
+            <label class="white-text" style="display: block; margin-bottom: 5px;">Reason prefix</label>
+            <%= text_field_tag :reason, params[:reason], class: "tui-input", style: "padding: 6px 10px;", placeholder: "talk: / buy: / admin:" %>
+          </div>
+          <%= submit_tag "Filter", class: "tui-button green-168", style: "padding: 6px 16px;" %>
+          <%= link_to "Clear", admin_grid_reputation_events_path, class: "tui-button", style: "padding: 6px 16px;" %>
+        </div>
+      <% end %>
+
+      <% if @hackr_filter_missing %>
+        <p class="yellow-168-text" style="margin-bottom: 15px;">No hackr found with alias '<%= params[:hackr_alias] %>'.</p>
+      <% end %>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">When</th>
+              <th style="text-align: left;">Hackr</th>
+              <th style="text-align: left;">Faction</th>
+              <th style="text-align: right;">Δ</th>
+              <th style="text-align: right;">After</th>
+              <th style="text-align: left;">Reason</th>
+              <th style="text-align: left;">Source</th>
+              <th style="text-align: left;">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @events.each do |e| %>
+              <tr>
+                <td style="color: #888; font-family: monospace; white-space: nowrap;"><%= e.created_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+                <td><span class="cyan-255-text"><%= e.grid_hackr.hackr_alias %></span></td>
+                <td style="color: #a78bfa;">
+                  <%= @faction_map[e.subject_id]&.display_name || "#{e.subject_type}##{e.subject_id}" %>
+                </td>
+                <td style="text-align: right; font-family: monospace;" class="<%= e.delta.positive? ? "green-255-text" : (e.delta.negative? ? "red-255-text" : "") %>">
+                  <%= e.delta.positive? ? "+" : "" %><%= e.delta %>
+                </td>
+                <td style="text-align: right; font-family: monospace; color: #ddd;"><%= e.value_after %></td>
+                <td style="color: #888; font-family: monospace;"><%= e.reason %></td>
+                <td style="color: #888;"><%= e.source_type.present? ? "#{e.source_type}##{e.source_id}" : "—" %></td>
+                <td style="color: #888;"><%= e.note %></td>
+              </tr>
+            <% end %>
+            <% if @events.empty? %>
+              <tr><td colspan="8" style="text-align: center; color: #666; padding: 20px;">No events match.</td></tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <p style="color: #666; margin-top: 10px;">Showing most recent <%= [Admin::GridReputationEventsController::PAGE_SIZE, @events.size].min %> events.</p>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Factions", admin_grid_factions_path, class: "tui-button green-168" %>
+        <%= link_to "Hackr Reps →", admin_grid_hackr_reputations_path, class: "tui-button", style: "margin-left: 8px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -86,6 +86,8 @@
           <%= link_to "Economy", admin_grid_economy_path, class: "green-168-text" %>
           <%= link_to "Shops", admin_grid_shop_listings_path, class: "green-168-text" %>
           <%= link_to "Achievements", admin_grid_achievements_path, class: "green-168-text" %>
+          <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
+          <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
         </div>
       </div>
       <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text", style: "text-decoration: none;" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,6 +268,23 @@ Rails.application.routes.draw do
       end
     end
 
+    # Grid factions (full CRUD + rep-link management)
+    resources :grid_factions do
+      collection do
+        post :update_rep_links
+      end
+    end
+
+    # Grid reputations (read + adjust per-hackr)
+    resources :grid_hackr_reputations, only: [:index] do
+      collection do
+        post :adjust
+      end
+    end
+
+    # Grid reputation event log (read-only)
+    resources :grid_reputation_events, only: [:index]
+
     # Grid shops (runtime CRUD + stock management)
     resources :grid_shop_listings do
       member do

--- a/data/world/factions.yml
+++ b/data/world/factions.yml
@@ -1,19 +1,85 @@
 # Grid Factions
+#
+# `parent_slug` sets the display hierarchy (used by admin tree + `rep` grouping).
+# It is NOT the rep-rollup path — rep math is configured separately via
+# `rep_links` below (source_slug → target_slug @ weight). Keeping the two
+# concerns independent lets GovCorp contribute NEGATIVELY to Fracture Network
+# rep without being a sub-faction of FN in the org chart.
 factions:
-  - name: The.CyberPul.se
-    slug: thecyberpulse
-    description: "The primary broadcast entity. XERAEN, Ryker, and Synthia unite the Fracture Network through music."
-    color_scheme: purple
-    artist_slug: thecyberpulse
+  - name: The Fracture Network
+    slug: fracture_network
+    kind: collective
+    color_scheme: violet
+    position: 10
+    description: "Umbrella resistance collective. Standing here is derived from rep with its member subfactions and antagonists."
 
-  - name: XERAEN
-    slug: xeraen
-    description: "Temporal guardian broadcasting from the future to prevent the timeline he lives in."
+  - name: Hackrcore
+    slug: hackrcore
+    parent_slug: fracture_network
+    kind: collective
     color_scheme: purple
-    artist_slug: xeraen
+    position: 20
+    artist_slug: thecyberpulse
+    description: "The broadcast spine of the resistance. XERAEN, Ryker, and Synthia push signal through the noise."
+
+  - name: Blackout
+    slug: blackout
+    parent_slug: fracture_network
+    kind: collective
+    color_scheme: red
+    position: 30
+    description: "Underground saboteurs. They kill the lights so others can move."
+
+  - name: Frontwave
+    slug: frontwave
+    parent_slug: fracture_network
+    kind: collective
+    color_scheme: cyan
+    position: 40
+    description: "Signal artists and culture-shapers. The Fracture Network's public face."
+
+  - name: Offline
+    slug: offline
+    parent_slug: fracture_network
+    kind: collective
+    color_scheme: gray
+    position: 50
+    description: "Analog refugees. They left the grid; they didn't leave the fight."
 
   - name: GovCorp
     slug: govcorp
-    description: "The totalitarian corporate-government entity. Enemy of the Fracture Network."
+    kind: collective
     color_scheme: red
-    artist_slug: null
+    position: 60
+    description: "The totalitarian corporate-government entity. Enemy of the Fracture Network."
+
+  - name: Dante Russo
+    slug: dante
+    kind: individual
+    color_scheme: amber
+    position: 70
+    description: "Unaffiliated operative. His favor is earned one conversation at a time."
+
+# Reputation graph. Directed edges: adjusting SOURCE rep shifts effective rep
+# computed for TARGET by `weight × source_value`. Multiple sources feeding one
+# target are summed. Edges are independent of parent_slug hierarchy above.
+rep_links:
+  - source_slug: hackrcore
+    target_slug: fracture_network
+    weight: 1.2
+
+  - source_slug: blackout
+    target_slug: fracture_network
+    weight: 0.8
+
+  - source_slug: frontwave
+    target_slug: fracture_network
+    weight: 1.0
+
+  - source_slug: offline
+    target_slug: fracture_network
+    weight: 0.9
+
+  - source_slug: govcorp
+    target_slug: fracture_network
+    weight: -0.2

--- a/db/migrate/20260413120001_extend_grid_factions_for_reputation.rb
+++ b/db/migrate/20260413120001_extend_grid_factions_for_reputation.rb
@@ -1,0 +1,18 @@
+class ExtendGridFactionsForReputation < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :grid_factions, :parent, foreign_key: {to_table: :grid_factions}, index: true, null: true
+    add_column :grid_factions, :kind, :string, default: "collective", null: false
+    add_column :grid_factions, :position, :integer, default: 0, null: false
+    add_index :grid_factions, :kind
+    add_index :grid_factions, :slug, unique: true unless index_exists?(:grid_factions, :slug, unique: true)
+
+    create_table :grid_faction_rep_links do |t|
+      t.references :source_faction, null: false, foreign_key: {to_table: :grid_factions}, index: true
+      t.references :target_faction, null: false, foreign_key: {to_table: :grid_factions}, index: true
+      t.decimal :weight, precision: 6, scale: 3, null: false
+      t.timestamps
+    end
+    add_index :grid_faction_rep_links, [:source_faction_id, :target_faction_id],
+      unique: true, name: "index_faction_rep_links_unique"
+  end
+end

--- a/db/migrate/20260413120002_create_grid_reputation_tables.rb
+++ b/db/migrate/20260413120002_create_grid_reputation_tables.rb
@@ -1,0 +1,34 @@
+class CreateGridReputationTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_hackr_reputations do |t|
+      t.references :grid_hackr, null: false, foreign_key: true, index: true
+      t.string :subject_type, null: false
+      t.bigint :subject_id, null: false
+      t.integer :value, default: 0, null: false
+      t.timestamps
+    end
+    add_index :grid_hackr_reputations, [:grid_hackr_id, :subject_type, :subject_id],
+      unique: true, name: "index_hackr_reputations_unique"
+    add_index :grid_hackr_reputations, [:subject_type, :subject_id],
+      name: "index_hackr_reputations_on_subject"
+
+    create_table :grid_reputation_events do |t|
+      t.references :grid_hackr, null: false, foreign_key: true, index: true
+      t.string :subject_type, null: false
+      t.bigint :subject_id, null: false
+      t.integer :delta, null: false
+      t.integer :value_after, null: false
+      t.string :reason
+      t.string :source_type
+      t.bigint :source_id
+      t.text :note
+      t.datetime :created_at, null: false
+    end
+    add_index :grid_reputation_events, [:grid_hackr_id, :created_at],
+      order: {created_at: :desc}, name: "index_rep_events_on_hackr_and_time"
+    add_index :grid_reputation_events, [:subject_type, :subject_id, :created_at],
+      order: {created_at: :desc}, name: "index_rep_events_on_subject_and_time"
+    add_index :grid_reputation_events, [:source_type, :source_id],
+      name: "index_rep_events_on_source"
+  end
+end

--- a/db/migrate/20260413120003_reshape_seeded_factions.rb
+++ b/db/migrate/20260413120003_reshape_seeded_factions.rb
@@ -1,0 +1,36 @@
+class ReshapeSeededFactions < ActiveRecord::Migration[8.1]
+  # Data migration: rename TCP faction → hackrcore, remove xeraen faction.
+  # The YAML seed (data/world/factions.yml) is the source of truth for the
+  # remaining faction tree; the data:factions rake task will fill in the rest.
+  def up
+    return unless table_exists?(:grid_factions)
+
+    tcp = GridFaction.find_by(slug: "thecyberpulse")
+    tcp&.update_columns(slug: "hackrcore", name: "Hackrcore")
+
+    xeraen = GridFaction.find_by(slug: "xeraen")
+    if xeraen
+      GridMob.where(grid_faction_id: xeraen.id).update_all(grid_faction_id: nil) if defined?(GridMob)
+      GridZone.where(grid_faction_id: xeraen.id).update_all(grid_faction_id: nil) if defined?(GridZone)
+      # Polymorphic rep tables have no FK constraint to grid_factions. Clean up
+      # any orphan rows explicitly so their `subject` association doesn't dangle.
+      if defined?(GridHackrReputation)
+        GridHackrReputation.where(subject_type: "GridFaction", subject_id: xeraen.id).delete_all
+      end
+      if defined?(GridReputationEvent)
+        GridReputationEvent.where(subject_type: "GridFaction", subject_id: xeraen.id).delete_all
+      end
+      xeraen.destroy
+    end
+  end
+
+  def down
+    # Recreate xeraen minimally; TCP rename is not reversed because the new slug
+    # is semantically correct and downstream data references it.
+    GridFaction.find_or_create_by!(slug: "xeraen") do |f|
+      f.name = "XERAEN"
+      f.description = "Temporal guardian broadcasting from the future to prevent the timeline he lives in."
+      f.color_scheme = "purple"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -186,14 +186,31 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
     t.index ["to_room_id"], name: "index_grid_exits_on_to_room_id"
   end
 
+  create_table "grid_faction_rep_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "source_faction_id", null: false
+    t.integer "target_faction_id", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "weight", precision: 6, scale: 3, null: false
+    t.index ["source_faction_id", "target_faction_id"], name: "index_faction_rep_links_unique", unique: true
+    t.index ["source_faction_id"], name: "index_grid_faction_rep_links_on_source_faction_id"
+    t.index ["target_faction_id"], name: "index_grid_faction_rep_links_on_target_faction_id"
+  end
+
   create_table "grid_factions", force: :cascade do |t|
     t.integer "artist_id"
     t.string "color_scheme"
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "kind", default: "collective", null: false
     t.string "name"
+    t.integer "parent_id"
+    t.integer "position", default: 0, null: false
     t.string "slug"
     t.datetime "updated_at", null: false
+    t.index ["kind"], name: "index_grid_factions_on_kind"
+    t.index ["parent_id"], name: "index_grid_factions_on_parent_id"
+    t.index ["slug"], name: "index_grid_factions_on_slug", unique: true
   end
 
   create_table "grid_hackr_achievements", force: :cascade do |t|
@@ -205,6 +222,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
     t.index ["grid_achievement_id"], name: "index_grid_hackr_achievements_on_grid_achievement_id"
     t.index ["grid_hackr_id", "grid_achievement_id"], name: "index_hackr_achievements_unique", unique: true
     t.index ["grid_hackr_id"], name: "index_grid_hackr_achievements_on_grid_hackr_id"
+  end
+
+  create_table "grid_hackr_reputations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.bigint "subject_id", null: false
+    t.string "subject_type", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 0, null: false
+    t.index ["grid_hackr_id", "subject_type", "subject_id"], name: "index_hackr_reputations_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_grid_hackr_reputations_on_grid_hackr_id"
+    t.index ["subject_type", "subject_id"], name: "index_hackr_reputations_on_subject"
   end
 
   create_table "grid_hackrs", force: :cascade do |t|
@@ -282,6 +311,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
     t.datetime "used_at"
     t.index ["email"], name: "index_grid_registration_tokens_on_email"
     t.index ["token"], name: "index_grid_registration_tokens_on_token", unique: true
+  end
+
+  create_table "grid_reputation_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "delta", null: false
+    t.integer "grid_hackr_id", null: false
+    t.text "note"
+    t.string "reason"
+    t.bigint "source_id"
+    t.string "source_type"
+    t.bigint "subject_id", null: false
+    t.string "subject_type", null: false
+    t.integer "value_after", null: false
+    t.index ["grid_hackr_id", "created_at"], name: "index_rep_events_on_hackr_and_time", order: { created_at: :desc }
+    t.index ["grid_hackr_id"], name: "index_grid_reputation_events_on_grid_hackr_id"
+    t.index ["source_type", "source_id"], name: "index_rep_events_on_source"
+    t.index ["subject_type", "subject_id", "created_at"], name: "index_rep_events_on_subject_and_time", order: { created_at: :desc }
   end
 
   create_table "grid_rooms", force: :cascade do |t|
@@ -809,8 +855,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_120002) do
   add_foreign_key "echoes", "grid_hackrs"
   add_foreign_key "echoes", "pulses"
   add_foreign_key "feature_grants", "grid_hackrs"
+  add_foreign_key "grid_faction_rep_links", "grid_factions", column: "source_faction_id"
+  add_foreign_key "grid_faction_rep_links", "grid_factions", column: "target_faction_id"
+  add_foreign_key "grid_factions", "grid_factions", column: "parent_id"
   add_foreign_key "grid_hackr_achievements", "grid_achievements"
   add_foreign_key "grid_hackr_achievements", "grid_hackrs"
+  add_foreign_key "grid_hackr_reputations", "grid_hackrs"
+  add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -459,9 +459,12 @@ namespace :data do
     end
 
     data = YAML.load_file(yaml_file)
-    factions_data = data["factions"]
+    factions_data = data["factions"] || []
+    links_data = data["rep_links"] || []
     created = updated = 0
 
+    # Pass 1: upsert factions without parent FK (parents may be defined later
+    # in the YAML than their children; resolve on pass 2).
     factions_data.each do |attrs|
       faction = GridFaction.find_or_initialize_by(slug: attrs["slug"])
       was_new = faction.new_record?
@@ -472,6 +475,8 @@ namespace :data do
         name: attrs["name"],
         description: attrs["description"],
         color_scheme: attrs["color_scheme"],
+        kind: attrs["kind"] || "collective",
+        position: attrs["position"] || 0,
         artist: artist
       )
 
@@ -482,7 +487,46 @@ namespace :data do
       end
     end
 
+    # Pass 2: resolve parent_slug → parent_id. Only writes when changed.
+    factions_data.each do |attrs|
+      faction = GridFaction.find_by(slug: attrs["slug"])
+      next unless faction
+      parent_id = attrs["parent_slug"].present? ? GridFaction.where(slug: attrs["parent_slug"]).pick(:id) : nil
+      if faction.parent_id != parent_id
+        faction.update!(parent_id: parent_id)
+      end
+    end
+
+    # Pass 3: rep-link graph. Idempotent — we fully reconcile to match YAML so
+    # removing a link from YAML removes it from DB (unlike other tasks here,
+    # because the link graph is small and fully declarative).
+    desired_keys = Set.new
+    links_data.each do |attrs|
+      source = GridFaction.find_by(slug: attrs["source_slug"])
+      target = GridFaction.find_by(slug: attrs["target_slug"])
+      unless source && target
+        puts "  ⚠ Skipping rep_link: unknown slug (#{attrs["source_slug"]} → #{attrs["target_slug"]})"
+        next
+      end
+
+      link = GridFactionRepLink.find_or_initialize_by(
+        source_faction_id: source.id, target_faction_id: target.id
+      )
+      link.weight = attrs["weight"]
+      link.save! if link.new_record? || link.changed?
+      desired_keys << [source.id, target.id]
+    end
+
+    removed = 0
+    GridFactionRepLink.find_each do |existing|
+      unless desired_keys.include?([existing.source_faction_id, existing.target_faction_id])
+        existing.destroy!
+        removed += 1
+      end
+    end
+
     puts "Factions: #{created} created, #{updated} updated, #{GridFaction.count} total"
+    puts "Rep links: #{GridFactionRepLink.count} active, #{removed} removed"
   end
 
   desc "Load zones from YAML"

--- a/spec/factories/grid_factions.rb
+++ b/spec/factories/grid_factions.rb
@@ -6,18 +6,39 @@
 #  id           :integer          not null, primary key
 #  color_scheme :string
 #  description  :text
+#  kind         :string           default("collective"), not null
 #  name         :string
+#  position     :integer          default(0), not null
 #  slug         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  artist_id    :integer
+#  parent_id    :integer
+#
+# Indexes
+#
+#  index_grid_factions_on_kind       (kind)
+#  index_grid_factions_on_parent_id  (parent_id)
+#  index_grid_factions_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  parent_id  (parent_id => grid_factions.id)
 #
 FactoryBot.define do
   factory :grid_faction do
-    name { "MyString" }
-    slug { "MyString" }
-    description { "MyText" }
-    color_scheme { "MyString" }
-    artist_id { 1 }
+    sequence(:name) { |n| "Faction #{n}" }
+    sequence(:slug) { |n| "faction_#{n}" }
+    description { "A faction in THE PULSE GRID" }
+    color_scheme { "purple" }
+    kind { "collective" }
+    position { 0 }
+    artist_id { nil }
+  end
+
+  factory :grid_faction_rep_link do
+    association :source_faction, factory: :grid_faction
+    association :target_faction, factory: :grid_faction
+    weight { 1.0 }
   end
 end

--- a/spec/models/grid_faction_rep_link_spec.rb
+++ b/spec/models/grid_faction_rep_link_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe GridFactionRepLink, type: :model do
+  let(:a) { create(:grid_faction) }
+  let(:b) { create(:grid_faction) }
+
+  it "rejects a self-link" do
+    link = build(:grid_faction_rep_link, source_faction: a, target_faction: a)
+    expect(link).not_to be_valid
+  end
+
+  it "enforces uniqueness on (source, target)" do
+    create(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 1.0)
+    dup = build(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 2.0)
+    expect(dup).not_to be_valid
+  end
+
+  it "accepts negative weights" do
+    link = build(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: -0.2)
+    expect(link).to be_valid
+  end
+
+  it "exposes the source and target factions via GridFaction associations" do
+    create(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 1.2)
+    expect(a.rep_targets).to include(b)
+    expect(b.rep_sources).to include(a)
+  end
+
+  describe "cycle prevention" do
+    let(:c) { create(:grid_faction) }
+
+    it "rejects a 2-node back-edge (A→B exists, B→A attempted)" do
+      create(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 1.0)
+      backedge = build(:grid_faction_rep_link, source_faction: b, target_faction: a, weight: 0.5)
+      expect(backedge).not_to be_valid
+      expect(backedge.errors[:base].join).to match(/cycle/)
+    end
+
+    it "rejects a 3-node cycle (A→B, B→C, C→A)" do
+      create(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 1.0)
+      create(:grid_faction_rep_link, source_faction: b, target_faction: c, weight: 1.0)
+      backedge = build(:grid_faction_rep_link, source_faction: c, target_faction: a, weight: 1.0)
+      expect(backedge).not_to be_valid
+    end
+
+    it "accepts a DAG with multiple incoming edges" do
+      create(:grid_faction_rep_link, source_faction: a, target_faction: c, weight: 1.0)
+      second = build(:grid_faction_rep_link, source_faction: b, target_faction: c, weight: 1.0)
+      expect(second).to be_valid
+    end
+
+    it "accepts updating an existing edge's weight without re-triggering cycle check against itself" do
+      link = create(:grid_faction_rep_link, source_faction: a, target_faction: b, weight: 1.0)
+      link.weight = 2.5
+      expect(link).to be_valid
+    end
+  end
+end

--- a/spec/models/grid_faction_spec.rb
+++ b/spec/models/grid_faction_spec.rb
@@ -6,14 +6,114 @@
 #  id           :integer          not null, primary key
 #  color_scheme :string
 #  description  :text
+#  kind         :string           default("collective"), not null
 #  name         :string
+#  position     :integer          default(0), not null
 #  slug         :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  artist_id    :integer
+#  parent_id    :integer
+#
+# Indexes
+#
+#  index_grid_factions_on_kind       (kind)
+#  index_grid_factions_on_parent_id  (parent_id)
+#  index_grid_factions_on_slug       (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  parent_id  (parent_id => grid_factions.id)
 #
 require "rails_helper"
 
 RSpec.describe GridFaction, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validations" do
+    it "requires a name" do
+      expect(build(:grid_faction, name: nil)).not_to be_valid
+    end
+
+    it "requires a unique slug" do
+      create(:grid_faction, slug: "same")
+      expect(build(:grid_faction, slug: "same")).not_to be_valid
+    end
+
+    it "restricts kind to KINDS" do
+      expect(build(:grid_faction, kind: "bogus")).not_to be_valid
+      GridFaction::KINDS.each do |k|
+        expect(build(:grid_faction, kind: k)).to be_valid
+      end
+    end
+  end
+
+  describe "hierarchy" do
+    it "exposes children via parent_id" do
+      parent = create(:grid_faction)
+      child1 = create(:grid_faction, parent: parent)
+      child2 = create(:grid_faction, parent: parent)
+      expect(parent.children).to match_array([child1, child2])
+    end
+
+    it "nullifies children on destroy (does not cascade)" do
+      parent = create(:grid_faction)
+      child = create(:grid_faction, parent: parent)
+      parent.destroy!
+      expect(child.reload.parent_id).to be_nil
+    end
+
+    it "rejects setting parent to self" do
+      f = create(:grid_faction)
+      f.parent_id = f.id
+      expect(f).not_to be_valid
+      expect(f.errors[:parent_id].join).to match(/self/)
+    end
+
+    it "rejects a 2-node parent cycle (A.parent=B, B.parent=A)" do
+      a = create(:grid_faction)
+      b = create(:grid_faction, parent: a)
+      a.parent_id = b.id
+      expect(a).not_to be_valid
+      expect(a.errors[:parent_id].join).to match(/cycle/)
+    end
+
+    it "rejects a 3-node parent cycle" do
+      a = create(:grid_faction)
+      b = create(:grid_faction, parent: a)
+      c = create(:grid_faction, parent: b)
+      a.parent_id = c.id
+      expect(a).not_to be_valid
+    end
+  end
+
+  describe "rep links" do
+    let(:a) { create(:grid_faction) }
+    let(:b) { create(:grid_faction) }
+
+    it "#aggregate? is true when incoming links exist" do
+      create(:grid_faction_rep_link, source_faction: a, target_faction: b)
+      expect(b.aggregate?).to be(true)
+      expect(a.aggregate?).to be(false)
+    end
+
+    it "destroys incoming + outgoing links on destroy" do
+      create(:grid_faction_rep_link, source_faction: a, target_faction: b)
+      expect { a.destroy! }.to change { GridFactionRepLink.count }.by(-1)
+    end
+  end
+
+  describe "polymorphic rep cascade" do
+    let(:faction) { create(:grid_faction) }
+    let(:hackr) { create(:grid_hackr) }
+
+    it "destroys associated grid_hackr_reputations on destroy" do
+      Grid::ReputationService.new(hackr).adjust!(faction, 50, reason: "test")
+      expect { faction.destroy! }.to change { GridHackrReputation.count }.by(-1)
+    end
+
+    it "destroys associated grid_reputation_events on destroy" do
+      Grid::ReputationService.new(hackr).adjust!(faction, 50, reason: "test")
+      Grid::ReputationService.new(hackr).adjust!(faction, 20, reason: "test:two")
+      expect { faction.destroy! }.to change { GridReputationEvent.count }.by(-2)
+    end
+  end
 end

--- a/spec/models/grid_hackr_reputation_spec.rb
+++ b/spec/models/grid_hackr_reputation_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe GridHackrReputation, type: :model do
+  let(:hackr) { create(:grid_hackr) }
+  let(:faction) { create(:grid_faction) }
+
+  it "enforces uniqueness on (hackr, subject)" do
+    create(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: 10)
+    dupe = build(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: 20)
+    expect(dupe).not_to be_valid
+  end
+
+  it "rejects values below MIN_VALUE" do
+    rep = build(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: -1001)
+    expect(rep).not_to be_valid
+  end
+
+  it "rejects values above MAX_VALUE" do
+    rep = build(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: 1001)
+    expect(rep).not_to be_valid
+  end
+
+  it "accepts zero" do
+    rep = build(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: 0)
+    expect(rep).to be_valid
+  end
+
+  describe "scopes" do
+    it ".nonzero excludes zero rows" do
+      create(:grid_hackr_reputation, grid_hackr: hackr, subject: faction, value: 0)
+      create(:grid_hackr_reputation, grid_hackr: hackr, subject: create(:grid_faction), value: 10)
+      expect(described_class.nonzero.count).to eq(1)
+    end
+  end
+end
+
+FactoryBot.define do
+  factory :grid_hackr_reputation do
+    association :grid_hackr
+    association :subject, factory: :grid_faction
+    value { 0 }
+  end
+end

--- a/spec/models/grid_mob_spec.rb
+++ b/spec/models/grid_mob_spec.rb
@@ -17,5 +17,28 @@
 require "rails_helper"
 
 RSpec.describe GridMob, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "faction_not_aggregate" do
+    let(:leaf) { create(:grid_faction, slug: "leaf") }
+    let(:aggregate) { create(:grid_faction, slug: "agg") }
+
+    before do
+      create(:grid_faction_rep_link, source_faction: leaf, target_faction: aggregate, weight: 1.0)
+    end
+
+    it "accepts a leaf faction" do
+      mob = build(:grid_mob, grid_faction: leaf)
+      expect(mob).to be_valid
+    end
+
+    it "accepts a nil faction" do
+      mob = build(:grid_mob, grid_faction: nil)
+      expect(mob).to be_valid
+    end
+
+    it "rejects an aggregate faction" do
+      mob = build(:grid_mob, grid_faction: aggregate)
+      expect(mob).not_to be_valid
+      expect(mob.errors[:grid_faction].join).to match(/aggregate/)
+    end
+  end
 end

--- a/spec/models/grid_reputation_event_spec.rb
+++ b/spec/models/grid_reputation_event_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe GridReputationEvent, type: :model do
+  let(:hackr) { create(:grid_hackr) }
+  let(:faction) { create(:grid_faction) }
+
+  def make(**attrs)
+    described_class.create!({
+      grid_hackr: hackr,
+      subject: faction,
+      delta: 5,
+      value_after: 5,
+      reason: "test"
+    }.merge(attrs))
+  end
+
+  it "requires delta and value_after" do
+    event = described_class.new(grid_hackr: hackr, subject: faction)
+    event.valid?
+    expect(event.errors[:delta]).not_to be_empty
+    expect(event.errors[:value_after]).not_to be_empty
+  end
+
+  it "rejects updates to persisted events (append-only)" do
+    event = make
+    event.note = "changed"
+    expect {
+      event.save!
+    }.to raise_error(ActiveRecord::ReadOnlyRecord)
+  end
+
+  it "allows destroy so hackr cascade works" do
+    make
+    expect {
+      hackr.destroy!
+    }.to change { described_class.count }.by(-1)
+  end
+
+  describe "scopes" do
+    it ".recent orders newest first" do
+      older = make(created_at: 2.days.ago)
+      newer = make(created_at: 1.hour.ago)
+      expect(described_class.recent.to_a).to eq([newer, older])
+    end
+
+    it ".for_subject scopes by subject polymorphic pair" do
+      other = create(:grid_faction)
+      make(subject: faction)
+      make(subject: other)
+      expect(described_class.for_subject(faction).count).to eq(1)
+    end
+  end
+end

--- a/spec/services/grid/reputation_command_spec.rb
+++ b/spec/services/grid/reputation_command_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe "CommandParser reputation integration" do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let!(:hackrcore) { create(:grid_faction, slug: "hackrcore", name: "Hackrcore") }
+  let!(:fn) { create(:grid_faction, slug: "fn", name: "Fracture Network") }
+
+  before do
+    create(:grid_faction_rep_link, source_faction: hackrcore, target_faction: fn, weight: 1.2)
+  end
+
+  def run(input)
+    Grid::CommandParser.new(hackr, input).execute
+  end
+
+  describe "rep command" do
+    it "renders a STANDING REPORT header" do
+      result = run("rep")
+      expect(result[:output]).to include("STANDING REPORT")
+    end
+
+    it "aliases to 'reputation' and 'standing'" do
+      expect(run("reputation")[:output]).to include("STANDING REPORT")
+      expect(run("standing")[:output]).to include("STANDING REPORT")
+    end
+
+    it "renders grandchildren when the hierarchy is >1 level deep" do
+      # Build top → mid → leaf → grand chain via parent_id
+      top = create(:grid_faction, slug: "top", name: "Top Syndicate")
+      mid = create(:grid_faction, slug: "mid", name: "Mid Cadre", parent: top)
+      leaf = create(:grid_faction, slug: "leaf", name: "Leaf Cell", parent: mid)
+      # Put rep somewhere so rows show without include_zero:false filtering.
+      Grid::ReputationService.new(hackr).adjust!(leaf, 10, reason: "test")
+
+      out = run("rep")[:output]
+      expect(out).to include("Top Syndicate")
+      expect(out).to include("Mid Cadre")
+      expect(out).to include("Leaf Cell")
+      # Depth-1 child: "└─ " prefix. Depth-2 grandchild: extra 2 spaces before "└─ ".
+      expect(out).to match(/└─ Mid Cadre/)
+      expect(out).to match(/  └─ Leaf Cell/)
+    end
+  end
+
+  describe "stat command" do
+    it "surfaces a STANDING block when the hackr has activity" do
+      Grid::ReputationService.new(hackr).adjust!(hackrcore, 75, reason: "test")
+      out = run("stat")[:output]
+      expect(out).to include("STANDING:")
+      expect(out).to include("Hackrcore")
+    end
+
+    it "omits STANDING when there's no rep activity" do
+      expect(run("stat")[:output]).not_to include("STANDING:")
+    end
+  end
+
+  describe "talk command rep hook" do
+    let(:mob) do
+      create(:grid_mob,
+        grid_room: room,
+        grid_faction: hackrcore,
+        dialogue_tree: {"greeting" => "hi"})
+    end
+
+    it "grants faction rep when talking to a faction-affiliated NPC" do
+      expect {
+        run("talk #{mob.name}")
+      }.to change { hackr.grid_reputation_events.count }.by(1)
+      expect(Grid::ReputationService.new(hackr).leaf_value(hackrcore)).to eq(1)
+    end
+
+    it "grants no rep for an NPC with no faction" do
+      unaffiliated = create(:grid_mob, grid_room: room, grid_faction: nil, dialogue_tree: {"greeting" => "hi"})
+      expect {
+        run("talk #{unaffiliated.name}")
+      }.not_to change { hackr.grid_reputation_events.count }
+    end
+
+    it "skips rep silently when an NPC is misconfigured on an aggregate faction" do
+      # Normal creation is now blocked by GridMob's faction_not_aggregate
+      # validator, but a mob can still end up pointing at an aggregate if the
+      # rep-link graph is edited AFTER the mob was created (or via bypass).
+      # Simulate that: assign to leaf first, then mutate the column directly.
+      bad = create(:grid_mob, grid_room: room, grid_faction: hackrcore, dialogue_tree: {"greeting" => "hi"})
+      bad.update_column(:grid_faction_id, fn.id)
+      expect {
+        result = run("talk #{bad.name}")
+        expect(result[:output]).to include(bad.name)
+      }.not_to change { hackr.grid_reputation_events.count }
+    end
+  end
+end

--- a/spec/services/grid/reputation_service_spec.rb
+++ b/spec/services/grid/reputation_service_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Grid::ReputationService do
+  let(:hackr) { create(:grid_hackr) }
+  let(:service) { described_class.new(hackr) }
+
+  let(:fn) { create(:grid_faction, slug: "fn", name: "Fracture Network") }
+  let(:hackrcore) { create(:grid_faction, slug: "hackrcore", name: "Hackrcore", parent: fn) }
+  let(:govcorp) { create(:grid_faction, slug: "govcorp", name: "GovCorp") }
+  let(:dante) { create(:grid_faction, slug: "dante", name: "Dante", kind: "individual") }
+
+  before do
+    # Graph: Hackrcore→FN +1.2, GovCorp→FN -0.2. Dante is unlinked.
+    create(:grid_faction_rep_link, source_faction: hackrcore, target_faction: fn, weight: 1.2)
+    create(:grid_faction_rep_link, source_faction: govcorp, target_faction: fn, weight: -0.2)
+  end
+
+  describe "#adjust!" do
+    it "creates a leaf row for a new subject" do
+      expect {
+        service.adjust!(hackrcore, 25, reason: "test")
+      }.to change { GridHackrReputation.count }.by(1)
+
+      rep = hackr.grid_hackr_reputations.find_by(subject: hackrcore)
+      expect(rep.value).to eq(25)
+    end
+
+    it "appends an event with value_after snapshot" do
+      service.adjust!(hackrcore, 10, reason: "test:a")
+      service.adjust!(hackrcore, 15, reason: "test:b")
+
+      events = hackr.grid_reputation_events.order(:created_at).to_a
+      expect(events.size).to eq(2)
+      expect(events.map(&:delta)).to eq([10, 15])
+      expect(events.map(&:value_after)).to eq([10, 25])
+      expect(events.map(&:reason)).to eq(["test:a", "test:b"])
+    end
+
+    it "clamps the stored value to MIN..MAX and reports applied_delta" do
+      service.adjust!(hackrcore, 950)
+      result = service.adjust!(hackrcore, 200)
+
+      expect(result[:new_value]).to eq(1000)
+      expect(result[:applied_delta]).to eq(50)
+      expect(result[:requested_delta]).to eq(200)
+    end
+
+    it "clamps downward at -1000" do
+      service.adjust!(govcorp, -900)
+      result = service.adjust!(govcorp, -500)
+
+      expect(result[:new_value]).to eq(-1000)
+      expect(result[:applied_delta]).to eq(-100)
+    end
+
+    it "reports rollup transitions when an aggregate crosses a tier" do
+      # Hackrcore +50 → FN effective = 60 (tier UNKNOWN → TRUSTED at 50)
+      result = service.adjust!(hackrcore, 50)
+      rollup = result[:rollups].find { |r| r[:faction].id == fn.id }
+
+      expect(rollup).not_to be_nil
+      expect(rollup[:old_value]).to eq(0)
+      expect(rollup[:new_value]).to eq(60)
+      expect(rollup[:tier_before][:key]).to eq(:unknown)
+      expect(rollup[:tier_after][:key]).to eq(:trusted)
+    end
+
+    it "reports NO rollup for a subject with no outgoing links" do
+      result = service.adjust!(dante, 100)
+      expect(result[:rollups]).to be_empty
+    end
+
+    it "raises SubjectMissing for an unknown slug" do
+      expect {
+        service.adjust!("no_such_faction", 10)
+      }.to raise_error(Grid::ReputationService::SubjectMissing)
+    end
+
+    it "refuses to adjust an aggregate subject" do
+      expect {
+        service.adjust!(fn, 50, reason: "test")
+      }.to raise_error(Grid::ReputationService::AggregateSubjectNotAdjustable, /derived/)
+    end
+
+    it "does NOT persist a rep row or event when refusing an aggregate write" do
+      reps_before = GridHackrReputation.count
+      events_before = GridReputationEvent.count
+      begin
+        service.adjust!(fn, 50)
+      rescue Grid::ReputationService::AggregateSubjectNotAdjustable
+      end
+      expect(GridHackrReputation.count).to eq(reps_before)
+      expect(GridReputationEvent.count).to eq(events_before)
+    end
+
+    it "accepts a faction slug as the subject" do
+      service.adjust!(:hackrcore, 10)
+      expect(service.leaf_value(hackrcore)).to eq(10)
+    end
+
+    it "is transactional — no rep row if event fails" do
+      allow(GridReputationEvent).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+      expect {
+        begin
+          service.adjust!(hackrcore, 10)
+        rescue ActiveRecord::RecordInvalid
+        end
+      }.not_to change { GridHackrReputation.count }
+    end
+  end
+
+  describe "#effective_rep" do
+    it "returns leaf value for a leaf subject" do
+      service.adjust!(hackrcore, 100)
+      expect(service.effective_rep(hackrcore)).to eq(100)
+    end
+
+    it "sums weighted contributions for an aggregate subject" do
+      service.adjust!(hackrcore, 100)   # +120 via 1.2x
+      service.adjust!(govcorp, 50)      # -10 via -0.2x
+      # Net: 120 - 10 = 110
+      expect(service.effective_rep(fn)).to eq(110)
+    end
+
+    it "clamps aggregate to MIN..MAX" do
+      svc_hc = service
+      svc_hc.adjust!(hackrcore, 900) # 900 × 1.2 = 1080 → clamped to 1000
+      expect(service.effective_rep(fn)).to eq(1000)
+    end
+
+    it "returns 0 when no contributions exist" do
+      expect(service.effective_rep(fn)).to eq(0)
+    end
+
+    it "handles a negative weighted edge" do
+      service.adjust!(govcorp, 100)
+      # 100 × -0.2 = -20
+      expect(service.effective_rep(fn)).to eq(-20)
+    end
+
+    it "propagates through chained aggregates (A → B → C)" do
+      # Build a fresh 3-level chain: leaf → mid → top
+      leaf = create(:grid_faction, slug: "chain_leaf")
+      mid  = create(:grid_faction, slug: "chain_mid")
+      top  = create(:grid_faction, slug: "chain_top")
+      create(:grid_faction_rep_link, source_faction: leaf, target_faction: mid, weight: 0.5)
+      create(:grid_faction_rep_link, source_faction: mid,  target_faction: top, weight: 2.0)
+
+      service.adjust!(leaf, 100)
+
+      expect(service.effective_rep(leaf)).to eq(100)
+      expect(service.effective_rep(mid)).to eq(50)   # 100 × 0.5
+      expect(service.effective_rep(top)).to eq(100)  # effective(mid) × 2.0 = 50 × 2
+    end
+  end
+
+  describe "#leaf_value" do
+    it "returns 0 for a subject with no stored row" do
+      expect(service.leaf_value(hackrcore)).to eq(0)
+    end
+
+    it "returns stored leaf after adjust" do
+      service.adjust!(hackrcore, 42)
+      expect(service.leaf_value(hackrcore)).to eq(42)
+    end
+  end
+
+  describe "#faction_standings" do
+    it "omits zero-rep factions by default" do
+      service.adjust!(hackrcore, 10)
+      slugs = service.faction_standings.map { |s| s[:faction].slug }
+      expect(slugs).to include("hackrcore", "fn")
+      expect(slugs).not_to include("dante")
+    end
+
+    it "includes all factions when include_zero: true" do
+      # Force all four factions into existence (let blocks are lazy)
+      [fn, hackrcore, govcorp, dante]
+      slugs = service.faction_standings(include_zero: true).map { |s| s[:faction].slug }
+      expect(slugs).to match_array(%w[fn hackrcore govcorp dante])
+    end
+
+    it "flags aggregates" do
+      service.adjust!(hackrcore, 100)
+      fn_row = service.faction_standings.find { |s| s[:faction].slug == "fn" }
+      expect(fn_row[:aggregate]).to be(true)
+
+      hc_row = service.faction_standings.find { |s| s[:faction].slug == "hackrcore" }
+      expect(hc_row[:aggregate]).to be(false)
+    end
+  end
+end

--- a/spec/services/grid/reputation_service_spec.rb
+++ b/spec/services/grid/reputation_service_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe Grid::ReputationService do
     it "propagates through chained aggregates (A → B → C)" do
       # Build a fresh 3-level chain: leaf → mid → top
       leaf = create(:grid_faction, slug: "chain_leaf")
-      mid  = create(:grid_faction, slug: "chain_mid")
-      top  = create(:grid_faction, slug: "chain_top")
+      mid = create(:grid_faction, slug: "chain_mid")
+      top = create(:grid_faction, slug: "chain_top")
       create(:grid_faction_rep_link, source_faction: leaf, target_faction: mid, weight: 0.5)
-      create(:grid_faction_rep_link, source_faction: mid,  target_faction: top, weight: 2.0)
+      create(:grid_faction_rep_link, source_faction: mid, target_faction: top, weight: 2.0)
 
       service.adjust!(leaf, 100)
 

--- a/spec/services/grid/reputation_spec.rb
+++ b/spec/services/grid/reputation_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Grid::Reputation do
+  describe ".tier_for" do
+    it "returns BLACKLISTED at floor" do
+      expect(described_class.tier_for(-1000)[:key]).to eq(:blacklisted)
+      expect(described_class.tier_for(-700)[:key]).to eq(:blacklisted)
+    end
+
+    it "returns ARCHITECT at ceiling" do
+      expect(described_class.tier_for(800)[:key]).to eq(:architect)
+      expect(described_class.tier_for(1000)[:key]).to eq(:architect)
+    end
+
+    it "returns UNKNOWN around zero" do
+      expect(described_class.tier_for(0)[:key]).to eq(:unknown)
+      expect(described_class.tier_for(-49)[:key]).to eq(:unknown)
+      expect(described_class.tier_for(49)[:key]).to eq(:unknown)
+    end
+
+    it "returns TRUSTED at 50..199" do
+      expect(described_class.tier_for(50)[:key]).to eq(:trusted)
+      expect(described_class.tier_for(199)[:key]).to eq(:trusted)
+    end
+
+    it "returns OPERATIVE at 200..499" do
+      expect(described_class.tier_for(200)[:key]).to eq(:operative)
+      expect(described_class.tier_for(499)[:key]).to eq(:operative)
+    end
+
+    it "returns SPECIALIST at 500..799" do
+      expect(described_class.tier_for(500)[:key]).to eq(:specialist)
+      expect(described_class.tier_for(799)[:key]).to eq(:specialist)
+    end
+
+    it "returns HOSTILE at -599..-200" do
+      expect(described_class.tier_for(-200)[:key]).to eq(:hostile)
+      expect(described_class.tier_for(-599)[:key]).to eq(:hostile)
+    end
+
+    it "tiers strictly increase by threshold" do
+      mins = described_class::TIERS.map { |t| t[:min] }
+      expect(mins).to eq(mins.sort)
+    end
+  end
+
+  describe ".next_tier_for" do
+    it "returns the next tier up" do
+      expect(described_class.next_tier_for(0)[:key]).to eq(:trusted)
+      expect(described_class.next_tier_for(100)[:key]).to eq(:operative)
+    end
+
+    it "returns nil at ceiling" do
+      expect(described_class.next_tier_for(1000)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
  Adds per-hackr reputation tracked as leaf values against GridFactions,
  with aggregate standings (e.g. Fracture Network) derived on read from a
  directed rep-link graph. Decouples display hierarchy from rep math so
  GovCorp can contribute negatively to FN without being its child.

  Core:
  - GridHackrReputation (polymorphic subject, -1000..+1000, unique per hackr+subject) stores only leaf values.
  - GridReputationEvent (polymorphic subject + source) is an append-only audit log with value_after snapshot and optional admin note.
  - GridFactionRepLink is the directed edge (source, target, signed weight). Model rejects self-links, duplicates, and cycles via DFS.
  - GridFaction extended with parent_id (display only), kind enum, position, and a parent_chain_has_no_cycle validator.
  - Grid::Reputation defines the 8-tier ladder BLACKLISTED..ARCHITECT.
  - Grid::ReputationService#adjust! is transactional (find_or_create then SELECT FOR UPDATE, retries once on RecordNotUnique). effective_rep recurses through the link graph so chains of aggregates propagate. Refuses to write to aggregates (AggregateSubjectNotAdjustable).

  Commands:
  - New `rep` / `reputation` / `standing` command renders the full tree with aligned tier badges, centered -1000..+1000 progress bars, and next-tier hints. Supports arbitrary hierarchy depth.
  - `stat` gains a compact STANDING block when the hackr has nonzero rep.
  - `talk` and `buy` award +1 / +2 with the NPC/vendor faction; writes are rescued for misconfigured aggregates so gameplay never crashes.

  Admin:
  - Full CRUD at /root/grid_factions with a bulk rep-link graph editor (blank rows delete edges, cycle-inducing edits roll back).
  - Read + manual-adjust at /root/grid_hackr_reputations (aggregates filtered out of the dropdown).
  - Read-only filterable log at /root/grid_reputation_events.
  - GridMob rejects assignment to aggregate factions at validation time.

  Seed:
  - data/world/factions.yml rewritten: fracture_network (aggregate), hackrcore/blackout/frontwave/offline (parent=FN, weights 1.2/0.8/1.0 /0.9), govcorp (standalone, weight -0.2 to FN), dante (individual). Rep-link section is declarative — task reconciles the graph.
  - Data migration renames thecyberpulse slug -> hackrcore (keeps artist link), removes xeraen faction with polymorphic orphan cleanup.

  Tests: 55+ new specs covering tier math, adjust/clamp/rollup, cycle
  rejection (rep-link and parent), chain propagation, aggregate-write
  refusal, polymorphic cascade on destroy, and command integration
  (rep output, STANDING block, talk/buy hooks, misconfig graceful skip).