### PR TITLE
[TPG] Unified Achievement/Badge System

### DIFF
--- a/app/channels/achievement_channel.rb
+++ b/app/channels/achievement_channel.rb
@@ -1,0 +1,13 @@
+class AchievementChannel < ApplicationCable::Channel
+  def self.stream_name_for(hackr)
+    "achievement_channel_#{hackr.id}"
+  end
+
+  def subscribed
+    unless current_hackr
+      reject
+      return
+    end
+    stream_from self.class.stream_name_for(current_hackr)
+  end
+end

--- a/app/controllers/admin/grid_achievements_controller.rb
+++ b/app/controllers/admin/grid_achievements_controller.rb
@@ -2,12 +2,15 @@ class Admin::GridAchievementsController < Admin::ApplicationController
   before_action :set_achievement, only: [:edit, :update, :destroy, :award]
 
   def index
-    @achievements = GridAchievement.includes(:grid_hackr_achievements).order(:trigger_type, :name)
+    scope = GridAchievement.includes(:grid_hackr_achievements)
+    scope = scope.by_category(params[:category]) if params[:category].present? && GridAchievement::CATEGORIES.include?(params[:category])
+    @category_filter = params[:category]
+    @achievements = scope.order(:category, :trigger_type, :name)
     @hackrs = GridHackr.order(:hackr_alias)
   end
 
   def new
-    @achievement = GridAchievement.new(trigger_data: {}, xp_reward: 0)
+    @achievement = GridAchievement.new(trigger_data: {}, xp_reward: 0, cred_reward: 0, category: "grid")
   end
 
   def create
@@ -43,13 +46,9 @@ class Admin::GridAchievementsController < Admin::ApplicationController
 
   def award
     hackr = GridHackr.find(params[:hackr_id])
-    gha = GridHackrAchievement.find_or_create_by!(
-      grid_hackr: hackr,
-      grid_achievement: @achievement
-    ) { |r| r.awarded_at = Time.current }
+    notification = Grid::AchievementAwarder.new(hackr, @achievement).award!
 
-    if gha.previously_new_record?
-      hackr.grant_xp!(@achievement.xp_reward) if @achievement.xp_reward > 0
+    if notification
       set_flash_success("Awarded '#{@achievement.name}' to #{hackr.hackr_alias}.")
     else
       set_flash_error("#{hackr.hackr_alias} already has '#{@achievement.name}'.")
@@ -66,7 +65,7 @@ class Admin::GridAchievementsController < Admin::ApplicationController
   def achievement_params
     permitted = params.require(:grid_achievement).permit(
       :slug, :name, :description, :badge_icon,
-      :trigger_type, :xp_reward, :hidden
+      :trigger_type, :xp_reward, :cred_reward, :category, :hidden
     )
     # Parse trigger_data from JSON string
     permitted[:trigger_data] = if params[:grid_achievement][:trigger_data_json].present?

--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -57,5 +57,31 @@ module Api
         }
       }
     end
+
+    # POST /api/artists/:id/bio_viewed
+    def bio_viewed
+      return head :no_content unless current_hackr
+
+      artist = Artist.find_by(slug: params[:id]) || Artist.find_by(id: params[:id])
+      return head :not_found unless artist
+
+      HackrPageView.record!(current_hackr, "bio", artist.id)
+      Grid::AchievementChecker.new(current_hackr).check("artist_bios_viewed_all")
+
+      head :no_content
+    end
+
+    # POST /api/artists/:id/release_index_viewed
+    def release_index_viewed
+      return head :no_content unless current_hackr
+
+      artist = Artist.find_by(slug: params[:id]) || Artist.find_by(id: params[:id])
+      return head :not_found unless artist
+
+      HackrPageView.record!(current_hackr, "release_index", artist.id)
+      Grid::AchievementChecker.new(current_hackr).check("release_indexes_viewed_all")
+
+      head :no_content
+    end
   end
 end

--- a/app/controllers/api/codex_controller.rb
+++ b/app/controllers/api/codex_controller.rb
@@ -61,5 +61,21 @@ module Api
     rescue ActiveRecord::RecordNotFound
       render json: {error: "Codex entry not found"}, status: :not_found
     end
+
+    # POST /api/codex/:slug/read
+    def mark_read
+      return head :no_content unless current_hackr
+
+      entry = CodexEntry.published.find_by(slug: params[:slug])
+      return head :not_found unless entry
+
+      CodexEntryRead.record!(current_hackr, entry)
+
+      checker = Grid::AchievementChecker.new(current_hackr)
+      checker.check("codex_entries_read")
+      checker.check("codex_entries_read_all")
+
+      head :no_content
+    end
   end
 end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -1,9 +1,58 @@
 class Api::GridController < ApplicationController
   include GridAuthentication
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action :require_admin_api, only: [:debit]
+
+  # GET /api/grid/achievements - All visible achievements grouped by
+  # category, with earned status, awarded_at, and live progress for
+  # cumulative triggers. Hidden achievements appear only if earned.
+  def achievements_index
+    earned_map = current_hackr.grid_hackr_achievements
+      .pluck(:grid_achievement_id, :awarded_at)
+      .to_h
+
+    checker = Grid::AchievementChecker.new(current_hackr)
+    achievements = GridAchievement.order(:category, :name).to_a
+
+    categories = Hash.new { |h, k| h[k] = [] }
+    summary = Hash.new { |h, k| h[k] = {total: 0, earned: 0} }
+
+    achievements.each do |a|
+      earned = earned_map.key?(a.id)
+
+      # Hidden achievements hide from the list until earned.
+      next if a.hidden && !earned
+
+      summary[a.category][:total] += 1
+      summary[a.category][:earned] += 1 if earned
+
+      categories[a.category] << {
+        slug: a.slug,
+        name: a.name,
+        description: a.description,
+        badge_icon: a.badge_icon,
+        category: a.category,
+        trigger_type: a.trigger_type,
+        xp_reward: a.xp_reward,
+        cred_reward: a.cred_reward,
+        earned: earned,
+        awarded_at: earned_map[a.id]&.iso8601,
+        progress: checker.progress(a)
+      }
+    end
+
+    total_summary = {
+      total: summary.values.sum { |s| s[:total] },
+      earned: summary.values.sum { |s| s[:earned] }
+    }
+
+    render json: {
+      categories: categories,
+      summary: {by_category: summary, total: total_summary}
+    }
+  end
 
   # GET /api/grid/current_hackr - Get current logged-in hackr info
   def current_hackr_info
@@ -36,6 +85,7 @@ class Api::GridController < ApplicationController
 
       log_in(hackr)
       hackr.touch_activity!
+      Grid::AchievementSweepJob.perform_later(hackr.id)
       Rails.logger.info("[AUTH] Login success: hackr_alias=#{hackr.hackr_alias} ip=#{request.remote_ip}")
       render json: {
         success: true,

--- a/app/controllers/api/hackr_streams_controller.rb
+++ b/app/controllers/api/hackr_streams_controller.rb
@@ -73,6 +73,19 @@ class Api::HackrStreamsController < ApplicationController
     }
   end
 
+  # POST /api/artists/:artist_slug/vods/:id/watch
+  def watch
+    return head :no_content unless current_hackr
+
+    artist = Artist.find_by!(slug: params[:artist_slug])
+    stream = artist.hackr_streams.find(params[:id])
+
+    HackrVodWatch.record!(current_hackr, stream)
+    Grid::AchievementChecker.new(current_hackr).check("vods_watched")
+
+    head :no_content
+  end
+
   private
 
   def record_not_found

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -61,4 +61,20 @@ class Api::LogsController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     render json: {error: "Log not found or not yet published."}, status: :not_found
   end
+
+  # POST /api/logs/:id/read
+  def mark_read
+    return head :no_content unless current_hackr
+
+    log = HackrLog.published.find_by(slug: params[:id])
+    return head :not_found unless log
+
+    HackrLogRead.record!(current_hackr, log)
+
+    checker = Grid::AchievementChecker.new(current_hackr)
+    checker.check("hackr_logs_read")
+    checker.check("hackr_logs_read_all")
+
+    head :no_content
+  end
 end

--- a/app/controllers/api/playlist_tracks_controller.rb
+++ b/app/controllers/api/playlist_tracks_controller.rb
@@ -19,9 +19,19 @@ module Api
         return
       end
 
+      # Note the playlist's track count BEFORE the add so we can tell
+      # if this add is what transitioned the playlist from empty to
+      # populated. `playlists_created` counts playlists with ≥1 track;
+      # its tally only changes on the 0→1 transition, so the achievement
+      # checker only needs to run then.
+      was_empty = @playlist.playlist_tracks.none?
+
       playlist_track = @playlist.playlist_tracks.build(track: track)
 
       if playlist_track.save
+        if was_empty
+          Grid::AchievementChecker.new(current_hackr).check("playlists_created")
+        end
         render json: {
           success: true,
           message: "Track added to playlist",

--- a/app/controllers/api/playlists_controller.rb
+++ b/app/controllers/api/playlists_controller.rb
@@ -68,6 +68,8 @@ module Api
       @playlist = current_hackr.playlists.build(playlist_params)
 
       if @playlist.save
+        # Note: `playlists_created` achievement requires ≥1 track — fires
+        # from PlaylistTracksController#create after the first track add.
         render json: {
           success: true,
           message: "Playlist created successfully",

--- a/app/controllers/api/pulses_controller.rb
+++ b/app/controllers/api/pulses_controller.rb
@@ -89,6 +89,9 @@ module Api
       @pulse = current_hackr.pulses.build(pulse_params)
 
       if @pulse.save
+        if @pulse.parent_pulse_id.nil?
+          Grid::AchievementChecker.new(current_hackr).check("wire_pulses_count")
+        end
         render json: {
           success: true,
           message: "Pulse broadcast successfully",

--- a/app/controllers/api/radio_controller.rb
+++ b/app/controllers/api/radio_controller.rb
@@ -78,5 +78,20 @@ module Api
     rescue ActiveRecord::RecordNotFound
       render json: {error: "Radio station not found"}, status: :not_found
     end
+
+    # POST /api/radio_stations/:id/tune_in
+    def tune_in
+      return head :no_content unless current_hackr
+
+      station = RadioStation.visible.find_by(id: params[:id])
+      return head :not_found unless station
+
+      HackrRadioTune.record!(current_hackr, station)
+      checker = Grid::AchievementChecker.new(current_hackr)
+      checker.check("radio_stations_tuned")
+      checker.check("radio_stations_tuned_all")
+
+      head :no_content
+    end
   end
 end

--- a/app/controllers/api/releases_controller.rb
+++ b/app/controllers/api/releases_controller.rb
@@ -134,6 +134,20 @@ module Api
       }
     end
 
+    # POST /api/releases/:id/viewed
+    def viewed
+      return head :no_content unless current_hackr
+
+      release = Release.find_by(slug: params[:id]) || Release.find_by(id: params[:id])
+      return head :not_found unless release
+      return head :unprocessable_entity if release.coming_soon
+
+      HackrPageView.record!(current_hackr, "release", release.id)
+      Grid::AchievementChecker.new(current_hackr).check("releases_viewed_all")
+
+      head :no_content
+    end
+
     private
 
     def parse_duration(duration_str)

--- a/app/controllers/api/tracks_controller.rb
+++ b/app/controllers/api/tracks_controller.rb
@@ -113,5 +113,28 @@ module Api
         vidz: @track.hackr_streams.map { |v| {id: v.id, title: v.title, vod_url: v.vod_url} }
       }
     end
+
+    # POST /api/tracks/:id/play_credit
+    # Records a 30s+ play toward achievement progress. No-op for anon.
+    # Only Pulse Vault tracks count — coming_soon tracks and tracks
+    # hidden from the vault are rejected to keep counter-based
+    # achievements (`track_plays_count`, `pulse_vault_completed`)
+    # honest.
+    def play_credit
+      return head :no_content unless current_hackr
+
+      track = Track.find_by(slug: params[:id]) || Track.find_by(id: params[:id])
+      return head :not_found unless track
+      return head :unprocessable_entity if track.release&.coming_soon
+      return head :unprocessable_entity unless track.show_in_pulse_vault
+
+      GridHackrTrackPlay.record!(current_hackr, track)
+
+      checker = Grid::AchievementChecker.new(current_hackr)
+      checker.check("track_plays_count")
+      checker.check("pulse_vault_completed")
+
+      head :no_content
+    end
   end
 end

--- a/app/controllers/api/uplink/packets_controller.rb
+++ b/app/controllers/api/uplink/packets_controller.rb
@@ -76,6 +76,14 @@ module Api
         )
 
         if @packet.save
+          # "Packet" is the in-world user-facing term for an Uplink
+          # message — aesthetic naming to preserve the Grid's fourth
+          # wall. Underlying model is `ChatMessage` (see @packet
+          # assignment above: `@channel.chat_messages.build(...)`).
+          # The `uplink_packets_count` achievement trigger counts
+          # `chat_messages` rows — same table, same rows, cosmetic
+          # alias only.
+          Grid::AchievementChecker.new(current_hackr).check("uplink_packets_count")
           render json: {
             success: true,
             message: "Packet transmitted",

--- a/app/javascript/components/AudioPlayer.tsx
+++ b/app/javascript/components/AudioPlayer.tsx
@@ -22,6 +22,12 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ onReady }) => {
   const stationContextRef = useRef<StationContext | null>(null) // Store station context
   const shuffledPlaylistRef = useRef<TrackData[]>([]) // Store shuffled playlist
   const lastTimeRef = useRef<number>(0) // Track last known playback time for stall detection
+  const creditedTrackIdsRef = useRef<Set<string>>(new Set()) // Achievement play_credit dedup (per session)
+  // Cumulative audio played per track (id → seconds). Used to gate the
+  // 30s play-credit — counts only forward-progression under 2s between
+  // samples, so seeking past the 30s mark does not award credit.
+  const playedSecondsByTrackRef = useRef<Map<string, number>>(new Map())
+  const lastPlaybackPosRef = useRef<{ id: string; time: number } | null>(null)
 
   // Update overlay paused state only (without changing track)
   const updateOverlayPaused = useCallback((paused: boolean) => {
@@ -408,6 +414,30 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ onReady }) => {
       // Only update time if not currently seeking to avoid conflicts
       if (!isSeeking) {
         setCurrentTime(audio.currentTime)
+      }
+
+      // Achievement: credit a track play once 30s of actual playback has
+      // been accumulated. Seeking past the mark does not count — we only
+      // add the delta between samples when it's a small forward step
+      // (< 2s), indicating real playback progression rather than a jump.
+      const track = currentTrack
+      if (track && !creditedTrackIdsRef.current.has(track.id)) {
+        const last = lastPlaybackPosRef.current
+        const now = audio.currentTime
+        if (last && last.id === track.id) {
+          const delta = now - last.time
+          if (delta > 0 && delta < 2) {
+            const prev = playedSecondsByTrackRef.current.get(track.id) || 0
+            const accumulated = prev + delta
+            playedSecondsByTrackRef.current.set(track.id, accumulated)
+            if (accumulated >= 30) {
+              creditedTrackIdsRef.current.add(track.id)
+              apiFetch(`/api/tracks/${encodeURIComponent(track.id)}/play_credit`, { method: 'POST' })
+                .catch(err => console.warn('play_credit failed:', err))
+            }
+          }
+        }
+        lastPlaybackPosRef.current = { id: track.id, time: now }
       }
     }
 

--- a/app/javascript/components/YouTubePlayer.tsx
+++ b/app/javascript/components/YouTubePlayer.tsx
@@ -5,6 +5,7 @@ interface YouTubePlayerProps {
   width?: number
   height?: number
   responsive?: boolean
+  onPlay?: () => void
 }
 
 // YouTube Player types
@@ -16,6 +17,11 @@ interface YTPlayer {
 
 interface YTPlayerEvent {
   target: YTPlayer
+}
+
+interface YTStateChangeEvent {
+  target: YTPlayer
+  data: number
 }
 
 // Extend Window interface to include YouTube API
@@ -36,12 +42,19 @@ export const YouTubePlayer: React.FC<YouTubePlayerProps> = ({
   videoId,
   width = 560,
   height = 315,
-  responsive = false
+  responsive = false,
+  onPlay
 }) => {
   const playerRef = useRef<HTMLDivElement>(null)
   const [player, setPlayer] = useState<YTPlayer | null>(null)
   const [showThumbnail, setShowThumbnail] = useState(true)
   const isAPIReadyRef = useRef(false)
+  const onPlayRef = useRef(onPlay)
+  const playFiredRef = useRef(false)
+
+  useEffect(() => {
+    onPlayRef.current = onPlay
+  }, [onPlay])
 
   // Load YouTube IFrame API
   useEffect(() => {
@@ -85,6 +98,17 @@ export const YouTubePlayer: React.FC<YouTubePlayerProps> = ({
       events: {
         onReady: (event: YTPlayerEvent) => {
           event.target.playVideo()
+        },
+        // Fire `onPlay` exactly once — the first time the YT player
+        // reports PLAYING state. This is the real "watched" signal
+        // (distinct from the page-load event), used by parent
+        // components for achievement credit.
+        onStateChange: (event: YTStateChangeEvent) => {
+          const playingState = window.YT?.PlayerState?.PLAYING ?? 1
+          if (event.data === playingState && !playFiredRef.current) {
+            playFiredRef.current = true
+            onPlayRef.current?.()
+          }
         }
       }
     })

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -25,6 +25,7 @@ const TrackDetailPage = lazy(() => import('~/components/pages/tracks/TrackDetail
 const ReleaseListPage = lazy(() => import('~/components/pages/releases/ReleaseListPage'))
 const ReleaseDetailPage = lazy(() => import('~/components/pages/releases/ReleaseDetailPage'))
 const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').then(m => ({ default: m.GridGamePage })))
+const AchievementsPage = lazy(() => import('~/components/pages/grid/AchievementsPage'))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
@@ -51,6 +52,7 @@ const NotFoundPage = lazy(() => import('~/components/errors/NotFoundPage').then(
 // Auth components
 import { ProtectedRoute } from '~/components/auth/ProtectedRoute'
 import { FeatureGate } from '~/components/auth/FeatureGate'
+import { AchievementToastContainer } from '~/components/shared/AchievementToast'
 
 export const AppLayout: React.FC = () => {
   const location = useLocation()
@@ -61,77 +63,81 @@ export const AppLayout: React.FC = () => {
   }, [location.pathname])
 
   return (
-    <Suspense fallback={<LoadingPage message="Loading page..." />}>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/fm" element={<FmLandingPage />} />
-        <Route path="/fm/releases" element={<FmReleasesPage />} />
-        <Route path="/vault" element={<PulseVaultPage />} />
-        <Route path="/fm/radio" element={<RadioPage />} />
-        <Route path="/f/net" element={<BandsPage />} />
-        {/* Playlist routes - protected */}
-        <Route path="/fm/playlists" element={<ProtectedRoute><PlaylistsPage /></ProtectedRoute>} />
-        <Route path="/fm/playlists/:id" element={<ProtectedRoute><PlaylistDetailPage /></ProtectedRoute>} />
-        {/* Shared playlist - public */}
-        <Route path="/shared/:token" element={<SharedPlaylistPage />} />
-        <Route path="/thecyberpulse" element={<TheCyberPulseLandingPage />} />
-        <Route path="/thecyberpulse/bio" element={<TheCyberPulsePage />} />
-        <Route path="/thecyberpulse/releases" element={<ReleaseListPage />} />
-        <Route path="/thecyberpulse/releases/:releaseSlug" element={<ReleaseDetailPage />} />
-        <Route path="/thecyberpulse/trackz/:trackSlug" element={<TrackDetailPage />} />
-        <Route path="/thecyberpulse/vidz" element={<VodzPage />} />
-        <Route path="/thecyberpulse/vidz/:id" element={<VodzShowPage />} />
-        <Route path="/xeraen" element={<XeraenLandingPage />} />
-        <Route path="/xeraen/bio" element={<XeraenPage />} />
-        <Route path="/xeraen/releases" element={<ReleaseListPage />} />
-        <Route path="/xeraen/releases/:releaseSlug" element={<ReleaseDetailPage />} />
-        <Route path="/xeraen/trackz/:trackSlug" element={<TrackDetailPage />} />
-        <Route path="/xeraen/vidz" element={<VodzPage />} />
-        <Route path="/xeraen/vidz/:id" element={<VodzShowPage />} />
-        <Route path="/sector/x" element={<SectorXPage />} />
-        {/* Wavelength Zero has a custom landing page */}
-        <Route path="/wavelength-zero" element={<WavelengthZeroPage />} />
-        {/* Dynamic artist routes — catches any artist slug */}
-        <Route path="/:artistSlug" element={<BandProfilePage />} />
-        <Route path="/:artistSlug/releases" element={<ReleaseListPage />} />
-        <Route path="/:artistSlug/releases/:releaseSlug" element={<ReleaseDetailPage />} />
-        <Route path="/:artistSlug/trackz/:trackSlug" element={<TrackDetailPage />} />
-        {/* THE PULSE GRID routes */}
-        <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
-        <Route path="/grid/login" element={<GridLoginPage />} />
-        <Route path="/grid/register" element={<GridRegisterPage />} />
-        <Route path="/grid/forgot_password" element={<ForgotPasswordPage />} />
-        <Route path="/grid/verify/:token" element={<GridVerifyPage />} />
-        <Route path="/grid/identity" element={<ProtectedRoute><IdentityPage /></ProtectedRoute>} />
-        <Route path="/grid/reset_password/:token" element={<ResetPasswordPage />} />
-        <Route path="/grid/confirm_email_change/:token" element={<GridConfirmEmailChangePage />} />
-        {/* Hackr Logs routes */}
-        <Route path="/logs" element={<LogsIndexPage />} />
-        <Route path="/logs/:slug" element={<LogDetailPage />} />
-        {/* Codex routes */}
-        <Route path="/codex" element={<CodexIndexPage />} />
-        <Route path="/codex/:slug" element={<CodexEntryPage />} />
-        {/* Handbook routes - login required */}
-        <Route path="/handbook" element={<ProtectedRoute><HandbookIndexPage /></ProtectedRoute>} />
-        <Route path="/handbook/:slug" element={<ProtectedRoute><HandbookArticlePage /></ProtectedRoute>} />
-        {/* Timeline route */}
-        <Route path="/timeline" element={<TimelinePage />} />
-        {/* PulseWire routes */}
-        <Route path="/wire" element={<HotwirePage />} />
-        <Route path="/wire/:username" element={<UserPulsesPage />} />
-        <Route path="/wire/pulse/:id" element={<SinglePulsePage />} />
-        {/* Uplink routes - protected */}
-        <Route path="/uplink" element={<ProtectedRoute><UplinkPage /></ProtectedRoute>} />
-        {/* Uplink popout - public for livestream viewing */}
-        <Route path="/uplink/popout" element={<UplinkPopoutPage />} />
-        {/* Code browser routes - protected */}
-        <Route path="/code" element={<ProtectedRoute><CodeIndexPage /></ProtectedRoute>} />
-        <Route path="/code/:repo" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
-        <Route path="/code/:repo/tree/*" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
-        <Route path="/code/:repo/blob/*" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
-        {/* 404 catch-all - must be last */}
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </Suspense>
+    <>
+      <AchievementToastContainer />
+      <Suspense fallback={<LoadingPage message="Loading page..." />}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/fm" element={<FmLandingPage />} />
+          <Route path="/fm/releases" element={<FmReleasesPage />} />
+          <Route path="/vault" element={<PulseVaultPage />} />
+          <Route path="/fm/radio" element={<RadioPage />} />
+          <Route path="/f/net" element={<BandsPage />} />
+          {/* Playlist routes - protected */}
+          <Route path="/fm/playlists" element={<ProtectedRoute><PlaylistsPage /></ProtectedRoute>} />
+          <Route path="/fm/playlists/:id" element={<ProtectedRoute><PlaylistDetailPage /></ProtectedRoute>} />
+          {/* Shared playlist - public */}
+          <Route path="/shared/:token" element={<SharedPlaylistPage />} />
+          <Route path="/thecyberpulse" element={<TheCyberPulseLandingPage />} />
+          <Route path="/thecyberpulse/bio" element={<TheCyberPulsePage />} />
+          <Route path="/thecyberpulse/releases" element={<ReleaseListPage />} />
+          <Route path="/thecyberpulse/releases/:releaseSlug" element={<ReleaseDetailPage />} />
+          <Route path="/thecyberpulse/trackz/:trackSlug" element={<TrackDetailPage />} />
+          <Route path="/thecyberpulse/vidz" element={<VodzPage />} />
+          <Route path="/thecyberpulse/vidz/:id" element={<VodzShowPage />} />
+          <Route path="/xeraen" element={<XeraenLandingPage />} />
+          <Route path="/xeraen/bio" element={<XeraenPage />} />
+          <Route path="/xeraen/releases" element={<ReleaseListPage />} />
+          <Route path="/xeraen/releases/:releaseSlug" element={<ReleaseDetailPage />} />
+          <Route path="/xeraen/trackz/:trackSlug" element={<TrackDetailPage />} />
+          <Route path="/xeraen/vidz" element={<VodzPage />} />
+          <Route path="/xeraen/vidz/:id" element={<VodzShowPage />} />
+          <Route path="/sector/x" element={<SectorXPage />} />
+          {/* Wavelength Zero has a custom landing page */}
+          <Route path="/wavelength-zero" element={<WavelengthZeroPage />} />
+          {/* Dynamic artist routes — catches any artist slug */}
+          <Route path="/:artistSlug" element={<BandProfilePage />} />
+          <Route path="/:artistSlug/releases" element={<ReleaseListPage />} />
+          <Route path="/:artistSlug/releases/:releaseSlug" element={<ReleaseDetailPage />} />
+          <Route path="/:artistSlug/trackz/:trackSlug" element={<TrackDetailPage />} />
+          {/* THE PULSE GRID routes */}
+          <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
+          <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
+          <Route path="/grid/login" element={<GridLoginPage />} />
+          <Route path="/grid/register" element={<GridRegisterPage />} />
+          <Route path="/grid/forgot_password" element={<ForgotPasswordPage />} />
+          <Route path="/grid/verify/:token" element={<GridVerifyPage />} />
+          <Route path="/grid/identity" element={<ProtectedRoute><IdentityPage /></ProtectedRoute>} />
+          <Route path="/grid/reset_password/:token" element={<ResetPasswordPage />} />
+          <Route path="/grid/confirm_email_change/:token" element={<GridConfirmEmailChangePage />} />
+          {/* Hackr Logs routes */}
+          <Route path="/logs" element={<LogsIndexPage />} />
+          <Route path="/logs/:slug" element={<LogDetailPage />} />
+          {/* Codex routes */}
+          <Route path="/codex" element={<CodexIndexPage />} />
+          <Route path="/codex/:slug" element={<CodexEntryPage />} />
+          {/* Handbook routes - login required */}
+          <Route path="/handbook" element={<ProtectedRoute><HandbookIndexPage /></ProtectedRoute>} />
+          <Route path="/handbook/:slug" element={<ProtectedRoute><HandbookArticlePage /></ProtectedRoute>} />
+          {/* Timeline route */}
+          <Route path="/timeline" element={<TimelinePage />} />
+          {/* PulseWire routes */}
+          <Route path="/wire" element={<HotwirePage />} />
+          <Route path="/wire/:username" element={<UserPulsesPage />} />
+          <Route path="/wire/pulse/:id" element={<SinglePulsePage />} />
+          {/* Uplink routes - protected */}
+          <Route path="/uplink" element={<ProtectedRoute><UplinkPage /></ProtectedRoute>} />
+          {/* Uplink popout - public for livestream viewing */}
+          <Route path="/uplink/popout" element={<UplinkPopoutPage />} />
+          {/* Code browser routes - protected */}
+          <Route path="/code" element={<ProtectedRoute><CodeIndexPage /></ProtectedRoute>} />
+          <Route path="/code/:repo" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
+          <Route path="/code/:repo/tree/*" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
+          <Route path="/code/:repo/blob/*" element={<ProtectedRoute><CodeRepoPage /></ProtectedRoute>} />
+          {/* 404 catch-all - must be last */}
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </Suspense>
+    </>
   )
 }

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -285,6 +285,9 @@ export const HeaderMenu: React.FC = () => {
                     <Link to="/grid/identity" className={`mobile-menu-item${isActive('/grid') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>identity
                     </Link>
+                    <Link to="/achievements" className={`mobile-menu-item${isActive('/achievements') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>achievements
+                    </Link>
                     <Link to="/fm/playlists" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>playlists
                     </Link>
@@ -550,7 +553,7 @@ export const HeaderMenu: React.FC = () => {
           </li>
 
           {/* THE PULSE GRID */}
-          <li className={`header-dropdown${isActive('/grid') || isActive('/code') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
+          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
             <span className="purple-168-text">{isLoggedIn ? '11' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
@@ -578,6 +581,11 @@ export const HeaderMenu: React.FC = () => {
                     <li>
                       <Link to="/grid/identity" onClick={closeDropdown}>
                         <span className="purple-168-text">/</span>identity
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/achievements" onClick={closeDropdown}>
+                        <span className="purple-168-text">/</span>achievements
                       </Link>
                     </li>
                     <li>

--- a/app/javascript/components/pages/artist/BandProfilePage.test.tsx
+++ b/app/javascript/components/pages/artist/BandProfilePage.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Regression coverage for the auth-timing race described in the
+ * achievement-system review: /api/grid/current_hackr resolves AFTER
+ * the artist fetch. Before the fix, the credit POST was gated inside
+ * the fetch .then() and silently dropped. The split-effect fix fires
+ * the credit when BOTH hackr and artist data are present — this test
+ * asserts that flow.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import BandProfilePage from './BandProfilePage'
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }))
+})
+
+// Controllable auth mock — mutate `mockGridAuth.hackr` between stages
+const mockGridAuth: { hackr: { id: number; hackr_alias: string } | null } = { hackr: null }
+vi.mock('~/hooks/useGridAuth', () => ({
+  useGridAuth: () => mockGridAuth
+}))
+
+// Stub layout + config so we don't need the whole tree
+vi.mock('~/components/layouts/BandProfileLayout', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div data-testid="layout">{children}</div>
+}))
+
+vi.mock('./bandProfileConfig', () => ({
+  bandProfiles: {
+    'system-rot': {
+      name: 'System Rot',
+      colorScheme: { primary: '#000' },
+      filterName: 'System Rot',
+      renderIntro: () => <div>intro</div>,
+      renderReleaseSection: () => <div>releases</div>,
+      renderPhilosophy: () => <div>philosophy</div>
+    }
+  }
+}))
+
+// Capture every apiFetch / apiJson call
+const apiCalls: Array<{ url: string; method: string }> = []
+
+vi.mock('~/utils/apiClient', () => ({
+  apiJson: vi.fn((url: string) => {
+    apiCalls.push({ url, method: 'GET' })
+    return Promise.resolve({ id: 1, name: 'System Rot', slug: 'system-rot', tracks: [] })
+  }),
+  apiFetch: vi.fn((url: string, init?: RequestInit) => {
+    apiCalls.push({ url, method: (init?.method as string) || 'GET' })
+    return Promise.resolve({ ok: true } as Response)
+  })
+}))
+
+const bioViewedCalls = () => apiCalls.filter(c => c.method === 'POST' && c.url.includes('/bio_viewed'))
+
+describe('BandProfilePage — achievement credit auth-timing race', () => {
+  beforeEach(() => {
+    apiCalls.length = 0
+    mockGridAuth.hackr = null
+  })
+
+  it('does not credit the bio view when unauthenticated', async () => {
+    render(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    // Wait for the artist fetch to resolve
+    await waitFor(() => {
+      expect(apiCalls.some(c => c.url === '/api/artists/system-rot')).toBe(true)
+    })
+
+    // Give React a tick to flush effects
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(bioViewedCalls()).toHaveLength(0)
+  })
+
+  it('credits the bio view when auth resolves AFTER the artist fetch', async () => {
+    // Start unauthenticated — auth context still loading
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    // Artist fetch lands first; no credit yet because hackr is null
+    await waitFor(() => {
+      expect(apiCalls.some(c => c.url === '/api/artists/system-rot')).toBe(true)
+    })
+    await new Promise(r => setTimeout(r, 10))
+    expect(bioViewedCalls()).toHaveLength(0)
+
+    // Auth resolves — re-render triggers the paired effect to fire now
+    mockGridAuth.hackr = { id: 42, hackr_alias: 'TestOperative' }
+    rerender(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(bioViewedCalls()).toHaveLength(1)
+    })
+    expect(bioViewedCalls()[0].url).toBe('/api/artists/system-rot/bio_viewed')
+  })
+
+  it('fires the credit exactly once even with repeated re-renders', async () => {
+    mockGridAuth.hackr = { id: 42, hackr_alias: 'TestOperative' }
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(bioViewedCalls()).toHaveLength(1)
+    })
+
+    // Force additional re-renders — the Set-backed dedup ref must
+    // prevent any further POSTs for the same slug.
+    rerender(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+    rerender(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    await new Promise(r => setTimeout(r, 20))
+    expect(bioViewedCalls()).toHaveLength(1)
+  })
+
+  it('credits a second hackr after a logout/login swap in the same session', async () => {
+    // Hackr A mounts, gets credited for system-rot.
+    mockGridAuth.hackr = { id: 42, hackr_alias: 'HackrA' }
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/system-rot']}>
+        <BandProfilePage />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(bioViewedCalls()).toHaveLength(1)
+    })
+
+    // Hackr swap — A signs out, B signs in, no full reload.
+    // The dedup ref is keyed to hackr.id via useHackrScopedDedupSet,
+    // so B's credit must fire even though A already posted for the
+    // same slug in the same SPA session.
+    await act(async () => {
+      mockGridAuth.hackr = null
+      rerender(
+        <MemoryRouter initialEntries={['/system-rot']}>
+          <BandProfilePage />
+        </MemoryRouter>
+      )
+    })
+
+    await act(async () => {
+      mockGridAuth.hackr = { id: 99, hackr_alias: 'HackrB' }
+      rerender(
+        <MemoryRouter initialEntries={['/system-rot']}>
+          <BandProfilePage />
+        </MemoryRouter>
+      )
+    })
+
+    await waitFor(() => {
+      expect(bioViewedCalls()).toHaveLength(2)
+    })
+  })
+})

--- a/app/javascript/components/pages/artist/BandProfilePage.tsx
+++ b/app/javascript/components/pages/artist/BandProfilePage.tsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 import BandProfileLayout from '~/components/layouts/BandProfileLayout'
 import { bandProfiles } from './bandProfileConfig'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 interface Track {
   id: number
@@ -20,6 +22,7 @@ interface Artist {
 
 const BandProfilePage: React.FC = () => {
   const location = useLocation()
+  const { hackr } = useGridAuth()
   const [artist, setArtist] = useState<Artist | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -40,6 +43,19 @@ const BandProfilePage: React.FC = () => {
         setLoading(false)
       })
   }, [slug, config])
+
+  // Credit the bio view once both the artist and auth have resolved —
+  // handles the case where /api/grid/current_hackr returns AFTER the
+  // artist API. Dedup set is scoped to hackr.id so a logout/login swap
+  // in the same SPA session does not silence the new user's credit.
+  const creditedSlugsRef = useHackrScopedDedupSet<string>(hackr?.id)
+  useEffect(() => {
+    if (!hackr || !artist?.slug) return
+    if (creditedSlugsRef.current.has(artist.slug)) return
+    creditedSlugsRef.current.add(artist.slug)
+    apiFetch(`/api/artists/${encodeURIComponent(artist.slug)}/bio_viewed`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, artist?.slug, creditedSlugsRef])
 
   if (!config) {
     return <div>Band not found</div>

--- a/app/javascript/components/pages/artist/TheCyberPulsePage.tsx
+++ b/app/javascript/components/pages/artist/TheCyberPulsePage.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react'
+import { useHackrScopedDedupFlag } from '~/hooks/useHackrScopedDedup'
 import { Link } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { YouTubePlayer } from '~/components/YouTubePlayer'
 import { CodexText } from '~/components/shared/CodexText'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
 
 const currentYear = new Date().getFullYear()
 const futureYear = currentYear + 100
@@ -34,6 +36,16 @@ const extractVideoId = (url: string): string | null => {
 const TheCyberPulsePage: React.FC = () => {
   const [latestVod, setLatestVod] = useState<Vod | null>(null)
   const { isMobile } = useMobileDetect()
+  const { hackr } = useGridAuth()
+  const bioCreditedRef = useHackrScopedDedupFlag(hackr?.id)
+
+  useEffect(() => {
+    if (hackr && !bioCreditedRef.current) {
+      bioCreditedRef.current = true
+      apiFetch('/api/artists/thecyberpulse/bio_viewed', { method: 'POST' })
+        .catch(() => { /* fire-and-forget */ })
+    }
+  }, [hackr, bioCreditedRef])
 
   useEffect(() => {
     const fetchLatestVod = async () => {

--- a/app/javascript/components/pages/artist/VodzShowPage.test.tsx
+++ b/app/javascript/components/pages/artist/VodzShowPage.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Regression coverage for the VOD achievement over-credit issue: page
+ * load alone must not fire the `watch` POST. Credit fires only when
+ * YouTubePlayer reports the PLAYING state via its `onPlay` callback.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import VodzShowPage from './VodzShowPage'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }))
+})
+
+const mockGridAuth: { hackr: { id: number; hackr_alias: string } | null } = {
+  hackr: { id: 1, hackr_alias: 'TestOperative' }
+}
+vi.mock('~/hooks/useGridAuth', () => ({
+  useGridAuth: () => mockGridAuth
+}))
+
+vi.mock('~/components/layouts/DefaultLayout', () => ({
+  DefaultLayout: ({ children }: { children?: React.ReactNode }) => <div data-testid="layout">{children}</div>
+}))
+
+// Capture the onPlay prop so the test can fire it manually — the real
+// YT IFrame API is too heavy to drive in JSDOM.
+let capturedOnPlay: (() => void) | null = null
+vi.mock('~/components/YouTubePlayer', () => ({
+  YouTubePlayer: ({ onPlay }: { onPlay?: () => void }) => {
+    capturedOnPlay = onPlay || null
+    return <div data-testid="yt-player" />
+  }
+}))
+
+const apiCalls: Array<{ url: string; method: string }> = []
+vi.mock('~/utils/apiClient', () => ({
+  apiJson: vi.fn(() => {
+    apiCalls.push({ url: '/api/artists/thecyberpulse/vods/42', method: 'GET' })
+    return Promise.resolve({
+      id: 42,
+      title: 'Test VOD',
+      vod_url: 'https://www.youtube.com/embed/abc12345678',
+      live_url: null,
+      started_at: '2026-01-01T00:00:00Z',
+      ended_at: null,
+      was_livestream: false,
+      artist: { id: 1, name: 'TCP', slug: 'thecyberpulse' }
+    })
+  }),
+  apiFetch: vi.fn((url: string, init?: RequestInit) => {
+    apiCalls.push({ url, method: (init?.method as string) || 'GET' })
+    return Promise.resolve({ ok: true } as Response)
+  })
+}))
+
+const watchCalls = () => apiCalls.filter(c => c.method === 'POST' && c.url.includes('/watch'))
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/thecyberpulse/vidz/42']}>
+      <Routes>
+        <Route path="/:artist/vidz/:id" element={<VodzShowPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('VodzShowPage — watch credit requires actual playback', () => {
+  beforeEach(() => {
+    apiCalls.length = 0
+    capturedOnPlay = null
+    mockGridAuth.hackr = { id: 1, hackr_alias: 'TestOperative' }
+  })
+
+  it('does NOT credit on page load — user has to click play', async () => {
+    renderPage()
+
+    // Wait for the VOD fetch and YouTubePlayer to mount
+    await waitFor(() => {
+      expect(capturedOnPlay).not.toBeNull()
+    })
+
+    // Give effects a tick to flush
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(watchCalls()).toHaveLength(0)
+  })
+
+  it('credits when YouTubePlayer reports PLAYING via onPlay', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(capturedOnPlay).not.toBeNull()
+    })
+
+    // User clicks play → YT API fires PLAYING → onPlay invoked
+    capturedOnPlay!()
+
+    await waitFor(() => {
+      expect(watchCalls()).toHaveLength(1)
+    })
+    expect(watchCalls()[0].url).toBe('/api/artists/thecyberpulse/vods/42/watch')
+  })
+
+  it('credits exactly once even if onPlay fires multiple times', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(capturedOnPlay).not.toBeNull()
+    })
+
+    // Repeated onPlay (pause/resume cycles) must not re-credit
+    capturedOnPlay!()
+    capturedOnPlay!()
+    capturedOnPlay!()
+
+    await waitFor(() => {
+      expect(watchCalls()).toHaveLength(1)
+    })
+  })
+
+  it('does not credit anon users even when onPlay fires', async () => {
+    mockGridAuth.hackr = null
+    renderPage()
+
+    await waitFor(() => {
+      expect(capturedOnPlay).not.toBeNull()
+    })
+
+    capturedOnPlay!()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(watchCalls()).toHaveLength(0)
+  })
+})

--- a/app/javascript/components/pages/artist/VodzShowPage.tsx
+++ b/app/javascript/components/pages/artist/VodzShowPage.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Link, useParams, useLocation } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
 import { YouTubePlayer } from '~/components/YouTubePlayer'
 import { formatFutureDate } from '~/utils/dateUtils'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 interface Vod {
   id: number
@@ -39,6 +41,7 @@ const extractVideoId = (url: string): string | null => {
 const VodzShowPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
   const location = useLocation()
+  const { hackr } = useGridAuth()
   const [vod, setVod] = useState<Vod | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -70,6 +73,21 @@ const VodzShowPage: React.FC = () => {
       fetchVod()
     }
   }, [artistSlug, id])
+
+  // Credit the watch only when the YouTube player reports PLAYING
+  // state (fired from YouTubePlayer's onPlay callback). This matches
+  // the achievement copy — "Watched your first VOD" — and filters out
+  // page-open/refresh traffic where no video ever plays. Dedup set is
+  // scoped to hackr.id so logout/login swap resets cleanly.
+  const creditedIdsRef = useHackrScopedDedupSet<number>(hackr?.id)
+  const handleWatchStarted = useCallback(() => {
+    if (!hackr || !vod?.id) return
+    if (creditedIdsRef.current.has(vod.id)) return
+    creditedIdsRef.current.add(vod.id)
+    apiFetch(`/api/artists/${encodeURIComponent(artistSlug)}/vods/${encodeURIComponent(String(vod.id))}/watch`, {
+      method: 'POST'
+    }).catch(() => { /* fire-and-forget */ })
+  }, [hackr, vod?.id, artistSlug, creditedIdsRef])
 
   if (loading) {
     return (
@@ -193,6 +211,7 @@ const VodzShowPage: React.FC = () => {
                   <YouTubePlayer
                     videoId={videoId}
                     responsive
+                    onPlay={handleWatchStarted}
                   />
                 </div>
               </div>

--- a/app/javascript/components/pages/artist/WavelengthZeroPage.tsx
+++ b/app/javascript/components/pages/artist/WavelengthZeroPage.tsx
@@ -1,8 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { apiFetch } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupFlag } from '~/hooks/useHackrScopedDedup'
 
 const WavelengthZeroPage: React.FC = () => {
+  const { hackr } = useGridAuth()
+  const bioCreditedRef = useHackrScopedDedupFlag(hackr?.id)
+
+  useEffect(() => {
+    if (hackr && !bioCreditedRef.current) {
+      bioCreditedRef.current = true
+      apiFetch('/api/artists/wavelength-zero/bio_viewed', { method: 'POST' })
+        .catch(() => { /* fire-and-forget */ })
+    }
+  }, [hackr, bioCreditedRef])
+
   return (
     <DefaultLayout>
       {/* Rainbow gradient border wrapper */}

--- a/app/javascript/components/pages/artist/XeraenPage.tsx
+++ b/app/javascript/components/pages/artist/XeraenPage.tsx
@@ -1,17 +1,29 @@
 import React, { useEffect, useState } from 'react'
+import { useHackrScopedDedupFlag } from '~/hooks/useHackrScopedDedup'
 import { Link } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { EmbeddedTrack } from '~/components/EmbeddedTrack'
 import { CodexText } from '~/components/shared/CodexText'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
 
 const currentYear = new Date().getFullYear()
 const futureYear = currentYear + 100
 
 const XeraenPage: React.FC = () => {
   const { isMobile } = useMobileDetect()
+  const { hackr } = useGridAuth()
   const [latestFeaturedSlug, setLatestFeaturedSlug] = useState<string | null>(null)
+  const bioCreditedRef = useHackrScopedDedupFlag(hackr?.id)
+
+  useEffect(() => {
+    if (hackr && !bioCreditedRef.current) {
+      bioCreditedRef.current = true
+      apiFetch('/api/artists/xeraen/bio_viewed', { method: 'POST' })
+        .catch(() => { /* fire-and-forget */ })
+    }
+  }, [hackr, bioCreditedRef])
 
   useEffect(() => {
     apiJson<{

--- a/app/javascript/components/pages/codex/CodexEntryPage.tsx
+++ b/app/javascript/components/pages/codex/CodexEntryPage.tsx
@@ -10,7 +10,9 @@ import type { CodexEntry } from '~/types/codex'
 import { transformMarkdownLinks } from '~/utils/codexLinks'
 import { useCodexMappings } from '~/hooks/useCodexMappings'
 import { formatFutureDate } from '~/utils/dateUtils'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 const ENTRY_TYPE_COLORS: Record<string, string> = {
   person: '#a78bfa',
@@ -42,6 +44,7 @@ export const CodexEntryPage: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const { mappings } = useCodexMappings()
+  const { hackr } = useGridAuth()
 
   useEffect(() => {
     if (!slug) return
@@ -67,6 +70,18 @@ export const CodexEntryPage: React.FC = () => {
       isMounted = false
     }
   }, [slug])
+
+  // Credit the read once BOTH the entry and auth have resolved. Fires
+  // even if auth resolves after the codex fetch. Dedup set is scoped
+  // to hackr.id so a logout/login swap resets cleanly.
+  const creditedSlugsRef = useHackrScopedDedupSet<string>(hackr?.id)
+  useEffect(() => {
+    if (!hackr || !entry?.slug) return
+    if (creditedSlugsRef.current.has(entry.slug)) return
+    creditedSlugsRef.current.add(entry.slug)
+    apiFetch(`/api/codex/${encodeURIComponent(entry.slug)}/read`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, entry?.slug, creditedSlugsRef])
 
   if (loading) {
     return (

--- a/app/javascript/components/pages/fm/RadioPage.test.tsx
+++ b/app/javascript/components/pages/fm/RadioPage.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Regression coverage for the radio false-positive credit path:
+ * before the fix, the tune_in POST fired before audioRef.play()
+ * resolved, so autoplay rejections / bad stream URLs still advanced
+ * the achievement counter. Fix: credit lives inside play().then().
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { RadioPage } from './RadioPage'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }))
+})
+
+const mockGridAuth: { hackr: { id: number; hackr_alias: string } | null } = {
+  hackr: { id: 1, hackr_alias: 'TestOperative' }
+}
+vi.mock('~/hooks/useGridAuth', () => ({
+  useGridAuth: () => mockGridAuth
+}))
+
+vi.mock('~/components/layouts/FmLayout', () => ({
+  FmLayout: ({ children }: { children?: React.ReactNode }) => <div data-testid="layout">{children}</div>
+}))
+
+vi.mock('~/hooks/useStreamStatus', () => ({
+  useStreamStatus: () => ({ isLive: false, streamInfo: null })
+}))
+
+// Isolate the test from the 500ms audioPlayer-context polling loop
+vi.mock('~/components/shared/CodexText', () => ({
+  CodexText: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>
+}))
+
+const apiCalls: Array<{ url: string; method: string }> = []
+vi.mock('~/utils/apiClient', () => ({
+  apiJson: vi.fn((url: string) => {
+    apiCalls.push({ url, method: 'GET' })
+    if (url === '/api/radio_stations') {
+      return Promise.resolve([
+        {
+          id: 7,
+          name: 'Test Stream Station',
+          slug: 'test-stream',
+          description: '',
+          genre: 'Test',
+          color: 'purple-168',
+          stream_url: 'http://example.test/stream.mp3',
+          playlists: []
+        }
+      ])
+    }
+    return Promise.resolve([])
+  }),
+  apiFetch: vi.fn((url: string, init?: RequestInit) => {
+    apiCalls.push({ url, method: (init?.method as string) || 'GET' })
+    return Promise.resolve({ ok: true } as Response)
+  })
+}))
+
+const tuneInCalls = () => apiCalls.filter(c => c.method === 'POST' && c.url.includes('/tune_in'))
+
+describe('RadioPage — raw-stream tune_in credit requires play() to resolve', () => {
+  beforeEach(() => {
+    apiCalls.length = 0
+    mockGridAuth.hackr = { id: 1, hackr_alias: 'TestOperative' }
+    vi.restoreAllMocks()
+    // Silence the alert() shown on play failure
+    vi.spyOn(window, 'alert').mockImplementation(() => {})
+  })
+
+  it('does NOT credit when play() rejects (autoplay blocked / bad URL)', async () => {
+    vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockRejectedValue(
+      new Error('NotAllowedError: autoplay blocked')
+    )
+
+    render(
+      <MemoryRouter>
+        <RadioPage />
+      </MemoryRouter>
+    )
+
+    // Wait for stations to load
+    const playButton = await screen.findByText(/PLAY STATION|TUNE IN|PLAY/i, {}, { timeout: 2000 })
+
+    await act(async () => {
+      await userEvent.click(playButton)
+    })
+
+    // Give the rejected promise a tick to settle
+    await new Promise(r => setTimeout(r, 20))
+
+    expect(tuneInCalls()).toHaveLength(0)
+  })
+
+  it('credits exactly once when play() resolves successfully', async () => {
+    vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined)
+
+    render(
+      <MemoryRouter>
+        <RadioPage />
+      </MemoryRouter>
+    )
+
+    const playButton = await screen.findByText(/PLAY STATION|TUNE IN|PLAY/i, {}, { timeout: 2000 })
+
+    await act(async () => {
+      await userEvent.click(playButton)
+    })
+
+    await waitFor(() => {
+      expect(tuneInCalls()).toHaveLength(1)
+    })
+    expect(tuneInCalls()[0].url).toBe('/api/radio_stations/7/tune_in')
+  })
+})

--- a/app/javascript/components/pages/fm/RadioPage.tsx
+++ b/app/javascript/components/pages/fm/RadioPage.tsx
@@ -5,7 +5,9 @@ import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
 import type { TrackData } from '~/types/track'
 import { CodexText } from '~/components/shared/CodexText'
 import { useStreamStatus } from '~/hooks/useStreamStatus'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 interface Playlist {
   id: number
@@ -45,6 +47,7 @@ interface StationPlaylist {
 }
 
 export const RadioPage: React.FC = () => {
+  const { hackr } = useGridAuth()
   const [stations, setStations] = useState<RadioStation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -54,7 +57,50 @@ export const RadioPage: React.FC = () => {
   const [volume, setVolume] = useState(70)
   const [playingStationId, setPlayingStationId] = useState<number | null>(null)
   const [audioPlayerIsPlaying, setAudioPlayerIsPlaying] = useState(false)
+  // Dedup is scoped to hackr.id — auto-resets on logout/login swap so
+  // a second user isn't silenced by the prior user's credits.
+  const tunedStationIdsRef = useHackrScopedDedupSet<number>(hackr?.id)
   const { isLive, streamInfo } = useStreamStatus()
+
+  // --- Dual-playback architecture ---------------------------------
+  // Radio stations come in two flavors, each with its own audio
+  // backend — a given station uses exactly one:
+  //
+  //   1. Playlist-backed (station.playlists.length > 0) — plays
+  //      through the SHARED global `window.audioPlayer` (same
+  //      instance that drives the Pulse Vault). Tune credit fires
+  //      from the useEffect below, which watches the player's
+  //      `playingStationId` + `isPlaying` state (polled every 500ms).
+  //
+  //   2. Raw stream URL (station.stream_url set, no playlists) —
+  //      plays through a LOCAL `<audio ref={audioRef}>` element
+  //      inside this component. Tune credit fires from the direct
+  //      `play().then()` signal inside `tuneIn()` further down.
+  //
+  // The two paths are dispatched by the render (see the station
+  // card JSX: `station.playlists?.length ? <playlist> : <stream>`).
+  // `tunedStationIdsRef` guards against a user stopping + re-tuning
+  // the SAME station, not against a cross-path double-fire — a
+  // single station only ever uses one path.
+  //
+  // Fire tune_in POST once per station per hackr when playback starts.
+  const creditTuneIn = React.useCallback((stationId: number) => {
+    if (!hackr || tunedStationIdsRef.current.has(stationId)) return
+    tunedStationIdsRef.current.add(stationId)
+    apiFetch(`/api/radio_stations/${stationId}/tune_in`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, tunedStationIdsRef])
+
+  // Path 1 — playlist-backed stations. Credit only when audio is
+  // actually playing. `playingStationId` alone proves nothing more
+  // than `setPlaylist` was called, which can race ahead of playback
+  // failure (bad audio URL, autoplay blocked, etc.). Requiring the
+  // `audioPlayerIsPlaying` signal filters those out.
+  useEffect(() => {
+    if (playingStationId != null && audioPlayerIsPlaying) {
+      creditTuneIn(playingStationId)
+    }
+  }, [playingStationId, audioPlayerIsPlaying, creditTuneIn])
 
   useEffect(() => {
     apiJson<RadioStation[]>('/api/radio_stations')
@@ -185,17 +231,24 @@ export const RadioPage: React.FC = () => {
     }
   }
 
-  const tuneIn = (streamUrl: string, stationName: string, genre: string) => {
+  // Path 2 — raw-stream stations (see dual-playback block above).
+  // Uses the local `audioRef` element; credits inside `.then()` so
+  // autoplay rejections / bad stream URLs do NOT advance the counter.
+  const tuneIn = (streamUrl: string, stationName: string, genre: string, stationId?: number) => {
     if (!audioRef.current) return
 
     audioRef.current.src = streamUrl
     setCurrentStation({ name: stationName, genre })
     setIsPlaying(true)
 
-    audioRef.current.play().catch((error) => {
-      console.error('Error playing stream:', error)
-      alert('Error: Unable to connect to radio stream. Please check the stream URL.')
-    })
+    audioRef.current.play()
+      .then(() => {
+        if (stationId != null) creditTuneIn(stationId)
+      })
+      .catch((error) => {
+        console.error('Error playing stream:', error)
+        alert('Error: Unable to connect to radio stream. Please check the stream URL.')
+      })
   }
 
   const stopRadio = () => {
@@ -327,7 +380,7 @@ export const RadioPage: React.FC = () => {
                             ) : station.stream_url ? (
                               <button
                                 className="tui-button tune-in-btn"
-                                onClick={() => tuneIn(station.stream_url, station.name, station.genre)}
+                                onClick={() => tuneIn(station.stream_url, station.name, station.genre, station.id)}
                                 style={{ width: '100%', background: '#14b8a6', color: 'white' }}
                               >
                                 ► TUNE IN
@@ -387,7 +440,7 @@ export const RadioPage: React.FC = () => {
                           ) : station.stream_url ? (
                             <button
                               className="tui-button tune-in-btn"
-                              onClick={() => tuneIn(station.stream_url, station.name, station.genre)}
+                              onClick={() => tuneIn(station.stream_url, station.name, station.genre, station.id)}
                               style={{ width: '100%', background: '#222', color: 'white' }}
                             >
                               ► TUNE IN

--- a/app/javascript/components/pages/grid/AchievementsPage.tsx
+++ b/app/javascript/components/pages/grid/AchievementsPage.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useState, useMemo } from 'react'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+
+interface Progress {
+  current: number
+  target: number
+  fraction: number
+  completed: boolean
+}
+
+interface AchievementRow {
+  slug: string
+  name: string
+  description: string | null
+  badge_icon: string | null
+  category: string
+  trigger_type: string
+  xp_reward: number
+  cred_reward: number
+  earned: boolean
+  awarded_at: string | null
+  progress: Progress | null
+}
+
+interface ApiResponse {
+  categories: Record<string, AchievementRow[]>
+  summary: {
+    total: { total: number; earned: number }
+    by_category: Record<string, { total: number; earned: number }>
+  }
+}
+
+const CATEGORY_ORDER = ['grid', 'music', 'social', 'meta', 'progression']
+
+const CATEGORY_META: Record<string, { label: string; color: string; icon: string }> = {
+  grid: { label: 'GRID', color: '#22d3ee', icon: '#' },
+  music: { label: 'MUSIC', color: '#f472b6', icon: '%' },
+  social: { label: 'SOCIAL', color: '#60a5fa', icon: '~' },
+  meta: { label: 'META', color: '#a3e635', icon: '>>' },
+  progression: { label: 'PROGRESSION', color: '#c084fc', icon: '▲' }
+}
+
+const formatAwardedAt = (iso: string): string => {
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+const AchievementsPage: React.FC = () => {
+  const [data, setData] = useState<ApiResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeCategory, setActiveCategory] = useState<string>('all')
+
+  useEffect(() => {
+    apiJson<ApiResponse>('/api/grid/achievements')
+      .then(json => {
+        setData(json)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Failed to load achievements')
+        setLoading(false)
+      })
+  }, [])
+
+  const visibleCategories = useMemo(() => {
+    if (!data) return []
+    return CATEGORY_ORDER.filter(cat => (data.categories[cat]?.length || 0) > 0)
+  }, [data])
+
+  const rowsToRender = useMemo(() => {
+    if (!data) return []
+    if (activeCategory === 'all') {
+      return visibleCategories.flatMap(cat => data.categories[cat] || [])
+    }
+    return data.categories[activeCategory] || []
+  }, [data, activeCategory, visibleCategories])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+          <LoadingSpinner message="Loading achievements..." color="yellow-168-text" size="large" />
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto', padding: 40, textAlign: 'center', color: '#f87171' }}>
+          {error || 'Failed to load achievements'}
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  const total = data.summary.total
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+        <div className="tui-window white-text" style={{ display: 'block', background: '#0a0a0a', border: '2px solid #fbbf24', boxShadow: '0 0 30px rgba(251, 191, 36, 0.3)' }}>
+          <fieldset style={{ borderColor: '#fbbf24' }}>
+            <legend className="center" style={{ color: '#fbbf24', textShadow: '0 0 15px rgba(251, 191, 36, 0.6)', letterSpacing: 3 }}>
+              ACHIEVEMENTS
+            </legend>
+            <div style={{ padding: 20 }}>
+              {/* Totals */}
+              <div style={{
+                background: '#111',
+                border: '1px solid #333',
+                padding: '14px 16px',
+                marginBottom: 20,
+                display: 'flex',
+                justifyContent: 'space-between',
+                flexWrap: 'wrap',
+                gap: 12
+              }}>
+                <div>
+                  <span style={{ color: '#9ca3af' }}>Earned:</span>{' '}
+                  <span style={{ color: '#22d3ee', fontWeight: 'bold' }}>{total.earned}</span>
+                  <span style={{ color: '#6b7280' }}> / {total.total}</span>
+                </div>
+                <div style={{ color: '#fbbf24' }}>
+                  {total.total > 0 ? `${Math.round((total.earned / total.total) * 100)}%` : '—'}
+                </div>
+              </div>
+
+              {/* Category tabs */}
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+                <CategoryTab
+                  label={`ALL (${total.earned}/${total.total})`}
+                  color="#fbbf24"
+                  active={activeCategory === 'all'}
+                  onClick={() => setActiveCategory('all')}
+                />
+                {visibleCategories.map(cat => {
+                  const meta = CATEGORY_META[cat]
+                  const sum = data.summary.by_category[cat] || { total: 0, earned: 0 }
+                  return (
+                    <CategoryTab
+                      key={cat}
+                      label={`${meta?.label || cat.toUpperCase()} (${sum.earned}/${sum.total})`}
+                      color={meta?.color || '#9ca3af'}
+                      active={activeCategory === cat}
+                      onClick={() => setActiveCategory(cat)}
+                    />
+                  )
+                })}
+              </div>
+
+              {/* Cards grid */}
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                gap: 12
+              }}>
+                {rowsToRender.map(a => (
+                  <AchievementCard key={a.slug} row={a} />
+                ))}
+              </div>
+
+              {rowsToRender.length === 0 && (
+                <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>
+                  Nothing in this category yet.
+                </div>
+              )}
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const CategoryTab: React.FC<{ label: string; color: string; active: boolean; onClick: () => void }> = ({ label, color, active, onClick }) => (
+  <button
+    className="tui-button"
+    onClick={onClick}
+    style={{
+      padding: '6px 14px',
+      background: active ? color : '#222',
+      color: active ? '#000' : color,
+      fontWeight: 'bold',
+      border: `1px solid ${color}`,
+      cursor: 'pointer',
+      boxShadow: 'none',
+      fontFamily: 'monospace'
+    }}
+  >
+    {label}
+  </button>
+)
+
+const AchievementCard: React.FC<{ row: AchievementRow }> = ({ row }) => {
+  const meta = CATEGORY_META[row.category] || { label: row.category.toUpperCase(), color: '#9ca3af', icon: '?' }
+  const isEarned = row.earned
+  const prog = row.progress
+
+  return (
+    <div
+      style={{
+        background: isEarned ? '#1a1a1a' : '#0f0f0f',
+        border: `1px solid ${isEarned ? meta.color : '#333'}`,
+        padding: 14,
+        opacity: isEarned ? 1 : 0.75,
+        position: 'relative',
+        fontFamily: 'monospace',
+        transition: 'border-color 0.2s'
+      }}
+    >
+      {/* Header: badge + name */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 6 }}>
+        <span
+          style={{
+            color: isEarned ? '#fbbf24' : '#4b5563',
+            fontWeight: 'bold',
+            minWidth: 28,
+            fontSize: '1em'
+          }}
+        >
+          {row.badge_icon || '?'}
+        </span>
+        <div style={{ flex: 1 }}>
+          <div style={{ color: isEarned ? '#22d3ee' : '#6b7280', fontWeight: 'bold', fontSize: '1em' }}>
+            {row.name}
+          </div>
+          <div style={{ color: meta.color, fontSize: '0.7em', letterSpacing: 1 }}>
+            [{meta.label}]
+          </div>
+        </div>
+        {isEarned && (
+          <span title="Earned" style={{ color: '#34d399', fontWeight: 'bold', fontSize: '1.2em' }}>
+            ✓
+          </span>
+        )}
+      </div>
+
+      {/* Description */}
+      {row.description && (
+        <div style={{ color: isEarned ? '#d0d0d0' : '#6b7280', fontSize: '0.85em', marginBottom: 10, lineHeight: 1.4 }}>
+          {row.description}
+        </div>
+      )}
+
+      {/* Progress bar (cumulative only, not yet earned) */}
+      {!isEarned && prog && prog.target > 0 && (
+        <div style={{ marginBottom: 8 }}>
+          <div style={{ color: '#9ca3af', fontSize: '0.75em', marginBottom: 4, display: 'flex', justifyContent: 'space-between' }}>
+            <span>Progress</span>
+            <span style={{ color: '#d0d0d0' }}>{prog.current} / {prog.target}</span>
+          </div>
+          <div style={{ background: '#0a0a0a', border: '1px solid #333', height: 6, overflow: 'hidden' }}>
+            <div
+              style={{
+                width: `${Math.min(100, Math.round(prog.fraction * 100))}%`,
+                height: '100%',
+                background: meta.color,
+                transition: 'width 0.3s'
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Footer: rewards + awarded_at */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75em', marginTop: 8, paddingTop: 8, borderTop: '1px solid #2a2a2a' }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {row.xp_reward > 0 && (
+            <span style={{ color: isEarned ? '#34d399' : '#4b5563' }}>+{row.xp_reward} XP</span>
+          )}
+          {row.cred_reward > 0 && (
+            <span style={{ color: isEarned ? '#fbbf24' : '#4b5563' }}>+{row.cred_reward} CRED</span>
+          )}
+        </div>
+        {isEarned && row.awarded_at && (
+          <span style={{ color: '#6b7280' }}>{formatAwardedAt(row.awarded_at)}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AchievementsPage

--- a/app/javascript/components/pages/logs/LogDetailPage.tsx
+++ b/app/javascript/components/pages/logs/LogDetailPage.tsx
@@ -5,11 +5,12 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeSanitize from 'rehype-sanitize'
 import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
 import { transformMarkdownLinks } from '~/utils/codexLinks'
 import { useCodexMappings } from '~/hooks/useCodexMappings'
 import { formatFutureDate } from '~/utils/dateUtils'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { TIMELINE_ORDER, TIMELINE_CONFIG, formatEra } from './timelineConfig'
 import type { TimelineSummary } from './timelineConfig'
@@ -64,6 +65,19 @@ export const LogDetailPage: React.FC = () => {
       .then(data => setTimelines(data?.meta?.timelines || null))
       .catch(() => {}) // Non-critical — tabs just won't render
   }, [slug])
+
+  // Credit the read once BOTH the log data and auth have resolved.
+  // Splitting this from the fetch effect avoids the race where the log
+  // API returns before /api/grid/current_hackr. Dedup set is scoped
+  // to hackr.id so logout/login swap does not suppress the new user.
+  const creditedSlugsRef = useHackrScopedDedupSet<string>(hackr?.id)
+  useEffect(() => {
+    if (!hackr || !log?.slug) return
+    if (creditedSlugsRef.current.has(log.slug)) return
+    creditedSlugsRef.current.add(log.slug)
+    apiFetch(`/api/logs/${encodeURIComponent(log.slug)}/read`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, log?.slug, creditedSlugsRef])
 
   if (loading) {
     return (

--- a/app/javascript/components/pages/releases/ReleaseDetailPage.tsx
+++ b/app/javascript/components/pages/releases/ReleaseDetailPage.tsx
@@ -4,7 +4,9 @@ import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
 import { getArtistColors } from '~/utils/artistColors'
 import { useAudio } from '~/contexts/AudioContext'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 interface ReleaseTrack {
   id: number
@@ -47,6 +49,7 @@ interface ReleaseDetail {
 const ReleaseDetailPage: React.FC = () => {
   const location = useLocation()
   const { audioPlayerAPI } = useAudio()
+  const { hackr } = useGridAuth()
   const [release, setRelease] = useState<ReleaseDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [currentTrackId, setCurrentTrackId] = useState<number | null>(null)
@@ -115,6 +118,19 @@ const ReleaseDetailPage: React.FC = () => {
         setLoading(false)
       })
   }, [releaseSlug])
+
+  // Credit the release view once both the release and auth have
+  // resolved. Coming-soon releases are excluded (the server rejects
+  // them too). Dedup set scoped to hackr.id so logout/login swap
+  // resets cleanly.
+  const creditedSlugsRef = useHackrScopedDedupSet<string>(hackr?.id)
+  useEffect(() => {
+    if (!hackr || !release?.slug || release.coming_soon) return
+    if (creditedSlugsRef.current.has(release.slug)) return
+    creditedSlugsRef.current.add(release.slug)
+    apiFetch(`/api/releases/${encodeURIComponent(release.slug)}/viewed`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, release?.slug, release?.coming_soon, creditedSlugsRef])
 
   // Track play state
   useEffect(() => {

--- a/app/javascript/components/pages/releases/ReleaseListPage.tsx
+++ b/app/javascript/components/pages/releases/ReleaseListPage.tsx
@@ -3,7 +3,9 @@ import { useLocation, Link } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
 import { getArtistColors } from '~/utils/artistColors'
-import { apiJson } from '~/utils/apiClient'
+import { apiFetch, apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useHackrScopedDedupSet } from '~/hooks/useHackrScopedDedup'
 
 interface Release {
   id: number
@@ -30,6 +32,7 @@ interface Release {
 
 const ReleaseListPage: React.FC = () => {
   const location = useLocation()
+  const { hackr } = useGridAuth()
   const [releases, setReleases] = useState<Release[]>([])
   const [comingSoon, setComingSoon] = useState<Release[]>([])
   const [loading, setLoading] = useState(true)
@@ -96,6 +99,19 @@ const ReleaseListPage: React.FC = () => {
         setLoading(false)
       })
   }, [artistSlug])
+
+  // Credit the release-index view once both artistSlug and auth have
+  // resolved. Handles the case where auth lands after the releases
+  // API call completes. Dedup scoped to hackr.id so logout/login
+  // swap resets cleanly.
+  const creditedSlugsRef = useHackrScopedDedupSet<string>(hackr?.id)
+  useEffect(() => {
+    if (!hackr || !artistSlug) return
+    if (creditedSlugsRef.current.has(artistSlug)) return
+    creditedSlugsRef.current.add(artistSlug)
+    apiFetch(`/api/artists/${encodeURIComponent(artistSlug)}/release_index_viewed`, { method: 'POST' })
+      .catch(() => { /* fire-and-forget */ })
+  }, [hackr, artistSlug, creditedSlugsRef])
 
   if (loading) {
     return (

--- a/app/javascript/components/shared/AchievementToast.tsx
+++ b/app/javascript/components/shared/AchievementToast.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useCallback } from 'react'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useAchievementChannel, type AchievementUnlockEvent } from '~/hooks/useAchievementChannel'
+
+const TOAST_DURATION_MS = 6000
+
+interface ToastEntry extends AchievementUnlockEvent {
+  key: number
+}
+
+const categoryColor = (category: string): string => {
+  switch (category) {
+  case 'music': return '#f472b6'
+  case 'social': return '#60a5fa'
+  case 'meta': return '#a3e635'
+  case 'progression': return '#c084fc'
+  default: return '#22d3ee' // grid
+  }
+}
+
+export const AchievementToastContainer: React.FC = () => {
+  const { hackr } = useGridAuth()
+  const [toasts, setToasts] = useState<ToastEntry[]>([])
+
+  const remove = useCallback((key: number) => {
+    setToasts(prev => prev.filter(t => t.key !== key))
+  }, [])
+
+  const onUnlock = useCallback((event: AchievementUnlockEvent) => {
+    const entry: ToastEntry = { ...event, key: Date.now() + Math.random() }
+    setToasts(prev => [entry, ...prev].slice(0, 5))
+    window.setTimeout(() => remove(entry.key), TOAST_DURATION_MS)
+  }, [remove])
+
+  useAchievementChannel({ enabled: !!hackr, onUnlock })
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '90px',
+        right: '20px',
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        pointerEvents: 'none',
+        maxWidth: '360px'
+      }}
+    >
+      {toasts.map((t) => {
+        const color = categoryColor(t.achievement.category)
+        return (
+          <div
+            key={t.key}
+            onClick={() => remove(t.key)}
+            style={{
+              pointerEvents: 'auto',
+              cursor: 'pointer',
+              background: '#111',
+              border: '2px solid #fbbf24',
+              padding: '12px 16px',
+              fontFamily: 'monospace',
+              color: '#d0d0d0',
+              boxShadow: '0 0 20px rgba(251, 191, 36, 0.4)',
+              animation: 'achievement-toast-slide-in 0.3s ease-out'
+            }}
+          >
+            <div style={{ color: '#fbbf24', fontSize: '0.8em', fontWeight: 'bold', letterSpacing: '1px', marginBottom: '4px' }}>
+              ACHIEVEMENT UNLOCKED
+              <span style={{ color, marginLeft: '8px' }}>[{t.achievement.category.toUpperCase()}]</span>
+            </div>
+            <div style={{ fontSize: '1.05em', marginBottom: '4px' }}>
+              {t.achievement.badge_icon ? (
+                <span style={{ color: '#fbbf24', marginRight: '6px' }}>{t.achievement.badge_icon}</span>
+              ) : null}
+              <span style={{ color: '#22d3ee', fontWeight: 'bold' }}>{t.achievement.name}</span>
+            </div>
+            {t.achievement.description ? (
+              <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: '6px' }}>
+                {t.achievement.description}
+              </div>
+            ) : null}
+            <div style={{ fontSize: '0.85em', display: 'flex', gap: '12px' }}>
+              {t.achievement.xp_reward > 0 && (
+                <span style={{ color: '#34d399' }}>+{t.achievement.xp_reward} XP</span>
+              )}
+              {t.achievement.cred_reward > 0 && (
+                <span style={{ color: '#fbbf24' }}>+{t.achievement.cred_reward} CRED</span>
+              )}
+              {t.leveled_up && t.new_clearance != null && (
+                <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>▲ CL {t.new_clearance}</span>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default AchievementToastContainer

--- a/app/javascript/hooks/useAchievementChannel.ts
+++ b/app/javascript/hooks/useAchievementChannel.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { Channel } from '@rails/actioncable'
+import { getActionCableConsumer } from '~/lib/actionCableConsumer'
+
+export interface AchievementUnlock {
+  slug: string
+  name: string
+  description: string | null
+  badge_icon: string | null
+  category: string
+  xp_reward: number
+  cred_reward: number
+}
+
+export interface AchievementUnlockEvent {
+  type: 'achievement_unlocked'
+  achievement: AchievementUnlock
+  leveled_up: boolean
+  new_clearance: number | null
+}
+
+interface UseAchievementChannelOptions {
+  enabled: boolean
+  onUnlock: (event: AchievementUnlockEvent) => void
+}
+
+/**
+ * Subscribes to the per-hackr AchievementChannel stream. When any
+ * achievement unlocks (via Terminal action, content-surface trigger, or
+ * login sweep job), the server broadcasts to this channel and the hook
+ * invokes `onUnlock`. Only active while `enabled` is true (logged in).
+ *
+ * Reuses the shared ActionCable consumer (`lib/actionCableConsumer`)
+ * so there is one WebSocket for the whole app — this hook only
+ * manages its own subscription lifecycle.
+ */
+export const useAchievementChannel = ({ enabled, onUnlock }: UseAchievementChannelOptions) => {
+  const channelRef = useRef<Channel | null>(null)
+  const handlerRef = useRef(onUnlock)
+
+  useEffect(() => {
+    handlerRef.current = onUnlock
+  }, [onUnlock])
+
+  const connect = useCallback(() => {
+    if (!enabled) return
+
+    const cable = getActionCableConsumer()
+    channelRef.current = cable.subscriptions.create(
+      { channel: 'AchievementChannel' },
+      {
+        received (data: AchievementUnlockEvent) {
+          if (data?.type === 'achievement_unlocked') {
+            handlerRef.current(data)
+          }
+        }
+      }
+    )
+  }, [enabled])
+
+  const disconnect = useCallback(() => {
+    // Unsubscribe THIS channel only; do not disconnect the shared
+    // cable — other hooks may still be subscribed on it.
+    channelRef.current?.unsubscribe()
+    channelRef.current = null
+  }, [])
+
+  useEffect(() => {
+    if (enabled) {
+      connect()
+    } else {
+      disconnect()
+    }
+    return disconnect
+  }, [enabled, connect, disconnect])
+}

--- a/app/javascript/hooks/useHackrScopedDedup.ts
+++ b/app/javascript/hooks/useHackrScopedDedup.ts
@@ -1,0 +1,28 @@
+import { useRef, useEffect } from 'react'
+
+/**
+ * Per-user dedup ref for achievement credit calls. Returns a stable
+ * Set ref that is automatically cleared whenever the authenticated
+ * hackr id changes (logout, login, A → B swap), so one hackr's prior
+ * credits do not suppress another hackr's first credit within the
+ * same SPA session.
+ */
+export const useHackrScopedDedupSet = <T>(hackrId: number | null | undefined) => {
+  const ref = useRef<Set<T>>(new Set())
+  useEffect(() => {
+    ref.current = new Set()
+  }, [hackrId])
+  return ref
+}
+
+/**
+ * Boolean variant for pages with a hardcoded single target (e.g. a
+ * custom bio page for one artist). Resets to `false` on hackr swap.
+ */
+export const useHackrScopedDedupFlag = (hackrId: number | null | undefined) => {
+  const ref = useRef(false)
+  useEffect(() => {
+    ref.current = false
+  }, [hackrId])
+  return ref
+}

--- a/app/javascript/lib/actionCableConsumer.ts
+++ b/app/javascript/lib/actionCableConsumer.ts
@@ -1,0 +1,37 @@
+import { createConsumer, Cable } from '@rails/actioncable'
+
+/**
+ * Singleton ActionCable consumer. One WebSocket per app session,
+ * shared across every channel subscription. Lazy-initialized on
+ * first access — module import is side-effect-free.
+ *
+ * Hooks should subscribe via `getActionCableConsumer().subscriptions.create(...)`
+ * and call `.unsubscribe()` on cleanup. Do NOT call `.disconnect()` on
+ * the returned cable — other hooks may still be using it. The cable
+ * stays up for the lifetime of the page.
+ *
+ * Migration status: `useAchievementChannel` uses this. Pre-existing
+ * hooks (`useActionCable`, `useStreamStatus`, `usePulseWire`,
+ * `useUplink`) each still open their own consumer — migrating them
+ * is tracked as follow-up work (each has its own reconnect / presence
+ * logic that needs careful validation, out of scope for the
+ * achievement feature).
+ */
+let cable: Cable | null = null
+
+export const getActionCableConsumer = (): Cable => {
+  if (!cable) {
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    cable = createConsumer(`${wsProtocol}//${window.location.host}/cable`)
+  }
+  return cable
+}
+
+/**
+ * Test-only reset. Disconnects the singleton and clears it so the
+ * next test run initializes fresh. Never call from production code.
+ */
+export const _resetActionCableConsumerForTests = (): void => {
+  cable?.disconnect()
+  cable = null
+}

--- a/app/jobs/grid/achievement_sweep_job.rb
+++ b/app/jobs/grid/achievement_sweep_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Grid
+  # Runs after login (and other catch-up moments) to evaluate all
+  # cumulative-trigger achievements for a hackr. Counter-based progress
+  # accumulates outside the Terminal (track plays, log reads, etc.), so a
+  # triggering command may never fire. This job closes that gap.
+  #
+  # Cost profile (reviewed 2026-04-15): one checker instance is reused
+  # across all 18 trigger types. That instance memoizes:
+  #   - `earned_ids` (one query instead of 18)
+  #   - each source count accessed by `progress` (e.g. `track_plays_count`
+  #     runs once even though 5 tier achievements reference it)
+  # For a brand-new user with nothing earned, the sweep is ~18 candidate
+  # queries + ~10 source counts + 0 awards + 0 transactions. Fine as a
+  # background job; worth re-measuring if the `GridAchievement` table
+  # grows dramatically or new trigger types with expensive source
+  # queries are added.
+  class AchievementSweepJob < ApplicationJob
+    queue_as :default
+
+    def perform(hackr_id)
+      hackr = GridHackr.find_by(id: hackr_id)
+      return unless hackr
+
+      checker = Grid::AchievementChecker.new(hackr)
+      GridAchievement::CUMULATIVE_TRIGGERS.each do |trigger_type|
+        checker.check(trigger_type)
+      end
+    end
+  end
+end

--- a/app/models/codex_entry_read.rb
+++ b/app/models/codex_entry_read.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: codex_entry_reads
+# Database name: primary
+#
+#  id             :integer          not null, primary key
+#  read_at        :datetime         not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  codex_entry_id :integer          not null
+#  grid_hackr_id  :integer          not null
+#
+# Indexes
+#
+#  index_codex_entry_reads_on_codex_entry_id  (codex_entry_id)
+#  index_codex_entry_reads_on_grid_hackr_id   (grid_hackr_id)
+#  index_codex_entry_reads_unique             (grid_hackr_id,codex_entry_id) UNIQUE
+#
+# Foreign Keys
+#
+#  codex_entry_id  (codex_entry_id => codex_entries.id)
+#  grid_hackr_id   (grid_hackr_id => grid_hackrs.id)
+#
+class CodexEntryRead < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :codex_entry
+
+  validates :grid_hackr_id, uniqueness: {scope: :codex_entry_id}
+  before_validation :set_read_at, on: :create
+
+  def self.record!(hackr, entry)
+    find_or_create_by!(grid_hackr: hackr, codex_entry: entry) { |r| r.read_at = Time.current }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(grid_hackr: hackr, codex_entry: entry)
+  end
+
+  private
+
+  def set_read_at
+    self.read_at ||= Time.current
+  end
+end

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -5,6 +5,8 @@
 #
 #  id           :integer          not null, primary key
 #  badge_icon   :string
+#  category     :string           default("grid"), not null
+#  cred_reward  :integer          default(0), not null
 #  description  :text
 #  hidden       :boolean          default(FALSE), not null
 #  name         :string           not null
@@ -17,10 +19,17 @@
 #
 # Indexes
 #
+#  index_grid_achievements_on_category      (category)
 #  index_grid_achievements_on_slug          (slug) UNIQUE
 #  index_grid_achievements_on_trigger_type  (trigger_type)
 #
 class GridAchievement < ApplicationRecord
+  # Naming note: `uplink_packets_count` tracks what players see as
+  # Uplink "packets" — an in-world aesthetic alias. The backing model
+  # is `ChatMessage`; there is no separate Packet table. Similarly,
+  # `wire_pulses_count` tracks WIRE "pulses" (model `Pulse`, which IS
+  # its own table). Keep the in-world terminology in trigger names so
+  # admin UI + YAML seed read consistently with user-facing copy.
   TRIGGER_TYPES = %w[
     rooms_visited
     room_visit
@@ -32,6 +41,38 @@ class GridAchievement < ApplicationRecord
     salvage_item
     salvage_count
     manual
+    track_plays_count
+    pulse_vault_completed
+    hackr_logs_read
+    hackr_logs_read_all
+    codex_entries_read
+    codex_entries_read_all
+    artist_bios_viewed_all
+    release_indexes_viewed_all
+    releases_viewed_all
+    wire_pulses_count
+    uplink_packets_count
+    playlists_created
+    vods_watched
+    radio_stations_tuned
+    radio_stations_tuned_all
+    clearance_level
+  ].freeze
+
+  CATEGORIES = %w[grid music social meta progression].freeze
+
+  # Trigger types that accumulate toward a threshold and can be resolved
+  # retroactively by a login sweep. Event-only triggers (take_item,
+  # room_visit, talk_npc, manual) are excluded — they fire on the action.
+  CUMULATIVE_TRIGGERS = %w[
+    rooms_visited items_collected salvage_count
+    track_plays_count pulse_vault_completed
+    hackr_logs_read hackr_logs_read_all
+    codex_entries_read codex_entries_read_all
+    artist_bios_viewed_all release_indexes_viewed_all releases_viewed_all
+    wire_pulses_count uplink_packets_count playlists_created
+    vods_watched radio_stations_tuned radio_stations_tuned_all
+    clearance_level
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy
@@ -40,7 +81,11 @@ class GridAchievement < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
   validates :name, presence: true
   validates :trigger_type, presence: true, inclusion: {in: TRIGGER_TYPES}
+  validates :category, presence: true, inclusion: {in: CATEGORIES}
+  validates :xp_reward, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :cred_reward, numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
   scope :by_trigger, ->(type) { where(trigger_type: type) }
+  scope :by_category, ->(cat) { where(category: cat) }
   scope :visible, -> { where(hidden: false) }
 end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -89,6 +89,12 @@ class GridHackr < ApplicationRecord
   has_many :grid_shop_transactions, dependent: :nullify
   has_many :grid_hackr_reputations, dependent: :destroy
   has_many :grid_reputation_events, dependent: :destroy
+  has_many :grid_hackr_track_plays, dependent: :destroy
+  has_many :hackr_log_reads, dependent: :destroy
+  has_many :codex_entry_reads, dependent: :destroy
+  has_many :hackr_page_views, dependent: :destroy
+  has_many :hackr_vod_watches, dependent: :destroy
+  has_many :hackr_radio_tunes, dependent: :destroy
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length

--- a/app/models/grid_hackr_track_play.rb
+++ b/app/models/grid_hackr_track_play.rb
@@ -1,0 +1,56 @@
+# == Schema Information
+#
+# Table name: grid_hackr_track_plays
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  first_played_at :datetime         not null
+#  play_count      :integer          default(1), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  track_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_track_plays_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_hackr_track_plays_on_track_id       (track_id)
+#  index_track_plays_unique                       (grid_hackr_id,track_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  track_id       (track_id => tracks.id)
+#
+class GridHackrTrackPlay < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :track
+
+  validates :grid_hackr_id, uniqueness: {scope: :track_id}
+  before_validation :set_first_played_at, on: :create
+
+  # Upsert: on first call, creates row with play_count=1.
+  # Subsequent calls increment play_count and return the record.
+  def self.record!(hackr, track)
+    record = find_or_initialize_by(grid_hackr: hackr, track: track)
+    if record.new_record?
+      record.first_played_at = Time.current
+      record.play_count = 1
+      record.save!
+    else
+      record.increment!(:play_count)
+    end
+    record
+  rescue ActiveRecord::RecordNotUnique
+    # Concurrent insert race — fetch the winning row and increment it.
+    record = find_by!(grid_hackr: hackr, track: track)
+    record.increment!(:play_count)
+    record
+  end
+
+  private
+
+  def set_first_played_at
+    self.first_played_at ||= Time.current
+  end
+end

--- a/app/models/hackr_log_read.rb
+++ b/app/models/hackr_log_read.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: hackr_log_reads
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  read_at       :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  hackr_log_id  :integer          not null
+#
+# Indexes
+#
+#  index_hackr_log_reads_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_log_reads_on_hackr_log_id   (hackr_log_id)
+#  index_hackr_log_reads_unique            (grid_hackr_id,hackr_log_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  hackr_log_id   (hackr_log_id => hackr_logs.id)
+#
+class HackrLogRead < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :hackr_log
+
+  validates :grid_hackr_id, uniqueness: {scope: :hackr_log_id}
+  before_validation :set_read_at, on: :create
+
+  def self.record!(hackr, log)
+    find_or_create_by!(grid_hackr: hackr, hackr_log: log) { |r| r.read_at = Time.current }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(grid_hackr: hackr, hackr_log: log)
+  end
+
+  private
+
+  def set_read_at
+    self.read_at ||= Time.current
+  end
+end

--- a/app/models/hackr_page_view.rb
+++ b/app/models/hackr_page_view.rb
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: hackr_page_views
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  page_type     :string           not null
+#  viewed_at     :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  resource_id   :integer          not null
+#
+# Indexes
+#
+#  index_hackr_page_views_hackr_type        (grid_hackr_id,page_type)
+#  index_hackr_page_views_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_page_views_unique            (grid_hackr_id,page_type,resource_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+# Polymorphic-lite view tracking. `resource_id` is an Artist id when
+# page_type is "bio" or "release_index", a Release id when page_type is
+# "release". No FK constraint — resource_type is implied by page_type.
+class HackrPageView < ApplicationRecord
+  PAGE_TYPES = %w[bio release_index release].freeze
+
+  belongs_to :grid_hackr
+
+  validates :page_type, inclusion: {in: PAGE_TYPES}
+  validates :resource_id, uniqueness: {scope: [:grid_hackr_id, :page_type]}
+  before_validation :set_viewed_at, on: :create
+
+  scope :of_type, ->(type) { where(page_type: type) }
+
+  def self.record!(hackr, page_type, resource_id)
+    find_or_create_by!(grid_hackr: hackr, page_type: page_type, resource_id: resource_id) do |r|
+      r.viewed_at = Time.current
+    end
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(grid_hackr: hackr, page_type: page_type, resource_id: resource_id)
+  end
+
+  private
+
+  def set_viewed_at
+    self.viewed_at ||= Time.current
+  end
+end

--- a/app/models/hackr_radio_tune.rb
+++ b/app/models/hackr_radio_tune.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: hackr_radio_tunes
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  tuned_at         :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  grid_hackr_id    :integer          not null
+#  radio_station_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_radio_tunes_on_grid_hackr_id     (grid_hackr_id)
+#  index_hackr_radio_tunes_on_radio_station_id  (radio_station_id)
+#  index_hackr_radio_tunes_unique               (grid_hackr_id,radio_station_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id     (grid_hackr_id => grid_hackrs.id)
+#  radio_station_id  (radio_station_id => radio_stations.id)
+#
+class HackrRadioTune < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :radio_station
+
+  validates :grid_hackr_id, uniqueness: {scope: :radio_station_id}
+  before_validation :set_tuned_at, on: :create
+
+  def self.record!(hackr, station)
+    find_or_create_by!(grid_hackr: hackr, radio_station: station) { |r| r.tuned_at = Time.current }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(grid_hackr: hackr, radio_station: station)
+  end
+
+  private
+
+  def set_tuned_at
+    self.tuned_at ||= Time.current
+  end
+end

--- a/app/models/hackr_stream.rb
+++ b/app/models/hackr_stream.rb
@@ -26,6 +26,7 @@
 class HackrStream < ApplicationRecord
   belongs_to :artist
   belongs_to :track, primary_key: :slug, foreign_key: :track_slug, optional: true
+  has_many :hackr_vod_watches, dependent: :destroy
 
   validates :live_url, presence: true, if: :is_live?
   validates :title, length: {maximum: 255}

--- a/app/models/hackr_vod_watch.rb
+++ b/app/models/hackr_vod_watch.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: hackr_vod_watches
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  watched_at      :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  hackr_stream_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_vod_watches_on_grid_hackr_id    (grid_hackr_id)
+#  index_hackr_vod_watches_on_hackr_stream_id  (hackr_stream_id)
+#  index_hackr_vod_watches_unique              (grid_hackr_id,hackr_stream_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id)
+#  hackr_stream_id  (hackr_stream_id => hackr_streams.id)
+#
+class HackrVodWatch < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :hackr_stream
+
+  validates :grid_hackr_id, uniqueness: {scope: :hackr_stream_id}
+  before_validation :set_watched_at, on: :create
+
+  def self.record!(hackr, stream)
+    find_or_create_by!(grid_hackr: hackr, hackr_stream: stream) { |r| r.watched_at = Time.current }
+  rescue ActiveRecord::RecordNotUnique
+    find_by!(grid_hackr: hackr, hackr_stream: stream)
+  end
+
+  private
+
+  def set_watched_at
+    self.watched_at ||= Time.current
+  end
+end

--- a/app/models/radio_station.rb
+++ b/app/models/radio_station.rb
@@ -24,6 +24,7 @@ class RadioStation < ApplicationRecord
   # Associations
   has_many :radio_station_playlists, -> { order(position: :asc) }, dependent: :destroy
   has_many :playlists, through: :radio_station_playlists
+  has_many :hackr_radio_tunes, dependent: :destroy
 
   # Validations
   validates :name, presence: true

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -50,6 +50,8 @@ class Release < ApplicationRecord
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: {scope: :artist_id}
 
+  scope :released, -> { where(coming_soon: false) }
+
   def to_param
     slug
   end

--- a/app/services/grid/achievement_awarder.rb
+++ b/app/services/grid/achievement_awarder.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Grid
+  # Applies rewards (join-row insert, XP grant, CRED mint) and pushes the
+  # unlock toast to the hackr's AchievementChannel stream. Returns the
+  # inline HTML notification string for Terminal commands, or nil when the
+  # achievement is already earned (race-guard).
+  #
+  # Used by:
+  #   - Grid::AchievementChecker#check (automatic unlocks)
+  #   - Admin::GridAchievementsController#award (manual admin grant)
+  class AchievementAwarder
+    def initialize(hackr, achievement)
+      @hackr = hackr
+      @achievement = achievement
+    end
+
+    def award!
+      xp_result = nil
+      minted_cred = false
+
+      ActiveRecord::Base.transaction do
+        GridHackrAchievement.create!(
+          grid_hackr: @hackr,
+          grid_achievement: @achievement,
+          awarded_at: Time.current
+        )
+
+        xp_result = @hackr.grant_xp!(@achievement.xp_reward) if @achievement.xp_reward.to_i.positive?
+
+        if @achievement.cred_reward.to_i.positive?
+          cache = @hackr.default_cache
+          if cache&.active?
+            Grid::TransactionService.mint_gameplay!(
+              to_cache: cache,
+              amount: @achievement.cred_reward,
+              memo: "Achievement: #{@achievement.name}"
+            )
+            minted_cred = true
+          else
+            Rails.logger.warn(
+              "[AchievementAwarder] skipped CRED mint for hackr=#{@hackr.id} " \
+              "achievement=#{@achievement.slug}: no active default cache"
+            )
+          end
+        end
+      end
+
+      broadcast_toast(xp_result, minted_cred)
+      build_notification(xp_result, minted_cred)
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      # RecordInvalid: the uniqueness validator on GridHackrAchievement
+      # caught the duplicate at the AR layer. RecordNotUnique: the DB
+      # unique index caught it (true race — two transactions committing
+      # simultaneously). Both mean "already awarded" — return nil so the
+      # checker skips this candidate without surfacing an error.
+      raise unless e.is_a?(ActiveRecord::RecordNotUnique) ||
+        e.record.is_a?(GridHackrAchievement)
+      nil
+    end
+
+    private
+
+    def broadcast_toast(xp_result, minted_cred)
+      ActionCable.server.broadcast(
+        AchievementChannel.stream_name_for(@hackr),
+        {
+          type: "achievement_unlocked",
+          achievement: {
+            slug: @achievement.slug,
+            name: @achievement.name,
+            description: @achievement.description,
+            badge_icon: @achievement.badge_icon,
+            category: @achievement.category,
+            xp_reward: @achievement.xp_reward,
+            cred_reward: minted_cred ? @achievement.cred_reward : 0
+          },
+          leveled_up: xp_result&.dig(:leveled_up) || false,
+          new_clearance: xp_result&.dig(:new_clearance)
+        }
+      )
+    rescue => e
+      Rails.logger.error("[AchievementAwarder] broadcast failed: #{e.message}")
+    end
+
+    def build_notification(xp_result, minted_cred)
+      icon = @achievement.badge_icon.present? ? "#{@achievement.badge_icon} " : ""
+      xp_line = @achievement.xp_reward.to_i.positive? ? " <span style='color: #34d399;'>+#{@achievement.xp_reward} XP</span>" : ""
+      cred_line = minted_cred ? " <span style='color: #fbbf24;'>+#{@achievement.cred_reward} CRED</span>" : ""
+      level_line = xp_result&.dig(:leveled_up) ? "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{xp_result[:new_clearance]}!</span>" : ""
+
+      "<div style='border: 1px solid #fbbf24; padding: 8px 12px; margin: 4px 0; background: #111;'>" \
+        "<span style='color: #fbbf24; font-weight: bold;'>ACHIEVEMENT UNLOCKED:</span> " \
+        "#{icon}<span style='color: #22d3ee;'>#{ERB::Util.html_escape(@achievement.name)}</span>" \
+        "#{xp_line}#{cred_line}" \
+        "</div>#{level_line}"
+    end
+  end
+end

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -1,89 +1,279 @@
 # frozen_string_literal: true
 
 module Grid
+  # Evaluates achievement unlocks for a single hackr. Caller passes a
+  # trigger_type (symbol/string) plus context hash; checker queries
+  # candidates for that trigger, skips already-earned, delegates the
+  # actual award + reward pipeline to AchievementAwarder.
+  #
+  # Returns an array of inline HTML notification strings — Terminal
+  # commands append these to the command output. The AchievementChannel
+  # toast broadcast fires from AchievementAwarder (async for the client).
+  #
+  # Source counts used by `progress` are memoized per-instance — the
+  # AchievementsPage endpoint iterates ~40 achievements but many share
+  # the same underlying query (e.g. all `hackr_logs_read` tiers read the
+  # same `hackr_log_reads.count`). Memoization collapses that to one
+  # query per source. Callers should discard the checker after use so
+  # counts aren't served stale across requests.
   class AchievementChecker
     def initialize(hackr)
       @hackr = hackr
     end
 
-    # Check achievements for a trigger type. Returns array of notification HTML strings.
     def check(trigger_type, context = {})
+      return [] unless @hackr
+
       candidates = GridAchievement.by_trigger(trigger_type.to_s)
       return [] if candidates.none?
 
-      earned_ids = @hackr.grid_hackr_achievements.pluck(:grid_achievement_id).to_set
       notifications = []
 
       candidates.each do |achievement|
         next if earned_ids.include?(achievement.id)
         next unless matches?(achievement, context)
 
-        notification = award!(achievement)
-        notifications << notification if notification
+        notification = Grid::AchievementAwarder.new(@hackr, achievement).award!
+        next unless notification
+
+        # Track the just-awarded id so subsequent check() calls on the
+        # same checker instance (login sweep's 18-trigger loop, or the
+        # CommandParser firing 3 checks after `take`) don't re-test it.
+        # award!() already raises on DB-level duplicate; skipping saves
+        # the round-trip.
+        earned_ids << achievement.id
+        notifications << notification
       end
 
       notifications
     end
 
-    private
-
-    def matches?(achievement, context)
+    # Returns {current:, target:, fraction:, completed:} for a cumulative
+    # achievement, or nil for event-only triggers (room_visit, take_item,
+    # use_item, talk_npc, rarity_owned, salvage_item, manual). Used by
+    # the `stat` command, the Handbook achievements page, and the
+    # `matches?` dispatch below (cumulative triggers unlock when
+    # `progress[:completed]` is true).
+    def progress(achievement)
       data = (achievement.trigger_data || {}).with_indifferent_access
 
       case achievement.trigger_type
       when "rooms_visited"
-        (@hackr.stat("rooms_visited") || 0) >= data[:count].to_i
-      when "room_visit"
-        data[:room_slug].present? && data[:room_slug] == context[:room_slug]
+        derive(@hackr.stat("rooms_visited").to_i, data[:count].to_i)
       when "items_collected"
-        @hackr.grid_items.count >= data[:count].to_i
-      when "take_item"
-        data[:item_name].blank? || data[:item_name].downcase == context[:item_name]&.downcase
-      when "rarity_owned"
-        data[:rarity].present? && @hackr.grid_items.exists?(rarity: data[:rarity])
-      when "talk_npc"
-        data[:npc_name].blank? || data[:npc_name].downcase == context[:npc_name]&.downcase
-      when "use_item"
-        data[:item_name].blank? || data[:item_name].downcase == context[:item_name]&.downcase
-      when "salvage_item"
-        true
+        derive(items_collected_count, data[:count].to_i)
       when "salvage_count"
-        (@hackr.stat("salvage_count") || 0) >= data[:count].to_i
+        derive(@hackr.stat("salvage_count").to_i, data[:count].to_i)
+      when "track_plays_count"
+        derive(track_plays_count, data[:count].to_i)
+      when "pulse_vault_completed"
+        derive(pulse_vault_played_count, pulse_vault_total)
+      when "hackr_logs_read"
+        derive(hackr_logs_read_count, data[:count].to_i)
+      when "hackr_logs_read_all"
+        derive(hackr_logs_read_published_count, hackr_logs_published_total)
+      when "codex_entries_read"
+        derive(codex_entries_read_count, data[:count].to_i)
+      when "codex_entries_read_all"
+        derive(codex_entries_read_published_count, codex_entries_published_total)
+      when "artist_bios_viewed_all"
+        derive(bios_viewed_for_bands_count, band_ids.size)
+      when "release_indexes_viewed_all"
+        derive(release_indexes_viewed_for_bands_count, band_ids.size)
+      when "releases_viewed_all"
+        derive(releases_viewed_for_released_count, released_release_ids.size)
+      when "wire_pulses_count"
+        derive(wire_pulses_count, data[:count].to_i)
+      when "uplink_packets_count"
+        # "Packet" is the in-world, user-facing term for an Uplink
+        # message — pure aesthetic naming to preserve the Grid's
+        # fourth wall. The underlying model is `ChatMessage`; there
+        # is no separate Packet table. Count reads chat_messages.
+        derive(uplink_packets_count, data[:count].to_i)
+      when "playlists_created"
+        derive(populated_playlist_count, data[:count].to_i)
+      when "vods_watched"
+        derive(vods_watched_count, data[:count].to_i)
+      when "radio_stations_tuned"
+        derive(radio_stations_tuned_count, data[:count].to_i)
+      when "radio_stations_tuned_all"
+        derive(radio_stations_tuned_visible_count, radio_stations_visible_total)
+      when "clearance_level"
+        derive(@hackr.stat("clearance").to_i, data[:level].to_i)
+      end
+    end
+
+    private
+
+    # Memoized set of achievement IDs the hackr has already earned.
+    # The login sweep job calls check() 18 times on one checker
+    # instance — without this memoization each call re-queries the
+    # join table. Stays fresh within the instance: check() appends
+    # to the set when award!() returns a notification. Refs should
+    # not survive past a single request/job (earned set is a snapshot).
+    def earned_ids
+      @earned_ids ||= @hackr.grid_hackr_achievements.pluck(:grid_achievement_id).to_set
+    end
+
+    def derive(current, target)
+      return nil if target.to_i <= 0
+      current = current.to_i
+      clamped = [current, target].min
+      {current: current, target: target, fraction: (clamped.to_f / target).round(2), completed: current >= target}
+    end
+
+    # --- Memoized source counts -------------------------------------
+    # Each method runs its underlying query at most once per checker
+    # instance. `defined?` + ||= handles the false/0/nil cases the
+    # naive `@x ||= ...` pattern would re-run on. Counts can be 0.
+
+    def items_collected_count
+      return @items_collected_count if defined?(@items_collected_count)
+      @items_collected_count = @hackr.grid_items.count
+    end
+
+    def track_plays_count
+      return @track_plays_count if defined?(@track_plays_count)
+      @track_plays_count = @hackr.grid_hackr_track_plays.count
+    end
+
+    def pulse_vault_total
+      return @pulse_vault_total if defined?(@pulse_vault_total)
+      @pulse_vault_total = Track.visible_in_pulse_vault.count
+    end
+
+    def pulse_vault_played_count
+      return @pulse_vault_played_count if defined?(@pulse_vault_played_count)
+      @pulse_vault_played_count = @hackr.grid_hackr_track_plays
+        .joins(:track).merge(Track.visible_in_pulse_vault).distinct.count
+    end
+
+    def hackr_logs_read_count
+      return @hackr_logs_read_count if defined?(@hackr_logs_read_count)
+      @hackr_logs_read_count = @hackr.hackr_log_reads.count
+    end
+
+    def hackr_logs_published_total
+      return @hackr_logs_published_total if defined?(@hackr_logs_published_total)
+      @hackr_logs_published_total = HackrLog.published.count
+    end
+
+    def hackr_logs_read_published_count
+      return @hackr_logs_read_published_count if defined?(@hackr_logs_read_published_count)
+      @hackr_logs_read_published_count = @hackr.hackr_log_reads
+        .joins(:hackr_log).merge(HackrLog.published).count
+    end
+
+    def codex_entries_read_count
+      return @codex_entries_read_count if defined?(@codex_entries_read_count)
+      @codex_entries_read_count = @hackr.codex_entry_reads.count
+    end
+
+    def codex_entries_published_total
+      return @codex_entries_published_total if defined?(@codex_entries_published_total)
+      @codex_entries_published_total = CodexEntry.published.count
+    end
+
+    def codex_entries_read_published_count
+      return @codex_entries_read_published_count if defined?(@codex_entries_read_published_count)
+      @codex_entries_read_published_count = @hackr.codex_entry_reads
+        .joins(:codex_entry).merge(CodexEntry.published).count
+    end
+
+    def band_ids
+      return @band_ids if defined?(@band_ids)
+      @band_ids = Artist.bands.pluck(:id)
+    end
+
+    def bios_viewed_for_bands_count
+      return @bios_viewed_for_bands_count if defined?(@bios_viewed_for_bands_count)
+      @bios_viewed_for_bands_count = @hackr.hackr_page_views
+        .of_type("bio").where(resource_id: band_ids).count
+    end
+
+    def release_indexes_viewed_for_bands_count
+      return @release_indexes_viewed_for_bands_count if defined?(@release_indexes_viewed_for_bands_count)
+      @release_indexes_viewed_for_bands_count = @hackr.hackr_page_views
+        .of_type("release_index").where(resource_id: band_ids).count
+    end
+
+    def released_release_ids
+      return @released_release_ids if defined?(@released_release_ids)
+      @released_release_ids = Release.released.pluck(:id)
+    end
+
+    def releases_viewed_for_released_count
+      return @releases_viewed_for_released_count if defined?(@releases_viewed_for_released_count)
+      @releases_viewed_for_released_count = @hackr.hackr_page_views
+        .of_type("release").where(resource_id: released_release_ids).count
+    end
+
+    def wire_pulses_count
+      return @wire_pulses_count if defined?(@wire_pulses_count)
+      @wire_pulses_count = @hackr.pulses.where(parent_pulse_id: nil).count
+    end
+
+    # Uplink "packets" are stored as `ChatMessage` rows — "packet" is
+    # a pure in-world aesthetic alias, not a separate model. This
+    # accessor counts every message the hackr has sent through the
+    # Uplink, which is what the `uplink_packets_count` achievement
+    # tier ladder advances on.
+    def uplink_packets_count
+      return @uplink_packets_count if defined?(@uplink_packets_count)
+      @uplink_packets_count = @hackr.chat_messages.count
+    end
+
+    def populated_playlist_count
+      return @populated_playlist_count if defined?(@populated_playlist_count)
+      @populated_playlist_count = @hackr.playlists.joins(:playlist_tracks).distinct.count
+    end
+
+    def vods_watched_count
+      return @vods_watched_count if defined?(@vods_watched_count)
+      @vods_watched_count = @hackr.hackr_vod_watches.count
+    end
+
+    def radio_stations_tuned_count
+      return @radio_stations_tuned_count if defined?(@radio_stations_tuned_count)
+      @radio_stations_tuned_count = @hackr.hackr_radio_tunes.count
+    end
+
+    def radio_stations_visible_total
+      return @radio_stations_visible_total if defined?(@radio_stations_visible_total)
+      @radio_stations_visible_total = RadioStation.visible.count
+    end
+
+    def radio_stations_tuned_visible_count
+      return @radio_stations_tuned_visible_count if defined?(@radio_stations_tuned_visible_count)
+      @radio_stations_tuned_visible_count = @hackr.hackr_radio_tunes
+        .joins(:radio_station).merge(RadioStation.visible).count
+    end
+
+    def matches?(achievement, context)
+      # Event-only triggers — unlock fires on the specific action, not
+      # a cumulative threshold. These are never catch-up swept.
+      data = (achievement.trigger_data || {}).with_indifferent_access
+      case achievement.trigger_type
+      when "room_visit"
+        return data[:room_slug].present? && data[:room_slug] == context[:room_slug]
+      when "take_item"
+        return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
+      when "rarity_owned"
+        return data[:rarity].present? && @hackr.grid_items.exists?(rarity: data[:rarity])
+      when "talk_npc"
+        return data[:npc_name].blank? || data[:npc_name].to_s.downcase == context[:npc_name].to_s.downcase
+      when "use_item"
+        return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
+      when "salvage_item"
+        return true
       when "manual"
-        false
-      else
-        false
-      end
-    end
-
-    def award!(achievement)
-      GridHackrAchievement.create!(
-        grid_hackr: @hackr,
-        grid_achievement: achievement,
-        awarded_at: Time.current
-      )
-
-      # Award XP for achievement
-      xp_result = nil
-      if achievement.xp_reward > 0
-        xp_result = @hackr.grant_xp!(achievement.xp_reward)
+        return false
       end
 
-      build_notification(achievement, xp_result)
-    rescue ActiveRecord::RecordNotUnique
-      nil # Already earned — race condition guard
-    end
-
-    def build_notification(achievement, xp_result)
-      icon = achievement.badge_icon.present? ? "#{achievement.badge_icon} " : ""
-      xp_line = (achievement.xp_reward > 0) ? " <span style='color: #34d399;'>+#{achievement.xp_reward} XP</span>" : ""
-      level_line = xp_result&.dig(:leveled_up) ? "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{xp_result[:new_clearance]}!</span>" : ""
-
-      "<div style='border: 1px solid #fbbf24; padding: 8px 12px; margin: 4px 0; background: #111;'>" \
-        "<span style='color: #fbbf24; font-weight: bold;'>ACHIEVEMENT UNLOCKED:</span> " \
-        "#{icon}<span style='color: #22d3ee;'>#{ERB::Util.html_escape(achievement.name)}</span>" \
-        "#{xp_line}" \
-        "</div>#{level_line}"
+      # Cumulative triggers — delegate to progress so match + progress
+      # share a single query. Returns nil for unknown trigger types.
+      progress_result = progress(achievement)
+      progress_result ? progress_result[:completed] : false
     end
   end
 end

--- a/app/views/admin/grid_achievements/_form.html.erb
+++ b/app/views/admin/grid_achievements/_form.html.erb
@@ -28,6 +28,11 @@
     </div>
 
     <div style="flex: 1;">
+      <%= f.label :category, "CATEGORY", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :category, GridAchievement::CATEGORIES.map { |c| [c, c] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+
+    <div style="flex: 1;">
       <%= f.label :trigger_type, "TRIGGER TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
       <%= f.select :trigger_type, GridAchievement::TRIGGER_TYPES.map { |t| [t, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
     </div>
@@ -37,6 +42,11 @@
     <div style="flex: 1;">
       <%= f.label :xp_reward, "XP REWARD", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
       <%= f.number_field :xp_reward, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+    </div>
+
+    <div style="flex: 1;">
+      <%= f.label :cred_reward, "CRED REWARD", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :cred_reward, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
     </div>
 
     <div style="flex: 1;">

--- a/app/views/admin/grid_achievements/index.html.erb
+++ b/app/views/admin/grid_achievements/index.html.erb
@@ -15,8 +15,18 @@
         </div>
       <% end %>
 
-      <div style="margin-bottom: 20px;">
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
         <%= link_to "+ New Achievement", new_admin_grid_achievement_path, class: "tui-button green-168" %>
+
+        <%= form_with url: admin_grid_achievements_path, method: :get, local: true, style: "display: inline-flex; gap: 8px; align-items: center; margin-left: 20px;" do %>
+          <label class="white-text" style="font-weight: bold;">FILTER:</label>
+          <%= select_tag :category,
+                options_for_select([["ALL", ""]] + GridAchievement::CATEGORIES.map { |c| [c.upcase, c] }, @category_filter),
+                class: "tui-input", style: "padding: 4px 8px;", onchange: "this.form.submit()" %>
+          <% if @category_filter.present? %>
+            <%= link_to "× clear", admin_grid_achievements_path, class: "tui-button", style: "padding: 4px 10px; font-size: 0.8em;" %>
+          <% end %>
+        <% end %>
       </div>
 
       <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
@@ -25,8 +35,10 @@
             <tr>
               <th style="text-align: left;">Name</th>
               <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Category</th>
               <th style="text-align: left;">Trigger</th>
               <th style="text-align: center;">XP</th>
+              <th style="text-align: center;">CRED</th>
               <th style="text-align: center;">Earned</th>
               <th style="text-align: center;">Hidden</th>
               <th style="text-align: right;">Actions</th>
@@ -40,8 +52,10 @@
                   <span class="cyan-255-text"><%= achievement.name %></span>
                 </td>
                 <td style="color: #666; font-family: monospace;"><%= achievement.slug %></td>
+                <td style="color: #a78bfa;"><%= achievement.category %></td>
                 <td style="color: #888;"><%= achievement.trigger_type %></td>
                 <td style="text-align: center;" class="green-255-text"><%= achievement.xp_reward %></td>
+                <td style="text-align: center; color: #fbbf24;"><%= achievement.cred_reward %></td>
                 <td style="text-align: center; color: #888;"><%= achievement.grid_hackr_achievements.size %></td>
                 <td style="text-align: center;">
                   <% if achievement.hidden? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Rails.application.routes.draw do
   # Timeline route - SPA
   get "timeline", to: "pages#spa_root", as: :timeline
 
+  # Achievements (login-gated SPA)
+  get "achievements", to: "pages#spa_root", as: :achievements
+
   # Codex (wiki) routes - SPA
   scope "codex" do
     get "/", to: "pages#spa_root", as: :codex
@@ -116,15 +119,27 @@ Rails.application.routes.draw do
 
     resources :artists, only: %i[index show] do
       resources :tracks, only: [:index]
+      member do
+        post :bio_viewed
+        post :release_index_viewed
+      end
     end
-    resources :tracks, only: %i[index show]
+    resources :tracks, only: %i[index show] do
+      member do
+        post :play_credit
+      end
+    end
     resources :releases, only: %i[index show] do
       get :latest, on: :collection
       get :coming_soon, on: :collection
+      member do
+        post :viewed
+      end
     end
     get "codex/mappings", to: "codex#mappings"
     get "codex", to: "codex#index"
     get "codex/:slug", to: "codex#show"
+    post "codex/:slug/read", to: "codex#mark_read"
 
     get "handbook/mappings", to: "handbook#mappings"
     get "handbook/recent", to: "handbook#recent"
@@ -132,12 +147,15 @@ Rails.application.routes.draw do
     get "handbook/:slug", to: "handbook#show"
     get "radio_stations", to: "radio#index"
     get "radio_stations/:id/playlists", to: "radio#station_playlists"
+    post "radio_stations/:id/tune_in", to: "radio#tune_in"
     get "hackr_stream", to: "hackr_streams#show"
     get "artists/:artist_slug/vods", to: "hackr_streams#index"
     get "artists/:artist_slug/vods/:id", to: "hackr_streams#vod_show"
+    post "artists/:artist_slug/vods/:id/watch", to: "hackr_streams#watch"
 
     # Grid API routes
     get "grid/current_hackr", to: "grid#current_hackr_info"
+    get "grid/achievements", to: "grid#achievements_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
     get "grid/verify/:token", to: "grid#verify_token"
@@ -159,6 +177,7 @@ Rails.application.routes.draw do
 
     # Hackr Logs API routes
     resources :logs, only: %i[index show]
+    post "logs/:id/read", to: "logs#mark_read"
 
     # Playlists API routes
     resources :playlists do

--- a/data/content/handbook.yml
+++ b/data/content/handbook.yml
@@ -164,6 +164,86 @@ handbook_sections:
           feel the same at CL3 as it does at CL30.
 
           Check your current CL any time with `stat`.
+      - slug: achievements
+        title: Achievements & Badges
+        kind: reference
+        difficulty: beginner
+        position: 2
+        published: true
+        summary: "Unlockable badges across the Grid, Vault, WIRE, Uplink, and more — with XP and CRED rewards."
+        metadata:
+          search_tags:
+            - achievements
+            - badges
+            - progression
+            - unlocks
+            - rewards
+        body: |
+          # Achievements & Badges
+
+          Achievements unlock permanently when you hit a milestone. Each
+          achievement awards **XP** toward your clearance level, and most
+          also drop **CRED** directly into your default cache.
+
+          ## Categories
+
+          Achievements are grouped into five categories:
+
+          - **GRID** — MUD exploration, items, NPC interaction, salvage.
+          - **MUSIC** — Pulse Vault listening, VODs, radio, artist pages.
+          - **SOCIAL** — WIRE pulses, Uplink packets, custom playlists.
+          - **META** — Hackr Logs and Codex reading.
+          - **PROGRESSION** — Clearance level milestones.
+
+          ## How you unlock them
+
+          Most achievements track automatically as you use the site:
+
+          - Move between rooms and `talk` / `take` / `use` / `salvage` in-Grid.
+          - Play tracks in the Vault (credit kicks in after ~30 seconds of playback).
+          - Read Hackr Logs and Codex entries.
+          - Visit band bios, release indexes, and individual releases.
+          - Watch VODs. Tune into radio stations.
+          - Post pulses on the WIRE. Send Uplink packets. Create playlists.
+
+          A handful of achievements are **hidden** — you'll only find out
+          what they are by earning them.
+
+          ## Rewards
+
+          The standard ladder for tiered counter-based achievements:
+
+          | Tier        | XP      | CRED   |
+          |-------------|--------:|-------:|
+          | Tier 1      |  25     |   1    |
+          | Tier 2      | 100     |  10    |
+          | Tier 3      | 250     |  20    |
+          | Completionist | 500   |  50    |
+          | Single-event |  10    |   0    |
+
+          Clearance-level achievements grant CRED only — the XP that got you
+          to that level is its own reward.
+
+          CRED payouts are minted from the Fracture Reserve and land in your
+          default cache automatically. Check `stat` or the `cache` command to
+          confirm the balance.
+
+          ## Where to see your progress
+
+          - `stat` in the Terminal lists every achievement you've earned, with
+            its badge icon, name, and XP value.
+          - When an achievement unlocks, a toast appears in the corner of the
+            screen anywhere on hackr.tv — even outside the Terminal.
+          - The Terminal shows the full `ACHIEVEMENT UNLOCKED` banner inline
+            when the trigger happens during a command.
+
+          ## Catch-up on login
+
+          When you log in, the system runs a quick sweep to award any
+          cumulative achievements you qualified for while away (e.g. you
+          hit 50 tracks played across multiple sessions but never triggered
+          a Terminal command to check). Expect a small burst of toasts on a
+          long-absence login.
 
   - slug: wire
     name: WIRE

--- a/data/world/achievements.yml
+++ b/data/world/achievements.yml
@@ -1,126 +1,160 @@
 # Grid Achievement Definitions
 # Loaded via: rails data:achievements
+#
+# Reward ladders (expansion): Tier-1 (+25 XP, +1 CRED), Tier-2 (+100 XP, +10 CRED),
+# Tier-3 (+250 XP, +20 CRED), Completionist (+500 XP, +50 CRED), Single-event (+10 XP, 0 CRED).
+# Existing MUD achievements retain their original XP values (no CRED) for backward compat.
 achievements:
+
+  # ============================================================
+  # GRID CATEGORY (MUD — existing)
+  # ============================================================
 
   # --- Exploration ---
   - slug: first_steps
     name: "First Steps"
     description: "Moved through the Grid for the first time."
     badge_icon: ">>"
+    category: grid
     trigger_type: rooms_visited
     trigger_data:
       count: 1
     xp_reward: 10
+    cred_reward: 0
 
   - slug: grid_walker
     name: "Grid Walker"
     description: "Explored 10 rooms across the Grid."
     badge_icon: ">>"
+    category: grid
     trigger_type: rooms_visited
     trigger_data:
       count: 10
     xp_reward: 50
+    cred_reward: 0
 
   - slug: grid_runner
     name: "Grid Runner"
     description: "Explored 25 rooms across the Grid."
     badge_icon: ">>>"
+    category: grid
     trigger_type: rooms_visited
     trigger_data:
       count: 25
     xp_reward: 150
+    cred_reward: 0
 
   - slug: grid_phantom
     name: "Grid Phantom"
     description: "Explored 50 rooms. You know every shadow."
     badge_icon: ">>>"
+    category: grid
     trigger_type: rooms_visited
     trigger_data:
       count: 50
     xp_reward: 500
+    cred_reward: 0
 
   # --- NPC Interaction ---
   - slug: first_contact
     name: "First Contact"
     description: "Established contact with a Grid operative."
     badge_icon: "~"
+    category: grid
     trigger_type: talk_npc
     trigger_data: {}
     xp_reward: 15
+    cred_reward: 0
 
   - slug: synthia_signal
     name: "Synthia Signal"
     description: "Made contact with Synthia."
     badge_icon: "S"
+    category: grid
     trigger_type: talk_npc
     trigger_data:
       npc_name: Synthia
     xp_reward: 100
+    cred_reward: 0
 
   # --- Collection ---
   - slug: data_acquired
     name: "Data Acquired"
     description: "Picked up your first item."
     badge_icon: "+"
+    category: grid
     trigger_type: items_collected
     trigger_data:
       count: 1
     xp_reward: 10
+    cred_reward: 0
 
   - slug: data_hoarder
     name: "Data Hoarder"
     description: "Collected 5 items."
     badge_icon: "++"
+    category: grid
     trigger_type: items_collected
     trigger_data:
       count: 5
     xp_reward: 50
+    cred_reward: 0
 
   - slug: pack_rat
     name: "Pack Rat"
     description: "Collected 15 items. Your inventory is full of secrets."
     badge_icon: "+++"
+    category: grid
     trigger_type: items_collected
     trigger_data:
       count: 15
     xp_reward: 200
+    cred_reward: 0
 
   - slug: fracture_contact
     name: "Fracture Contact"
     description: "Recovered Fracture Network encrypted data."
     badge_icon: "F"
+    category: grid
     trigger_type: take_item
     trigger_data:
       item_name: fracture network data chip
     xp_reward: 100
+    cred_reward: 0
 
   # --- Rarity ---
   - slug: rare_find
     name: "Rare Find"
     description: "Obtained a Rare-tier item."
     badge_icon: "R"
+    category: grid
     trigger_type: rarity_owned
     trigger_data:
       rarity: rare
     xp_reward: 100
+    cred_reward: 0
 
   - slug: ultra_rare_find
     name: "Ultra-Rare Find"
     description: "Obtained an Ultra-Rare item."
     badge_icon: "U"
+    category: grid
     trigger_type: rarity_owned
     trigger_data:
       rarity: ultra_rare
     xp_reward: 300
+    cred_reward: 0
 
   - slug: unicorn_hunter
     name: "Unicorn Hunter"
     description: "You found something that shouldn't exist."
     badge_icon: "*"
+    category: grid
     trigger_type: rarity_owned
     trigger_data:
       rarity: unicorn
     xp_reward: 500
+    cred_reward: 0
     hidden: true
 
   # --- Salvage ---
@@ -128,24 +162,533 @@ achievements:
     name: "Scrapper"
     description: "Salvaged your first item."
     badge_icon: "%"
+    category: grid
     trigger_type: salvage_item
     trigger_data: {}
     xp_reward: 15
+    cred_reward: 0
 
   - slug: junk_dealer
     name: "Junk Dealer"
     description: "Salvaged 5 items."
     badge_icon: "%%"
+    category: grid
     trigger_type: salvage_count
     trigger_data:
       count: 5
     xp_reward: 50
+    cred_reward: 0
 
   - slug: chop_shop
     name: "Chop Shop"
     description: "Salvaged 20 items. Nothing is safe around you."
     badge_icon: "%%%"
+    category: grid
     trigger_type: salvage_count
     trigger_data:
       count: 20
     xp_reward: 200
+    cred_reward: 0
+
+  # ============================================================
+  # MUSIC CATEGORY (Pulse Vault + Radio + VODs + Livestream + Bands)
+  # ============================================================
+
+  # --- Pulse Vault track plays (30s+ counted) ---
+  - slug: first_signal
+    name: "Signal Acquired"
+    description: "Played your first track for 30+ seconds."
+    badge_icon: ">>"
+    category: music
+    trigger_type: track_plays_count
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: vault_listener_10
+    name: "Data Streamer"
+    description: "Played 10 unique tracks from the Pulse Vault."
+    badge_icon: "%"
+    category: music
+    trigger_type: track_plays_count
+    trigger_data:
+      count: 10
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: vault_listener_25
+    name: "Frequency Hunter"
+    description: "Played 25 unique tracks from the Pulse Vault."
+    badge_icon: "%%"
+    category: music
+    trigger_type: track_plays_count
+    trigger_data:
+      count: 25
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: vault_listener_50
+    name: "Archive Diver"
+    description: "Played 50 unique tracks from the Pulse Vault."
+    badge_icon: "%%%"
+    category: music
+    trigger_type: track_plays_count
+    trigger_data:
+      count: 50
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: vault_complete
+    name: "The Completionist"
+    description: "Listened to every track in the Pulse Vault."
+    badge_icon: "[*]"
+    category: music
+    trigger_type: pulse_vault_completed
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- Radio ---
+  - slug: channel_found
+    name: "Channel Found"
+    description: "Tuned into a hackr.fm radio station."
+    badge_icon: "~"
+    category: music
+    trigger_type: radio_stations_tuned
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: radio_all
+    name: "Full Spectrum"
+    description: "Tuned into every radio station."
+    badge_icon: "~~~"
+    category: music
+    trigger_type: radio_stations_tuned_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- Band discovery (bio + release index + release pages) ---
+  - slug: bio_all
+    name: "Band Intel"
+    description: "Viewed every band's bio page."
+    badge_icon: "ID"
+    category: music
+    trigger_type: artist_bios_viewed_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  - slug: release_index_all
+    name: "Catalog Sweep"
+    description: "Browsed every band's release index."
+    badge_icon: "RX"
+    category: music
+    trigger_type: release_indexes_viewed_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  - slug: release_all
+    name: "Full Discography"
+    description: "Viewed every published release across every band."
+    badge_icon: "DX"
+    category: music
+    trigger_type: releases_viewed_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- VODs ---
+  - slug: vod_1
+    name: "Screen Tap"
+    description: "Watched your first VOD."
+    badge_icon: "VD"
+    category: music
+    trigger_type: vods_watched
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: vod_5
+    name: "Replay Buffer"
+    description: "Watched 5 VODs."
+    badge_icon: "VD5"
+    category: music
+    trigger_type: vods_watched
+    trigger_data:
+      count: 5
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: vod_10
+    name: "Live Archive"
+    description: "Watched 10 VODs."
+    badge_icon: "VDA"
+    category: music
+    trigger_type: vods_watched
+    trigger_data:
+      count: 10
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: vod_15
+    name: "Broadcast Hound"
+    description: "Watched 15 VODs."
+    badge_icon: "VDB"
+    category: music
+    trigger_type: vods_watched
+    trigger_data:
+      count: 15
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: vod_20
+    name: "Signal Archivist"
+    description: "Watched 20 VODs."
+    badge_icon: "VDX"
+    category: music
+    trigger_type: vods_watched
+    trigger_data:
+      count: 20
+    xp_reward: 500
+    cred_reward: 50
+
+  # ============================================================
+  # SOCIAL CATEGORY (WIRE + Uplink + Playlists)
+  # ============================================================
+
+  # --- WIRE pulses ---
+  - slug: first_pulse
+    name: "Signal Sent"
+    description: "Posted your first pulse to the WIRE."
+    badge_icon: "W"
+    category: social
+    trigger_type: wire_pulses_count
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: wire_10
+    name: "WIRE Veteran"
+    description: "Posted 10 pulses to the WIRE."
+    badge_icon: "WW"
+    category: social
+    trigger_type: wire_pulses_count
+    trigger_data:
+      count: 10
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: wire_50
+    name: "Broadcaster"
+    description: "Posted 50 pulses to the WIRE."
+    badge_icon: "WB"
+    category: social
+    trigger_type: wire_pulses_count
+    trigger_data:
+      count: 50
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: wire_100
+    name: "Signal Flooder"
+    description: "Posted 100 pulses to the WIRE."
+    badge_icon: "WF"
+    category: social
+    trigger_type: wire_pulses_count
+    trigger_data:
+      count: 100
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: wire_500
+    name: "Transmission Legend"
+    description: "Posted 500 pulses to the WIRE."
+    badge_icon: "W*"
+    category: social
+    trigger_type: wire_pulses_count
+    trigger_data:
+      count: 500
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- Uplink packets ---
+  - slug: first_packet
+    name: "Uplink Active"
+    description: "Sent your first Uplink packet."
+    badge_icon: "UP"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: uplink_50
+    name: "Chat Regular"
+    description: "Sent 50 Uplink packets."
+    badge_icon: "UP5"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 50
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: uplink_100
+    name: "Comms Operator"
+    description: "Sent 100 Uplink packets."
+    badge_icon: "UPA"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 100
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: uplink_500
+    name: "Protocol Master"
+    description: "Sent 500 Uplink packets."
+    badge_icon: "UPM"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 500
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: uplink_5000
+    name: "Signal Saturator"
+    description: "Sent 5,000 Uplink packets."
+    badge_icon: "UPS"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 5000
+    xp_reward: 500
+    cred_reward: 50
+
+  - slug: uplink_50000
+    name: "Flood Protocol"
+    description: "Sent 50,000 Uplink packets."
+    badge_icon: "UPF"
+    category: social
+    trigger_type: uplink_packets_count
+    trigger_data:
+      count: 50000
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- Custom playlists (only playlists with ≥1 track count) ---
+  - slug: first_playlist
+    name: "Curator Online"
+    description: "Created your first playlist with a track in it."
+    badge_icon: "PL"
+    category: social
+    trigger_type: playlists_created
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: playlists_5
+    name: "Mix Architect"
+    description: "Created 5 playlists."
+    badge_icon: "PL5"
+    category: social
+    trigger_type: playlists_created
+    trigger_data:
+      count: 5
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: playlists_10
+    name: "DJ Protocol"
+    description: "Created 10 playlists."
+    badge_icon: "PLX"
+    category: social
+    trigger_type: playlists_created
+    trigger_data:
+      count: 10
+    xp_reward: 100
+    cred_reward: 10
+
+  # ============================================================
+  # META CATEGORY (Hackr Logs + Codex reading)
+  # ============================================================
+
+  # --- Hackr Logs ---
+  - slug: first_log_read
+    name: "Log Intercepted"
+    description: "Read your first Hackr Log."
+    badge_icon: ">>"
+    category: meta
+    trigger_type: hackr_logs_read
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: logs_read_10
+    name: "Archive Seeker"
+    description: "Read 10 Hackr Logs."
+    badge_icon: "LG"
+    category: meta
+    trigger_type: hackr_logs_read
+    trigger_data:
+      count: 10
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: logs_read_25
+    name: "Log Hound"
+    description: "Read 25 Hackr Logs."
+    badge_icon: "LGA"
+    category: meta
+    trigger_type: hackr_logs_read
+    trigger_data:
+      count: 25
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: logs_read_50
+    name: "Transmission Scholar"
+    description: "Read 50 Hackr Logs."
+    badge_icon: "LGS"
+    category: meta
+    trigger_type: hackr_logs_read
+    trigger_data:
+      count: 50
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: logs_read_all
+    name: "Full Chronicle"
+    description: "Read every published Hackr Log."
+    badge_icon: "[L]"
+    category: meta
+    trigger_type: hackr_logs_read_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  # --- Codex ---
+  - slug: first_codex_read
+    name: "Entry Found"
+    description: "Read your first Codex entry."
+    badge_icon: "CX"
+    category: meta
+    trigger_type: codex_entries_read
+    trigger_data:
+      count: 1
+    xp_reward: 10
+    cred_reward: 0
+
+  - slug: codex_read_10
+    name: "Codex Explorer"
+    description: "Read 10 Codex entries."
+    badge_icon: "CXA"
+    category: meta
+    trigger_type: codex_entries_read
+    trigger_data:
+      count: 10
+    xp_reward: 25
+    cred_reward: 1
+
+  - slug: codex_read_25
+    name: "Knowledge Broker"
+    description: "Read 25 Codex entries."
+    badge_icon: "CXB"
+    category: meta
+    trigger_type: codex_entries_read
+    trigger_data:
+      count: 25
+    xp_reward: 100
+    cred_reward: 10
+
+  - slug: codex_read_50
+    name: "Lore Master"
+    description: "Read 50 Codex entries."
+    badge_icon: "CXM"
+    category: meta
+    trigger_type: codex_entries_read
+    trigger_data:
+      count: 50
+    xp_reward: 250
+    cred_reward: 20
+
+  - slug: codex_read_all
+    name: "The Archivist"
+    description: "Read every published Codex entry."
+    badge_icon: "[C]"
+    category: meta
+    trigger_type: codex_entries_read_all
+    trigger_data: {}
+    xp_reward: 500
+    cred_reward: 50
+
+  # ============================================================
+  # PROGRESSION CATEGORY (Clearance milestones)
+  # ============================================================
+
+  - slug: clearance_5
+    name: "CLEARANCE 5"
+    description: "Reached Clearance Level 5."
+    badge_icon: "CL5"
+    category: progression
+    trigger_type: clearance_level
+    trigger_data:
+      level: 5
+    xp_reward: 0
+    cred_reward: 1
+
+  - slug: clearance_10
+    name: "CLEARANCE 10"
+    description: "Reached Clearance Level 10. The Blacksite is open."
+    badge_icon: "CL10"
+    category: progression
+    trigger_type: clearance_level
+    trigger_data:
+      level: 10
+    xp_reward: 0
+    cred_reward: 10
+
+  - slug: clearance_25
+    name: "CLEARANCE 25"
+    description: "Reached Clearance Level 25."
+    badge_icon: "CL25"
+    category: progression
+    trigger_type: clearance_level
+    trigger_data:
+      level: 25
+    xp_reward: 0
+    cred_reward: 20
+
+  - slug: clearance_50
+    name: "CLEARANCE 50"
+    description: "Reached Clearance Level 50."
+    badge_icon: "CL50"
+    category: progression
+    trigger_type: clearance_level
+    trigger_data:
+      level: 50
+    xp_reward: 0
+    cred_reward: 50
+
+  - slug: clearance_99
+    name: "CLEARANCE 99"
+    description: "Reached max clearance. The Chronology Fracture remembers."
+    badge_icon: "CL99"
+    category: progression
+    trigger_type: clearance_level
+    trigger_data:
+      level: 99
+    xp_reward: 0
+    cred_reward: 50
+    hidden: true

--- a/db/migrate/20260414000001_add_category_and_cred_reward_to_grid_achievements.rb
+++ b/db/migrate/20260414000001_add_category_and_cred_reward_to_grid_achievements.rb
@@ -1,0 +1,7 @@
+class AddCategoryAndCredRewardToGridAchievements < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_achievements, :cred_reward, :integer, default: 0, null: false
+    add_column :grid_achievements, :category, :string, default: "grid", null: false
+    add_index :grid_achievements, :category
+  end
+end

--- a/db/migrate/20260414000002_create_grid_hackr_track_plays.rb
+++ b/db/migrate/20260414000002_create_grid_hackr_track_plays.rb
@@ -1,0 +1,12 @@
+class CreateGridHackrTrackPlays < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_hackr_track_plays do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :track, null: false, foreign_key: true
+      t.datetime :first_played_at, null: false
+      t.integer :play_count, default: 1, null: false
+      t.timestamps
+    end
+    add_index :grid_hackr_track_plays, [:grid_hackr_id, :track_id], unique: true, name: "index_track_plays_unique"
+  end
+end

--- a/db/migrate/20260414000003_create_hackr_log_reads.rb
+++ b/db/migrate/20260414000003_create_hackr_log_reads.rb
@@ -1,0 +1,11 @@
+class CreateHackrLogReads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hackr_log_reads do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :hackr_log, null: false, foreign_key: true
+      t.datetime :read_at, null: false
+      t.timestamps
+    end
+    add_index :hackr_log_reads, [:grid_hackr_id, :hackr_log_id], unique: true, name: "index_hackr_log_reads_unique"
+  end
+end

--- a/db/migrate/20260414000004_create_codex_entry_reads.rb
+++ b/db/migrate/20260414000004_create_codex_entry_reads.rb
@@ -1,0 +1,11 @@
+class CreateCodexEntryReads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :codex_entry_reads do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :codex_entry, null: false, foreign_key: true
+      t.datetime :read_at, null: false
+      t.timestamps
+    end
+    add_index :codex_entry_reads, [:grid_hackr_id, :codex_entry_id], unique: true, name: "index_codex_entry_reads_unique"
+  end
+end

--- a/db/migrate/20260414000005_create_hackr_page_views.rb
+++ b/db/migrate/20260414000005_create_hackr_page_views.rb
@@ -1,0 +1,15 @@
+class CreateHackrPageViews < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hackr_page_views do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.string :page_type, null: false
+      t.integer :resource_id, null: false
+      t.datetime :viewed_at, null: false
+      t.timestamps
+    end
+    add_index :hackr_page_views, [:grid_hackr_id, :page_type, :resource_id],
+      unique: true, name: "index_hackr_page_views_unique"
+    add_index :hackr_page_views, [:grid_hackr_id, :page_type],
+      name: "index_hackr_page_views_hackr_type"
+  end
+end

--- a/db/migrate/20260414000006_create_hackr_vod_watches.rb
+++ b/db/migrate/20260414000006_create_hackr_vod_watches.rb
@@ -1,0 +1,12 @@
+class CreateHackrVodWatches < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hackr_vod_watches do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :hackr_stream, null: false, foreign_key: true
+      t.datetime :watched_at, null: false
+      t.timestamps
+    end
+    add_index :hackr_vod_watches, [:grid_hackr_id, :hackr_stream_id],
+      unique: true, name: "index_hackr_vod_watches_unique"
+  end
+end

--- a/db/migrate/20260414000007_create_hackr_radio_tunes.rb
+++ b/db/migrate/20260414000007_create_hackr_radio_tunes.rb
@@ -1,0 +1,12 @@
+class CreateHackrRadioTunes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hackr_radio_tunes do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :radio_station, null: false, foreign_key: true
+      t.datetime :tuned_at, null: false
+      t.timestamps
+    end
+    add_index :hackr_radio_tunes, [:grid_hackr_id, :radio_station_id],
+      unique: true, name: "index_hackr_radio_tunes_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_000007) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -119,6 +119,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.index ["slug"], name: "index_codex_entries_on_slug", unique: true
   end
 
+  create_table "codex_entry_reads", force: :cascade do |t|
+    t.integer "codex_entry_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.datetime "read_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["codex_entry_id"], name: "index_codex_entry_reads_on_codex_entry_id"
+    t.index ["grid_hackr_id", "codex_entry_id"], name: "index_codex_entry_reads_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_codex_entry_reads_on_grid_hackr_id"
+  end
+
   create_table "echoes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "echoed_at", null: false
@@ -145,7 +156,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
 
   create_table "grid_achievements", force: :cascade do |t|
     t.string "badge_icon"
+    t.string "category", default: "grid", null: false
     t.datetime "created_at", null: false
+    t.integer "cred_reward", default: 0, null: false
     t.text "description"
     t.boolean "hidden", default: false, null: false
     t.string "name", null: false
@@ -154,6 +167,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.string "trigger_type", null: false
     t.datetime "updated_at", null: false
     t.integer "xp_reward", default: 0, null: false
+    t.index ["category"], name: "index_grid_achievements_on_category"
     t.index ["slug"], name: "index_grid_achievements_on_slug", unique: true
     t.index ["trigger_type"], name: "index_grid_achievements_on_trigger_type"
   end
@@ -234,6 +248,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.index ["grid_hackr_id", "subject_type", "subject_id"], name: "index_hackr_reputations_unique", unique: true
     t.index ["grid_hackr_id"], name: "index_grid_hackr_reputations_on_grid_hackr_id"
     t.index ["subject_type", "subject_id"], name: "index_hackr_reputations_on_subject"
+  end
+
+  create_table "grid_hackr_track_plays", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "first_played_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "play_count", default: 1, null: false
+    t.integer "track_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "track_id"], name: "index_track_plays_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_grid_hackr_track_plays_on_grid_hackr_id"
+    t.index ["track_id"], name: "index_grid_hackr_track_plays_on_track_id"
   end
 
   create_table "grid_hackrs", force: :cascade do |t|
@@ -437,6 +463,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.index ["ambient_playlist_id"], name: "index_grid_zones_on_ambient_playlist_id"
   end
 
+  create_table "hackr_log_reads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "hackr_log_id", null: false
+    t.datetime "read_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "hackr_log_id"], name: "index_hackr_log_reads_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_hackr_log_reads_on_grid_hackr_id"
+    t.index ["hackr_log_id"], name: "index_hackr_log_reads_on_hackr_log_id"
+  end
+
   create_table "hackr_logs", force: :cascade do |t|
     t.text "body", null: false
     t.datetime "created_at", null: false
@@ -452,6 +489,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.index ["timeline"], name: "index_hackr_logs_on_timeline"
   end
 
+  create_table "hackr_page_views", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.string "page_type", null: false
+    t.integer "resource_id", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "viewed_at", null: false
+    t.index ["grid_hackr_id", "page_type", "resource_id"], name: "index_hackr_page_views_unique", unique: true
+    t.index ["grid_hackr_id", "page_type"], name: "index_hackr_page_views_hackr_type"
+    t.index ["grid_hackr_id"], name: "index_hackr_page_views_on_grid_hackr_id"
+  end
+
+  create_table "hackr_radio_tunes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "radio_station_id", null: false
+    t.datetime "tuned_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "radio_station_id"], name: "index_hackr_radio_tunes_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_hackr_radio_tunes_on_grid_hackr_id"
+    t.index ["radio_station_id"], name: "index_hackr_radio_tunes_on_radio_station_id"
+  end
+
   create_table "hackr_streams", force: :cascade do |t|
     t.integer "artist_id", null: false
     t.datetime "created_at", null: false
@@ -464,6 +524,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
     t.datetime "updated_at", null: false
     t.string "vod_url"
     t.index ["artist_id"], name: "index_hackr_streams_on_artist_id"
+  end
+
+  create_table "hackr_vod_watches", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "hackr_stream_id", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "watched_at", null: false
+    t.index ["grid_hackr_id", "hackr_stream_id"], name: "index_hackr_vod_watches_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_hackr_vod_watches_on_grid_hackr_id"
+    t.index ["hackr_stream_id"], name: "index_hackr_vod_watches_on_hackr_stream_id"
   end
 
   create_table "handbook_articles", force: :cascade do |t|
@@ -852,6 +923,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
   add_foreign_key "chat_messages", "chat_channels"
   add_foreign_key "chat_messages", "grid_hackrs"
   add_foreign_key "chat_messages", "hackr_streams"
+  add_foreign_key "codex_entry_reads", "codex_entries"
+  add_foreign_key "codex_entry_reads", "grid_hackrs"
   add_foreign_key "echoes", "grid_hackrs"
   add_foreign_key "echoes", "pulses"
   add_foreign_key "feature_grants", "grid_hackrs"
@@ -861,13 +934,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_120003) do
   add_foreign_key "grid_hackr_achievements", "grid_achievements"
   add_foreign_key "grid_hackr_achievements", "grid_hackrs"
   add_foreign_key "grid_hackr_reputations", "grid_hackrs"
+  add_foreign_key "grid_hackr_track_plays", "grid_hackrs"
+  add_foreign_key "grid_hackr_track_plays", "tracks"
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"
+  add_foreign_key "hackr_log_reads", "grid_hackrs"
+  add_foreign_key "hackr_log_reads", "hackr_logs"
   add_foreign_key "hackr_logs", "grid_hackrs"
+  add_foreign_key "hackr_page_views", "grid_hackrs"
+  add_foreign_key "hackr_radio_tunes", "grid_hackrs"
+  add_foreign_key "hackr_radio_tunes", "radio_stations"
   add_foreign_key "hackr_streams", "artists"
+  add_foreign_key "hackr_vod_watches", "grid_hackrs"
+  add_foreign_key "hackr_vod_watches", "hackr_streams"
   add_foreign_key "handbook_articles", "handbook_sections"
   add_foreign_key "moderation_logs", "chat_messages"
   add_foreign_key "moderation_logs", "grid_hackrs", column: "actor_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -765,6 +765,8 @@ namespace :data do
         trigger_type: attrs["trigger_type"],
         trigger_data: attrs["trigger_data"] || {},
         xp_reward: attrs["xp_reward"] || 0,
+        cred_reward: attrs["cred_reward"] || 0,
+        category: attrs["category"] || "grid",
         hidden: attrs["hidden"] || false
       )
 

--- a/spec/channels/achievement_channel_spec.rb
+++ b/spec/channels/achievement_channel_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe AchievementChannel, type: :channel do
+  let(:hackr) { create(:grid_hackr) }
+
+  it "rejects anonymous connections" do
+    stub_connection current_hackr: nil
+    subscribe
+    expect(subscription).to be_rejected
+  end
+
+  it "streams from the per-hackr stream when authenticated" do
+    stub_connection current_hackr: hackr
+    subscribe
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_from("achievement_channel_#{hackr.id}")
+  end
+
+  it "exposes the stream name via the class helper" do
+    expect(described_class.stream_name_for(hackr)).to eq("achievement_channel_#{hackr.id}")
+  end
+end

--- a/spec/controllers/api/artists_controller_spec.rb
+++ b/spec/controllers/api/artists_controller_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Api::ArtistsController, type: :controller do
+  let!(:artist) { create(:artist, slug: "system-rot", name: "System Rot") }
+
+  shared_examples "a page_view tracking endpoint" do |action_name, page_type:|
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no view record" do
+        expect {
+          post action_name, params: {id: artist.slug}, format: :json
+        }.not_to change { HackrPageView.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a #{page_type} view row" do
+        expect {
+          post action_name, params: {id: artist.slug}, format: :json
+        }.to change { HackrPageView.where(page_type: page_type, resource_id: artist.id).count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent per hackr+resource" do
+        post action_name, params: {id: artist.slug}, format: :json
+        expect {
+          post action_name, params: {id: artist.slug}, format: :json
+        }.not_to change { HackrPageView.count }
+      end
+
+      it "returns 404 for an unknown artist slug" do
+        post action_name, params: {id: "no-such-band"}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST #bio_viewed" do
+    it_behaves_like "a page_view tracking endpoint", :bio_viewed, page_type: "bio"
+  end
+
+  describe "POST #release_index_viewed" do
+    it_behaves_like "a page_view tracking endpoint", :release_index_viewed, page_type: "release_index"
+  end
+
+  describe "bio_viewed and release_index_viewed write to different page_type rows for the same artist" do
+    let(:hackr) { create(:grid_hackr) }
+    before { session[:grid_hackr_id] = hackr.id }
+
+    it "records both side-by-side without collision" do
+      post :bio_viewed, params: {id: artist.slug}, format: :json
+      post :release_index_viewed, params: {id: artist.slug}, format: :json
+
+      rows = HackrPageView.where(grid_hackr: hackr, resource_id: artist.id).pluck(:page_type).sort
+      expect(rows).to eq(%w[bio release_index])
+    end
+  end
+end

--- a/spec/controllers/api/codex_controller_spec.rb
+++ b/spec/controllers/api/codex_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Api::CodexController, type: :controller do
+  describe "POST #mark_read" do
+    let!(:entry) { create(:codex_entry, slug: "synthia", name: "Synthia", published: true) }
+
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no read record" do
+        expect {
+          post :mark_read, params: {slug: entry.slug}, format: :json
+        }.not_to change { CodexEntryRead.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a read" do
+        expect {
+          post :mark_read, params: {slug: entry.slug}, format: :json
+        }.to change { CodexEntryRead.count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent for the same entry" do
+        post :mark_read, params: {slug: entry.slug}, format: :json
+        expect {
+          post :mark_read, params: {slug: entry.slug}, format: :json
+        }.not_to change { CodexEntryRead.count }
+      end
+
+      it "returns 404 for an unknown slug" do
+        post :mark_read, params: {slug: "does-not-exist"}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "refuses to mark an unpublished entry as read" do
+        draft = create(:codex_entry, slug: "draft-entry", published: false)
+        post :mark_read, params: {slug: draft.slug}, format: :json
+        expect(response).to have_http_status(:not_found)
+        expect(CodexEntryRead.where(codex_entry_id: draft.id).count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/grid_achievements_index_spec.rb
+++ b/spec/controllers/api/grid_achievements_index_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+# Dedicated spec for GET /api/grid/achievements — the endpoint
+# powering the /achievements SPA status page. Kept separate from the
+# pre-existing grid_controller_spec (auth flow focused) to isolate
+# the achievement concerns.
+RSpec.describe Api::GridController, type: :controller do
+  describe "GET #achievements_index" do
+    context "with no logged-in hackr" do
+      it "returns 401 unauthorized" do
+        get :achievements_index, format: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "returns achievements grouped by category with earned+progress per row" do
+        create(:grid_achievement,
+          slug: "music-10",
+          category: "music",
+          trigger_type: "track_plays_count",
+          trigger_data: {"count" => 10},
+          xp_reward: 25,
+          cred_reward: 1)
+
+        earned = create(:grid_achievement,
+          slug: "music-1",
+          category: "music",
+          trigger_type: "track_plays_count",
+          trigger_data: {"count" => 1},
+          xp_reward: 10)
+        create(:grid_hackr_achievement, grid_hackr: hackr, grid_achievement: earned, awarded_at: Time.current)
+
+        get :achievements_index, format: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).to have_key("categories")
+        expect(json).to have_key("summary")
+        expect(json["categories"]).to have_key("music")
+
+        music_rows = json["categories"]["music"]
+        slugs = music_rows.map { |r| r["slug"] }
+        expect(slugs).to contain_exactly("music-1", "music-10")
+
+        earned_row = music_rows.find { |r| r["slug"] == "music-1" }
+        expect(earned_row["earned"]).to be true
+        expect(earned_row["awarded_at"]).to be_present
+
+        unearned_row = music_rows.find { |r| r["slug"] == "music-10" }
+        expect(unearned_row["earned"]).to be false
+        expect(unearned_row["awarded_at"]).to be_nil
+        # Progress shape is computed by the checker and should be present
+        # for cumulative triggers.
+        expect(unearned_row["progress"]).to include("current", "target", "fraction", "completed")
+        expect(unearned_row["progress"]["target"]).to eq(10)
+      end
+
+      it "hides unearned hidden achievements from the payload" do
+        create(:grid_achievement, slug: "secret", category: "grid",
+          trigger_type: "manual", trigger_data: {}, hidden: true)
+
+        get :achievements_index, format: :json
+
+        json = JSON.parse(response.body)
+        all_slugs = json["categories"].values.flatten.map { |r| r["slug"] }
+        expect(all_slugs).not_to include("secret")
+      end
+
+      it "includes hidden achievements in the payload once earned" do
+        hidden = create(:grid_achievement, slug: "secret-earned", category: "grid",
+          trigger_type: "manual", trigger_data: {}, hidden: true)
+        create(:grid_hackr_achievement, grid_hackr: hackr, grid_achievement: hidden, awarded_at: Time.current)
+
+        get :achievements_index, format: :json
+
+        json = JSON.parse(response.body)
+        all_slugs = json["categories"].values.flatten.map { |r| r["slug"] }
+        expect(all_slugs).to include("secret-earned")
+      end
+
+      it "reports earned/total in the summary block" do
+        create(:grid_achievement, slug: "a", category: "grid", trigger_type: "manual", trigger_data: {})
+        a_earned = create(:grid_achievement, slug: "b", category: "grid", trigger_type: "manual", trigger_data: {})
+        create(:grid_hackr_achievement, grid_hackr: hackr, grid_achievement: a_earned, awarded_at: Time.current)
+
+        get :achievements_index, format: :json
+
+        json = JSON.parse(response.body)
+        expect(json["summary"]["total"]).to eq({"total" => 2, "earned" => 1})
+        expect(json["summary"]["by_category"]["grid"]).to eq({"total" => 2, "earned" => 1})
+      end
+    end
+  end
+end

--- a/spec/controllers/api/hackr_streams_watch_spec.rb
+++ b/spec/controllers/api/hackr_streams_watch_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+# Dedicated spec for the `watch` action — split into its own file so
+# the existing `hackr_streams_controller_spec.rb` (pre-existing
+# coverage for show/index/vod_show) remains focused on those actions.
+RSpec.describe Api::HackrStreamsController, type: :controller do
+  let!(:artist) { create(:artist, slug: "thecyberpulse") }
+  let!(:stream) { create(:hackr_stream, artist: artist, title: "Test VOD") }
+
+  describe "POST #watch" do
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no watch record" do
+        expect {
+          post :watch, params: {artist_slug: artist.slug, id: stream.id}, format: :json
+        }.not_to change { HackrVodWatch.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a vod watch" do
+        expect {
+          post :watch, params: {artist_slug: artist.slug, id: stream.id}, format: :json
+        }.to change { HackrVodWatch.count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent for the same hackr+stream" do
+        post :watch, params: {artist_slug: artist.slug, id: stream.id}, format: :json
+        expect {
+          post :watch, params: {artist_slug: artist.slug, id: stream.id}, format: :json
+        }.not_to change { HackrVodWatch.count }
+      end
+
+      it "returns 404 for an unknown artist slug" do
+        post :watch, params: {artist_slug: "nobody", id: stream.id}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 for an unknown stream id" do
+        post :watch, params: {artist_slug: artist.slug, id: 999_999}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Api::LogsController, type: :controller do
+  describe "POST #mark_read" do
+    let!(:log) { create(:hackr_log, :published, slug: "signal-test") }
+
+    context "with no logged-in hackr" do
+      it "returns 204 and does not create a read record" do
+        expect {
+          post :mark_read, params: {id: log.slug}, format: :json
+        }.not_to change { HackrLogRead.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a read" do
+        expect {
+          post :mark_read, params: {id: log.slug}, format: :json
+        }.to change { HackrLogRead.count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent" do
+        post :mark_read, params: {id: log.slug}, format: :json
+        expect {
+          post :mark_read, params: {id: log.slug}, format: :json
+        }.not_to change { HackrLogRead.count }
+      end
+
+      it "returns 404 for an unknown slug" do
+        post :mark_read, params: {id: "does-not-exist"}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "refuses to mark an unpublished log as read" do
+        draft = create(:hackr_log, slug: "draft", published: false)
+        post :mark_read, params: {id: draft.slug}, format: :json
+        expect(response).to have_http_status(:not_found)
+        expect(HackrLogRead.where(hackr_log_id: draft.id).count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/playlist_tracks_achievement_spec.rb
+++ b/spec/controllers/api/playlist_tracks_achievement_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# Regression: the `playlists_created` achievement check was previously
+# fired on EVERY track add to any playlist. Since the checker's
+# populated_playlist_count only changes on a 0→1 transition per
+# playlist, we now gate the check to that transition to avoid useless
+# per-add checker runs.
+RSpec.describe Api::PlaylistTracksController, type: :controller do
+  let(:hackr) { create(:grid_hackr) }
+  let(:playlist) { create(:playlist, grid_hackr: hackr) }
+  let(:track_a) { create(:track) }
+  let(:track_b) { create(:track) }
+  let(:track_c) { create(:track) }
+
+  before { session[:grid_hackr_id] = hackr.id }
+
+  describe "achievement check gating on POST #create" do
+    it "fires `playlists_created` exactly once on the playlist's first track" do
+      expect_any_instance_of(Grid::AchievementChecker)
+        .to receive(:check).with("playlists_created").once
+
+      post :create, params: {playlist_id: playlist.id, track_id: track_a.id}, format: :json
+      expect(response).to have_http_status(:created)
+    end
+
+    it "does NOT fire on the 2nd or 3rd track add — population count already counted this playlist" do
+      post :create, params: {playlist_id: playlist.id, track_id: track_a.id}, format: :json
+
+      expect_any_instance_of(Grid::AchievementChecker).not_to receive(:check)
+
+      post :create, params: {playlist_id: playlist.id, track_id: track_b.id}, format: :json
+      post :create, params: {playlist_id: playlist.id, track_id: track_c.id}, format: :json
+      expect(response).to have_http_status(:created)
+    end
+
+    it "fires again when a DIFFERENT playlist receives its first track" do
+      # First playlist's first track — should fire once
+      post :create, params: {playlist_id: playlist.id, track_id: track_a.id}, format: :json
+
+      second_playlist = create(:playlist, grid_hackr: hackr)
+
+      expect_any_instance_of(Grid::AchievementChecker)
+        .to receive(:check).with("playlists_created").once
+
+      post :create, params: {playlist_id: second_playlist.id, track_id: track_b.id}, format: :json
+    end
+  end
+end

--- a/spec/controllers/api/radio_tune_in_spec.rb
+++ b/spec/controllers/api/radio_tune_in_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# Dedicated spec for the `tune_in` action — split from the pre-existing
+# `radio_controller_spec.rb` which focuses on index/station_playlists.
+RSpec.describe Api::RadioController, type: :controller do
+  let!(:station) { create(:radio_station, hidden: false) }
+
+  describe "POST #tune_in" do
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no tune record" do
+        expect {
+          post :tune_in, params: {id: station.id}, format: :json
+        }.not_to change { HackrRadioTune.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a tune_in" do
+        expect {
+          post :tune_in, params: {id: station.id}, format: :json
+        }.to change { HackrRadioTune.count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent for the same hackr+station" do
+        post :tune_in, params: {id: station.id}, format: :json
+        expect {
+          post :tune_in, params: {id: station.id}, format: :json
+        }.not_to change { HackrRadioTune.count }
+      end
+
+      it "returns 404 for a hidden station" do
+        hidden = create(:radio_station, hidden: true)
+        post :tune_in, params: {id: hidden.id}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 for an unknown station id" do
+        post :tune_in, params: {id: 999_999}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/releases_controller_spec.rb
+++ b/spec/controllers/api/releases_controller_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Api::ReleasesController, type: :controller do
+  let!(:artist) { create(:artist) }
+  let!(:release) { create(:release, artist: artist, slug: "test-release", coming_soon: false) }
+
+  describe "POST #viewed" do
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no view" do
+        expect {
+          post :viewed, params: {id: release.slug}, format: :json
+        }.not_to change { HackrPageView.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a release view" do
+        expect {
+          post :viewed, params: {id: release.slug}, format: :json
+        }.to change { HackrPageView.where(page_type: "release", resource_id: release.id).count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "is idempotent per hackr+release" do
+        post :viewed, params: {id: release.slug}, format: :json
+        expect {
+          post :viewed, params: {id: release.slug}, format: :json
+        }.not_to change { HackrPageView.count }
+      end
+
+      it "refuses coming_soon releases" do
+        coming = create(:release, artist: artist, slug: "teaser", coming_soon: true)
+
+        post :viewed, params: {id: coming.slug}, format: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(HackrPageView.count).to eq(0)
+      end
+
+      it "returns 404 for an unknown slug" do
+        post :viewed, params: {id: "no-such-release"}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/tracks_controller_play_credit_spec.rb
+++ b/spec/controllers/api/tracks_controller_play_credit_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Api::TracksController, type: :controller do
+  describe "POST #play_credit" do
+    let(:artist) { create(:artist) }
+    let(:release) { create(:release, artist: artist, coming_soon: false) }
+    let!(:track) { create(:track, artist: artist, release: release, slug: "test-track") }
+
+    context "with no logged-in hackr" do
+      it "returns 204 and creates no record" do
+        expect {
+          post :play_credit, params: {id: track.slug}, format: :json
+        }.not_to change { GridHackrTrackPlay.count }
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "records a play" do
+        expect {
+          post :play_credit, params: {id: track.slug}, format: :json
+        }.to change { GridHackrTrackPlay.count }.by(1)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "increments play_count on re-play" do
+        post :play_credit, params: {id: track.slug}, format: :json
+        post :play_credit, params: {id: track.slug}, format: :json
+
+        record = GridHackrTrackPlay.find_by(grid_hackr: hackr, track: track)
+        expect(record.play_count).to eq(2)
+      end
+
+      it "returns 404 for an unknown track" do
+        post :play_credit, params: {id: "no-such-track"}, format: :json
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "refuses to credit a coming_soon release's tracks" do
+        coming = create(:release, artist: artist, coming_soon: true)
+        teaser = create(:track, artist: artist, release: coming, slug: "teaser")
+
+        post :play_credit, params: {id: teaser.slug}, format: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(GridHackrTrackPlay.count).to eq(0)
+      end
+
+      it "refuses to credit a track hidden from the pulse vault" do
+        hidden = create(:track, artist: artist, release: release, slug: "hidden", show_in_pulse_vault: false)
+
+        post :play_credit, params: {id: hidden.slug}, format: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(GridHackrTrackPlay.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/factories/codex_entry_reads.rb
+++ b/spec/factories/codex_entry_reads.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: codex_entry_reads
+# Database name: primary
+#
+#  id             :integer          not null, primary key
+#  read_at        :datetime         not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  codex_entry_id :integer          not null
+#  grid_hackr_id  :integer          not null
+#
+# Indexes
+#
+#  index_codex_entry_reads_on_codex_entry_id  (codex_entry_id)
+#  index_codex_entry_reads_on_grid_hackr_id   (grid_hackr_id)
+#  index_codex_entry_reads_unique             (grid_hackr_id,codex_entry_id) UNIQUE
+#
+# Foreign Keys
+#
+#  codex_entry_id  (codex_entry_id => codex_entries.id)
+#  grid_hackr_id   (grid_hackr_id => grid_hackrs.id)
+#
+FactoryBot.define do
+  factory :codex_entry_read do
+    association :grid_hackr
+    association :codex_entry
+    read_at { Time.current }
+  end
+end

--- a/spec/factories/grid_achievements.rb
+++ b/spec/factories/grid_achievements.rb
@@ -1,0 +1,48 @@
+# == Schema Information
+#
+# Table name: grid_achievements
+# Database name: primary
+#
+#  id           :integer          not null, primary key
+#  badge_icon   :string
+#  category     :string           default("grid"), not null
+#  cred_reward  :integer          default(0), not null
+#  description  :text
+#  hidden       :boolean          default(FALSE), not null
+#  name         :string           not null
+#  slug         :string           not null
+#  trigger_data :json
+#  trigger_type :string           not null
+#  xp_reward    :integer          default(0), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_grid_achievements_on_category      (category)
+#  index_grid_achievements_on_slug          (slug) UNIQUE
+#  index_grid_achievements_on_trigger_type  (trigger_type)
+#
+FactoryBot.define do
+  factory :grid_achievement do
+    sequence(:slug) { |n| "test-achievement-#{n}" }
+    sequence(:name) { |n| "Test Achievement #{n}" }
+    description { "A test achievement." }
+    badge_icon { "*" }
+    trigger_type { "rooms_visited" }
+    trigger_data { {"count" => 1} }
+    xp_reward { 10 }
+    cred_reward { 0 }
+    category { "grid" }
+    hidden { false }
+
+    trait :manual do
+      trigger_type { "manual" }
+      trigger_data { {} }
+    end
+
+    trait :with_cred do
+      cred_reward { 10 }
+    end
+  end
+end

--- a/spec/factories/grid_hackr_achievements.rb
+++ b/spec/factories/grid_hackr_achievements.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :grid_hackr_achievement do
+    association :grid_hackr
+    association :grid_achievement
+    awarded_at { Time.current }
+  end
+end

--- a/spec/factories/grid_hackr_track_plays.rb
+++ b/spec/factories/grid_hackr_track_plays.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: grid_hackr_track_plays
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  first_played_at :datetime         not null
+#  play_count      :integer          default(1), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  track_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_track_plays_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_hackr_track_plays_on_track_id       (track_id)
+#  index_track_plays_unique                       (grid_hackr_id,track_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  track_id       (track_id => tracks.id)
+#
+FactoryBot.define do
+  factory :grid_hackr_track_play do
+    association :grid_hackr
+    association :track
+    first_played_at { Time.current }
+    play_count { 1 }
+  end
+end

--- a/spec/factories/hackr_log_reads.rb
+++ b/spec/factories/hackr_log_reads.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: hackr_log_reads
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  read_at       :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  hackr_log_id  :integer          not null
+#
+# Indexes
+#
+#  index_hackr_log_reads_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_log_reads_on_hackr_log_id   (hackr_log_id)
+#  index_hackr_log_reads_unique            (grid_hackr_id,hackr_log_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  hackr_log_id   (hackr_log_id => hackr_logs.id)
+#
+FactoryBot.define do
+  factory :hackr_log_read do
+    association :grid_hackr
+    association :hackr_log
+    read_at { Time.current }
+  end
+end

--- a/spec/factories/hackr_page_views.rb
+++ b/spec/factories/hackr_page_views.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: hackr_page_views
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  page_type     :string           not null
+#  viewed_at     :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  resource_id   :integer          not null
+#
+# Indexes
+#
+#  index_hackr_page_views_hackr_type        (grid_hackr_id,page_type)
+#  index_hackr_page_views_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_page_views_unique            (grid_hackr_id,page_type,resource_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+FactoryBot.define do
+  factory :hackr_page_view do
+    association :grid_hackr
+    page_type { "bio" }
+    resource_id { 1 }
+    viewed_at { Time.current }
+  end
+end

--- a/spec/factories/hackr_radio_tunes.rb
+++ b/spec/factories/hackr_radio_tunes.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: hackr_radio_tunes
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  tuned_at         :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  grid_hackr_id    :integer          not null
+#  radio_station_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_radio_tunes_on_grid_hackr_id     (grid_hackr_id)
+#  index_hackr_radio_tunes_on_radio_station_id  (radio_station_id)
+#  index_hackr_radio_tunes_unique               (grid_hackr_id,radio_station_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id     (grid_hackr_id => grid_hackrs.id)
+#  radio_station_id  (radio_station_id => radio_stations.id)
+#
+FactoryBot.define do
+  factory :hackr_radio_tune do
+    association :grid_hackr
+    association :radio_station
+    tuned_at { Time.current }
+  end
+end

--- a/spec/factories/hackr_vod_watches.rb
+++ b/spec/factories/hackr_vod_watches.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: hackr_vod_watches
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  watched_at      :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  hackr_stream_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_vod_watches_on_grid_hackr_id    (grid_hackr_id)
+#  index_hackr_vod_watches_on_hackr_stream_id  (hackr_stream_id)
+#  index_hackr_vod_watches_unique              (grid_hackr_id,hackr_stream_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id)
+#  hackr_stream_id  (hackr_stream_id => hackr_streams.id)
+#
+FactoryBot.define do
+  factory :hackr_vod_watch do
+    association :grid_hackr
+    association :hackr_stream
+    watched_at { Time.current }
+  end
+end

--- a/spec/jobs/grid/achievement_sweep_job_spec.rb
+++ b/spec/jobs/grid/achievement_sweep_job_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Grid::AchievementSweepJob do
+  let(:hackr) { create(:grid_hackr) }
+
+  it "no-ops for an unknown hackr_id" do
+    expect { described_class.perform_now(999_999) }.not_to raise_error
+  end
+
+  it "invokes the checker for every cumulative trigger" do
+    checker = instance_double(Grid::AchievementChecker)
+    allow(Grid::AchievementChecker).to receive(:new).with(hackr).and_return(checker)
+
+    GridAchievement::CUMULATIVE_TRIGGERS.each do |trigger_type|
+      expect(checker).to receive(:check).with(trigger_type).and_return([])
+    end
+
+    described_class.perform_now(hackr.id)
+  end
+
+  it "retroactively awards a cumulative achievement reached between sessions" do
+    create(:grid_achievement,
+      slug: "rooms-sweep",
+      trigger_type: "rooms_visited",
+      trigger_data: {"count" => 5},
+      xp_reward: 25)
+
+    hackr.set_stat!("rooms_visited", 5)
+
+    expect { described_class.perform_now(hackr.id) }
+      .to change { hackr.grid_hackr_achievements.count }.by(1)
+  end
+end

--- a/spec/models/grid_faction_rep_link_spec.rb
+++ b/spec/models/grid_faction_rep_link_spec.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_faction_rep_links
+# Database name: primary
+#
+#  id                :integer          not null, primary key
+#  weight            :decimal(6, 3)    not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  source_faction_id :integer          not null
+#  target_faction_id :integer          not null
+#
+# Indexes
+#
+#  index_faction_rep_links_unique                     (source_faction_id,target_faction_id) UNIQUE
+#  index_grid_faction_rep_links_on_source_faction_id  (source_faction_id)
+#  index_grid_faction_rep_links_on_target_faction_id  (target_faction_id)
+#
+# Foreign Keys
+#
+#  source_faction_id  (source_faction_id => grid_factions.id)
+#  target_faction_id  (target_faction_id => grid_factions.id)
+#
 require "rails_helper"
 
 RSpec.describe GridFactionRepLink, type: :model do

--- a/spec/models/grid_hackr_reputation_spec.rb
+++ b/spec/models/grid_hackr_reputation_spec.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_hackr_reputations
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  subject_type  :string           not null
+#  value         :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  subject_id    :bigint           not null
+#
+# Indexes
+#
+#  index_grid_hackr_reputations_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_reputations_on_subject             (subject_type,subject_id)
+#  index_hackr_reputations_unique                 (grid_hackr_id,subject_type,subject_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
 require "rails_helper"
 
 RSpec.describe GridHackrReputation, type: :model do

--- a/spec/models/grid_hackr_track_play_spec.rb
+++ b/spec/models/grid_hackr_track_play_spec.rb
@@ -1,0 +1,58 @@
+# == Schema Information
+#
+# Table name: grid_hackr_track_plays
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  first_played_at :datetime         not null
+#  play_count      :integer          default(1), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  track_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_track_plays_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_hackr_track_plays_on_track_id       (track_id)
+#  index_track_plays_unique                       (grid_hackr_id,track_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  track_id       (track_id => tracks.id)
+#
+require "rails_helper"
+
+RSpec.describe GridHackrTrackPlay do
+  let(:hackr) { create(:grid_hackr) }
+  let(:track) { create(:track) }
+
+  describe ".record!" do
+    it "creates a new row with play_count=1 on first call" do
+      record = described_class.record!(hackr, track)
+      expect(record.play_count).to eq(1)
+      expect(record.first_played_at).to be_within(1.second).of(Time.current)
+    end
+
+    it "increments play_count on subsequent calls" do
+      described_class.record!(hackr, track)
+      record = described_class.record!(hackr, track)
+      expect(record.play_count).to eq(2)
+    end
+
+    it "does not create a duplicate for the same hackr+track" do
+      described_class.record!(hackr, track)
+      expect {
+        described_class.record!(hackr, track)
+      }.not_to change { described_class.count }
+    end
+
+    it "creates separate rows for different tracks" do
+      other = create(:track)
+      described_class.record!(hackr, track)
+      described_class.record!(hackr, other)
+      expect(described_class.count).to eq(2)
+    end
+  end
+end

--- a/spec/models/grid_reputation_event_spec.rb
+++ b/spec/models/grid_reputation_event_spec.rb
@@ -1,3 +1,31 @@
+# == Schema Information
+#
+# Table name: grid_reputation_events
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  delta         :integer          not null
+#  note          :text
+#  reason        :string
+#  source_type   :string
+#  subject_type  :string           not null
+#  value_after   :integer          not null
+#  created_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  source_id     :bigint
+#  subject_id    :bigint           not null
+#
+# Indexes
+#
+#  index_grid_reputation_events_on_grid_hackr_id  (grid_hackr_id)
+#  index_rep_events_on_hackr_and_time             (grid_hackr_id,created_at DESC)
+#  index_rep_events_on_source                     (source_type,source_id)
+#  index_rep_events_on_subject_and_time           (subject_type,subject_id,created_at DESC)
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
 require "rails_helper"
 
 RSpec.describe GridReputationEvent, type: :model do

--- a/spec/models/hackr_log_read_spec.rb
+++ b/spec/models/hackr_log_read_spec.rb
@@ -1,0 +1,48 @@
+# == Schema Information
+#
+# Table name: hackr_log_reads
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  read_at       :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  hackr_log_id  :integer          not null
+#
+# Indexes
+#
+#  index_hackr_log_reads_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_log_reads_on_hackr_log_id   (hackr_log_id)
+#  index_hackr_log_reads_unique            (grid_hackr_id,hackr_log_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  hackr_log_id   (hackr_log_id => hackr_logs.id)
+#
+require "rails_helper"
+
+RSpec.describe HackrLogRead do
+  let(:hackr) { create(:grid_hackr) }
+  let(:log) { create(:hackr_log, :published) }
+
+  describe ".record!" do
+    it "creates a row on first call" do
+      expect { described_class.record!(hackr, log) }
+        .to change { described_class.count }.by(1)
+    end
+
+    it "is idempotent for the same hackr+log" do
+      described_class.record!(hackr, log)
+      expect { described_class.record!(hackr, log) }
+        .not_to change { described_class.count }
+    end
+
+    it "enforces uniqueness at the model validation level" do
+      described_class.create!(grid_hackr: hackr, hackr_log: log, read_at: Time.current)
+      dup = described_class.new(grid_hackr: hackr, hackr_log: log, read_at: Time.current)
+      expect(dup).not_to be_valid
+    end
+  end
+end

--- a/spec/models/hackr_page_view_spec.rb
+++ b/spec/models/hackr_page_view_spec.rb
@@ -1,0 +1,57 @@
+# == Schema Information
+#
+# Table name: hackr_page_views
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  page_type     :string           not null
+#  viewed_at     :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  resource_id   :integer          not null
+#
+# Indexes
+#
+#  index_hackr_page_views_hackr_type        (grid_hackr_id,page_type)
+#  index_hackr_page_views_on_grid_hackr_id  (grid_hackr_id)
+#  index_hackr_page_views_unique            (grid_hackr_id,page_type,resource_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+require "rails_helper"
+
+RSpec.describe HackrPageView do
+  let(:hackr) { create(:grid_hackr) }
+  let(:artist) { create(:artist) }
+
+  describe "validations" do
+    it "rejects unknown page_type" do
+      view = described_class.new(grid_hackr: hackr, page_type: "bogus", resource_id: 1, viewed_at: Time.current)
+      expect(view).not_to be_valid
+    end
+
+    it "accepts bio / release_index / release" do
+      %w[bio release_index release].each do |type|
+        view = described_class.new(grid_hackr: hackr, page_type: type, resource_id: 1, viewed_at: Time.current)
+        expect(view).to be_valid
+      end
+    end
+  end
+
+  describe ".record!" do
+    it "is idempotent per hackr+page_type+resource_id" do
+      described_class.record!(hackr, "bio", artist.id)
+      expect { described_class.record!(hackr, "bio", artist.id) }
+        .not_to change { described_class.count }
+    end
+
+    it "allows the same hackr+resource under a different page_type" do
+      described_class.record!(hackr, "bio", artist.id)
+      expect { described_class.record!(hackr, "release_index", artist.id) }
+        .to change { described_class.count }.by(1)
+    end
+  end
+end

--- a/spec/services/grid/achievement_awarder_spec.rb
+++ b/spec/services/grid/achievement_awarder_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe Grid::AchievementAwarder do
+  let(:hackr) { create(:grid_hackr) }
+  let!(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let!(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+
+  before do
+    # Fund the gameplay pool so mint_gameplay! can succeed
+    genesis_source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: genesis_source, to_cache: gameplay_pool, amount: 1_000_000,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  describe "#award!" do
+    let(:achievement) do
+      create(:grid_achievement,
+        slug: "test-cred",
+        xp_reward: 25,
+        cred_reward: 10)
+    end
+
+    it "creates the join row" do
+      expect { described_class.new(hackr, achievement).award! }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "grants XP" do
+      expect {
+        described_class.new(hackr, achievement).award!
+        hackr.reload
+      }.to change { hackr.stat("xp") }.from(0).to(25)
+    end
+
+    it "mints CRED from the gameplay pool to the hackr's default cache" do
+      expect { described_class.new(hackr, achievement).award! }
+        .to change { cache.reload.balance }.by(10)
+    end
+
+    it "skips the CRED mint (but still awards XP + join row) when cache is inactive" do
+      cache.update!(status: "abandoned")
+
+      expect {
+        described_class.new(hackr, achievement).award!
+        hackr.reload
+      }.to change { hackr.grid_hackr_achievements.count }.by(1)
+        .and change { hackr.stat("xp") }.by(25)
+
+      expect(cache.reload.balance).to eq(0)
+    end
+
+    it "rolls back XP + join row when mint_gameplay! raises mid-transaction" do
+      allow(Grid::TransactionService).to receive(:mint_gameplay!)
+        .and_raise(Grid::TransactionService::InsufficientBalance, "pool empty")
+
+      expect {
+        described_class.new(hackr, achievement).award!
+      }.to raise_error(Grid::TransactionService::InsufficientBalance)
+
+      hackr.reload
+      expect(hackr.grid_hackr_achievements.count).to eq(0)
+      expect(hackr.stat("xp")).to eq(0)
+    end
+
+    it "returns a notification string when newly awarded" do
+      result = described_class.new(hackr, achievement).award!
+      expect(result).to include("ACHIEVEMENT UNLOCKED")
+      expect(result).to include(achievement.name)
+      expect(result).to include("+25 XP")
+      expect(result).to include("+10 CRED")
+    end
+
+    it "returns nil on duplicate award (race guard)" do
+      described_class.new(hackr, achievement).award!
+      result = described_class.new(hackr, achievement).award!
+      expect(result).to be_nil
+    end
+
+    it "broadcasts to the per-hackr AchievementChannel stream" do
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "achievement_channel_#{hackr.id}",
+        hash_including(type: "achievement_unlocked")
+      )
+      described_class.new(hackr, achievement).award!
+    end
+
+    it "skips CRED mint when cred_reward is zero" do
+      no_cred = create(:grid_achievement, slug: "no-cred", xp_reward: 10, cred_reward: 0)
+
+      expect(Grid::TransactionService).not_to receive(:mint_gameplay!)
+      described_class.new(hackr, no_cred).award!
+    end
+  end
+
+  describe "#award! — awarder survives broadcast failure" do
+    let(:achievement) { create(:grid_achievement, xp_reward: 10) }
+
+    it "does not raise if ActionCable broadcast throws" do
+      allow(ActionCable.server).to receive(:broadcast).and_raise(StandardError, "oops")
+
+      expect {
+        described_class.new(hackr, achievement).award!
+      }.not_to raise_error
+      expect(hackr.grid_hackr_achievements.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/grid/achievement_checker_spec.rb
+++ b/spec/services/grid/achievement_checker_spec.rb
@@ -1,0 +1,283 @@
+require "rails_helper"
+
+RSpec.describe Grid::AchievementChecker do
+  let(:hackr) { create(:grid_hackr) }
+  let(:checker) { described_class.new(hackr) }
+
+  describe "#check — existing MUD triggers still work" do
+    let!(:achievement) do
+      create(:grid_achievement,
+        slug: "rooms-5",
+        trigger_type: "rooms_visited",
+        trigger_data: {"count" => 5},
+        xp_reward: 25)
+    end
+
+    it "awards when stat meets threshold" do
+      hackr.set_stat!("rooms_visited", 5)
+      expect { checker.check("rooms_visited") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "does not award when below threshold" do
+      hackr.set_stat!("rooms_visited", 3)
+      expect { checker.check("rooms_visited") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+
+    it "is idempotent across multiple calls" do
+      hackr.set_stat!("rooms_visited", 5)
+      checker.check("rooms_visited")
+      expect { checker.check("rooms_visited") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+
+    it "returns a notification array when awarded" do
+      hackr.set_stat!("rooms_visited", 5)
+      notifications = checker.check("rooms_visited")
+      expect(notifications.size).to eq(1)
+      expect(notifications.first).to include("ACHIEVEMENT UNLOCKED")
+    end
+
+    it "returns [] when no matches" do
+      hackr.set_stat!("rooms_visited", 0)
+      expect(checker.check("rooms_visited")).to eq([])
+    end
+  end
+
+  describe "#check — track_plays_count" do
+    let!(:artist) { create(:artist) }
+    let!(:release) { create(:release, artist: artist) }
+    let!(:tracks) { create_list(:track, 3, artist: artist, release: release) }
+
+    before do
+      create(:grid_achievement,
+        slug: "music-3-tracks",
+        category: "music",
+        trigger_type: "track_plays_count",
+        trigger_data: {"count" => 3},
+        xp_reward: 25)
+    end
+
+    it "awards when 3 unique tracks have been credited" do
+      tracks.each { |t| GridHackrTrackPlay.record!(hackr, t) }
+      expect { checker.check("track_plays_count") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "does not award with only 2 plays" do
+      tracks.take(2).each { |t| GridHackrTrackPlay.record!(hackr, t) }
+      expect { checker.check("track_plays_count") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+
+    it "counts replays of the same track only once" do
+      3.times { GridHackrTrackPlay.record!(hackr, tracks.first) }
+      expect { checker.check("track_plays_count") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+  end
+
+  describe "#check — hackr_logs_read_all" do
+    before do
+      create(:grid_achievement,
+        slug: "all-logs",
+        category: "meta",
+        trigger_type: "hackr_logs_read_all",
+        trigger_data: {},
+        xp_reward: 500)
+    end
+
+    it "does not fire when no logs are published" do
+      expect { checker.check("hackr_logs_read_all") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+
+    it "fires when all published logs have been read" do
+      logs = create_list(:hackr_log, 3, :published)
+      logs.each { |log| HackrLogRead.record!(hackr, log) }
+      expect { checker.check("hackr_logs_read_all") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "does not fire when one log is unread" do
+      logs = create_list(:hackr_log, 3, :published)
+      logs.take(2).each { |log| HackrLogRead.record!(hackr, log) }
+      expect { checker.check("hackr_logs_read_all") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+  end
+
+  describe "#check — radio_stations_tuned_all" do
+    before do
+      create(:grid_achievement,
+        slug: "all-radio",
+        category: "music",
+        trigger_type: "radio_stations_tuned_all",
+        trigger_data: {},
+        xp_reward: 500)
+    end
+
+    it "awards when every visible station has been tuned" do
+      stations = create_list(:radio_station, 3)
+      stations.each { |s| HackrRadioTune.record!(hackr, s) }
+      expect { checker.check("radio_stations_tuned_all") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "ignores hidden stations from the target count" do
+      create_list(:radio_station, 2) # visible
+      hidden = create(:radio_station, hidden: true)
+      # Tune only the 2 visible stations — the hidden one doesn't count toward "all"
+      RadioStation.visible.each { |s| HackrRadioTune.record!(hackr, s) }
+      HackrRadioTune.record!(hackr, hidden)
+      expect { checker.check("radio_stations_tuned_all") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+  end
+
+  describe "#check — clearance_level" do
+    before do
+      create(:grid_achievement,
+        slug: "cl-5",
+        category: "progression",
+        trigger_type: "clearance_level",
+        trigger_data: {"level" => 5},
+        xp_reward: 0,
+        cred_reward: 0)
+    end
+
+    it "fires once the hackr reaches the target clearance" do
+      hackr.set_stat!("clearance", 5)
+      expect { checker.check("clearance_level") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "does not fire at CL4" do
+      hackr.set_stat!("clearance", 4)
+      expect { checker.check("clearance_level") }
+        .not_to change { hackr.grid_hackr_achievements.count }
+    end
+  end
+
+  describe "#check — earned_ids memoization" do
+    # Regression: the login sweep job calls check() 18 times on one
+    # checker instance. Without earned_ids memoization, each call
+    # re-pluck's the join table — 18 identical queries per sweep.
+
+    it "reads grid_hackr_achievements.id only once across repeated check() calls" do
+      create(:grid_achievement, slug: "a", trigger_type: "rooms_visited", trigger_data: {"count" => 1})
+      create(:grid_achievement, slug: "b", trigger_type: "track_plays_count", trigger_data: {"count" => 1})
+      create(:grid_achievement, slug: "c", trigger_type: "hackr_logs_read", trigger_data: {"count" => 1})
+
+      query_count = 0
+      counter = ->(_name, _start, _finish, _id, payload) do
+        sql = payload[:sql].to_s
+        query_count += 1 if sql.include?("grid_hackr_achievements") && sql.include?("grid_achievement_id")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        checker.check("rooms_visited")
+        checker.check("track_plays_count")
+        checker.check("hackr_logs_read")
+      end
+
+      expect(query_count).to eq(1)
+    end
+
+    it "marks awards from within the same instance as earned so later check() calls skip them" do
+      create(:grid_achievement,
+        slug: "rooms-1",
+        trigger_type: "rooms_visited",
+        trigger_data: {"count" => 1},
+        xp_reward: 10)
+      hackr.set_stat!("rooms_visited", 1)
+
+      # First check — awards it and tracks earned_ids internally.
+      expect { checker.check("rooms_visited") }
+        .to change { hackr.grid_hackr_achievements.count }.by(1)
+
+      # Second check on same instance — earned_ids now contains this
+      # achievement, so it's skipped. award! is never re-invoked even
+      # at the Awarder layer.
+      expect(Grid::AchievementAwarder).not_to receive(:new)
+      checker.check("rooms_visited")
+    end
+  end
+
+  describe "#progress query count (memoization)" do
+    # Regression: the AchievementsPage endpoint calls `progress` for
+    # every achievement. Many share the same underlying count (e.g.
+    # all `hackr_logs_read` tiers hit `hackr_log_reads.count`).
+    # Memoization must collapse repeated reads to one query each.
+
+    it "reads hackr_log_reads.count only once across many achievements" do
+      a1 = create(:grid_achievement, slug: "lr-1", trigger_type: "hackr_logs_read", trigger_data: {"count" => 1})
+      a2 = create(:grid_achievement, slug: "lr-10", trigger_type: "hackr_logs_read", trigger_data: {"count" => 10})
+      a3 = create(:grid_achievement, slug: "lr-25", trigger_type: "hackr_logs_read", trigger_data: {"count" => 25})
+
+      # Query counter for the specific count query
+      query_count = 0
+      counter = ->(_name, _start, _finish, _id, payload) do
+        sql = payload[:sql].to_s
+        query_count += 1 if sql.include?("hackr_log_reads") && sql.include?("COUNT(")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        checker.progress(a1)
+        checker.progress(a2)
+        checker.progress(a3)
+      end
+
+      expect(query_count).to eq(1)
+    end
+
+    it "reads published HackrLog total only once" do
+      a1 = create(:grid_achievement, slug: "lra-1", trigger_type: "hackr_logs_read_all", trigger_data: {})
+      a2 = create(:grid_achievement, slug: "lra-2", trigger_type: "hackr_logs_read_all", trigger_data: {})
+
+      query_count = 0
+      counter = ->(_name, _start, _finish, _id, payload) do
+        sql = payload[:sql].to_s
+        # Matches the `HackrLog.published.count` for the target total
+        query_count += 1 if sql.include?("hackr_logs") && sql.include?("COUNT(") && !sql.include?("hackr_log_reads")
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        checker.progress(a1)
+        checker.progress(a2)
+      end
+
+      expect(query_count).to eq(1)
+    end
+  end
+
+  describe "#progress" do
+    let!(:achievement) do
+      create(:grid_achievement,
+        trigger_type: "rooms_visited",
+        trigger_data: {"count" => 10})
+    end
+
+    it "returns fraction/current/target for cumulative triggers" do
+      hackr.set_stat!("rooms_visited", 3)
+      progress = checker.progress(achievement)
+      expect(progress).to include(current: 3, target: 10, fraction: 0.3, completed: false)
+    end
+
+    it "clamps the fraction at 1.0 when exceeded" do
+      hackr.set_stat!("rooms_visited", 25)
+      progress = checker.progress(achievement)
+      expect(progress[:fraction]).to eq(1.0)
+      expect(progress[:completed]).to be true
+    end
+
+    it "returns nil for event-only triggers like take_item" do
+      event_achievement = create(:grid_achievement,
+        slug: "take-specific",
+        trigger_type: "take_item",
+        trigger_data: {"item_name" => "data chip"})
+      expect(checker.progress(event_achievement)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
  Expands the MUD-only achievement system to cover music discovery,
  content reading, band exploration, VOD watching, radio listening,
  and social activity across hackr.tv. Grants XP + CRED via the
  Fracture Reserve gameplay pool.

  Schema (7 migrations):
  - grid_achievements: + category (grid/music/social/meta/progression) and cred_reward columns
  - 6 per-surface join tables with (hackr, resource) unique indexes: grid_hackr_track_plays, hackr_log_reads, codex_entry_reads, hackr_page_views (bio/release_index/release via page_type), hackr_vod_watches, hackr_radio_tunes

  Services:
  - Grid::AchievementAwarder — new, transaction-wraps join-row + grant_xp! + mint_gameplay! (Rails.logger.warn on inactive cache, rescues RecordInvalid + RecordNotUnique on duplicate)
  - Grid::AchievementChecker — rewritten with memoized earned_ids and source counts (one query per source across the sweep's 18 trigger types), matches? delegates cumulative triggers to progress() for DRY
  - Grid::AchievementSweepJob — enqueued from login, catches up any cumulative achievement earned outside the Terminal

  Channel:
  - AchievementChannel.stream_name_for(hackr) broadcasts achievement_unlocked payloads per hackr; awarder pushes to it from inside the transaction

  Controllers (7 new endpoints + 4 hooks):
  - POST /api/tracks/:id/play_credit (30s threshold, vault-only)
  - POST /api/logs/:id/read
  - POST /api/codex/:slug/read
  - POST /api/artists/:id/bio_viewed + release_index_viewed
  - POST /api/releases/:id/viewed
  - POST /api/artists/:artist_slug/vods/:id/watch
  - POST /api/radio_stations/:id/tune_in
  - GET  /api/grid/achievements (login-gated index for the SPA page)
  - Hooks: pulses#create, playlist_tracks#create (0→1 transition only), uplink/packets#create, grid#login (sweep enqueue)
  - All tracking endpoints are no-op for anon (head :no_content)

  Admin:
  - Category filter + cred_reward field on /root/grid_achievements
  - Manual award routes through AchievementAwarder (same path as auto unlocks)

  Seed:
  - data/world/achievements.yml: 16 existing MUD entries backfilled with category:grid, cred_reward:0; 44 new entries across music/ social/meta/progression. Ladder: T1 25/1, T2 100/10, T3 250/20, completionist 500/50, single-event 10/0.

  Frontend:
  - New /achievements SPA page (login-gated) with category tabs, progress bars, earned/awarded dates
  - AchievementToastContainer mounted outside Suspense in AppLayout
  - useAchievementChannel hook subscribes via a shared ActionCable consumer singleton (new lib/actionCableConsumer.ts)
  - useHackrScopedDedup hook — Set/flag refs auto-reset on hackr.id change so logout/login swap doesn't silence the next user's credits
  - Cheat-resistant AudioPlayer play credit: accumulates cumulative played seconds, only counts forward deltas <2s (seeking past 30s does NOT award)
  - YouTubePlayer gains onPlay callback; VodzShowPage credits only on real PLAYING state, not page load
  - RadioPage dual-playback architecture (window.audioPlayer for playlist-backed stations, local audioRef for raw stream URLs) — credits only after play() actually resolves / isPlaying fires
  - Tracking wired into LogDetailPage, CodexEntryPage, BandProfile/ TCP/XERAEN/WavelengthZero pages, ReleaseListPage, ReleaseDetail Page, VodzShowPage, RadioPage — all split-effect pattern that handles the auth-resolves-after-fetch race
  - "THE PULSE GRID" nav dropdown (desktop + mobile) gains an /achievements link

  Handbook:
  - New /handbook/achievements reference article under THE PULSE GRID section

  Tests: ~80 new specs
  - Models: grid_hackr_track_play, hackr_log_read, hackr_page_view (+ 4 new factories)
  - Services: achievement_checker (trigger branches, progress shape, earned_ids + source-count memoization), achievement_awarder (XP/CRED atomicity, inactive-cache skip, rollback on mint failure, broadcast), achievement_sweep_job
  - Channel: per-hackr stream, anon rejection
  - Controllers: logs/codex/tracks/artists/releases/hackr_streams/ radio tracking endpoints, grid#achievements_index, playlist_ tracks 0→1 achievement gating
  - Frontend: auth-timing race (BandProfilePage), VOD onPlay gate (VodzShowPage), radio play() rejection gate (RadioPage)