### PR TITLE
[TPG] Mission System - structured objectives, storylines, and rewards

### DIFF
--- a/app/controllers/admin/grid_hackr_missions_controller.rb
+++ b/app/controllers/admin/grid_hackr_missions_controller.rb
@@ -1,0 +1,22 @@
+class Admin::GridHackrMissionsController < Admin::ApplicationController
+  def index
+    scope = GridHackrMission.includes(:grid_hackr, grid_mission: :giver_mob).order(accepted_at: :desc)
+    scope = scope.where(status: params[:status]) if %w[active completed].include?(params[:status])
+
+    if params[:hackr_alias].present?
+      hackr = GridHackr.find_by("LOWER(hackr_alias) = ?", params[:hackr_alias].downcase)
+      scope = hackr ? scope.where(grid_hackr_id: hackr.id) : GridHackrMission.none
+    end
+
+    @status_filter = params[:status]
+    @hackr_alias_filter = params[:hackr_alias]
+    @hackr_missions = scope.limit(200)
+  end
+
+  def show
+    @hackr_mission = GridHackrMission.includes(
+      grid_hackr_mission_objectives: :grid_mission_objective,
+      grid_mission: :grid_mission_objectives
+    ).find(params[:id])
+  end
+end

--- a/app/controllers/admin/grid_mission_arcs_controller.rb
+++ b/app/controllers/admin/grid_mission_arcs_controller.rb
@@ -1,0 +1,53 @@
+class Admin::GridMissionArcsController < Admin::ApplicationController
+  before_action :set_arc, only: %i[edit update destroy]
+
+  def index
+    @arcs = GridMissionArc.ordered
+  end
+
+  def new
+    @arc = GridMissionArc.new(position: (GridMissionArc.maximum(:position) || 0) + 1, published: true)
+  end
+
+  def create
+    @arc = GridMissionArc.new(arc_params)
+    if @arc.save
+      set_flash_success("Mission arc '#{@arc.name}' created.")
+      redirect_to admin_grid_mission_arcs_path
+    else
+      flash.now[:error] = @arc.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @arc.update(arc_params)
+      set_flash_success("Mission arc '#{@arc.name}' updated.")
+      redirect_to admin_grid_mission_arcs_path
+    else
+      flash.now[:error] = @arc.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @arc.name
+    @arc.destroy!
+    set_flash_success("Mission arc '#{name}' deleted.")
+    redirect_to admin_grid_mission_arcs_path
+  end
+
+  private
+
+  def set_arc
+    # GridMissionArc overrides to_param to return slug — look up by slug.
+    @arc = GridMissionArc.find_by!(slug: params[:id])
+  end
+
+  def arc_params
+    params.require(:grid_mission_arc).permit(:slug, :name, :description, :position, :published)
+  end
+end

--- a/app/controllers/admin/grid_missions_controller.rb
+++ b/app/controllers/admin/grid_missions_controller.rb
@@ -1,0 +1,86 @@
+class Admin::GridMissionsController < Admin::ApplicationController
+  before_action :set_mission, only: %i[edit update destroy]
+
+  def index
+    @missions = GridMission.ordered
+      .includes(:grid_mission_arc, :giver_mob, :grid_mission_objectives, :grid_mission_rewards)
+      .to_a
+    @active_counts = GridHackrMission.active.group(:grid_mission_id).count
+    @completed_counts = GridHackrMission.completed.group(:grid_mission_id).sum(:turn_in_count)
+  end
+
+  def new
+    @mission = GridMission.new(
+      published: true,
+      position: (GridMission.maximum(:position) || 0) + 1
+    )
+    @mission.grid_mission_objectives.build(position: 1)
+    @mission.grid_mission_rewards.build(position: 1, reward_type: "xp")
+    load_selects
+  end
+
+  def create
+    @mission = GridMission.new(mission_params)
+    if @mission.save
+      set_flash_success("Mission '#{@mission.name}' created.")
+      redirect_to admin_grid_missions_path
+    else
+      flash.now[:error] = @mission.errors.full_messages.join(", ")
+      load_selects
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @mission.update(mission_params)
+      set_flash_success("Mission '#{@mission.name}' updated.")
+      redirect_to admin_grid_missions_path
+    else
+      flash.now[:error] = @mission.errors.full_messages.join(", ")
+      load_selects
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @mission.name
+    @mission.destroy!
+    set_flash_success("Mission '#{name}' deleted.")
+    redirect_to admin_grid_missions_path
+  end
+
+  private
+
+  def set_mission
+    # GridMission overrides to_param to return slug, so URL helpers emit
+    # slug-based paths — look up by slug to match.
+    @mission = GridMission.find_by!(slug: params[:id])
+  end
+
+  def load_selects
+    @arcs = GridMissionArc.ordered
+    @missions_for_prereq = GridMission.ordered.where.not(id: @mission.id)
+    # Restrict giver choices to mob types that plausibly hand out work:
+    # quest_givers (obvious) and vendors (can offer repeatable
+    # commerce-flavored missions like "spend N CRED at my shop").
+    # `lore` and `special` mobs exist for flavor only and would be a
+    # miscast as mission givers.
+    @mobs = GridMob.where(mob_type: %w[quest_giver vendor])
+      .order(:name).includes(:grid_room)
+    @factions = GridFaction.order(:name)
+  end
+
+  def mission_params
+    params.require(:grid_mission).permit(
+      :slug, :name, :description, :giver_mob_id, :grid_mission_arc_id,
+      :prereq_mission_id, :min_clearance, :min_rep_faction_id, :min_rep_value,
+      :repeatable, :position, :published,
+      grid_mission_objectives_attributes: %i[id position objective_type label target_slug target_count _destroy],
+      grid_mission_rewards_attributes: %i[id position reward_type amount target_slug quantity _destroy]
+    )
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -1,7 +1,7 @@
 class Api::GridController < ApplicationController
   include GridAuthentication
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action :require_admin_api, only: [:debit]
 
@@ -51,6 +51,21 @@ class Api::GridController < ApplicationController
     render json: {
       categories: categories,
       summary: {by_category: summary, total: total_summary}
+    }
+  end
+
+  # GET /api/grid/missions - Active + completed + available-in-current-room missions.
+  def missions_index
+    service = Grid::MissionService.new(current_hackr)
+
+    active = service.active_hackr_missions.to_a
+    completed = service.completed_hackr_missions(limit: 20).to_a
+    available = service.available_missions(current_hackr.current_room).to_a
+
+    render json: {
+      active: active.map { |hm| hackr_mission_json(hm, include_progress: true) },
+      completed: completed.map { |hm| hackr_mission_json(hm, include_progress: false) },
+      available: available.map { |m| mission_json(m, include_gate_status: true) }
     }
   end
 
@@ -579,5 +594,90 @@ class Api::GridController < ApplicationController
         }
       end
     }
+  end
+
+  # --- Mission JSON helpers ---
+
+  def mission_json(mission, include_gate_status: false)
+    data = {
+      slug: mission.slug,
+      name: mission.name,
+      description: mission.description,
+      repeatable: mission.repeatable,
+      arc: mission.grid_mission_arc ? {slug: mission.grid_mission_arc.slug, name: mission.grid_mission_arc.name} : nil,
+      giver: mission.giver_mob ? {
+        name: mission.giver_mob.name,
+        room_id: mission.giver_mob.grid_room_id,
+        room_slug: mission.giver_mob.grid_room&.slug
+      } : nil,
+      prereq_slug: mission.prereq_mission&.slug,
+      min_clearance: mission.min_clearance,
+      min_rep: mission.min_rep_faction ? {faction_slug: mission.min_rep_faction.slug, value: mission.min_rep_value} : nil,
+      objectives: mission.grid_mission_objectives.map { |o|
+        {
+          id: o.id,
+          position: o.position,
+          objective_type: o.objective_type,
+          label: o.label,
+          target_slug: o.target_slug,
+          target_count: o.target_count
+        }
+      },
+      rewards: mission.grid_mission_rewards.map { |r|
+        {
+          id: r.id,
+          reward_type: r.reward_type,
+          amount: r.amount,
+          target_slug: r.target_slug,
+          quantity: r.quantity
+        }
+      }
+    }
+
+    if include_gate_status
+      status = mission_service.gate_status(mission)
+      data[:gates] = {
+        clearance_met: status.clearance_met,
+        prereq_met: status.prereq_met,
+        rep_met: status.rep_met
+      }
+    end
+
+    data
+  end
+
+  # Memoized per-request. Reuses one MissionService instance across all
+  # mission_json calls in a serializer loop so ReputationService preload
+  # + completed_mission_ids don't re-query per row.
+  def mission_service
+    @mission_service ||= Grid::MissionService.new(current_hackr)
+  end
+
+  def hackr_mission_json(hackr_mission, include_progress: true)
+    mission = hackr_mission.grid_mission
+    base = {
+      id: hackr_mission.id,
+      status: hackr_mission.status,
+      accepted_at: hackr_mission.accepted_at&.iso8601,
+      completed_at: hackr_mission.completed_at&.iso8601,
+      turn_in_count: hackr_mission.turn_in_count,
+      mission: mission_json(mission)
+    }
+
+    if include_progress
+      progress_by_obj = hackr_mission.grid_hackr_mission_objectives.index_by(&:grid_mission_objective_id)
+      base[:objective_progress] = mission.grid_mission_objectives.map do |obj|
+        hobj = progress_by_obj[obj.id]
+        {
+          objective_id: obj.id,
+          progress: hobj&.progress.to_i,
+          target_count: obj.target_count,
+          completed: hobj&.completed_at.present?
+        }
+      end
+      base[:ready_to_turn_in] = hackr_mission.all_objectives_completed?
+    end
+
+    base
   end
 end

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -26,6 +26,7 @@ const ReleaseListPage = lazy(() => import('~/components/pages/releases/ReleaseLi
 const ReleaseDetailPage = lazy(() => import('~/components/pages/releases/ReleaseDetailPage'))
 const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').then(m => ({ default: m.GridGamePage })))
 const AchievementsPage = lazy(() => import('~/components/pages/grid/AchievementsPage'))
+const MissionsPage = lazy(() => import('~/components/pages/grid/MissionsPage'))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
@@ -102,6 +103,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/:artistSlug/trackz/:trackSlug" element={<TrackDetailPage />} />
           {/* THE PULSE GRID routes */}
           <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
+          <Route path="/missions" element={<ProtectedRoute><MissionsPage /></ProtectedRoute>} />
           <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
           <Route path="/grid/login" element={<GridLoginPage />} />
           <Route path="/grid/register" element={<GridRegisterPage />} />

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -288,6 +288,9 @@ export const HeaderMenu: React.FC = () => {
                     <Link to="/achievements" className={`mobile-menu-item${isActive('/achievements') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>achievements
                     </Link>
+                    <Link to="/missions" className={`mobile-menu-item${isActive('/missions') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>missions
+                    </Link>
                     <Link to="/fm/playlists" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>playlists
                     </Link>
@@ -553,7 +556,7 @@ export const HeaderMenu: React.FC = () => {
           </li>
 
           {/* THE PULSE GRID */}
-          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
+          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') || isActive('/missions') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
             <span className="purple-168-text">{isLoggedIn ? '11' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
@@ -586,6 +589,11 @@ export const HeaderMenu: React.FC = () => {
                     <li>
                       <Link to="/achievements" onClick={closeDropdown}>
                         <span className="purple-168-text">/</span>achievements
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/missions" onClick={closeDropdown}>
+                        <span className="purple-168-text">/</span>missions
                       </Link>
                     </li>
                     <li>

--- a/app/javascript/components/pages/grid/MissionsPage.tsx
+++ b/app/javascript/components/pages/grid/MissionsPage.tsx
@@ -1,0 +1,306 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+import type {
+  MissionsIndexResponse,
+  Mission,
+  HackrMission,
+  MissionObjective,
+  MissionReward,
+  ObjectiveProgress
+} from '~/types/mission'
+
+type Tab = 'active' | 'available' | 'completed'
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  } catch {
+    return iso
+  }
+}
+
+const rewardLine = (r: MissionReward): string => {
+  switch (r.reward_type) {
+  case 'xp': return `+${r.amount} XP`
+  case 'cred': return `+${r.amount} CRED`
+  case 'faction_rep': return `${r.amount >= 0 ? '+' : ''}${r.amount} rep (${r.target_slug ?? '?'})`
+  case 'item_grant': {
+    const qty = r.quantity > 1 ? ` ×${r.quantity}` : ''
+    return `+ ${r.target_slug ?? 'item'}${qty}`
+  }
+  case 'grant_achievement': return `◆ Achievement: ${r.target_slug ?? '?'}`
+  default: return r.reward_type
+  }
+}
+
+const rewardColor = (r: MissionReward): string => {
+  switch (r.reward_type) {
+  case 'xp': return '#34d399'
+  case 'cred': return '#fbbf24'
+  case 'faction_rep': return r.amount >= 0 ? '#34d399' : '#ef4444'
+  case 'item_grant': return '#60a5fa'
+  case 'grant_achievement': return '#fbbf24'
+  default: return '#9ca3af'
+  }
+}
+
+const MissionsPage: React.FC = () => {
+  const [data, setData] = useState<MissionsIndexResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<Tab>('active')
+  const [refetchToken, setRefetchToken] = useState(0)
+
+  useEffect(() => {
+    apiJson<MissionsIndexResponse>('/api/grid/missions')
+      .then(json => { setData(json); setLoading(false) })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Failed to load missions')
+        setLoading(false)
+      })
+  }, [refetchToken])
+
+  // Listen for the DOM event dispatched by AchievementToastContainer
+  // when a mission completes. This avoids opening a second ActionCable
+  // subscription — the toast container is the single subscriber, and
+  // it fans out via CustomEvent for any component that needs to react.
+  useEffect(() => {
+    const handler = () => setRefetchToken(t => t + 1)
+    window.addEventListener('grid:mission_completed', handler)
+    return () => window.removeEventListener('grid:mission_completed', handler)
+  }, [])
+
+  const counts = useMemo(() => ({
+    active: data?.active.length ?? 0,
+    available: data?.available.length ?? 0,
+    completed: data?.completed.length ?? 0
+  }), [data])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+          <LoadingSpinner message="Loading missions..." color="cyan-255-text" size="large" />
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto', padding: 40, textAlign: 'center', color: '#f87171' }}>
+          {error || 'Failed to load missions'}
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+        <div
+          className="tui-window white-text"
+          style={{
+            display: 'block',
+            background: '#0a0a0a',
+            border: '2px solid #22d3ee',
+            boxShadow: '0 0 30px rgba(34, 211, 238, 0.3)'
+          }}
+        >
+          <fieldset style={{ borderColor: '#22d3ee' }}>
+            <legend
+              className="center"
+              style={{ color: '#22d3ee', textShadow: '0 0 15px rgba(34, 211, 238, 0.6)', letterSpacing: 3 }}
+            >
+              MISSIONS
+            </legend>
+            <div style={{ padding: 20 }}>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+                <TabButton label={`ACTIVE (${counts.active})`} color="#22d3ee" active={activeTab === 'active'} onClick={() => setActiveTab('active')} />
+                <TabButton label={`AVAILABLE (${counts.available})`} color="#34d399" active={activeTab === 'available'} onClick={() => setActiveTab('available')} />
+                <TabButton label={`COMPLETED (${counts.completed})`} color="#fbbf24" active={activeTab === 'completed'} onClick={() => setActiveTab('completed')} />
+              </div>
+
+              {activeTab === 'active' && (
+                <MissionList empty="No active missions. Travel to an NPC and 'ask &lt;npc&gt; about missions' in the Terminal to find work.">
+                  {data.active.map(hm => <ActiveMissionCard key={hm.id} hackrMission={hm} />)}
+                </MissionList>
+              )}
+
+              {activeTab === 'available' && (
+                <MissionList empty="Nothing available in your current room. Travel and talk to NPCs to find work.">
+                  {data.available.map(m => <AvailableMissionCard key={m.slug} mission={m} />)}
+                </MissionList>
+              )}
+
+              {activeTab === 'completed' && (
+                <MissionList empty="You haven't completed any missions yet.">
+                  {data.completed.map(hm => <CompletedMissionCard key={hm.id} hackrMission={hm} />)}
+                </MissionList>
+              )}
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const TabButton: React.FC<{ label: string; color: string; active: boolean; onClick: () => void }> = ({ label, color, active, onClick }) => (
+  <button
+    className="tui-button"
+    onClick={onClick}
+    style={{
+      padding: '6px 14px',
+      background: active ? color : '#222',
+      color: active ? '#000' : color,
+      fontWeight: 'bold',
+      border: `1px solid ${color}`,
+      cursor: 'pointer',
+      boxShadow: 'none',
+      fontFamily: 'monospace'
+    }}
+  >
+    {label}
+  </button>
+)
+
+const MissionList: React.FC<{ empty: string; children: React.ReactNode }> = ({ empty, children }) => {
+  const count = React.Children.count(children)
+  if (count === 0) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>
+        {empty}
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 12 }}>
+      {children}
+    </div>
+  )
+}
+
+const CardShell: React.FC<{ borderColor: string; children: React.ReactNode }> = ({ borderColor, children }) => (
+  <div
+    style={{
+      background: '#0f0f0f',
+      border: `1px solid ${borderColor}`,
+      padding: 14,
+      fontFamily: 'monospace'
+    }}
+  >
+    {children}
+  </div>
+)
+
+const MissionHeader: React.FC<{ mission: Mission; statusBadge?: React.ReactNode }> = ({ mission, statusBadge }) => (
+  <div style={{ marginBottom: 8 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+      <span style={{ color: '#22d3ee', fontWeight: 'bold', fontSize: '1.05em' }}>{mission.name}</span>
+      {statusBadge}
+    </div>
+    <div style={{ color: '#6b7280', fontSize: '0.75em', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <span style={{ fontFamily: 'monospace' }}>{mission.slug}</span>
+      {mission.arc ? <span style={{ color: '#a78bfa' }}>[{mission.arc.name}]</span> : null}
+      {mission.giver ? <span>giver: {mission.giver.name}</span> : null}
+      {mission.repeatable ? <span style={{ color: '#34d399' }}>(repeatable)</span> : null}
+    </div>
+  </div>
+)
+
+const ObjectivesList: React.FC<{ objectives: MissionObjective[]; progress?: ObjectiveProgress[] }> = ({ objectives, progress }) => {
+  const progressById = new Map<number, ObjectiveProgress>()
+  progress?.forEach(p => progressById.set(p.objective_id, p))
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ color: '#fbbf24', fontSize: '0.8em', marginBottom: 4 }}>Objectives:</div>
+      {objectives.map(o => {
+        const p = progressById.get(o.id)
+        const done = p?.completed === true
+        const current = p?.progress ?? 0
+        const target = o.target_count
+        return (
+          <div key={o.id} style={{ display: 'flex', gap: 6, alignItems: 'flex-start', fontSize: '0.9em', color: done ? '#34d399' : '#d0d0d0' }}>
+            <span style={{ color: done ? '#34d399' : '#6b7280', minWidth: 12 }}>{done ? '✓' : '▸'}</span>
+            <span style={{ flex: 1 }}>{o.label}</span>
+            {target > 1 && <span style={{ color: '#9ca3af', fontSize: '0.85em' }}>{current}/{target}</span>}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+const RewardsList: React.FC<{ rewards: MissionReward[] }> = ({ rewards }) => {
+  if (rewards.length === 0) return null
+  return (
+    <div style={{ marginTop: 10, paddingTop: 8, borderTop: '1px solid #2a2a2a', display: 'flex', flexWrap: 'wrap', gap: 10, fontSize: '0.8em' }}>
+      {rewards.map((r) => (
+        <span key={r.id} style={{ color: rewardColor(r) }}>{rewardLine(r)}</span>
+      ))}
+    </div>
+  )
+}
+
+const ActiveMissionCard: React.FC<{ hackrMission: HackrMission }> = ({ hackrMission }) => {
+  const m = hackrMission.mission
+  const ready = hackrMission.ready_to_turn_in
+  const badge = ready ? (
+    <span style={{ color: '#fbbf24', fontSize: '0.7em', background: '#221a00', padding: '2px 6px', border: '1px solid #fbbf24' }}>
+      READY FOR TURN-IN
+    </span>
+  ) : null
+
+  return (
+    <CardShell borderColor={ready ? '#fbbf24' : '#22d3ee'}>
+      <MissionHeader mission={m} statusBadge={badge} />
+      {m.description && <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: 6, lineHeight: 1.4 }}>{m.description}</div>}
+      <ObjectivesList objectives={m.objectives} progress={hackrMission.objective_progress} />
+      <RewardsList rewards={m.rewards} />
+      <div style={{ marginTop: 10, color: '#6b7280', fontSize: '0.75em' }}>
+        {ready
+          ? `Return to ${m.giver?.name ?? 'the giver'}. Use 'turn_in ${m.slug}' in the Terminal.`
+          : `Accepted ${formatDate(hackrMission.accepted_at)}.`}
+      </div>
+    </CardShell>
+  )
+}
+
+const AvailableMissionCard: React.FC<{ mission: Mission }> = ({ mission }) => (
+  <CardShell borderColor="#34d399">
+    <MissionHeader mission={mission} />
+    {mission.description && <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: 6, lineHeight: 1.4 }}>{mission.description}</div>}
+    <ObjectivesList objectives={mission.objectives} />
+    <RewardsList rewards={mission.rewards} />
+    <div style={{ marginTop: 10, color: '#6b7280', fontSize: '0.75em' }}>
+      Available. Use <code style={{ color: '#34d399' }}>accept {mission.slug}</code> in the Terminal
+      {mission.giver ? ` while in the same room as ${mission.giver.name}` : ''}.
+    </div>
+  </CardShell>
+)
+
+const CompletedMissionCard: React.FC<{ hackrMission: HackrMission }> = ({ hackrMission }) => {
+  const m = hackrMission.mission
+  const badge = hackrMission.turn_in_count > 1
+    ? (<span style={{ color: '#34d399', fontSize: '0.7em' }}>×{hackrMission.turn_in_count}</span>)
+    : null
+
+  return (
+    <CardShell borderColor="#4b5563">
+      <MissionHeader mission={m} statusBadge={badge} />
+      <div style={{ color: '#6b7280', fontSize: '0.75em' }}>
+        Completed {formatDate(hackrMission.completed_at)}
+      </div>
+      <RewardsList rewards={m.rewards} />
+    </CardShell>
+  )
+}
+
+export default MissionsPage

--- a/app/javascript/components/shared/AchievementToast.tsx
+++ b/app/javascript/components/shared/AchievementToast.tsx
@@ -1,12 +1,20 @@
 import React, { useState, useCallback } from 'react'
 import { useGridAuth } from '~/hooks/useGridAuth'
-import { useAchievementChannel, type AchievementUnlockEvent } from '~/hooks/useAchievementChannel'
+import {
+  useAchievementChannel,
+  type AchievementUnlockEvent,
+  type MissionCompletedEvent
+} from '~/hooks/useAchievementChannel'
 
 const TOAST_DURATION_MS = 6000
 
-interface ToastEntry extends AchievementUnlockEvent {
-  key: number
-}
+// Toasts have two shapes (achievement unlock + mission completion).
+// We union them and discriminate on `kind` at render time. Mission toasts
+// reuse the same stack / auto-dismiss / click-to-dismiss machinery so the
+// player sees one visual language regardless of source.
+type ToastEntry =
+  | ({ kind: 'achievement'; key: number } & AchievementUnlockEvent)
+  | ({ kind: 'mission'; key: number } & MissionCompletedEvent)
 
 const categoryColor = (category: string): string => {
   switch (category) {
@@ -18,6 +26,8 @@ const categoryColor = (category: string): string => {
   }
 }
 
+const makeKey = (): number => Date.now() + Math.random()
+
 export const AchievementToastContainer: React.FC = () => {
   const { hackr } = useGridAuth()
   const [toasts, setToasts] = useState<ToastEntry[]>([])
@@ -26,13 +36,24 @@ export const AchievementToastContainer: React.FC = () => {
     setToasts(prev => prev.filter(t => t.key !== key))
   }, [])
 
-  const onUnlock = useCallback((event: AchievementUnlockEvent) => {
-    const entry: ToastEntry = { ...event, key: Date.now() + Math.random() }
+  const pushToast = useCallback((entry: ToastEntry) => {
     setToasts(prev => [entry, ...prev].slice(0, 5))
     window.setTimeout(() => remove(entry.key), TOAST_DURATION_MS)
   }, [remove])
 
-  useAchievementChannel({ enabled: !!hackr, onUnlock })
+  const onUnlock = useCallback((event: AchievementUnlockEvent) => {
+    pushToast({ ...event, kind: 'achievement', key: makeKey() })
+  }, [pushToast])
+
+  const onMissionComplete = useCallback((event: MissionCompletedEvent) => {
+    pushToast({ ...event, kind: 'mission', key: makeKey() })
+    // Dispatch a DOM event so other components (e.g. MissionsPage) can
+    // react to mission completions without opening a second ActionCable
+    // subscription. Listeners use `window.addEventListener(...)`.
+    window.dispatchEvent(new CustomEvent('grid:mission_completed', { detail: event }))
+  }, [pushToast])
+
+  useAchievementChannel({ enabled: !!hackr, onUnlock, onMissionComplete })
 
   if (toasts.length === 0) return null
 
@@ -51,52 +72,104 @@ export const AchievementToastContainer: React.FC = () => {
       }}
     >
       {toasts.map((t) => {
-        const color = categoryColor(t.achievement.category)
-        return (
-          <div
-            key={t.key}
-            onClick={() => remove(t.key)}
-            style={{
-              pointerEvents: 'auto',
-              cursor: 'pointer',
-              background: '#111',
-              border: '2px solid #fbbf24',
-              padding: '12px 16px',
-              fontFamily: 'monospace',
-              color: '#d0d0d0',
-              boxShadow: '0 0 20px rgba(251, 191, 36, 0.4)',
-              animation: 'achievement-toast-slide-in 0.3s ease-out'
-            }}
-          >
-            <div style={{ color: '#fbbf24', fontSize: '0.8em', fontWeight: 'bold', letterSpacing: '1px', marginBottom: '4px' }}>
-              ACHIEVEMENT UNLOCKED
-              <span style={{ color, marginLeft: '8px' }}>[{t.achievement.category.toUpperCase()}]</span>
-            </div>
-            <div style={{ fontSize: '1.05em', marginBottom: '4px' }}>
-              {t.achievement.badge_icon ? (
-                <span style={{ color: '#fbbf24', marginRight: '6px' }}>{t.achievement.badge_icon}</span>
-              ) : null}
-              <span style={{ color: '#22d3ee', fontWeight: 'bold' }}>{t.achievement.name}</span>
-            </div>
-            {t.achievement.description ? (
-              <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: '6px' }}>
-                {t.achievement.description}
-              </div>
-            ) : null}
-            <div style={{ fontSize: '0.85em', display: 'flex', gap: '12px' }}>
-              {t.achievement.xp_reward > 0 && (
-                <span style={{ color: '#34d399' }}>+{t.achievement.xp_reward} XP</span>
-              )}
-              {t.achievement.cred_reward > 0 && (
-                <span style={{ color: '#fbbf24' }}>+{t.achievement.cred_reward} CRED</span>
-              )}
-              {t.leveled_up && t.new_clearance != null && (
-                <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>▲ CL {t.new_clearance}</span>
-              )}
-            </div>
-          </div>
-        )
+        if (t.kind === 'mission') return <MissionToast key={t.key} toast={t} onDismiss={() => remove(t.key)} />
+        return <AchievementToast key={t.key} toast={t} onDismiss={() => remove(t.key)} />
       })}
+    </div>
+  )
+}
+
+const AchievementToast: React.FC<{ toast: AchievementUnlockEvent; onDismiss: () => void }> = ({ toast, onDismiss }) => {
+  const color = categoryColor(toast.achievement.category)
+  return (
+    <div
+      onClick={onDismiss}
+      style={{
+        pointerEvents: 'auto',
+        cursor: 'pointer',
+        background: '#111',
+        border: '2px solid #fbbf24',
+        padding: '12px 16px',
+        fontFamily: 'monospace',
+        color: '#d0d0d0',
+        boxShadow: '0 0 20px rgba(251, 191, 36, 0.4)',
+        animation: 'achievement-toast-slide-in 0.3s ease-out'
+      }}
+    >
+      <div style={{ color: '#fbbf24', fontSize: '0.8em', fontWeight: 'bold', letterSpacing: '1px', marginBottom: '4px' }}>
+        ACHIEVEMENT UNLOCKED
+        <span style={{ color, marginLeft: '8px' }}>[{toast.achievement.category.toUpperCase()}]</span>
+      </div>
+      <div style={{ fontSize: '1.05em', marginBottom: '4px' }}>
+        {toast.achievement.badge_icon ? (
+          <span style={{ color: '#fbbf24', marginRight: '6px' }}>{toast.achievement.badge_icon}</span>
+        ) : null}
+        <span style={{ color: '#22d3ee', fontWeight: 'bold' }}>{toast.achievement.name}</span>
+      </div>
+      {toast.achievement.description ? (
+        <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: '6px' }}>
+          {toast.achievement.description}
+        </div>
+      ) : null}
+      <div style={{ fontSize: '0.85em', display: 'flex', gap: '12px' }}>
+        {toast.achievement.xp_reward > 0 && (
+          <span style={{ color: '#34d399' }}>+{toast.achievement.xp_reward} XP</span>
+        )}
+        {toast.achievement.cred_reward > 0 && (
+          <span style={{ color: '#fbbf24' }}>+{toast.achievement.cred_reward} CRED</span>
+        )}
+        {toast.leveled_up && toast.new_clearance != null && (
+          <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>▲ CL {toast.new_clearance}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const MissionToast: React.FC<{ toast: MissionCompletedEvent; onDismiss: () => void }> = ({ toast, onDismiss }) => {
+  const { rewards } = toast
+  return (
+    <div
+      onClick={onDismiss}
+      style={{
+        pointerEvents: 'auto',
+        cursor: 'pointer',
+        background: '#111',
+        border: '2px solid #22d3ee',
+        padding: '12px 16px',
+        fontFamily: 'monospace',
+        color: '#d0d0d0',
+        boxShadow: '0 0 20px rgba(34, 211, 238, 0.4)',
+        animation: 'achievement-toast-slide-in 0.3s ease-out'
+      }}
+    >
+      <div style={{ color: '#22d3ee', fontSize: '0.8em', fontWeight: 'bold', letterSpacing: '1px', marginBottom: '4px' }}>
+        MISSION COMPLETE
+        {toast.mission.arc_name ? (
+          <span style={{ color: '#a78bfa', marginLeft: '8px' }}>[{toast.mission.arc_name}]</span>
+        ) : null}
+      </div>
+      <div style={{ fontSize: '1.05em', marginBottom: '6px' }}>
+        <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>{toast.mission.name}</span>
+      </div>
+      <div style={{ fontSize: '0.85em', display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+        {rewards.xp > 0 && <span style={{ color: '#34d399' }}>+{rewards.xp} XP</span>}
+        {rewards.cred > 0 && <span style={{ color: '#fbbf24' }}>+{rewards.cred} CRED</span>}
+        {rewards.rep.map((r, i) => (
+          <span key={`rep-${i}`} style={{ color: r.delta >= 0 ? '#34d399' : '#ef4444' }}>
+            {r.delta >= 0 ? '+' : ''}{r.delta} {r.faction}
+          </span>
+        ))}
+        {rewards.items.map((item, i) => (
+          <span key={`item-${i}`} style={{ color: '#60a5fa' }}>+ {item.name}</span>
+        ))}
+        {rewards.achievements.map((a, i) => (
+          <span key={`ach-${i}`} style={{ color: '#fbbf24' }}>◆ {a.name}</span>
+        ))}
+        {toast.leveled_up && toast.new_clearance != null && (
+          <span style={{ color: '#fbbf24', fontWeight: 'bold' }}>▲ CL {toast.new_clearance}</span>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/javascript/hooks/useAchievementChannel.ts
+++ b/app/javascript/hooks/useAchievementChannel.ts
@@ -19,28 +19,53 @@ export interface AchievementUnlockEvent {
   new_clearance: number | null
 }
 
+export interface MissionCompletionRewards {
+  xp: number
+  cred: number
+  rep: Array<{ faction: string; delta: number }>
+  items: Array<{ name: string }>
+  achievements: Array<{ slug: string; name: string }>
+}
+
+export interface MissionCompletedEvent {
+  type: 'mission_completed'
+  mission: { slug: string; name: string; arc_name: string | null }
+  rewards: MissionCompletionRewards
+  leveled_up: boolean
+  new_clearance: number | null
+}
+
+// Union of every event the channel fans out. The server discriminates on
+// `type` so clients can filter without a separate channel per feature.
+export type GridChannelEvent = AchievementUnlockEvent | MissionCompletedEvent
+
 interface UseAchievementChannelOptions {
   enabled: boolean
-  onUnlock: (event: AchievementUnlockEvent) => void
+  onUnlock?: (event: AchievementUnlockEvent) => void
+  onMissionComplete?: (event: MissionCompletedEvent) => void
 }
 
 /**
- * Subscribes to the per-hackr AchievementChannel stream. When any
- * achievement unlocks (via Terminal action, content-surface trigger, or
- * login sweep job), the server broadcasts to this channel and the hook
- * invokes `onUnlock`. Only active while `enabled` is true (logged in).
+ * Subscribes to the per-hackr AchievementChannel stream. Routes inbound
+ * events by `type` to the appropriate callback. The channel carries
+ * achievement unlocks AND mission completion broadcasts — one WebSocket
+ * subscription serves both surfaces. Only active while `enabled` is true.
  *
  * Reuses the shared ActionCable consumer (`lib/actionCableConsumer`)
  * so there is one WebSocket for the whole app — this hook only
  * manages its own subscription lifecycle.
  */
-export const useAchievementChannel = ({ enabled, onUnlock }: UseAchievementChannelOptions) => {
+export const useAchievementChannel = ({ enabled, onUnlock, onMissionComplete }: UseAchievementChannelOptions) => {
   const channelRef = useRef<Channel | null>(null)
-  const handlerRef = useRef(onUnlock)
+  const unlockRef = useRef(onUnlock)
+  const missionRef = useRef(onMissionComplete)
 
   useEffect(() => {
-    handlerRef.current = onUnlock
+    unlockRef.current = onUnlock
   }, [onUnlock])
+  useEffect(() => {
+    missionRef.current = onMissionComplete
+  }, [onMissionComplete])
 
   const connect = useCallback(() => {
     if (!enabled) return
@@ -49,9 +74,11 @@ export const useAchievementChannel = ({ enabled, onUnlock }: UseAchievementChann
     channelRef.current = cable.subscriptions.create(
       { channel: 'AchievementChannel' },
       {
-        received (data: AchievementUnlockEvent) {
+        received (data: GridChannelEvent) {
           if (data?.type === 'achievement_unlocked') {
-            handlerRef.current(data)
+            unlockRef.current?.(data)
+          } else if (data?.type === 'mission_completed') {
+            missionRef.current?.(data)
           }
         }
       }

--- a/app/javascript/types/mission.ts
+++ b/app/javascript/types/mission.ts
@@ -1,0 +1,65 @@
+// Shape of /api/grid/missions response and related SPA types.
+
+export type MissionStatus = 'active' | 'completed' | 'available'
+
+export interface MissionObjective {
+  id: number
+  position: number
+  objective_type: string
+  label: string
+  target_slug: string | null
+  target_count: number
+}
+
+export interface MissionReward {
+  id: number
+  reward_type: 'xp' | 'cred' | 'faction_rep' | 'item_grant' | 'grant_achievement'
+  amount: number
+  target_slug: string | null
+  quantity: number
+}
+
+export interface MissionGates {
+  clearance_met: boolean
+  prereq_met: boolean
+  rep_met: boolean
+}
+
+export interface Mission {
+  slug: string
+  name: string
+  description: string | null
+  repeatable: boolean
+  arc: { slug: string; name: string } | null
+  giver: { name: string; room_id: number | null; room_slug: string | null } | null
+  prereq_slug: string | null
+  min_clearance: number
+  min_rep: { faction_slug: string; value: number } | null
+  objectives: MissionObjective[]
+  rewards: MissionReward[]
+  gates?: MissionGates
+}
+
+export interface ObjectiveProgress {
+  objective_id: number
+  progress: number
+  target_count: number
+  completed: boolean
+}
+
+export interface HackrMission {
+  id: number
+  status: 'active' | 'completed'
+  accepted_at: string
+  completed_at: string | null
+  turn_in_count: number
+  mission: Mission
+  objective_progress?: ObjectiveProgress[]
+  ready_to_turn_in?: boolean
+}
+
+export interface MissionsIndexResponse {
+  active: HackrMission[]
+  completed: HackrMission[]
+  available: Mission[]
+}

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -41,6 +41,7 @@ class GridAchievement < ApplicationRecord
     salvage_item
     salvage_count
     manual
+    purchase_item
     track_plays_count
     pulse_vault_completed
     hackr_logs_read
@@ -57,6 +58,8 @@ class GridAchievement < ApplicationRecord
     radio_stations_tuned
     radio_stations_tuned_all
     clearance_level
+    missions_completed_count
+    mission_completed
   ].freeze
 
   CATEGORIES = %w[grid music social meta progression].freeze
@@ -73,6 +76,7 @@ class GridAchievement < ApplicationRecord
     wire_pulses_count uplink_packets_count playlists_created
     vods_watched radio_stations_tuned radio_stations_tuned_all
     clearance_level
+    missions_completed_count
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -95,6 +95,8 @@ class GridHackr < ApplicationRecord
   has_many :hackr_page_views, dependent: :destroy
   has_many :hackr_vod_watches, dependent: :destroy
   has_many :hackr_radio_tunes, dependent: :destroy
+  has_many :grid_hackr_missions, dependent: :destroy
+  has_many :grid_missions, through: :grid_hackr_missions
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length

--- a/app/models/grid_hackr_mission.rb
+++ b/app/models/grid_hackr_mission.rb
@@ -1,0 +1,99 @@
+# == Schema Information
+#
+# Table name: grid_hackr_missions
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  accepted_at     :datetime         not null
+#  completed_at    :datetime
+#  status          :string           default("active"), not null
+#  turn_in_count   :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_missions_on_grid_hackr_id    (grid_hackr_id)
+#  index_grid_hackr_missions_on_grid_mission_id  (grid_mission_id)
+#  index_hackr_missions_on_hackr_and_status      (grid_hackr_id,status)
+#  index_hackr_missions_unique_active            (grid_hackr_id,grid_mission_id) UNIQUE WHERE status = 'active'
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+class GridHackrMission < ApplicationRecord
+  STATUSES = %w[active completed].freeze
+
+  belongs_to :grid_hackr
+  belongs_to :grid_mission
+
+  has_many :grid_hackr_mission_objectives, dependent: :destroy
+
+  validates :status, inclusion: {in: STATUSES}
+  validate :one_active_instance_per_mission, on: :create
+
+  before_validation { self.accepted_at ||= Time.current }
+
+  scope :active, -> { where(status: "active") }
+  scope :completed, -> { where(status: "completed") }
+  scope :for_hackr, ->(h) { where(grid_hackr: h) }
+
+  def active?
+    status == "active"
+  end
+
+  def completed?
+    status == "completed"
+  end
+
+  # Returns true once every objective row (one per mission objective) has
+  # `completed_at` set. Evaluated live at `turn_in!` time — no stored
+  # `ready_to_turn_in` state, which prevents drift when objectives advance
+  # through async paths (login-sweep, rep changes, clearance level-ups).
+  # Uses preloaded associations when available (the missions API + terminal
+  # listing both preload `grid_hackr_mission_objectives` and nested
+  # `grid_mission.grid_mission_objectives`). Falls back to `pluck` only
+  # for unpreloaded callers so turn_in! on a fresh record still works.
+  def all_objectives_completed?
+    required_ids =
+      if grid_mission.association(:grid_mission_objectives).loaded?
+        grid_mission.grid_mission_objectives.map(&:id)
+      else
+        grid_mission.grid_mission_objectives.pluck(:id)
+      end
+    return false if required_ids.empty?
+
+    completed_ids =
+      if association(:grid_hackr_mission_objectives).loaded?
+        grid_hackr_mission_objectives.select { |o| o.completed_at.present? }.map(&:grid_mission_objective_id)
+      else
+        grid_hackr_mission_objectives.where.not(completed_at: nil).pluck(:grid_mission_objective_id)
+      end
+
+    (required_ids - completed_ids).empty?
+  end
+
+  private
+
+  # Completed rows accumulate for history (and count toward
+  # `missions_completed_count` achievements), so there is no DB unique
+  # index on (hackr, mission). Guard accept-time to prevent two active
+  # instances of the same mission — repeatables re-accept by creating a
+  # fresh row only AFTER the previous one is completed or destroyed.
+  # Validation is `on: :create` — `id` is always nil at this point, so
+  # `.where.not(id: id)` was a no-op. Dropped to match reality. The
+  # DB-level partial unique index (`index_hackr_missions_unique_active`)
+  # is the authoritative guard; this validator surfaces the error before
+  # the INSERT for a friendlier message.
+  def one_active_instance_per_mission
+    return unless status == "active" && grid_hackr_id && grid_mission_id
+    exists = self.class.active.where(
+      grid_hackr_id: grid_hackr_id, grid_mission_id: grid_mission_id
+    ).exists?
+    errors.add(:base, "already has an active instance of this mission") if exists
+  end
+end

--- a/app/models/grid_hackr_mission_objective.rb
+++ b/app/models/grid_hackr_mission_objective.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: grid_hackr_mission_objectives
+# Database name: primary
+#
+#  id                        :integer          not null, primary key
+#  completed_at              :datetime
+#  progress                  :integer          default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  grid_hackr_mission_id     :integer          not null
+#  grid_mission_objective_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_mission_objs_on_hackr_mission  (grid_hackr_mission_id)
+#  index_hackr_mission_objs_on_objective      (grid_mission_objective_id)
+#  index_hackr_mission_objs_unique            (grid_hackr_mission_id,grid_mission_objective_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_mission_id      (grid_hackr_mission_id => grid_hackr_missions.id) ON DELETE => cascade
+#  grid_mission_objective_id  (grid_mission_objective_id => grid_mission_objectives.id) ON DELETE => restrict
+#
+class GridHackrMissionObjective < ApplicationRecord
+  belongs_to :grid_hackr_mission
+  belongs_to :grid_mission_objective
+
+  validates :grid_mission_objective_id, uniqueness: {scope: :grid_hackr_mission_id}
+  validates :progress, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :completed, -> { where.not(completed_at: nil) }
+
+  def completed?
+    completed_at.present?
+  end
+end

--- a/app/models/grid_mission.rb
+++ b/app/models/grid_mission.rb
@@ -1,0 +1,89 @@
+# == Schema Information
+#
+# Table name: grid_missions
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  description         :text
+#  min_clearance       :integer          default(0), not null
+#  min_rep_value       :integer          default(0), not null
+#  name                :string           not null
+#  position            :integer          default(0), not null
+#  published           :boolean          default(FALSE), not null
+#  repeatable          :boolean          default(FALSE), not null
+#  slug                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  giver_mob_id        :integer
+#  grid_mission_arc_id :integer
+#  min_rep_faction_id  :integer
+#  prereq_mission_id   :integer
+#
+# Indexes
+#
+#  index_grid_missions_on_giver_mob_id         (giver_mob_id)
+#  index_grid_missions_on_grid_mission_arc_id  (grid_mission_arc_id)
+#  index_grid_missions_on_min_rep_faction_id   (min_rep_faction_id)
+#  index_grid_missions_on_prereq_mission_id    (prereq_mission_id)
+#  index_grid_missions_on_slug                 (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  giver_mob_id         (giver_mob_id => grid_mobs.id) ON DELETE => nullify
+#  grid_mission_arc_id  (grid_mission_arc_id => grid_mission_arcs.id) ON DELETE => nullify
+#  min_rep_faction_id   (min_rep_faction_id => grid_factions.id) ON DELETE => nullify
+#  prereq_mission_id    (prereq_mission_id => grid_missions.id) ON DELETE => nullify
+#
+class GridMission < ApplicationRecord
+  # Objective type allowlist. Extending the mission system with a new
+  # action verb is a three-line change: add here, add case branch in
+  # Grid::MissionProgressor#record, and wire a `progressor.record(:...)`
+  # call into the command that fires the event. No schema migration.
+  OBJECTIVE_TYPES = %w[
+    visit_room talk_npc collect_item deliver_item
+    spend_cred buy_item reach_rep reach_clearance
+    use_item salvage_item
+  ].freeze
+
+  # Reward type allowlist. `amount` is the scalar for XP/CRED/rep deltas;
+  # `target_slug` points the row at a faction/item/achievement;
+  # `quantity` scales item grants. Mission unlocks are expressed as
+  # `prereq_mission_id` on the next mission — not a reward row — so
+  # there's no stored no-op data and the admin UI reads prereqs directly.
+  REWARD_TYPES = %w[
+    xp cred faction_rep item_grant grant_achievement
+  ].freeze
+
+  belongs_to :giver_mob, class_name: "GridMob", optional: true
+  belongs_to :grid_mission_arc, optional: true
+  belongs_to :prereq_mission, class_name: "GridMission", optional: true
+  belongs_to :min_rep_faction, class_name: "GridFaction", optional: true
+
+  has_many :grid_mission_objectives, -> { order(:position) }, dependent: :destroy
+  has_many :grid_mission_rewards, -> { order(:position) }, dependent: :destroy
+  has_many :grid_hackr_missions, dependent: :destroy
+
+  accepts_nested_attributes_for :grid_mission_objectives, allow_destroy: true,
+    reject_if: ->(attrs) { attrs["objective_type"].blank? && attrs["label"].blank? }
+  accepts_nested_attributes_for :grid_mission_rewards, allow_destroy: true,
+    reject_if: ->(attrs) { attrs["reward_type"].blank? }
+
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+  validates :giver_mob_id, presence: {message: "is required for published missions"}, if: :published?
+  validate :prereq_not_self
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(:position, :name) }
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def prereq_not_self
+    return unless prereq_mission_id.present? && prereq_mission_id == id
+    errors.add(:prereq_mission_id, "cannot reference itself")
+  end
+end

--- a/app/models/grid_mission_arc.rb
+++ b/app/models/grid_mission_arc.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: grid_mission_arcs
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer          default(0), not null
+#  published   :boolean          default(FALSE), not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_mission_arcs_on_slug  (slug) UNIQUE
+#
+class GridMissionArc < ApplicationRecord
+  has_many :grid_missions, dependent: :nullify
+
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(:position, :name) }
+
+  def to_param
+    slug
+  end
+end

--- a/app/models/grid_mission_objective.rb
+++ b/app/models/grid_mission_objective.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: grid_mission_objectives
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  label           :string           not null
+#  objective_type  :string           not null
+#  position        :integer          default(0), not null
+#  target_count    :integer          default(1), not null
+#  target_slug     :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_mission_objectives_on_grid_mission_id  (grid_mission_id)
+#  index_mission_objectives_on_mission_and_position  (grid_mission_id,position)
+#
+# Foreign Keys
+#
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+class GridMissionObjective < ApplicationRecord
+  belongs_to :grid_mission
+  has_many :grid_hackr_mission_objectives, dependent: :restrict_with_exception
+
+  validates :objective_type, presence: true, inclusion: {in: GridMission::OBJECTIVE_TYPES}
+  validates :label, presence: true
+  validates :target_count, numericality: {only_integer: true, greater_than: 0}
+end

--- a/app/models/grid_mission_reward.rb
+++ b/app/models/grid_mission_reward.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: grid_mission_rewards
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  amount          :integer          default(0), not null
+#  position        :integer          default(0), not null
+#  quantity        :integer          default(1), not null
+#  reward_type     :string           not null
+#  target_slug     :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_mission_rewards_on_grid_mission_id  (grid_mission_id)
+#
+# Foreign Keys
+#
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+class GridMissionReward < ApplicationRecord
+  belongs_to :grid_mission
+
+  validates :reward_type, presence: true, inclusion: {in: GridMission::REWARD_TYPES}
+  validates :amount, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :quantity, numericality: {only_integer: true, greater_than: 0}
+end

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -19,6 +19,9 @@ class GridMob < ApplicationRecord
   belongs_to :grid_faction, optional: true
   has_many :grid_shop_listings, dependent: :destroy
   has_many :grid_shop_transactions, dependent: :nullify
+  # When a giver mob is deleted, the missions lose their giver (FK nullified
+  # at the DB level). Missions are world data — an admin can reassign.
+  has_many :given_missions, class_name: "GridMission", foreign_key: :giver_mob_id, dependent: :nullify
 
   validates :name, presence: true
   validates :mob_type, inclusion: {in: %w[quest_giver vendor lore special], allow_nil: true}
@@ -26,6 +29,10 @@ class GridMob < ApplicationRecord
 
   def vendor?
     mob_type == "vendor"
+  end
+
+  def quest_giver?
+    mob_type == "quest_giver"
   end
 
   def shop_type

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -100,6 +100,8 @@ module Grid
         derive(radio_stations_tuned_visible_count, radio_stations_visible_total)
       when "clearance_level"
         derive(@hackr.stat("clearance").to_i, data[:level].to_i)
+      when "missions_completed_count"
+        derive(missions_completed_count, data[:count].to_i)
       end
     end
 
@@ -249,6 +251,17 @@ module Grid
         .joins(:radio_station).merge(RadioStation.visible).count
     end
 
+    def missions_completed_count
+      return @missions_completed_count if defined?(@missions_completed_count)
+      # Turn-ins increment `turn_in_count` on the (possibly repeatable)
+      # hackr_mission row. A repeatable mission turned in 3 times should
+      # count as 3 completions toward the achievement ladder; a single
+      # completed row is at minimum 1 turn-in.
+      @missions_completed_count = @hackr.grid_hackr_missions
+        .where(status: "completed")
+        .sum(:turn_in_count)
+    end
+
     def matches?(achievement, context)
       # Event-only triggers — unlock fires on the specific action, not
       # a cumulative threshold. These are never catch-up swept.
@@ -266,6 +279,14 @@ module Grid
         return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
       when "salvage_item"
         return true
+      when "purchase_item"
+        return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
+      when "mission_completed"
+        # Fires when a specific mission turns in. `mission_slug` in
+        # trigger_data pins the achievement to a specific mission;
+        # leaving it blank unlocks on ANY mission turn-in (rarely
+        # useful — `missions_completed_count` covers the generic case).
+        return data[:mission_slug].blank? || data[:mission_slug].to_s == context[:mission_slug].to_s
       when "manual"
         return false
       end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -76,6 +76,18 @@ module Grid
         buy_command(args.join(" "))
       when "sell"
         sell_command(args.join(" "))
+      when "missions", "quests"
+        missions_command
+      when "mission", "quest"
+        mission_detail_command(args.first)
+      when "accept"
+        accept_mission_command(args.first)
+      when "abandon"
+        abandon_mission_command(args.first)
+      when "turn_in", "turnin", "ti"
+        turn_in_command(args.first)
+      when "give"
+        give_command(args)
       when "help", "?"
         help_command
       when "who"
@@ -176,6 +188,10 @@ module Grid
       look_output = look_command
       notifications = achievement_checker.check(:room_visit, room_slug: new_room.slug)
       notifications += achievement_checker.check(:rooms_visited)
+      notifications += mission_progressor.record(:visit_room, room_slug: new_room.slug)
+      # Clearance may have changed if level-up happened above; check missions
+      # that track reach_clearance too (cheap — progressor no-ops if none exist).
+      notifications += mission_progressor.record(:reach_clearance, clearance: hackr.stat("clearance").to_i)
       look_output = append_notifications(look_output, notifications)
 
       {
@@ -256,6 +272,7 @@ module Grid
       notifications = achievement_checker.check(:take_item, item_name: item.name)
       notifications += achievement_checker.check(:items_collected)
       notifications += achievement_checker.check(:rarity_owned, rarity: item.rarity) if item.rarity.present?
+      notifications += mission_progressor.record(:collect_item, item_name: item.name)
       output = append_notifications(output, notifications)
 
       {
@@ -358,6 +375,15 @@ module Grid
       rep_notif = grant_faction_rep(mob.grid_faction, 1, reason: "talk:#{slugify(mob.name)}", source: mob)
       notifications = achievement_checker.check(:talk_npc, npc_name: mob.name)
       notifications.unshift(rep_notif) if rep_notif
+      notifications += mission_progressor.record(:talk_npc, npc_name: mob.name)
+      # Rep changed from the talk grant — fire reach_rep for this faction.
+      if mob.grid_faction
+        notifications += mission_progressor.record(
+          :reach_rep,
+          faction_slug: mob.grid_faction.slug,
+          rep_value: reputation_service.effective_rep(mob.grid_faction)
+        )
+      end
       append_notifications(output, notifications)
     end
 
@@ -388,6 +414,13 @@ module Grid
       dialogue = mob.dialogue_tree
       topics = dialogue["topics"] || {}
 
+      # Mission intercepts — checked BEFORE topic dictionary lookup so a
+      # quest_giver's topic list doesn't need to enumerate every mission
+      # slug or the literal "missions"/"work" keyword. A dialogue_tree
+      # topic with the same key still overrides if the author defined one.
+      mission_topic = mission_topic_response(mob, topic, room)
+      return dialogue_box(mission_topic) if mission_topic
+
       # Try exact match first, then case-insensitive match
       response = topics[topic] || topics[topic.downcase] || topics.find { |k, v| k.downcase == topic.downcase }&.last
 
@@ -398,6 +431,120 @@ module Grid
         content = "<span style='color: #c084fc;'>#{h(mob.name)}</span> doesn't know about '#{h(topic)}'. <span style='color: #9ca3af;'>Try asking about:</span> <span style='color: #fbbf24;'>#{available}</span>"
       end
       dialogue_box(content)
+    end
+
+    # Returns HTML content (without dialogue_box wrapping) when `topic`
+    # is a mission-related keyword or a specific mission slug offered by
+    # this NPC. Nil otherwise — caller falls through to generic topics.
+    def mission_topic_response(mob, topic, room)
+      normalized = topic.to_s.downcase.strip
+      return missions_offered_by_response(mob, room) if %w[missions quests work assignments].include?(normalized)
+
+      # Specific mission slug lookup. Case-insensitive. Match only missions
+      # this NPC actually gives.
+      mission = GridMission.published.find_by(
+        "LOWER(slug) = ? AND giver_mob_id = ?", normalized, mob.id
+      )
+      return mission_brief_response(mob, mission, room) if mission
+
+      nil
+    end
+
+    def missions_offered_by_response(mob, room)
+      available = mission_service.available_missions(room).select { |m| m.giver_mob_id == mob.id }
+      if available.empty?
+        return "<span style='color: #c084fc;'>#{h(mob.name)}</span>: " \
+          "<span style='color: #60a5fa;'>\"Nothing for you right now.\"</span>"
+      end
+
+      lines = ["<span style='color: #c084fc;'>#{h(mob.name)}</span>: " \
+        "<span style='color: #60a5fa;'>\"Here's what I've got.\"</span>"]
+      lines << ""
+      available.each do |m|
+        arc = m.grid_mission_arc ? " <span style='color: #6b7280;'>[#{h(m.grid_mission_arc.name)}]</span>" : ""
+        rep_tag = m.repeatable? ? " <span style='color: #34d399;'>(repeatable)</span>" : ""
+        lines << "  <span style='color: #fbbf24;'>#{h(m.slug)}</span>#{rep_tag} " \
+          "<span style='color: #9ca3af;'>::</span> <span style='color: #d0d0d0;'>#{h(m.name)}</span>#{arc}"
+        lines << "    <span style='color: #6b7280;'>#{h(m.description.to_s.truncate(120))}</span>" if m.description.present?
+      end
+      lines << ""
+      lines << "<span style='color: #9ca3af;'>Use 'ask #{h(mob.name)} about &lt;slug&gt;' for details, or 'accept &lt;slug&gt;' to take the job.</span>"
+      lines.join("\n")
+    end
+
+    def mission_brief_response(mob, mission, room)
+      lines = []
+      arc = mission.grid_mission_arc ? " <span style='color: #6b7280;'>[#{h(mission.grid_mission_arc.name)}]</span>" : ""
+      # Giver may be nil — schema allows it and the loader leaves the FK
+      # null if the YAML `giver_mob_name` can't be resolved. Render a
+      # neutral header rather than dereferencing nil.
+      speaker = mob ? "<span style='color: #c084fc;'>#{h(mob.name)}</span>: " : ""
+      lines << "#{speaker}<span style='color: #22d3ee; font-weight: bold;'>#{h(mission.name)}</span>#{arc}"
+      lines << "<span style='color: #d0d0d0;'>#{h(mission.description)}</span>" if mission.description.present?
+
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Objectives:</span>"
+      mission.grid_mission_objectives.each do |obj|
+        lines << "  <span style='color: #9ca3af;'>▸</span> #{h(obj.label)}" + ((obj.target_count > 1) ? " <span style='color: #6b7280;'>(×#{obj.target_count})</span>" : "")
+      end
+
+      rewards_summary = mission_rewards_summary(mission)
+      if rewards_summary.present?
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>Rewards:</span> #{rewards_summary}"
+      end
+
+      status_hint = mission_status_hint(mission, room)
+      lines << ""
+      lines << status_hint if status_hint
+      lines.join("\n")
+    end
+
+    def mission_rewards_summary(mission)
+      parts = []
+      mission.grid_mission_rewards.each do |r|
+        case r.reward_type
+        when "xp"
+          parts << "<span style='color: #34d399;'>+#{r.amount} XP</span>" if r.amount.to_i.positive?
+        when "cred"
+          parts << "<span style='color: #fbbf24;'>+#{r.amount} CRED</span>" if r.amount.to_i.positive?
+        when "faction_rep"
+          sign = (r.amount.to_i >= 0) ? "+" : ""
+          color = (r.amount.to_i >= 0) ? "#34d399" : "#ef4444"
+          parts << "<span style='color: #{color};'>#{sign}#{r.amount} rep</span> <span style='color: #9ca3af;'>(#{h(r.target_slug.to_s)})</span>" if r.amount.to_i != 0
+        when "item_grant"
+          qty_tag = (r.quantity.to_i > 1) ? " x#{r.quantity}" : ""
+          parts << "<span style='color: #22d3ee;'>+ #{h(r.target_slug.to_s)}#{qty_tag}</span>"
+        when "grant_achievement"
+          parts << "<span style='color: #fbbf24;'>◆ Achievement</span>"
+        end
+      end
+      parts.join(" <span style='color: #4b5563;'>|</span> ")
+    end
+
+    def mission_status_hint(mission, room)
+      active = hackr.grid_hackr_missions.active.where(grid_mission_id: mission.id).exists?
+      return "<span style='color: #fbbf24;'>You're already working on this. Use 'mission #{h(mission.slug)}' to see progress.</span>" if active
+
+      completed_count = hackr.grid_hackr_missions.completed.where(grid_mission_id: mission.id).sum(:turn_in_count)
+      if completed_count.positive? && !mission.repeatable?
+        return "<span style='color: #9ca3af;'>You've already completed this job.</span>"
+      end
+
+      reason = refusal_reason(mission, room)
+      if reason
+        "<span style='color: #f87171;'>#{reason}</span>"
+      else
+        "<span style='color: #34d399;'>Available. Use 'accept #{h(mission.slug)}' to take this job.</span>"
+      end
+    end
+
+    def refusal_reason(mission, room)
+      unless room && mission.giver_mob_id && room.grid_mobs.exists?(id: mission.giver_mob_id)
+        return "You need to speak to the giver in person to accept."
+      end
+      status = mission_service.gate_status(mission)
+      status.reason ? h(status.reason) : nil
     end
 
     def help_command
@@ -422,6 +569,15 @@ module Grid
         <span style='color: #fbbf24;'>NPCs:</span>
           <span style='color: #34d399;'>talk &lt;npc&gt;</span>                - Talk to an NPC
           <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>   - Ask an NPC about a topic
+          <span style='color: #34d399;'>give &lt;item&gt; to &lt;npc&gt;</span>     - Hand an item to an NPC (for delivery missions)
+
+        <span style='color: #fbbf24;'>Missions:</span>
+          <span style='color: #34d399;'>missions</span>                  - List your active missions
+          <span style='color: #34d399;'>mission &lt;slug&gt;</span>           - View details for a specific mission
+          <span style='color: #34d399;'>ask &lt;npc&gt; about missions</span> - See what work an NPC is offering
+          <span style='color: #34d399;'>accept &lt;slug&gt;</span>            - Accept a mission (must be with giver)
+          <span style='color: #34d399;'>abandon &lt;slug&gt;</span>           - Drop an active mission
+          <span style='color: #34d399;'>turn_in &lt;slug&gt;, ti</span>       - Turn in a completed mission (must be with giver)
 
         <span style='color: #fbbf24;'>Commerce:</span>
           <span style='color: #34d399;'>shop, browse</span>              - View vendor inventory &amp; prices
@@ -598,6 +754,7 @@ module Grid
       end
 
       notifications = achievement_checker.check(:use_item, item_name: saved_name)
+      notifications += mission_progressor.record(:use_item, item_name: saved_name)
       output = append_notifications(result, notifications)
       {output: output, event: nil}
     end
@@ -624,6 +781,8 @@ module Grid
 
       notifications = achievement_checker.check(:salvage_item)
       notifications += achievement_checker.check(:salvage_count)
+      notifications += mission_progressor.record(:salvage_item, item_name: item.name)
+      notifications += mission_progressor.record(:reach_clearance, clearance: hackr.stat("clearance").to_i)
       output = append_notifications(output, notifications)
       {output: output, event: nil}
     end
@@ -809,6 +968,15 @@ module Grid
       rep_notif = grant_faction_rep(vendor.grid_faction, 2, reason: "buy:#{slugify(item.name)}", source: vendor)
       notifications = achievement_checker.check(:purchase_item, item_name: item.name)
       notifications.unshift(rep_notif) if rep_notif
+      notifications += mission_progressor.record(:buy_item, item_name: item.name)
+      notifications += mission_progressor.record(:spend_cred, amount: result[:price_paid].to_i)
+      if vendor.grid_faction
+        notifications += mission_progressor.record(
+          :reach_rep,
+          faction_slug: vendor.grid_faction.slug,
+          rep_value: reputation_service.effective_rep(vendor.grid_faction)
+        )
+      end
       output = append_notifications(output, notifications)
       {output: output, event: nil}
     rescue Grid::ShopService::AccessDenied => e
@@ -1383,6 +1551,267 @@ module Grid
 
     def reputation_service
       @reputation_service ||= Grid::ReputationService.new(hackr)
+    end
+
+    def mission_service
+      @mission_service ||= Grid::MissionService.new(hackr)
+    end
+
+    def mission_progressor
+      @mission_progressor ||= Grid::MissionProgressor.new(hackr)
+    end
+
+    # --- Mission commands ---
+
+    def missions_command
+      active = mission_service.active_hackr_missions.to_a
+      completed = mission_service.completed_hackr_missions(limit: 5).to_a
+
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output << "<span style='color: #22d3ee; font-weight: bold;'>ACTIVE MISSIONS</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+
+      if active.empty?
+        output << ""
+        output << "<span style='color: #9ca3af;'>You have no active missions.</span>"
+        output << "<span style='color: #6b7280;'>Talk to NPCs and 'ask &lt;npc&gt; about missions' to find work.</span>"
+      else
+        active.each do |hm|
+          output << ""
+          output << format_active_mission_row(hm)
+        end
+      end
+
+      if completed.any?
+        output << ""
+        output << "<span style='color: #fbbf24;'>Recently completed:</span>"
+        completed.each do |hm|
+          m = hm.grid_mission
+          output << "  <span style='color: #34d399;'>✓</span> <span style='color: #6b7280;'>#{h(m.slug)}</span> " \
+            "<span style='color: #9ca3af;'>::</span> <span style='color: #d0d0d0;'>#{h(m.name)}</span>" +
+            ((hm.turn_in_count.to_i > 1) ? " <span style='color: #6b7280;'>(×#{hm.turn_in_count})</span>" : "")
+        end
+      end
+
+      output << ""
+      output << "<span style='color: #6b7280;'>Commands: mission &lt;slug&gt; | accept &lt;slug&gt; | turn_in &lt;slug&gt; | abandon &lt;slug&gt;</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output.join("\n")
+    end
+
+    def format_active_mission_row(hackr_mission)
+      m = hackr_mission.grid_mission
+      giver = m.giver_mob ? " <span style='color: #6b7280;'>[giver: #{h(m.giver_mob.name)}]</span>" : ""
+      arc = m.grid_mission_arc ? " <span style='color: #6b7280;'>[#{h(m.grid_mission_arc.name)}]</span>" : ""
+
+      lines = []
+      lines << "  <span style='color: #fbbf24;'>#{h(m.slug)}</span> " \
+        "<span style='color: #9ca3af;'>::</span> <span style='color: #22d3ee;'>#{h(m.name)}</span>#{giver}#{arc}"
+
+      all_done, obj_lines = mission_objective_lines(hackr_mission, indent: "    ")
+      lines.concat(obj_lines)
+
+      if all_done
+        giver_hint = m.giver_mob ? "Return to #{h(m.giver_mob.name)}" : "Ready"
+        lines << "    <span style='color: #fbbf24;'>▲ READY FOR TURN-IN</span> <span style='color: #6b7280;'>(#{giver_hint}. 'turn_in #{h(m.slug)}')</span>"
+      end
+
+      lines.join("\n")
+    end
+
+    # Render the objective checklist for a hackr_mission. Returns
+    # [all_done?, Array<String>] so callers can decide whether to append
+    # a READY notice. Used by both the summary row (`missions`) and the
+    # detail view (`mission <slug>`).
+    def mission_objective_lines(hackr_mission, indent:)
+      progress_by_obj = hackr_mission.grid_hackr_mission_objectives.index_by(&:grid_mission_objective_id)
+      all_done = true
+      lines = hackr_mission.grid_mission.grid_mission_objectives.map do |obj|
+        hobj = progress_by_obj[obj.id]
+        current = hobj&.progress.to_i
+        target = obj.target_count.to_i
+        done = hobj&.completed_at.present?
+        all_done &&= done
+        check = done ? "<span style='color: #34d399;'>✓</span>" : "<span style='color: #6b7280;'>▸</span>"
+        count_tag = (target > 1) ? " <span style='color: #9ca3af;'>(#{current}/#{target})</span>" : ""
+        "#{indent}#{check} #{h(obj.label)}#{count_tag}"
+      end
+      [all_done, lines]
+    end
+
+    def mission_detail_command(slug)
+      return "<span style='color: #fbbf24;'>Usage: mission &lt;slug&gt;</span>" if slug.blank?
+
+      # First check active instance (player's current progress view)
+      active = hackr.grid_hackr_missions.active.joins(:grid_mission)
+        .where(grid_missions: {slug: slug}).first
+      if active
+        return format_active_mission_detail(active)
+      end
+
+      # Otherwise show definition (if in giver's room, show accept hint)
+      mission = GridMission.published.find_by(slug: slug)
+      return "<span style='color: #f87171;'>No mission with slug '#{h(slug)}'.</span>" unless mission
+
+      room = hackr.current_room
+      mission_brief_response(mission.giver_mob, mission, room) || "<span style='color: #9ca3af;'>Nothing to show.</span>"
+    end
+
+    def format_active_mission_detail(hackr_mission)
+      m = hackr_mission.grid_mission
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output << "<span style='color: #22d3ee; font-weight: bold;'>#{h(m.name)}</span>" +
+        (m.grid_mission_arc ? " <span style='color: #6b7280;'>[#{h(m.grid_mission_arc.name)}]</span>" : "")
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output << ""
+      output << "<span style='color: #d0d0d0;'>#{h(m.description)}</span>" if m.description.present?
+      output << ""
+      output << "<span style='color: #fbbf24;'>Objectives:</span>"
+
+      _all_done, obj_lines = mission_objective_lines(hackr_mission, indent: "  ")
+      output.concat(obj_lines)
+
+      rewards_summary = mission_rewards_summary(m)
+      if rewards_summary.present?
+        output << ""
+        output << "<span style='color: #fbbf24;'>Rewards:</span> #{rewards_summary}"
+      end
+
+      if hackr_mission.all_objectives_completed?
+        giver_hint = m.giver_mob ? "Return to #{h(m.giver_mob.name)}" : "Ready"
+        output << ""
+        output << "<span style='color: #fbbf24;'>▲ READY FOR TURN-IN</span> <span style='color: #6b7280;'>(#{giver_hint}. Use 'turn_in #{h(m.slug)}')</span>"
+      end
+
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output.join("\n")
+    end
+
+    def accept_mission_command(slug)
+      return "<span style='color: #fbbf24;'>Usage: accept &lt;slug&gt;</span>" if slug.blank?
+
+      room = hackr.current_room
+      mission_service.accept!(slug, room: room)
+
+      mission = GridMission.find_by(slug: slug)
+      giver = mission&.giver_mob
+      giver_line = giver ? " <span style='color: #6b7280;'>from #{h(giver.name)}</span>" : ""
+
+      "<span style='color: #34d399;'>▲ MISSION ACCEPTED:</span> " \
+        "<span style='color: #22d3ee;'>#{h(mission&.name)}</span>#{giver_line}\n" \
+        "<span style='color: #6b7280;'>Use 'mission #{h(slug)}' to view objectives.</span>"
+    rescue Grid::MissionService::MissionMissing,
+      Grid::MissionService::NotAtGiver,
+      Grid::MissionService::PrereqUnmet,
+      Grid::MissionService::ClearanceTooLow,
+      Grid::MissionService::RepTooLow,
+      Grid::MissionService::AlreadyActive,
+      Grid::MissionService::AlreadyCompletedNonRepeatable => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def abandon_mission_command(slug)
+      return "<span style='color: #fbbf24;'>Usage: abandon &lt;slug&gt;</span>" if slug.blank?
+
+      hackr_mission = mission_service.abandon!(slug)
+      "<span style='color: #fbbf24;'>Mission abandoned:</span> " \
+        "<span style='color: #d0d0d0;'>#{h(hackr_mission.grid_mission.name)}</span>\n" \
+        "<span style='color: #6b7280;'>Progress has been cleared. You can re-accept it anytime.</span>"
+    rescue Grid::MissionService::NotActive => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def turn_in_command(slug)
+      return "<span style='color: #fbbf24;'>Usage: turn_in &lt;slug&gt;</span>" if slug.blank?
+
+      room = hackr.current_room
+      outcome = mission_service.turn_in!(slug, room: room)
+
+      output = outcome[:notification_html]
+      output = append_notifications(output, outcome[:progressor_notifs] || [])
+      output = append_notifications(output, outcome[:achievement_notifs] || [])
+      {output: output, event: nil}
+    rescue Grid::MissionService::NotActive,
+      Grid::MissionService::ObjectivesIncomplete,
+      Grid::MissionService::NotAtTurnIn => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    # "give <item> to <npc>" — consumes the item and fires a :deliver_item
+    # mission tick if any active mission has a matching objective. If no
+    # objective matches, the item is NOT consumed (flavor-only delivery)
+    # and the NPC offers a non-committal line.
+    def give_command(args)
+      return "<span style='color: #fbbf24;'>Usage: give &lt;item&gt; to &lt;npc&gt;</span>" if args.length < 3
+
+      # Split on the last occurrence of "to" so multi-word item + NPC names
+      # round-trip correctly (e.g. "give Signal Fragment to Codec Prime").
+      to_index = args.rindex { |w| w.downcase == "to" }
+      return "<span style='color: #fbbf24;'>Usage: give &lt;item&gt; to &lt;npc&gt;</span>" unless to_index && to_index > 0 && to_index < args.length - 1
+
+      item_name = args[0...to_index].join(" ")
+      npc_name = args[(to_index + 1)..].join(" ")
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+
+      mob = room.grid_mobs.find_by("LOWER(name) = ?", npc_name.downcase)
+      return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
+
+      # Wrap progressor + consumption in one transaction so a mid-flow
+      # exception can't leave the objective advanced without the item
+      # consumed (free repeat deliveries) or the item gone without
+      # progress (lost reward). All-or-nothing.
+      notifications = []
+      tx_committed = false
+      begin
+        ActiveRecord::Base.transaction do
+          notifications = mission_progressor.record(
+            :deliver_item, item_name: item.name, npc_name: mob.name
+          )
+
+          if notifications.empty?
+            # No mission objective matched — roll back the transaction
+            # so nothing is written and the NPC politely declines. The
+            # item stays in the player's inventory.
+            raise ActiveRecord::Rollback
+          end
+
+          # Consume the item only when a delivery objective matched.
+          if item.quantity.to_i > 1
+            item.update!(quantity: item.quantity - 1)
+          else
+            item.destroy!
+          end
+          tx_committed = true
+        end
+      ensure
+        # If the transaction rolled back (either ActiveRecord::Rollback
+        # or an exception from item.destroy!), the progressor's memoized
+        # `@active_hackr_missions` holds AR objects whose `completed_at`
+        # was mutated in-memory by `save!` before the rollback. Drop
+        # the memoization so any subsequent `record` call in this same
+        # command execution re-reads from the DB.
+        @mission_progressor = nil unless tx_committed
+      end
+
+      if notifications.empty?
+        return dialogue_box(
+          "<span style='color: #c084fc;'>#{h(mob.name)}</span>: " \
+          "<span style='color: #60a5fa;'>\"I appreciate the gesture, but I have no use for that.\"</span>"
+        )
+      end
+
+      output = "<span style='color: #34d399;'>You hand the </span>" \
+        "<span style='color: #d0d0d0;'>#{h(item.name)}</span>" \
+        "<span style='color: #34d399;'> to </span>" \
+        "<span style='color: #c084fc;'>#{h(mob.name)}</span><span style='color: #34d399;'>.</span>"
+      append_notifications(output, notifications)
     end
 
     def increment_stat!(key, amount = 1)

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+module Grid
+  # Advances mission objective progress for a single hackr. Called from
+  # Grid::CommandParser hooks (go/talk/take/give/use/salvage/buy) and
+  # post-commit hooks on rep/clearance changes. Only emits HTML
+  # notification strings when an objective transitions from incomplete
+  # to completed — every other tick is silent.
+  #
+  # Lifecycle: instantiate once per request/job, call `record(...)` as
+  # many times as needed, discard. The per-instance memoization on
+  # active_hackr_missions avoids re-querying across multiple records
+  # firing from one command (e.g. a single `go` emits :visit_room
+  # AND :rooms_visited-equivalent mission events).
+  class MissionProgressor
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Record a gameplay event against all active missions. Returns an
+    # array of inline HTML notifications for objectives that JUST
+    # completed on this call; progress-only ticks are silent (spec).
+    #
+    # `context` keys expected per trigger_type:
+    #   :visit_room       → room_slug:
+    #   :talk_npc         → npc_name:  (case-insensitive match on target_slug)
+    #   :collect_item     → item_name: (case-insensitive)
+    #   :deliver_item     → item_name:, npc_name:
+    #   :spend_cred       → amount:   (accumulator, capped at target_count)
+    #   :buy_item         → item_name:
+    #   :reach_rep        → faction_slug:, rep_value:  (threshold; rep_value is NEW value)
+    #   :reach_clearance  → clearance: (threshold; NEW value)
+    #   :use_item         → item_name:
+    #   :salvage_item     → item_name:
+    def record(trigger_type, context = {})
+      return [] unless @hackr
+
+      matched_objectives = candidates_for(trigger_type)
+      return [] if matched_objectives.empty?
+
+      notifications = []
+
+      matched_objectives.each do |pair|
+        hackr_mission, objective = pair
+        next unless objective_target_matches?(objective, trigger_type, context, hackr_mission)
+
+        # accept! pre-creates a progress row per objective, so normally
+        # `find_or_initialize_by` finds an existing record. But if a
+        # definition gains a new objective AFTER a hackr has accepted
+        # (admin edit, YAML re-seed), the first tick creates the row on
+        # the fly. Two concurrent ticks could race on that create — the
+        # retry mirrors ReputationService#adjust!'s two-step pattern.
+        hackr_obj = hackr_mission.grid_hackr_mission_objectives
+          .find_or_initialize_by(grid_mission_objective_id: objective.id)
+
+        # Already done — don't re-notify or re-advance. Spec: state-change only.
+        next if hackr_obj.completed_at.present?
+
+        new_progress = next_progress_value(hackr_obj.progress.to_i, trigger_type, context, objective.target_count.to_i)
+        next if new_progress == hackr_obj.progress.to_i
+
+        hackr_obj.progress = new_progress
+        just_completed = new_progress >= objective.target_count.to_i
+        hackr_obj.completed_at = Time.current if just_completed
+        begin
+          hackr_obj.save!
+        rescue ActiveRecord::RecordNotUnique
+          # Another writer just created the row. Reload and retry once
+          # with the latest persisted state so we don't clobber it.
+          hackr_obj = hackr_mission.grid_hackr_mission_objectives
+            .find_by!(grid_mission_objective_id: objective.id)
+          next if hackr_obj.completed_at.present?
+          next if new_progress <= hackr_obj.progress.to_i
+          hackr_obj.progress = new_progress
+          hackr_obj.completed_at = Time.current if just_completed
+          hackr_obj.save!
+        end
+
+        if just_completed
+          notifications << build_objective_completed_notification(hackr_mission, objective)
+          ready_notif = build_ready_notification_if_applicable(hackr_mission, objective, hackr_obj)
+          notifications << ready_notif if ready_notif
+        end
+      end
+
+      notifications
+    end
+
+    private
+
+    # Build [hackr_mission, objective] pairs for all active missions of this
+    # hackr whose definition has an objective of the given type. Preloads
+    # objectives + mission to avoid N+1 across the progressor's iteration.
+    def candidates_for(trigger_type)
+      active_hackr_missions.flat_map do |hackr_mission|
+        hackr_mission.grid_mission.grid_mission_objectives
+          .select { |o| o.objective_type == trigger_type.to_s }
+          .map { |o| [hackr_mission, o] }
+      end
+    end
+
+    def active_hackr_missions
+      return @active_hackr_missions if defined?(@active_hackr_missions)
+      @active_hackr_missions = @hackr.grid_hackr_missions.active
+        .includes(grid_mission: :grid_mission_objectives).to_a
+    end
+
+    # True when the objective's target_slug matches the event context.
+    # A blank target_slug is a wildcard — matches any room/npc/item of
+    # that event type (used for "explore N rooms" etc.).
+    def objective_target_matches?(objective, trigger_type, context, hackr_mission)
+      target = objective.target_slug.to_s
+      case trigger_type.to_s
+      when "visit_room"
+        target.blank? || target.casecmp?(context[:room_slug].to_s)
+      when "talk_npc", "use_item", "salvage_item", "buy_item", "collect_item"
+        target.blank? || target.casecmp?(name_context(context).to_s)
+      when "deliver_item"
+        # Convention: `target_slug` holds the item name. The delivery
+        # recipient is always the mission's giver_mob — this matches the
+        # "bring X back to Y" RPG pattern and avoids a secondary target
+        # column for v1. If future missions need drop-off NPCs distinct
+        # from the giver, add a `secondary_target_slug` column.
+        item_matches = target.blank? || target.casecmp?(context[:item_name].to_s)
+        giver = hackr_mission.grid_mission.giver_mob
+        npc_matches = giver.nil? || giver.name.to_s.casecmp?(context[:npc_name].to_s)
+        item_matches && npc_matches
+      when "spend_cred", "reach_rep", "reach_clearance"
+        # Threshold triggers — target is a single faction (reach_rep) or
+        # bare number (reach_clearance, spend_cred). For reach_rep the
+        # target_slug pins the faction; others ignore target_slug.
+        (trigger_type.to_s == "reach_rep") ? target.casecmp?(context[:faction_slug].to_s) : true
+      else
+        false
+      end
+    end
+
+    # Map event context to the name used for string-match triggers.
+    def name_context(context)
+      context[:item_name] || context[:npc_name]
+    end
+
+    # Compute the new `progress` column value given the event semantics.
+    # Event-style triggers (visit, talk, take, use, salvage, buy, deliver)
+    # increment by 1 per event. Threshold triggers (spend_cred accumulates,
+    # reach_rep / reach_clearance take the NEW value directly) clamp to
+    # target_count so the `progress >= target_count` completion check fires.
+    def next_progress_value(current, trigger_type, context, target_count)
+      case trigger_type.to_s
+      when "visit_room", "talk_npc", "use_item", "salvage_item", "buy_item", "collect_item", "deliver_item"
+        [current + 1, target_count].min
+      when "spend_cred"
+        [current + context[:amount].to_i, target_count].min
+      when "reach_rep"
+        [context[:rep_value].to_i, target_count].min
+      when "reach_clearance"
+        [context[:clearance].to_i, target_count].min
+      else
+        current
+      end
+    end
+
+    def build_objective_completed_notification(hackr_mission, objective)
+      mission_name = hackr_mission.grid_mission.name
+      "<span style='color: #22d3ee;'>▸ MISSION</span> " \
+        "<span style='color: #a78bfa;'>#{ERB::Util.html_escape(mission_name)}</span> " \
+        "<span style='color: #9ca3af;'>::</span> " \
+        "<span style='color: #34d399;'>✓ #{ERB::Util.html_escape(objective.label)}</span>"
+    end
+
+    # When the objective that just completed was the LAST one for the
+    # mission, surface a READY FOR TURN-IN notification right after the
+    # per-objective check line. Computed in-memory from the preloaded
+    # association so we don't fire extra queries per tick — the model's
+    # `all_objectives_completed?` would re-query twice per call, which
+    # adds up across a tick that completes multiple objectives.
+    def build_ready_notification_if_applicable(hackr_mission, just_completed_objective, saved_hackr_obj)
+      mission = hackr_mission.grid_mission
+      # Collect the set of objective_ids with `completed_at` set using
+      # the cached rows the progressor is already tracking. Include the
+      # just-saved row (whose membership in the AR cache depends on
+      # find_or_initialize_by vs. find), since saved_hackr_obj may have
+      # been newly built. The in-memory set is the source of truth.
+      completed_ids = hackr_mission.grid_hackr_mission_objectives
+        .each_with_object(Set.new) { |ho, set| set << ho.grid_mission_objective_id if ho.completed_at.present? }
+      completed_ids << just_completed_objective.id
+
+      required_ids = mission.grid_mission_objectives.map(&:id).to_set
+      return nil unless (required_ids - completed_ids).empty?
+
+      giver = mission.giver_mob
+      giver_label = giver ? "Return to #{ERB::Util.html_escape(giver.name)}" : "Ready to turn in"
+      "  <span style='color: #fbbf24;'>▲ READY FOR TURN-IN</span> " \
+        "<span style='color: #6b7280;'>(#{giver_label}. Use 'turn_in #{ERB::Util.html_escape(mission.slug)}')</span>"
+    end
+  end
+end

--- a/app/services/grid/mission_reward_granter.rb
+++ b/app/services/grid/mission_reward_granter.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+module Grid
+  # Transactional reward pipeline for mission turn-in. Mirrors the shape of
+  # Grid::AchievementAwarder (one transaction wraps the state change + all
+  # reward writes; broadcasts and inline notifications built after commit).
+  #
+  # Called by Grid::MissionService#turn_in! — not by any other path.
+  class MissionRewardGranter
+    def initialize(hackr, hackr_mission)
+      @hackr = hackr
+      @hackr_mission = hackr_mission
+      @mission = hackr_mission.grid_mission
+    end
+
+    def grant!
+      outcome = {
+        xp_granted: 0, cred_granted: 0, minted_cred: false,
+        leveled_up: false, new_clearance: nil,
+        rep_awards: [], items_granted: [], achievements_granted: [],
+        # Threshold-tick notifications from OTHER active missions whose
+        # reach_clearance / reach_rep objectives advanced because of
+        # this turn-in's rewards. Surfaced inline to the player so the
+        # cross-mission cascade is visible immediately rather than
+        # waiting for an unrelated future event to re-fire the hook.
+        progressor_notifs: []
+      }
+
+      ActiveRecord::Base.transaction do
+        # Lock the row before re-checking status so two concurrent
+        # turn_in commands can't both pass the active-check and pay
+        # out twice. Second-in-line sees `completed` and aborts.
+        @hackr_mission.lock!
+        raise Grid::MissionService::NotActive, "Mission is no longer active." unless @hackr_mission.active?
+
+        @hackr_mission.update!(
+          status: "completed",
+          completed_at: Time.current,
+          turn_in_count: @hackr_mission.turn_in_count.to_i + 1
+        )
+
+        @mission.grid_mission_rewards.each do |reward|
+          apply_reward(reward, outcome)
+        end
+      end
+
+      # Post-commit: broadcast + fire missions_completed_count achievement
+      # sweep. These run outside the transaction so a broadcast failure
+      # or achievement check error can't roll back the mission completion.
+      broadcast_completion(outcome)
+      outcome[:achievement_notifs] = fire_post_commit_achievement_checks
+      outcome[:notification_html] = build_notification(outcome)
+      outcome
+    end
+
+    private
+
+    def apply_reward(reward, outcome)
+      case reward.reward_type
+      when "xp"
+        amount = reward.amount.to_i
+        return if amount <= 0
+        result = @hackr.grant_xp!(amount)
+        outcome[:xp_granted] += amount
+        if result[:leveled_up]
+          outcome[:leveled_up] = true
+          outcome[:new_clearance] = result[:new_clearance]
+          # The clearance change might satisfy reach_clearance objectives
+          # on OTHER active missions. The just-completed mission is
+          # already flipped to "completed" and is filtered out by the
+          # progressor's active-scope, so firing here is safe.
+          outcome[:progressor_notifs].concat(
+            mission_progressor.record(:reach_clearance, clearance: result[:new_clearance])
+          )
+        end
+      when "cred"
+        amount = reward.amount.to_i
+        return if amount <= 0
+        cache = @hackr.default_cache
+        if cache&.active?
+          Grid::TransactionService.mint_gameplay!(
+            to_cache: cache, amount: amount,
+            memo: "Mission: #{@mission.name}"
+          )
+          outcome[:cred_granted] += amount
+          outcome[:minted_cred] = true
+        else
+          Rails.logger.warn(
+            "[MissionRewardGranter] skipped CRED mint for hackr=#{@hackr.id} " \
+            "mission=#{@mission.slug}: no active default cache"
+          )
+        end
+      when "faction_rep"
+        faction = GridFaction.find_by(slug: reward.target_slug)
+        return unless faction
+        amount = reward.amount.to_i
+        return if amount.zero?
+        begin
+          result = reputation_service.adjust!(
+            faction, amount,
+            reason: "mission:#{@mission.slug}",
+            source: @mission.giver_mob
+          )
+          outcome[:rep_awards] << {faction: faction, applied_delta: result[:applied_delta], tier_after: result[:tier_after]}
+
+          # Rep change might satisfy a reach_rep objective on another
+          # active mission. Use the post-adjust value from the result
+          # hash — no extra `effective_rep` read needed (the leaf
+          # value IS the effective value for leaf factions, which is
+          # what `adjust!` writes to).
+          outcome[:progressor_notifs].concat(
+            mission_progressor.record(
+              :reach_rep,
+              faction_slug: faction.slug,
+              rep_value: result[:new_value]
+            )
+          )
+          # Aggregate factions this leaf contributes to may have also
+          # crossed a threshold — fire for each rolled-up aggregate.
+          result[:rollups].each do |rollup|
+            next if rollup[:faction].nil?
+            outcome[:progressor_notifs].concat(
+              mission_progressor.record(
+                :reach_rep,
+                faction_slug: rollup[:faction].slug,
+                rep_value: rollup[:new_value]
+              )
+            )
+          end
+        rescue Grid::ReputationService::SubjectMissing,
+          Grid::ReputationService::AggregateSubjectNotAdjustable => e
+          Rails.logger.warn("[MissionRewardGranter] rep grant skipped: #{e.message}")
+        end
+      when "item_grant"
+        item = build_item_grant(reward)
+        outcome[:items_granted] << item if item
+      when "grant_achievement"
+        ach = GridAchievement.find_by(slug: reward.target_slug)
+        return unless ach
+        # Route through the awarder so XP/CRED/broadcast/join-row semantics
+        # match every other achievement path. Duplicate grant returns nil
+        # (idempotent) — don't add to outcome if nothing happened.
+        notif = Grid::AchievementAwarder.new(@hackr, ach).award!
+        outcome[:achievements_granted] << {achievement: ach, notification: notif} if notif
+      end
+    end
+
+    # Materialize a new GridItem in the hackr's inventory from the reward
+    # row. `target_slug` may point to an existing shop_listing slug (to
+    # copy its full definition) OR be a bare item name. For v1 we use
+    # target_slug as the name and lean on reward.amount + reward.quantity
+    # for value + stack size. More elaborate templating can extend this.
+    def build_item_grant(reward)
+      name = reward.target_slug.presence || "Mission Reward"
+      GridItem.create!(
+        grid_hackr: @hackr,
+        name: name,
+        description: "Reward from mission: #{@mission.name}",
+        item_type: "collectible",
+        rarity: "uncommon",
+        value: reward.amount.to_i,
+        quantity: reward.quantity.to_i.clamp(1, 9999)
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("[MissionRewardGranter] item grant failed: #{e.message}")
+      nil
+    end
+
+    def broadcast_completion(outcome)
+      ActionCable.server.broadcast(
+        AchievementChannel.stream_name_for(@hackr),
+        {
+          type: "mission_completed",
+          mission: {
+            slug: @mission.slug,
+            name: @mission.name,
+            arc_name: @mission.grid_mission_arc&.name
+          },
+          rewards: {
+            xp: outcome[:xp_granted],
+            cred: outcome[:minted_cred] ? outcome[:cred_granted] : 0,
+            rep: outcome[:rep_awards].map { |r| {faction: r[:faction].display_name, delta: r[:applied_delta]} },
+            items: outcome[:items_granted].map { |i| {name: i.name} },
+            achievements: outcome[:achievements_granted].map { |a| {slug: a[:achievement].slug, name: a[:achievement].name} }
+          },
+          leveled_up: outcome[:leveled_up],
+          new_clearance: outcome[:new_clearance]
+        }
+      )
+    rescue => e
+      Rails.logger.error("[MissionRewardGranter] broadcast failed: #{e.message}")
+    end
+
+    # Fire missions_completed_count + mission_completed achievement triggers
+    # now that the hackr_mission row is `completed`. Returns notification
+    # HTML strings to append to the terminal output.
+    def fire_post_commit_achievement_checks
+      checker = Grid::AchievementChecker.new(@hackr)
+      notifs = []
+      notifs += checker.check(:mission_completed, mission_slug: @mission.slug)
+      notifs += checker.check(:missions_completed_count)
+      notifs
+    rescue => e
+      Rails.logger.error("[MissionRewardGranter] achievement check failed: #{e.message}")
+      []
+    end
+
+    def reputation_service
+      @reputation_service ||= Grid::ReputationService.new(@hackr)
+    end
+
+    def mission_progressor
+      @mission_progressor ||= Grid::MissionProgressor.new(@hackr)
+    end
+
+    # Build the inline turn-in notification block — appended to the
+    # turn_in command's output. Achievement notifications fired during
+    # post-commit checks are appended by the caller.
+    def build_notification(outcome)
+      lines = []
+      lines << "<div style='border: 1px solid #fbbf24; padding: 8px 12px; margin: 4px 0; background: #111;'>"
+      lines << "  <span style='color: #fbbf24; font-weight: bold;'>▲ MISSION COMPLETE:</span> " \
+        "<span style='color: #22d3ee;'>#{ERB::Util.html_escape(@mission.name)}</span>"
+
+      reward_lines = []
+      reward_lines << "<span style='color: #34d399;'>+#{outcome[:xp_granted]} XP</span>" if outcome[:xp_granted].positive?
+      reward_lines << "<span style='color: #fbbf24;'>+#{outcome[:cred_granted]} CRED</span>" if outcome[:minted_cred]
+
+      outcome[:rep_awards].each do |r|
+        sign = (r[:applied_delta].to_i >= 0) ? "+" : ""
+        color = (r[:applied_delta].to_i >= 0) ? "#34d399" : "#ef4444"
+        reward_lines << "<span style='color: #{color};'>#{sign}#{r[:applied_delta]} rep</span> " \
+          "<span style='color: #9ca3af;'>::</span> " \
+          "<span style='color: #a78bfa;'>#{ERB::Util.html_escape(r[:faction].display_name)}</span>"
+      end
+      outcome[:items_granted].each do |item|
+        color = item.rarity_color
+        reward_lines << "<span style='color: #{color};'>+ #{ERB::Util.html_escape(item.name)}</span>"
+      end
+
+      if reward_lines.any?
+        lines << "  <span style='color: #6b7280;'>Rewards:</span> #{reward_lines.join(" <span style='color: #4b5563;'>|</span> ")}"
+      end
+
+      if outcome[:leveled_up]
+        lines << "  <span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{outcome[:new_clearance]}!</span>"
+      end
+
+      outcome[:achievements_granted].each do |a|
+        lines << "  <span style='color: #fbbf24;'>◆ Achievement unlocked: #{ERB::Util.html_escape(a[:achievement].name)}</span>"
+      end
+
+      lines << "</div>"
+      lines.join("\n")
+    end
+  end
+end

--- a/app/services/grid/mission_service.rb
+++ b/app/services/grid/mission_service.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+module Grid
+  # Orchestrates mission lifecycle for a single hackr. Delegates reward
+  # grants to Grid::MissionRewardGranter and progress ticks to
+  # Grid::MissionProgressor. Every mutation is transactional; gate checks
+  # raise specific error classes so the command path can render friendly
+  # messages.
+  class MissionService
+    class Error < StandardError; end
+    class MissionMissing < Error; end
+    class NotAtGiver < Error; end
+    class PrereqUnmet < Error; end
+    class ClearanceTooLow < Error; end
+    class RepTooLow < Error; end
+    class AlreadyActive < Error; end
+    class AlreadyCompletedNonRepeatable < Error; end
+    class NotActive < Error; end
+    class ObjectivesIncomplete < Error; end
+    class NotAtTurnIn < Error; end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Missions this hackr could accept RIGHT NOW from a given room.
+    # Only returns missions whose giver is in the room and whose gates
+    # (prereq, clearance, min-rep) are satisfied. Already-active missions
+    # are filtered out; completed non-repeatable missions are filtered;
+    # completed repeatable missions ARE included (re-acceptable).
+    def available_missions(room)
+      return [] unless room
+      mob_ids = room.grid_mobs.pluck(:id)
+      return [] if mob_ids.empty?
+
+      candidate_missions = GridMission.published
+        .where(giver_mob_id: mob_ids)
+        .includes(:grid_mission_arc, :prereq_mission, :min_rep_faction, :grid_mission_objectives, :grid_mission_rewards)
+        .ordered
+
+      candidate_missions.select { |m| gates_met?(m) && !already_active?(m) && !completed_nonrepeatable?(m) }
+    end
+
+    # All active mission rows for the `missions` command and the
+    # /api/grid/missions index. Preloads the progress rows too so the
+    # serializer's `all_objectives_completed?` + per-objective progress
+    # lookup each run against loaded associations, not fresh queries.
+    def active_hackr_missions
+      @hackr.grid_hackr_missions.active
+        .includes(:grid_hackr_mission_objectives,
+          grid_mission: [:grid_mission_objectives, :grid_mission_arc, :giver_mob])
+        .order(accepted_at: :desc)
+    end
+
+    def completed_hackr_missions(limit: 10)
+      @hackr.grid_hackr_missions.completed
+        .includes(grid_mission: [:grid_mission_arc, :giver_mob])
+        .order(completed_at: :desc).limit(limit)
+    end
+
+    # Returns a struct of gate flags + a human-readable refusal reason
+    # for the first failing gate (or nil when all gates pass). Callers:
+    # CommandParser renders `reason`; Api serializer returns flags;
+    # internal accept! path re-uses the predicates. Single source of truth.
+    GateStatus = Struct.new(:clearance_met, :prereq_met, :rep_met, :reason, keyword_init: true) do
+      def all_met?
+        clearance_met && prereq_met && rep_met
+      end
+    end
+
+    def gate_status(mission)
+      clearance = clearance_met?(mission)
+      prereq = prereq_met?(mission)
+      rep = rep_met?(mission)
+
+      reason = if !prereq
+        "Complete '#{mission.prereq_mission&.name || "prerequisite"}' first."
+      elsif !clearance
+        "Requires clearance #{mission.min_clearance}."
+      elsif !rep
+        "Your reputation with #{mission.min_rep_faction&.display_name} is too low."
+      end
+
+      GateStatus.new(clearance_met: clearance, prereq_met: prereq, rep_met: rep, reason: reason)
+    end
+
+    # Accept a mission. Validates room/prereq/clearance/rep/duplicate and
+    # creates GridHackrMission + GridHackrMissionObjective rows (one per
+    # definition objective). Raises on any gate failure.
+    def accept!(mission_slug, room:)
+      # Only published missions are acceptable. Unpublished/draft missions
+      # are invisible to players even by direct slug lookup — matches the
+      # `available_missions` scope so admins can stage content safely.
+      mission = GridMission.published.find_by(slug: mission_slug)
+      raise MissionMissing, "No mission with that slug." unless mission
+      raise NotAtGiver, "You need to be in the same room as the mission giver." unless at_giver?(mission, room)
+      raise PrereqUnmet, "This mission requires completing '#{mission.prereq_mission&.name || "a prerequisite"}' first." unless prereq_met?(mission)
+      raise ClearanceTooLow, "This mission requires clearance #{mission.min_clearance}." unless clearance_met?(mission)
+      raise RepTooLow, "Your reputation with #{mission.min_rep_faction&.display_name} is too low." unless rep_met?(mission)
+      raise AlreadyActive, "You are already working on that mission." if already_active?(mission)
+      raise AlreadyCompletedNonRepeatable, "You have already completed that mission." if completed_nonrepeatable?(mission)
+
+      hackr_mission = nil
+      ActiveRecord::Base.transaction do
+        # The DB-level partial unique index on (hackr_id, mission_id)
+        # WHERE status = 'active' turns any concurrent accept race into
+        # a RecordNotUnique that we surface as AlreadyActive — the
+        # guarantee doesn't rely on the app-level guard alone.
+        hackr_mission = @hackr.grid_hackr_missions.create!(
+          grid_mission: mission,
+          status: "active",
+          accepted_at: Time.current
+        )
+
+        mission.grid_mission_objectives.each do |obj|
+          hackr_mission.grid_hackr_mission_objectives.create!(
+            grid_mission_objective: obj,
+            progress: 0
+          )
+        end
+
+        # Seed threshold-trigger objectives with the hackr's current
+        # state so a "reach clearance 5" mission with the hackr already
+        # at CL5 doesn't require a pointless level-up tick to complete
+        # at accept time. Inside the same transaction so a failure
+        # rolls back the whole accept.
+        seed_threshold_objectives(hackr_mission)
+      end
+
+      invalidate_mission_ids_cache!
+      hackr_mission
+    rescue ActiveRecord::RecordNotUnique => e
+      # Only the partial index on active (hackr, mission) pairs is the
+      # user-facing race we want to surface as AlreadyActive. Other
+      # unique-constraint violations (objective progress rows, future
+      # indexes, etc.) should propagate with their real error so bugs
+      # don't hide behind a misleading "already active" message.
+      raise AlreadyActive, "You are already working on that mission." if e.message.include?("index_hackr_missions_unique_active")
+      raise
+    end
+
+    # Drop a mission. Destroys the row so a one-shot mission is freely
+    # re-acceptable (no cooldown per spec).
+    def abandon!(mission_slug)
+      hackr_mission = active_for_slug(mission_slug)
+      raise NotActive, "You are not working on that mission." unless hackr_mission
+      hackr_mission.destroy!
+      invalidate_mission_ids_cache!
+      hackr_mission
+    end
+
+    # Turn in. Requires all objectives complete AND hackr in giver's room.
+    # Delegates reward pipeline to MissionRewardGranter.
+    def turn_in!(mission_slug, room:)
+      hackr_mission = active_for_slug(mission_slug)
+      raise NotActive, "You are not working on that mission." unless hackr_mission
+      raise ObjectivesIncomplete, "Not all objectives are complete." unless hackr_mission.all_objectives_completed?
+      raise NotAtTurnIn, "Return to #{hackr_mission.grid_mission.giver_mob&.name || "the mission giver"} to turn in." unless at_giver?(hackr_mission.grid_mission, room)
+
+      result = Grid::MissionRewardGranter.new(@hackr, hackr_mission).grant!
+      invalidate_mission_ids_cache!
+      result
+    end
+
+    private
+
+    def at_giver?(mission, room)
+      return false unless room && mission.giver_mob_id
+      mission.giver_mob_id && room.grid_mobs.where(id: mission.giver_mob_id).exists?
+    end
+
+    def gates_met?(mission)
+      gate_status(mission).all_met?
+    end
+
+    def prereq_met?(mission)
+      return true if mission.prereq_mission_id.nil?
+      completed_mission_ids.include?(mission.prereq_mission_id)
+    end
+
+    def clearance_met?(mission)
+      @hackr.stat("clearance").to_i >= mission.min_clearance.to_i
+    end
+
+    def rep_met?(mission)
+      return true if mission.min_rep_faction_id.nil?
+      faction = mission.min_rep_faction
+      return true unless faction
+      reputation_service.effective_rep(faction) >= mission.min_rep_value.to_i
+    end
+
+    public :prereq_met?, :clearance_met?, :rep_met?
+
+    def completed_mission_ids
+      return @completed_mission_ids if defined?(@completed_mission_ids)
+      @completed_mission_ids = @hackr.grid_hackr_missions.completed.pluck(:grid_mission_id).to_set
+    end
+
+    # Drop memoized active + completed sets. Called after any mutation
+    # the service performs on its own hackr's missions, so
+    # subsequent queries (e.g. another `accept!`, `available_missions`)
+    # see the post-mutation state. External writes between service
+    # calls aren't covered — by design, the service expects a
+    # short-lived per-request instance.
+    def invalidate_mission_ids_cache!
+      remove_instance_variable(:@active_mission_ids) if defined?(@active_mission_ids)
+      remove_instance_variable(:@completed_mission_ids) if defined?(@completed_mission_ids)
+    end
+
+    # Memoized per-instance so `available_missions` (and any other
+    # caller iterating candidates) doesn't fire one EXISTS per mission.
+    # Discard the service instance after a request/job — the snapshot
+    # isn't refreshed mid-flight by design.
+    def active_mission_ids
+      return @active_mission_ids if defined?(@active_mission_ids)
+      @active_mission_ids = @hackr.grid_hackr_missions.active.pluck(:grid_mission_id).to_set
+    end
+
+    def already_active?(mission)
+      active_mission_ids.include?(mission.id)
+    end
+
+    def completed_nonrepeatable?(mission)
+      return false if mission.repeatable?
+      completed_mission_ids.include?(mission.id)
+    end
+
+    def active_for_slug(slug)
+      @hackr.grid_hackr_missions.active
+        .joins(:grid_mission).where(grid_missions: {slug: slug}).first
+    end
+
+    def reputation_service
+      @reputation_service ||= Grid::ReputationService.new(@hackr)
+    end
+
+    # For `reach_rep` / `reach_clearance` objectives, evaluate the hackr's
+    # current state on accept so pre-met conditions auto-complete.
+    #
+    # Scoped strictly to this hackr_mission. We write progress rows
+    # directly rather than delegating to MissionProgressor — the
+    # progressor is a fan-out over ALL active missions and would advance
+    # sibling missions' thresholds as a side effect of accepting THIS
+    # one, which is surprising (users expect accept to touch the
+    # accepted mission and nothing else). Sibling thresholds catch up
+    # via the normal command-path hooks (go, talk, salvage, buy, turn_in).
+    def seed_threshold_objectives(hackr_mission)
+      clearance = @hackr.stat("clearance").to_i
+
+      hackr_mission.grid_mission.grid_mission_objectives.each do |obj|
+        value = case obj.objective_type
+        when "reach_clearance"
+          clearance
+        when "reach_rep"
+          faction = GridFaction.find_by(slug: obj.target_slug)
+          next unless faction
+          reputation_service.effective_rep(faction)
+        end
+        next if value.nil?
+
+        hackr_obj = hackr_mission.grid_hackr_mission_objectives
+          .find_by(grid_mission_objective_id: obj.id)
+        next unless hackr_obj && hackr_obj.completed_at.nil?
+
+        new_progress = [value.to_i, obj.target_count.to_i].min
+        next if new_progress <= hackr_obj.progress.to_i
+
+        hackr_obj.progress = new_progress
+        hackr_obj.completed_at = Time.current if new_progress >= obj.target_count.to_i
+        hackr_obj.save!
+      end
+    end
+  end
+end

--- a/app/views/admin/grid_hackr_missions/index.html.erb
+++ b/app/views/admin/grid_hackr_missions/index.html.erb
@@ -1,0 +1,68 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/hackr_missions :: HACKR MISSION LOG</legend>
+
+    <div style="padding: 20px;">
+      <%= form_with url: admin_grid_hackr_missions_path, method: :get, local: true, style: "display: flex; gap: 10px; align-items: center; margin-bottom: 20px;" do %>
+        <label class="white-text" style="font-weight: bold;">STATUS:</label>
+        <%= select_tag :status,
+              options_for_select([["ALL", ""], ["ACTIVE", "active"], ["COMPLETED", "completed"]], @status_filter),
+              class: "tui-input", style: "padding: 4px 8px;", onchange: "this.form.submit()" %>
+        <label class="white-text" style="font-weight: bold; margin-left: 10px;">HACKR:</label>
+        <%= text_field_tag :hackr_alias, @hackr_alias_filter, class: "tui-input", style: "padding: 4px 8px;", placeholder: "hackr alias" %>
+        <%= submit_tag "Filter", class: "tui-button green-168", style: "padding: 4px 12px;" %>
+        <% if @status_filter.present? || @hackr_alias_filter.present? %>
+          <%= link_to "× clear", admin_grid_hackr_missions_path, class: "tui-button", style: "padding: 4px 10px; font-size: 0.8em;" %>
+        <% end %>
+      <% end %>
+
+      <% if @hackr_alias_filter.present? && @hackr_missions.empty? %>
+        <p style="color: #fbbf24;">No hackr found with alias '<%= @hackr_alias_filter %>'.</p>
+      <% end %>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Hackr</th>
+              <th style="text-align: left;">Mission</th>
+              <th style="text-align: left;">Status</th>
+              <th style="text-align: left;">Accepted</th>
+              <th style="text-align: left;">Completed</th>
+              <th style="text-align: center;">Turn-ins</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @hackr_missions.each do |hm| %>
+              <tr>
+                <td style="color: #a78bfa;"><%= hm.grid_hackr.hackr_alias %></td>
+                <td>
+                  <span class="cyan-255-text"><%= hm.grid_mission.name %></span>
+                  <span style="color: #6b7280; font-family: monospace; margin-left: 6px;"><%= hm.grid_mission.slug %></span>
+                </td>
+                <td>
+                  <% if hm.active? %>
+                    <span style="color: #22d3ee;">ACTIVE</span>
+                  <% else %>
+                    <span class="green-255-text">COMPLETED</span>
+                  <% end %>
+                </td>
+                <td style="color: #9ca3af;"><%= hm.accepted_at.strftime("%Y-%m-%d %H:%M") %></td>
+                <td style="color: #9ca3af;"><%= hm.completed_at&.strftime("%Y-%m-%d %H:%M") || "—" %></td>
+                <td style="text-align: center; color: #fbbf24;"><%= hm.turn_in_count %></td>
+                <td style="text-align: right;">
+                  <%= link_to "View", admin_grid_hackr_mission_path(hm), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Missions", admin_grid_missions_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_hackr_missions/show.html.erb
+++ b/app/views/admin/grid_hackr_missions/show.html.erb
@@ -1,0 +1,54 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/hackr_missions/<%= @hackr_mission.id %> :: HACKR MISSION</legend>
+
+    <div style="padding: 20px;">
+      <h3 class="cyan-255-text"><%= @hackr_mission.grid_mission.name %></h3>
+      <p style="color: #9ca3af;"><strong>Hackr:</strong> <%= @hackr_mission.grid_hackr.hackr_alias %></p>
+      <p style="color: #9ca3af;"><strong>Status:</strong> <%= @hackr_mission.status.upcase %></p>
+      <p style="color: #9ca3af;"><strong>Accepted:</strong> <%= @hackr_mission.accepted_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+      <% if @hackr_mission.completed_at %>
+        <p style="color: #9ca3af;"><strong>Completed:</strong> <%= @hackr_mission.completed_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+      <% end %>
+      <p style="color: #9ca3af;"><strong>Turn-in count:</strong> <%= @hackr_mission.turn_in_count %></p>
+
+      <h3 class="cyan-255-text" style="margin-top: 25px;">[:: OBJECTIVES ::]</h3>
+      <table class="tui-table" style="width: 100%; margin-top: 10px;">
+        <thead>
+          <tr>
+            <th style="text-align: left;">Label</th>
+            <th style="text-align: left;">Type</th>
+            <th style="text-align: left;">Target</th>
+            <th style="text-align: center;">Progress</th>
+            <th style="text-align: center;">Completed</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% hobj_by_id = @hackr_mission.grid_hackr_mission_objectives.index_by(&:grid_mission_objective_id) %>
+          <% @hackr_mission.grid_mission.grid_mission_objectives.each do |obj| %>
+            <% hobj = hobj_by_id[obj.id] %>
+            <tr>
+              <td><%= obj.label %></td>
+              <td style="color: #888;"><%= obj.objective_type %></td>
+              <td style="color: #888; font-family: monospace;"><%= obj.target_slug || "—" %></td>
+              <td style="text-align: center; color: #9ca3af;">
+                <%= hobj&.progress.to_i %> / <%= obj.target_count %>
+              </td>
+              <td style="text-align: center;">
+                <% if hobj&.completed_at %>
+                  <span class="green-255-text">✓</span>
+                <% else %>
+                  <span style="color: #444;">–</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Hackr Missions", admin_grid_hackr_missions_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_mission_arcs/_form.html.erb
+++ b/app/views/admin/grid_mission_arcs/_form.html.erb
@@ -1,0 +1,40 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @arc.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @arc.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 60px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+    </div>
+
+    <div style="flex: 1;">
+      <%= f.label :published, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :published, style: "margin-right: 8px;" %> PUBLISHED
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @arc.new_record? ? "Create Arc" : "Update Arc", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_grid_mission_arcs_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  </div>
+</div>

--- a/app/views/admin/grid_mission_arcs/edit.html.erb
+++ b/app/views/admin/grid_mission_arcs/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mission_arcs/<%= @arc.slug %> :: EDIT ARC</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @arc, url: admin_grid_mission_arc_path(@arc), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_mission_arcs/index.html.erb
+++ b/app/views/admin/grid_mission_arcs/index.html.erb
@@ -1,0 +1,64 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mission_arcs :: MISSION ARCS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="margin-bottom: 20px;">
+        <%= link_to "+ New Arc", new_admin_grid_mission_arc_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: center;">Position</th>
+              <th style="text-align: center;">Missions</th>
+              <th style="text-align: center;">Published</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @arcs.each do |arc| %>
+              <tr>
+                <td class="cyan-255-text"><%= arc.name %></td>
+                <td style="color: #666; font-family: monospace;"><%= arc.slug %></td>
+                <td style="text-align: center; color: #9ca3af;"><%= arc.position %></td>
+                <td style="text-align: center; color: #888;"><%= arc.grid_missions.size %></td>
+                <td style="text-align: center;">
+                  <% if arc.published? %>
+                    <span class="green-255-text">YES</span>
+                  <% else %>
+                    <span style="color: #444;">no</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_mission_arc_path(arc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= button_to "Delete", admin_grid_mission_arc_path(arc), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete arc '#{arc.name}'?" } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Grid Admin", admin_grid_path, class: "tui-button green-168" %>
+        <%= link_to "Missions", admin_grid_missions_path, class: "tui-button", style: "margin-left: 10px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_mission_arcs/new.html.erb
+++ b/app/views/admin/grid_mission_arcs/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mission_arcs/new :: NEW ARC</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @arc, url: admin_grid_mission_arcs_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_missions/_form.html.erb
+++ b/app/views/admin/grid_missions/_form.html.erb
@@ -1,0 +1,174 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @mission.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @mission.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: DEFINITION ::]</h3>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+    </div>
+    <div style="flex: 2;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 70px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :giver_mob_id, "GIVER NPC", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :giver_mob_id,
+            options_from_collection_for_select(@mobs, :id, ->(m) { "#{m.name} @ #{m.grid_room&.name || "—"}" }, @mission.giver_mob_id),
+            { include_blank: "—" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :grid_mission_arc_id, "ARC (OPTIONAL)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :grid_mission_arc_id,
+            options_from_collection_for_select(@arcs, :id, :name, @mission.grid_mission_arc_id),
+            { include_blank: "— No Arc —" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :prereq_mission_id, "PREREQUISITE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :prereq_mission_id,
+            options_from_collection_for_select(@missions_for_prereq, :id, :name, @mission.prereq_mission_id),
+            { include_blank: "— None —" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :min_rep_faction_id, "MIN REP FACTION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :min_rep_faction_id,
+            options_from_collection_for_select(@factions, :id, :display_name, @mission.min_rep_faction_id),
+            { include_blank: "— None —" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :min_rep_value, "MIN REP VALUE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :min_rep_value, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :repeatable, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :repeatable, style: "margin-right: 8px;" %> REPEATABLE
+      <% end %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :published, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :published, style: "margin-right: 8px;" %> PUBLISHED
+      <% end %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 25px 0 10px;">[:: OBJECTIVES ::]</h3>
+  <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
+    Objective types: <code><%= GridMission::OBJECTIVE_TYPES.join(", ") %></code>.
+    <code>target_slug</code> is the room/item/npc/faction slug — leave blank to match any.
+    <code>target_count</code> is the number needed to complete (1 for event-based, higher for count-based).
+  </p>
+  <table class="tui-table" style="width: 100%; margin-bottom: 10px;">
+    <thead>
+      <tr>
+        <th style="text-align: left; width: 70px;">Pos</th>
+        <th style="text-align: left; width: 180px;">Type</th>
+        <th style="text-align: left;">Label (player-visible)</th>
+        <th style="text-align: left; width: 200px;">Target Slug</th>
+        <th style="text-align: center; width: 80px;">Count</th>
+        <th style="text-align: center; width: 50px;">×</th>
+      </tr>
+    </thead>
+    <tbody id="objectives-rows">
+      <%= f.fields_for :grid_mission_objectives do |ff| %>
+        <tr>
+          <td><%= ff.number_field :position, class: "tui-input", style: "width: 60px; padding: 4px;" %></td>
+          <td>
+            <%= ff.select :objective_type,
+                  options_for_select(GridMission::OBJECTIVE_TYPES.map { |t| [t, t] }, ff.object.objective_type),
+                  {}, class: "tui-input", style: "width: 100%; padding: 4px;" %>
+          </td>
+          <td><%= ff.text_field :label, class: "tui-input", style: "width: 100%; padding: 4px;" %></td>
+          <td><%= ff.text_field :target_slug, class: "tui-input", style: "width: 100%; padding: 4px; font-family: monospace;" %></td>
+          <td style="text-align: center;"><%= ff.number_field :target_count, class: "tui-input", style: "width: 70px; padding: 4px; text-align: center;", min: 1 %></td>
+          <td style="text-align: center;">
+            <% unless ff.object.new_record? %>
+              <%= ff.hidden_field :_destroy %>
+              <button type="button" class="tui-button red-168" style="padding: 2px 6px; font-size: 0.8em;" onclick="this.previousElementSibling.value='1'; this.closest('tr').style.display='none';">×</button>
+            <% else %>
+              <button type="button" class="tui-button red-168" style="padding: 2px 6px; font-size: 0.8em;" onclick="this.closest('tr').remove();">×</button>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <h3 class="cyan-255-text" style="margin: 25px 0 10px;">[:: REWARDS ::]</h3>
+  <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
+    Reward types: <code><%= GridMission::REWARD_TYPES.join(", ") %></code>.
+    <code>target_slug</code> is faction/item/mission/achievement slug.
+    XP/CRED use <code>amount</code>; item grants use <code>quantity</code>.
+  </p>
+  <table class="tui-table" style="width: 100%; margin-bottom: 10px;">
+    <thead>
+      <tr>
+        <th style="text-align: left; width: 70px;">Pos</th>
+        <th style="text-align: left; width: 180px;">Type</th>
+        <th style="text-align: center; width: 100px;">Amount</th>
+        <th style="text-align: left;">Target Slug</th>
+        <th style="text-align: center; width: 80px;">Qty</th>
+        <th style="text-align: center; width: 50px;">×</th>
+      </tr>
+    </thead>
+    <tbody id="rewards-rows">
+      <%= f.fields_for :grid_mission_rewards do |ff| %>
+        <tr>
+          <td><%= ff.number_field :position, class: "tui-input", style: "width: 60px; padding: 4px;" %></td>
+          <td>
+            <%= ff.select :reward_type,
+                  options_for_select(GridMission::REWARD_TYPES.map { |t| [t, t] }, ff.object.reward_type),
+                  {}, class: "tui-input", style: "width: 100%; padding: 4px;" %>
+          </td>
+          <td style="text-align: center;"><%= ff.number_field :amount, class: "tui-input", style: "width: 90px; padding: 4px; text-align: right;" %></td>
+          <td><%= ff.text_field :target_slug, class: "tui-input", style: "width: 100%; padding: 4px; font-family: monospace;" %></td>
+          <td style="text-align: center;"><%= ff.number_field :quantity, class: "tui-input", style: "width: 70px; padding: 4px; text-align: center;", min: 1 %></td>
+          <td style="text-align: center;">
+            <% unless ff.object.new_record? %>
+              <%= ff.hidden_field :_destroy %>
+              <button type="button" class="tui-button red-168" style="padding: 2px 6px; font-size: 0.8em;" onclick="this.previousElementSibling.value='1'; this.closest('tr').style.display='none';">×</button>
+            <% else %>
+              <button type="button" class="tui-button red-168" style="padding: 2px 6px; font-size: 0.8em;" onclick="this.closest('tr').remove();">×</button>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <p style="color: #6b7280; font-size: 0.85em; margin-top: 5px;">
+    Need more rows? Save and re-edit — the form will include the saved rows plus a new blank slot,
+    or seed via YAML (<code>data/world/missions.yml</code>).
+  </p>
+
+  <div style="margin-top: 25px;">
+    <%= f.submit @mission.new_record? ? "Create Mission" : "Update Mission", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_grid_missions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  </div>
+</div>

--- a/app/views/admin/grid_missions/edit.html.erb
+++ b/app/views/admin/grid_missions/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/missions/<%= @mission.slug %> :: EDIT MISSION</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @mission, url: admin_grid_mission_path(@mission), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_missions/index.html.erb
+++ b/app/views/admin/grid_missions/index.html.erb
@@ -1,0 +1,85 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/missions :: MISSION DEFINITIONS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Mission", new_admin_grid_mission_path, class: "tui-button green-168" %>
+        <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "tui-button", style: "margin-left: 10px;" %>
+        <%= link_to "Hackr Missions Log", admin_grid_hackr_missions_path, class: "tui-button", style: "margin-left: 10px;" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 1000px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Arc</th>
+              <th style="text-align: left;">Giver</th>
+              <th style="text-align: left;">Prereq</th>
+              <th style="text-align: center;">CL</th>
+              <th style="text-align: center;">Repeatable</th>
+              <th style="text-align: center;">Obj</th>
+              <th style="text-align: center;">Rewards</th>
+              <th style="text-align: center;">Active</th>
+              <th style="text-align: center;">Done</th>
+              <th style="text-align: center;">Pub</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @missions.each do |mission| %>
+              <tr>
+                <td class="cyan-255-text"><%= mission.name %></td>
+                <td style="color: #666; font-family: monospace;"><%= mission.slug %></td>
+                <td style="color: #a78bfa;"><%= mission.grid_mission_arc&.name || "—" %></td>
+                <td style="color: #c084fc;"><%= mission.giver_mob&.name || "—" %></td>
+                <td style="color: #888; font-family: monospace; font-size: 0.85em;"><%= mission.prereq_mission&.slug || "—" %></td>
+                <td style="text-align: center; color: #fbbf24;"><%= mission.min_clearance %></td>
+                <td style="text-align: center;">
+                  <% if mission.repeatable? %>
+                    <span class="green-255-text">YES</span>
+                  <% else %>
+                    <span style="color: #444;">-</span>
+                  <% end %>
+                </td>
+                <td style="text-align: center; color: #9ca3af;"><%= mission.grid_mission_objectives.size %></td>
+                <td style="text-align: center; color: #9ca3af;"><%= mission.grid_mission_rewards.size %></td>
+                <td style="text-align: center; color: #22d3ee;"><%= @active_counts[mission.id] || 0 %></td>
+                <td style="text-align: center; color: #34d399;"><%= @completed_counts[mission.id] || 0 %></td>
+                <td style="text-align: center;">
+                  <% if mission.published? %>
+                    <span class="green-255-text">YES</span>
+                  <% else %>
+                    <span style="color: #444;">no</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_mission_path(mission), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= button_to "Delete", admin_grid_mission_path(mission), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete mission '#{mission.name}'?" } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "<- Grid Admin", admin_grid_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_missions/new.html.erb
+++ b/app/views/admin/grid_missions/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/missions/new :: NEW MISSION</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @mission, url: admin_grid_missions_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -86,6 +86,8 @@
           <%= link_to "Economy", admin_grid_economy_path, class: "green-168-text" %>
           <%= link_to "Shops", admin_grid_shop_listings_path, class: "green-168-text" %>
           <%= link_to "Achievements", admin_grid_achievements_path, class: "green-168-text" %>
+          <%= link_to "Missions", admin_grid_missions_path, class: "green-168-text" %>
+          <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,11 @@ Rails.application.routes.draw do
   # Achievements (login-gated SPA)
   get "achievements", to: "pages#spa_root", as: :achievements
 
+  # Missions (login-gated SPA). Per-mission detail renders inline in
+  # the MissionsPage card grid — no dedicated per-slug React route, so
+  # we don't expose `/missions/:slug` as a Rails SPA path either.
+  get "missions", to: "pages#spa_root", as: :missions
+
   # Codex (wiki) routes - SPA
   scope "codex" do
     get "/", to: "pages#spa_root", as: :codex
@@ -156,6 +161,7 @@ Rails.application.routes.draw do
     # Grid API routes
     get "grid/current_hackr", to: "grid#current_hackr_info"
     get "grid/achievements", to: "grid#achievements_index"
+    get "grid/missions", to: "grid#missions_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
     get "grid/verify/:token", to: "grid#verify_token"
@@ -311,6 +317,11 @@ Rails.application.routes.draw do
       end
     end
     resources :grid_shop_transactions, only: [:index]
+
+    # Grid missions (runtime CRUD + YAML-seedable)
+    resources :grid_mission_arcs
+    resources :grid_missions
+    resources :grid_hackr_missions, only: %i[index show]
 
     # Hackr Handbook (docs — full CRUD, YAML-seedable)
     resources :handbook_sections

--- a/data/content/handbook.yml
+++ b/data/content/handbook.yml
@@ -244,6 +244,100 @@ handbook_sections:
           hit 50 tracks played across multiple sessions but never triggered
           a Terminal command to check). Expect a small burst of toasts on a
           long-absence login.
+      - slug: missions
+        title: Missions & Quests
+        kind: reference
+        difficulty: beginner
+        position: 3
+        published: true
+        summary: "Accept structured objectives from NPCs for XP, CRED, rep, items, and unlocks."
+        metadata:
+          search_tags:
+            - missions
+            - quests
+            - storylines
+            - objectives
+            - turn-in
+            - deliver
+            - give
+        body: |
+          # Missions
+
+          Missions are structured jobs offered by NPCs. Each mission is a set
+          of objectives (visit a room, talk to someone, retrieve an item,
+          etc.) with rewards paid out on turn-in.
+
+          ## Finding work
+
+          Travel to an NPC and ask about their work:
+
+          ```
+          ask Coordinator about missions
+          ```
+
+          You'll see a list of slugs and short descriptions for every mission
+          that NPC is currently offering you. Specific mission details live
+          one keyword deeper:
+
+          ```
+          ask Coordinator about first-contact
+          ```
+
+          You can only accept a mission from the NPC who gives it, and you
+          have to be in the same room.
+
+          ## Accept, progress, turn in
+
+          | Command              | What it does |
+          |----------------------|--------------|
+          | `accept <slug>`      | Take the job (must be with the giver). |
+          | `missions`           | List your active missions + objective progress. |
+          | `mission <slug>`     | Full detail for one mission. |
+          | `abandon <slug>`     | Drop a mission. Progress clears; re-acceptable anytime. |
+          | `turn_in <slug>`     | Complete the mission (must be with the giver, all objectives met). |
+          | `give <item> to <npc>` | Hand an item to an NPC — used for delivery objectives. |
+
+          Objectives advance automatically as you do the matching action in
+          the Grid. The Terminal shows a short ✓ line on every objective
+          that just completed; progress-only ticks are silent.
+
+          When every objective on a mission is done, the Terminal surfaces
+          `▲ READY FOR TURN-IN`. Return to the giver's room and
+          `turn_in <slug>`.
+
+          ## Storylines and repeatable jobs
+
+          Some missions have a **prerequisite** — you need to complete the
+          prereq before the next one opens up. Related missions can be
+          grouped into an **arc** (e.g. "Signal Recovery") for flavor.
+
+          Missions flagged **repeatable** can be accepted again and again.
+          Each turn-in counts toward any `missions_completed_count`
+          achievements.
+
+          Missions that aren't repeatable are one-shot: once you turn one
+          in, it's done for you. If you abandon it before turn-in, you can
+          re-accept freely.
+
+          ## Rewards
+
+          Mission rewards are a mix of:
+
+          - **XP** and **CRED** (minted from the Fracture Reserve).
+          - **Faction rep** deltas against one or more factions.
+          - **Item grants** dropped into your inventory on turn-in.
+          - **Achievement** unlocks.
+          - **Prereq unlocks** — completing a mission opens the next in its chain.
+
+          See the rewards preview inline when you `ask <npc> about <slug>` or
+          on the `/missions` page.
+
+          ## The `/missions` page
+
+          The SPA page at `/missions` (dropdown under THE PULSE GRID) shows
+          your active jobs, every job available from NPCs in your current
+          room, and your recent completion history. It live-refreshes
+          whenever you turn a mission in.
 
   - slug: wire
     name: WIRE

--- a/data/world/missions.yml
+++ b/data/world/missions.yml
@@ -1,0 +1,114 @@
+# Missions for THE PULSE GRID.
+#
+# Runs via `rails data:missions` (or `rails data:world` which includes it).
+# Idempotent: mission definitions upsert by slug, objective rows reconcile
+# by position, reward rows replace fully on each run.
+#
+# Objective types: visit_room, talk_npc, collect_item, deliver_item,
+# spend_cred, buy_item, reach_rep, reach_clearance, use_item, salvage_item
+# Reward types: xp, cred, faction_rep, item_grant, grant_achievement
+#   (mission unlocks: use `prereq_mission_slug` on the next mission)
+#
+# Giver resolution: giver_mob_name + giver_room_slug (case-insensitive name
+# match, scoped to the room). Prereq: prereq_mission_slug.
+
+arcs:
+  - slug: signal-recovery
+    name: Signal Recovery
+    description: >-
+      A series of operations from the Fracture Network Coordinator to
+      shore up trans-temporal broadcast infrastructure and recover lost
+      signal fragments scattered through the RIDE.
+    position: 1
+    published: true
+
+missions:
+  - slug: first-contact
+    name: First Contact
+    description: >-
+      The Coordinator wants to test your nerve. Find your way to the
+      Blacksite and make contact with GHOST. Return when it's done.
+    arc_slug: signal-recovery
+    giver_mob_name: Fracture Network Coordinator
+    giver_room_slug: hackr-tv-broadcast-station
+    min_clearance: 0
+    repeatable: false
+    position: 1
+    published: true
+    objectives:
+      - position: 1
+        objective_type: visit_room
+        label: "Reach the Blacksite"
+        target_slug: the-blacksite
+        target_count: 1
+      - position: 2
+        objective_type: talk_npc
+        label: "Make contact with GHOST"
+        target_slug: GHOST
+        target_count: 1
+    rewards:
+      - reward_type: xp
+        amount: 50
+      - reward_type: cred
+        amount: 25
+      - reward_type: faction_rep
+        target_slug: hackrcore
+        amount: 5
+
+  - slug: shard-recovery
+    name: Chronology Shard Recovery
+    description: >-
+      GHOST confirmed what the Coordinator suspected: a Chronology Shard
+      has been sitting right under the broadcast tower. Recover it and
+      bring it back.
+    arc_slug: signal-recovery
+    giver_mob_name: Fracture Network Coordinator
+    giver_room_slug: hackr-tv-broadcast-station
+    prereq_mission_slug: first-contact
+    min_clearance: 1
+    repeatable: false
+    position: 2
+    published: true
+    objectives:
+      - position: 1
+        objective_type: collect_item
+        label: "Retrieve the Chronology Shard"
+        target_slug: Chronology Shard
+        target_count: 1
+      - position: 2
+        objective_type: deliver_item
+        label: "Hand the Shard to the Coordinator"
+        target_slug: Chronology Shard
+        target_count: 1
+    rewards:
+      - reward_type: xp
+        amount: 150
+      - reward_type: cred
+        amount: 100
+      - reward_type: faction_rep
+        target_slug: hackrcore
+        amount: 15
+
+  - slug: daily-intel-drop
+    name: Daily Intel Drop
+    description: >-
+      Codec always needs updated signal readings. Bring them business
+      (buy something from the Bazaar) and they'll pay a finder's fee.
+      Can be run daily for steady CRED.
+    giver_mob_name: Codec
+    giver_room_slug: the-signal-bazaar
+    min_clearance: 0
+    repeatable: true
+    position: 10
+    published: true
+    objectives:
+      - position: 1
+        objective_type: spend_cred
+        label: "Spend 50 CRED at The Signal Bazaar"
+        target_slug: ~
+        target_count: 50
+    rewards:
+      - reward_type: xp
+        amount: 20
+      - reward_type: cred
+        amount: 10

--- a/db/migrate/20260415120001_create_grid_mission_tables.rb
+++ b/db/migrate/20260415120001_create_grid_mission_tables.rb
@@ -1,0 +1,76 @@
+class CreateGridMissionTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_mission_arcs do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.text :description
+      t.integer :position, default: 0, null: false
+      t.boolean :published, default: false, null: false
+      t.timestamps
+    end
+    add_index :grid_mission_arcs, :slug, unique: true
+
+    create_table :grid_missions do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.text :description
+      t.references :giver_mob, foreign_key: {to_table: :grid_mobs, on_delete: :nullify}, index: true
+      t.references :grid_mission_arc, foreign_key: {on_delete: :nullify}, index: true
+      t.references :prereq_mission, foreign_key: {to_table: :grid_missions, on_delete: :nullify}, index: true
+      t.integer :min_clearance, default: 0, null: false
+      t.references :min_rep_faction, foreign_key: {to_table: :grid_factions, on_delete: :nullify}, index: true
+      t.integer :min_rep_value, default: 0, null: false
+      t.boolean :repeatable, default: false, null: false
+      t.integer :position, default: 0, null: false
+      t.boolean :published, default: false, null: false
+      t.timestamps
+    end
+    add_index :grid_missions, :slug, unique: true
+
+    create_table :grid_mission_objectives do |t|
+      t.references :grid_mission, null: false, foreign_key: {on_delete: :cascade}, index: true
+      t.integer :position, default: 0, null: false
+      t.string :objective_type, null: false
+      t.string :label, null: false
+      t.string :target_slug
+      t.integer :target_count, default: 1, null: false
+      t.timestamps
+    end
+    add_index :grid_mission_objectives, [:grid_mission_id, :position],
+      name: "index_mission_objectives_on_mission_and_position"
+
+    create_table :grid_mission_rewards do |t|
+      t.references :grid_mission, null: false, foreign_key: {on_delete: :cascade}, index: true
+      t.integer :position, default: 0, null: false
+      t.string :reward_type, null: false
+      t.integer :amount, default: 0, null: false
+      t.string :target_slug
+      t.integer :quantity, default: 1, null: false
+      t.timestamps
+    end
+
+    create_table :grid_hackr_missions do |t|
+      t.references :grid_hackr, null: false, foreign_key: {on_delete: :cascade}, index: true
+      t.references :grid_mission, null: false, foreign_key: {on_delete: :cascade}, index: true
+      t.string :status, null: false, default: "active"
+      t.datetime :accepted_at, null: false
+      t.datetime :completed_at
+      t.integer :turn_in_count, default: 0, null: false
+      t.timestamps
+    end
+    add_index :grid_hackr_missions, [:grid_hackr_id, :status], name: "index_hackr_missions_on_hackr_and_status"
+    # No unique index on (hackr, mission) — completed rows accumulate;
+    # the current attempt is queried via scope(:active) on the hackr.
+
+    create_table :grid_hackr_mission_objectives do |t|
+      t.references :grid_hackr_mission, null: false, foreign_key: {on_delete: :cascade}, index: {name: "index_hackr_mission_objs_on_hackr_mission"}
+      t.references :grid_mission_objective, null: false, foreign_key: {on_delete: :restrict}, index: {name: "index_hackr_mission_objs_on_objective"}
+      t.integer :progress, default: 0, null: false
+      t.datetime :completed_at
+      t.timestamps
+    end
+    add_index :grid_hackr_mission_objectives,
+      [:grid_hackr_mission_id, :grid_mission_objective_id],
+      unique: true, name: "index_hackr_mission_objs_unique"
+  end
+end

--- a/db/migrate/20260415120002_add_active_mission_unique_index.rb
+++ b/db/migrate/20260415120002_add_active_mission_unique_index.rb
@@ -1,0 +1,14 @@
+class AddActiveMissionUniqueIndex < ActiveRecord::Migration[8.1]
+  # Partial unique index serializes concurrent accept!/turn_in! races at the
+  # DB level. Only one "active" row per (hackr, mission) may exist — once
+  # turned in (status flips to "completed"), history rows accumulate without
+  # blocking re-accept of repeatable missions.
+  #
+  # SQLite and Postgres both support `WHERE` on unique indexes.
+  def change
+    add_index :grid_hackr_missions, [:grid_hackr_id, :grid_mission_id],
+      unique: true,
+      where: "status = 'active'",
+      name: "index_hackr_missions_unique_active"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_000007) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -238,6 +238,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_000007) do
     t.index ["grid_hackr_id"], name: "index_grid_hackr_achievements_on_grid_hackr_id"
   end
 
+  create_table "grid_hackr_mission_objectives", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_mission_id", null: false
+    t.integer "grid_mission_objective_id", null: false
+    t.integer "progress", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_mission_id", "grid_mission_objective_id"], name: "index_hackr_mission_objs_unique", unique: true
+    t.index ["grid_hackr_mission_id"], name: "index_hackr_mission_objs_on_hackr_mission"
+    t.index ["grid_mission_objective_id"], name: "index_hackr_mission_objs_on_objective"
+  end
+
+  create_table "grid_hackr_missions", force: :cascade do |t|
+    t.datetime "accepted_at", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "grid_mission_id", null: false
+    t.string "status", default: "active", null: false
+    t.integer "turn_in_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "grid_mission_id"], name: "index_hackr_missions_unique_active", unique: true, where: "status = 'active'"
+    t.index ["grid_hackr_id", "status"], name: "index_hackr_missions_on_hackr_and_status"
+    t.index ["grid_hackr_id"], name: "index_grid_hackr_missions_on_grid_hackr_id"
+    t.index ["grid_mission_id"], name: "index_grid_hackr_missions_on_grid_mission_id"
+  end
+
   create_table "grid_hackr_reputations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "grid_hackr_id", null: false
@@ -313,6 +340,64 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_000007) do
     t.datetime "last_tick_at"
     t.datetime "updated_at", null: false
     t.index ["grid_hackr_id"], name: "index_grid_mining_rigs_on_grid_hackr_id", unique: true
+  end
+
+  create_table "grid_mission_arcs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: false, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_grid_mission_arcs_on_slug", unique: true
+  end
+
+  create_table "grid_mission_objectives", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_mission_id", null: false
+    t.string "label", null: false
+    t.string "objective_type", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "target_count", default: 1, null: false
+    t.string "target_slug"
+    t.datetime "updated_at", null: false
+    t.index ["grid_mission_id", "position"], name: "index_mission_objectives_on_mission_and_position"
+    t.index ["grid_mission_id"], name: "index_grid_mission_objectives_on_grid_mission_id"
+  end
+
+  create_table "grid_mission_rewards", force: :cascade do |t|
+    t.integer "amount", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_mission_id", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "quantity", default: 1, null: false
+    t.string "reward_type", null: false
+    t.string "target_slug"
+    t.datetime "updated_at", null: false
+    t.index ["grid_mission_id"], name: "index_grid_mission_rewards_on_grid_mission_id"
+  end
+
+  create_table "grid_missions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "giver_mob_id"
+    t.integer "grid_mission_arc_id"
+    t.integer "min_clearance", default: 0, null: false
+    t.integer "min_rep_faction_id"
+    t.integer "min_rep_value", default: 0, null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "prereq_mission_id"
+    t.boolean "published", default: false, null: false
+    t.boolean "repeatable", default: false, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["giver_mob_id"], name: "index_grid_missions_on_giver_mob_id"
+    t.index ["grid_mission_arc_id"], name: "index_grid_missions_on_grid_mission_arc_id"
+    t.index ["min_rep_faction_id"], name: "index_grid_missions_on_min_rep_faction_id"
+    t.index ["prereq_mission_id"], name: "index_grid_missions_on_prereq_mission_id"
+    t.index ["slug"], name: "index_grid_missions_on_slug", unique: true
   end
 
   create_table "grid_mobs", force: :cascade do |t|
@@ -933,9 +1018,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_000007) do
   add_foreign_key "grid_factions", "grid_factions", column: "parent_id"
   add_foreign_key "grid_hackr_achievements", "grid_achievements"
   add_foreign_key "grid_hackr_achievements", "grid_hackrs"
+  add_foreign_key "grid_hackr_mission_objectives", "grid_hackr_missions", on_delete: :cascade
+  add_foreign_key "grid_hackr_mission_objectives", "grid_mission_objectives", on_delete: :restrict
+  add_foreign_key "grid_hackr_missions", "grid_hackrs", on_delete: :cascade
+  add_foreign_key "grid_hackr_missions", "grid_missions", on_delete: :cascade
   add_foreign_key "grid_hackr_reputations", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "tracks"
+  add_foreign_key "grid_mission_objectives", "grid_missions", on_delete: :cascade
+  add_foreign_key "grid_mission_rewards", "grid_missions", on_delete: :cascade
+  add_foreign_key "grid_missions", "grid_factions", column: "min_rep_faction_id", on_delete: :nullify
+  add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
+  add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
+  add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_shop_listings", "grid_mobs"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -192,7 +192,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, zones, rooms, etc.)"
-  task world: [:factions, :zones, :rooms, :exits, :mobs, :items, :achievements, :shop_listings]
+  task world: [:factions, :zones, :rooms, :exits, :mobs, :items, :achievements, :shop_listings, :missions]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -1865,6 +1865,143 @@ namespace :data do
     puts "  DRY_RUN=true   - Preview without attaching"
     puts "  CLEANUP=true   - Delete local source files after attaching (ignored for S3)"
     puts "=" * 80 + "\n"
+  end
+
+  desc "Load missions and arcs from YAML"
+  task missions: :environment do
+    puts "\n--- Loading Mission Arcs & Missions ---"
+    yaml_file = Rails.root.join("data", "world", "missions.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file) || {}
+    arcs_data = data["arcs"] || []
+    missions_data = data["missions"] || []
+
+    # Pass 1: upsert arcs
+    arc_created = arc_updated = 0
+    arcs_data.each do |attrs|
+      arc = GridMissionArc.find_or_initialize_by(slug: attrs["slug"])
+      was_new = arc.new_record?
+      arc.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"],
+        position: attrs["position"] || 0,
+        published: attrs.fetch("published", true)
+      )
+      if arc.new_record? || arc.changed?
+        arc.save!
+        was_new ? (arc_created += 1) : (arc_updated += 1)
+        puts "  #{was_new ? "✓ Arc Created" : "↻ Arc Updated"}: #{arc.name}"
+      end
+    end
+
+    # Pass 2: upsert missions WITHOUT prereq (resolved in pass 3 so order
+    # in YAML doesn't matter — a mission can prereq a later-declared one).
+    mission_created = mission_updated = 0
+    missions_data.each do |attrs|
+      mission = GridMission.find_or_initialize_by(slug: attrs["slug"])
+      was_new = mission.new_record?
+
+      giver = if attrs["giver_mob_name"].present?
+        query = GridMob.where("LOWER(name) = ?", attrs["giver_mob_name"].to_s.downcase)
+        if attrs["giver_room_slug"].present?
+          room = GridRoom.find_by(slug: attrs["giver_room_slug"])
+          query = query.where(grid_room_id: room.id) if room
+        end
+        query.first
+      end
+      if giver.nil? && attrs["giver_mob_name"].present?
+        puts "  ⚠ Mission '#{attrs["slug"]}': giver '#{attrs["giver_mob_name"]}' not found — saving without giver"
+      end
+
+      arc = attrs["arc_slug"].present? ? GridMissionArc.find_by(slug: attrs["arc_slug"]) : nil
+      min_rep_faction = attrs["min_rep_faction_slug"].present? ? GridFaction.find_by(slug: attrs["min_rep_faction_slug"]) : nil
+
+      mission.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"],
+        giver_mob: giver,
+        grid_mission_arc: arc,
+        min_clearance: attrs["min_clearance"] || 0,
+        min_rep_faction: min_rep_faction,
+        min_rep_value: attrs["min_rep_value"] || 0,
+        repeatable: attrs.fetch("repeatable", false),
+        position: attrs["position"] || 0,
+        published: attrs.fetch("published", true)
+      )
+
+      if mission.new_record? || mission.changed?
+        mission.save!
+        was_new ? (mission_created += 1) : (mission_updated += 1)
+        puts "  #{was_new ? "✓ Mission Created" : "↻ Mission Updated"}: #{mission.name}"
+      end
+
+      # Reconcile objectives declaratively by position. Objectives not in
+      # YAML are removed (including the "empty list" case — fully
+      # clearing objectives from YAML deletes all existing rows so
+      # authors see the change reflected).
+      desired_obj_positions = (attrs["objectives"] || []).map { |o| o["position"].to_i }
+      mission.grid_mission_objectives.where.not(position: desired_obj_positions).destroy_all
+
+      (attrs["objectives"] || []).each do |o|
+        pos = o["position"].to_i
+        objective = mission.grid_mission_objectives.find_or_initialize_by(position: pos)
+        objective.assign_attributes(
+          objective_type: o["objective_type"],
+          label: o["label"],
+          target_slug: o["target_slug"],
+          target_count: o["target_count"] || 1
+        )
+        objective.save! if objective.new_record? || objective.changed?
+      end
+
+      # Rewards: same declarative reconcile by position. Matches
+      # factions/objectives idiom — upsert on `changed?`, destroy
+      # rows no longer in YAML. Avoids churn on idempotent re-runs.
+      desired_reward_positions = (attrs["rewards"] || []).each_with_index.map { |r, i| r["position"] || (i + 1) }
+      mission.grid_mission_rewards.where.not(position: desired_reward_positions).destroy_all
+
+      (attrs["rewards"] || []).each_with_index do |r, i|
+        pos = r["position"] || (i + 1)
+        reward = mission.grid_mission_rewards.find_or_initialize_by(position: pos)
+        reward.assign_attributes(
+          reward_type: r["reward_type"],
+          amount: r["amount"] || 0,
+          target_slug: r["target_slug"],
+          quantity: r["quantity"] || 1
+        )
+        reward.save! if reward.new_record? || reward.changed?
+      end
+    end
+
+    # Pass 3: reconcile prereq_mission_slug → prereq_mission_id declaratively.
+    # Handles three cases per mission:
+    #   1. YAML adds/changes prereq → resolve slug → set FK
+    #   2. YAML removes prereq → null out the FK (prevents stale prereq drift)
+    #   3. YAML references an unknown prereq slug → warn, leave existing FK
+    missions_data.each do |attrs|
+      mission = GridMission.find_by(slug: attrs["slug"])
+      next unless mission
+
+      desired_prereq_id = if attrs["prereq_mission_slug"].present?
+        prereq = GridMission.find_by(slug: attrs["prereq_mission_slug"])
+        unless prereq
+          puts "  ⚠ Mission '#{attrs["slug"]}': prereq '#{attrs["prereq_mission_slug"]}' not found — leaving existing FK"
+          next
+        end
+        prereq.id
+      end
+
+      next if mission.prereq_mission_id == desired_prereq_id
+      mission.update!(prereq_mission_id: desired_prereq_id)
+    end
+
+    puts "Arcs: #{arc_created} created, #{arc_updated} updated, #{GridMissionArc.count} total"
+    puts "Missions: #{mission_created} created, #{mission_updated} updated, #{GridMission.count} total"
   end
 end
 

--- a/spec/factories/grid_hackr_achievements.rb
+++ b/spec/factories/grid_hackr_achievements.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_hackr_achievements
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  awarded_at          :datetime         not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  grid_achievement_id :integer          not null
+#  grid_hackr_id       :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_achievements_on_grid_achievement_id  (grid_achievement_id)
+#  index_grid_hackr_achievements_on_grid_hackr_id        (grid_hackr_id)
+#  index_hackr_achievements_unique                       (grid_hackr_id,grid_achievement_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_achievement_id  (grid_achievement_id => grid_achievements.id)
+#  grid_hackr_id        (grid_hackr_id => grid_hackrs.id)
+#
 FactoryBot.define do
   factory :grid_hackr_achievement do
     association :grid_hackr

--- a/spec/factories/grid_hackr_mission_objectives.rb
+++ b/spec/factories/grid_hackr_mission_objectives.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: grid_hackr_mission_objectives
+# Database name: primary
+#
+#  id                        :integer          not null, primary key
+#  completed_at              :datetime
+#  progress                  :integer          default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  grid_hackr_mission_id     :integer          not null
+#  grid_mission_objective_id :integer          not null
+#
+# Indexes
+#
+#  index_hackr_mission_objs_on_hackr_mission  (grid_hackr_mission_id)
+#  index_hackr_mission_objs_on_objective      (grid_mission_objective_id)
+#  index_hackr_mission_objs_unique            (grid_hackr_mission_id,grid_mission_objective_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_mission_id      (grid_hackr_mission_id => grid_hackr_missions.id) ON DELETE => cascade
+#  grid_mission_objective_id  (grid_mission_objective_id => grid_mission_objectives.id) ON DELETE => restrict
+#
+FactoryBot.define do
+  factory :grid_hackr_mission_objective do
+    association :grid_hackr_mission
+    association :grid_mission_objective
+    progress { 0 }
+    completed_at { nil }
+
+    trait :completed do
+      progress { 1 }
+      completed_at { Time.current }
+    end
+  end
+end

--- a/spec/factories/grid_hackr_missions.rb
+++ b/spec/factories/grid_hackr_missions.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: grid_hackr_missions
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  accepted_at     :datetime         not null
+#  completed_at    :datetime
+#  status          :string           default("active"), not null
+#  turn_in_count   :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_hackr_id   :integer          not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_hackr_missions_on_grid_hackr_id    (grid_hackr_id)
+#  index_grid_hackr_missions_on_grid_mission_id  (grid_mission_id)
+#  index_hackr_missions_on_hackr_and_status      (grid_hackr_id,status)
+#  index_hackr_missions_unique_active            (grid_hackr_id,grid_mission_id) UNIQUE WHERE status = 'active'
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :grid_hackr_mission do
+    association :grid_hackr
+    association :grid_mission
+    status { "active" }
+    accepted_at { Time.current }
+    turn_in_count { 0 }
+
+    trait :completed do
+      status { "completed" }
+      completed_at { Time.current }
+      turn_in_count { 1 }
+    end
+  end
+end

--- a/spec/factories/grid_mission_arcs.rb
+++ b/spec/factories/grid_mission_arcs.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: grid_mission_arcs
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer          default(0), not null
+#  published   :boolean          default(FALSE), not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_mission_arcs_on_slug  (slug) UNIQUE
+#
+FactoryBot.define do
+  factory :grid_mission_arc do
+    sequence(:slug) { |n| "test-arc-#{n}" }
+    sequence(:name) { |n| "Test Arc #{n}" }
+    description { "An arc for tests." }
+    position { 1 }
+    published { true }
+  end
+end

--- a/spec/factories/grid_mission_objectives.rb
+++ b/spec/factories/grid_mission_objectives.rb
@@ -1,0 +1,66 @@
+# == Schema Information
+#
+# Table name: grid_mission_objectives
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  label           :string           not null
+#  objective_type  :string           not null
+#  position        :integer          default(0), not null
+#  target_count    :integer          default(1), not null
+#  target_slug     :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_mission_objectives_on_grid_mission_id  (grid_mission_id)
+#  index_mission_objectives_on_mission_and_position  (grid_mission_id,position)
+#
+# Foreign Keys
+#
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :grid_mission_objective do
+    association :grid_mission
+    sequence(:position) { |n| n }
+    objective_type { "visit_room" }
+    label { "Reach the target room" }
+    target_slug { "test-room" }
+    target_count { 1 }
+
+    trait :talk_npc do
+      objective_type { "talk_npc" }
+      target_slug { "TestNPC" }
+      label { "Talk to TestNPC" }
+    end
+
+    trait :collect_item do
+      objective_type { "collect_item" }
+      target_slug { "Test Item" }
+      label { "Collect the Test Item" }
+    end
+
+    trait :deliver_item do
+      objective_type { "deliver_item" }
+      target_slug { "Test Item" }
+      label { "Deliver the Test Item" }
+    end
+
+    trait :spend_cred do
+      objective_type { "spend_cred" }
+      target_slug { nil }
+      target_count { 100 }
+      label { "Spend 100 CRED" }
+    end
+
+    trait :reach_clearance do
+      objective_type { "reach_clearance" }
+      target_slug { nil }
+      target_count { 5 }
+      label { "Reach clearance 5" }
+    end
+  end
+end

--- a/spec/factories/grid_mission_rewards.rb
+++ b/spec/factories/grid_mission_rewards.rb
@@ -1,0 +1,57 @@
+# == Schema Information
+#
+# Table name: grid_mission_rewards
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  amount          :integer          default(0), not null
+#  position        :integer          default(0), not null
+#  quantity        :integer          default(1), not null
+#  reward_type     :string           not null
+#  target_slug     :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  grid_mission_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_mission_rewards_on_grid_mission_id  (grid_mission_id)
+#
+# Foreign Keys
+#
+#  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :grid_mission_reward do
+    association :grid_mission
+    sequence(:position) { |n| n }
+    reward_type { "xp" }
+    amount { 50 }
+    target_slug { nil }
+    quantity { 1 }
+
+    trait :cred do
+      reward_type { "cred" }
+      amount { 25 }
+    end
+
+    trait :faction_rep do
+      reward_type { "faction_rep" }
+      amount { 10 }
+      target_slug { "hackrcore" }
+    end
+
+    trait :item_grant do
+      reward_type { "item_grant" }
+      target_slug { "Test Reward Item" }
+      amount { 5 }
+      quantity { 1 }
+    end
+
+    trait :grant_achievement do
+      reward_type { "grant_achievement" }
+      target_slug { "test-achievement" }
+      amount { 0 }
+    end
+  end
+end

--- a/spec/factories/grid_missions.rb
+++ b/spec/factories/grid_missions.rb
@@ -1,0 +1,60 @@
+# == Schema Information
+#
+# Table name: grid_missions
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  description         :text
+#  min_clearance       :integer          default(0), not null
+#  min_rep_value       :integer          default(0), not null
+#  name                :string           not null
+#  position            :integer          default(0), not null
+#  published           :boolean          default(FALSE), not null
+#  repeatable          :boolean          default(FALSE), not null
+#  slug                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  giver_mob_id        :integer
+#  grid_mission_arc_id :integer
+#  min_rep_faction_id  :integer
+#  prereq_mission_id   :integer
+#
+# Indexes
+#
+#  index_grid_missions_on_giver_mob_id         (giver_mob_id)
+#  index_grid_missions_on_grid_mission_arc_id  (grid_mission_arc_id)
+#  index_grid_missions_on_min_rep_faction_id   (min_rep_faction_id)
+#  index_grid_missions_on_prereq_mission_id    (prereq_mission_id)
+#  index_grid_missions_on_slug                 (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  giver_mob_id         (giver_mob_id => grid_mobs.id) ON DELETE => nullify
+#  grid_mission_arc_id  (grid_mission_arc_id => grid_mission_arcs.id) ON DELETE => nullify
+#  min_rep_faction_id   (min_rep_faction_id => grid_factions.id) ON DELETE => nullify
+#  prereq_mission_id    (prereq_mission_id => grid_missions.id) ON DELETE => nullify
+#
+FactoryBot.define do
+  factory :grid_mission do
+    sequence(:slug) { |n| "test-mission-#{n}" }
+    sequence(:name) { |n| "Test Mission #{n}" }
+    description { "A test mission." }
+    association :giver_mob, factory: %i[grid_mob quest_giver]
+    grid_mission_arc { nil }
+    prereq_mission { nil }
+    min_clearance { 0 }
+    min_rep_faction { nil }
+    min_rep_value { 0 }
+    repeatable { false }
+    position { 1 }
+    published { true }
+
+    trait :repeatable do
+      repeatable { true }
+    end
+
+    trait :unpublished do
+      published { false }
+    end
+  end
+end

--- a/spec/models/grid_mission_spec.rb
+++ b/spec/models/grid_mission_spec.rb
@@ -1,0 +1,166 @@
+# == Schema Information
+#
+# Table name: grid_missions
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  description         :text
+#  min_clearance       :integer          default(0), not null
+#  min_rep_value       :integer          default(0), not null
+#  name                :string           not null
+#  position            :integer          default(0), not null
+#  published           :boolean          default(FALSE), not null
+#  repeatable          :boolean          default(FALSE), not null
+#  slug                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  giver_mob_id        :integer
+#  grid_mission_arc_id :integer
+#  min_rep_faction_id  :integer
+#  prereq_mission_id   :integer
+#
+# Indexes
+#
+#  index_grid_missions_on_giver_mob_id         (giver_mob_id)
+#  index_grid_missions_on_grid_mission_arc_id  (grid_mission_arc_id)
+#  index_grid_missions_on_min_rep_faction_id   (min_rep_faction_id)
+#  index_grid_missions_on_prereq_mission_id    (prereq_mission_id)
+#  index_grid_missions_on_slug                 (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  giver_mob_id         (giver_mob_id => grid_mobs.id) ON DELETE => nullify
+#  grid_mission_arc_id  (grid_mission_arc_id => grid_mission_arcs.id) ON DELETE => nullify
+#  min_rep_faction_id   (min_rep_faction_id => grid_factions.id) ON DELETE => nullify
+#  prereq_mission_id    (prereq_mission_id => grid_missions.id) ON DELETE => nullify
+#
+require "rails_helper"
+
+RSpec.describe GridMission do
+  describe "validations" do
+    it "requires a slug" do
+      expect(build(:grid_mission, slug: nil)).not_to be_valid
+    end
+
+    it "requires a unique slug" do
+      create(:grid_mission, slug: "dupe")
+      expect(build(:grid_mission, slug: "dupe")).not_to be_valid
+    end
+
+    it "requires a giver_mob when published" do
+      mission = build(:grid_mission, giver_mob: nil, published: true)
+      expect(mission).not_to be_valid
+      expect(mission.errors[:giver_mob_id]).to include(/required for published/)
+    end
+
+    it "allows nil giver_mob when unpublished (draft)" do
+      mission = build(:grid_mission, giver_mob: nil, published: false)
+      expect(mission).to be_valid
+    end
+
+    it "rejects a prereq that points to itself" do
+      mission = create(:grid_mission)
+      mission.prereq_mission_id = mission.id
+      expect(mission).not_to be_valid
+      expect(mission.errors[:prereq_mission_id]).to include(/itself/)
+    end
+  end
+
+  describe "associations + cascade" do
+    it "destroys objectives and rewards on destroy" do
+      mission = create(:grid_mission)
+      create(:grid_mission_objective, grid_mission: mission)
+      create(:grid_mission_reward, grid_mission: mission)
+
+      expect { mission.destroy! }
+        .to change(GridMissionObjective, :count).by(-1)
+        .and change(GridMissionReward, :count).by(-1)
+    end
+
+    it "destroys hackr instances on destroy" do
+      mission = create(:grid_mission)
+      create(:grid_hackr_mission, grid_mission: mission)
+
+      expect { mission.destroy! }.to change(GridHackrMission, :count).by(-1)
+    end
+  end
+
+  it "uses slug as to_param" do
+    mission = create(:grid_mission, slug: "hello-world")
+    expect(mission.to_param).to eq("hello-world")
+  end
+end
+
+RSpec.describe GridMissionArc do
+  it "validates uniqueness of slug" do
+    create(:grid_mission_arc, slug: "arc-dupe")
+    expect(build(:grid_mission_arc, slug: "arc-dupe")).not_to be_valid
+  end
+end
+
+RSpec.describe GridMissionObjective do
+  it "validates objective_type against allowlist" do
+    obj = build(:grid_mission_objective, objective_type: "bogus")
+    expect(obj).not_to be_valid
+    expect(obj.errors[:objective_type]).to be_present
+  end
+
+  it "requires target_count > 0" do
+    obj = build(:grid_mission_objective, target_count: 0)
+    expect(obj).not_to be_valid
+  end
+end
+
+RSpec.describe GridMissionReward do
+  it "validates reward_type against allowlist" do
+    r = build(:grid_mission_reward, reward_type: "bogus")
+    expect(r).not_to be_valid
+  end
+end
+
+RSpec.describe GridHackrMission do
+  describe "#all_objectives_completed?" do
+    let(:mission) { create(:grid_mission) }
+    let!(:obj1) { create(:grid_mission_objective, grid_mission: mission) }
+    let!(:obj2) { create(:grid_mission_objective, :talk_npc, grid_mission: mission) }
+    let(:hackr) { create(:grid_hackr) }
+    let(:hackr_mission) { create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission) }
+
+    it "is false when no objectives have been completed" do
+      create(:grid_hackr_mission_objective, grid_hackr_mission: hackr_mission, grid_mission_objective: obj1)
+      create(:grid_hackr_mission_objective, grid_hackr_mission: hackr_mission, grid_mission_objective: obj2)
+      expect(hackr_mission.all_objectives_completed?).to eq(false)
+    end
+
+    it "is true only when ALL objectives have completed_at set" do
+      create(:grid_hackr_mission_objective, :completed, grid_hackr_mission: hackr_mission, grid_mission_objective: obj1)
+      create(:grid_hackr_mission_objective, :completed, grid_hackr_mission: hackr_mission, grid_mission_objective: obj2)
+      expect(hackr_mission.all_objectives_completed?).to eq(true)
+    end
+
+    it "is false when only some objectives are complete" do
+      create(:grid_hackr_mission_objective, :completed, grid_hackr_mission: hackr_mission, grid_mission_objective: obj1)
+      create(:grid_hackr_mission_objective, grid_hackr_mission: hackr_mission, grid_mission_objective: obj2)
+      expect(hackr_mission.all_objectives_completed?).to eq(false)
+    end
+  end
+
+  it "prevents two active instances of the same mission" do
+    hackr = create(:grid_hackr)
+    mission = create(:grid_mission)
+    create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission, status: "active")
+
+    dup = build(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission, status: "active")
+    expect(dup).not_to be_valid
+    expect(dup.errors[:base].join).to match(/active instance/)
+  end
+
+  it "allows a fresh active instance when the previous is completed" do
+    hackr = create(:grid_hackr)
+    mission = create(:grid_mission, :repeatable)
+    create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission)
+
+    fresh = build(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission, status: "active")
+    expect(fresh).to be_valid
+  end
+end

--- a/spec/services/grid/achievement_checker_mission_triggers_spec.rb
+++ b/spec/services/grid/achievement_checker_mission_triggers_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe Grid::AchievementChecker, "mission-related triggers" do
+  let(:hackr) { create(:grid_hackr) }
+  let(:checker) { described_class.new(hackr) }
+  let!(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let!(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+
+  before do
+    genesis_source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: genesis_source, to_cache: gameplay_pool, amount: 1_000_000,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  describe "purchase_item" do
+    it "is in the trigger types allowlist" do
+      expect(GridAchievement::TRIGGER_TYPES).to include("purchase_item")
+    end
+
+    it "matches when target item_name equals context item_name (case-insensitive)" do
+      ach = create(:grid_achievement,
+        slug: "first-buy", trigger_type: "purchase_item",
+        trigger_data: {"item_name" => "Signal Fragment"},
+        xp_reward: 5)
+      notifs = checker.check(:purchase_item, item_name: "signal fragment")
+      expect(notifs.size).to eq(1)
+      expect(hackr.grid_hackr_achievements.pluck(:grid_achievement_id)).to include(ach.id)
+    end
+
+    it "matches with blank target (unlocks on any purchase)" do
+      create(:grid_achievement,
+        slug: "any-buy", trigger_type: "purchase_item",
+        trigger_data: {}, xp_reward: 5)
+      notifs = checker.check(:purchase_item, item_name: "anything")
+      expect(notifs.size).to eq(1)
+    end
+  end
+
+  describe "missions_completed_count" do
+    it "is in CUMULATIVE_TRIGGERS" do
+      expect(GridAchievement::CUMULATIVE_TRIGGERS).to include("missions_completed_count")
+    end
+
+    it "counts turn_in_count summed across all completed hackr missions" do
+      mission_a = create(:grid_mission)
+      mission_b = create(:grid_mission, :repeatable)
+      create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission_a, turn_in_count: 1)
+      create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission_b, turn_in_count: 3)
+
+      ach = create(:grid_achievement,
+        slug: "mission-vet", trigger_type: "missions_completed_count",
+        trigger_data: {"count" => 3}, xp_reward: 50)
+
+      progress = checker.progress(ach)
+      expect(progress[:current]).to eq(4)
+      expect(progress[:target]).to eq(3)
+      expect(progress[:completed]).to eq(true)
+    end
+  end
+
+  describe "mission_completed" do
+    it "matches when mission_slug matches context" do
+      ach = create(:grid_achievement,
+        slug: "first-mission-done", trigger_type: "mission_completed",
+        trigger_data: {"mission_slug" => "first-contact"}, xp_reward: 50)
+
+      notifs = checker.check(:mission_completed, mission_slug: "first-contact")
+      expect(notifs.size).to eq(1)
+      expect(hackr.grid_hackr_achievements.pluck(:grid_achievement_id)).to include(ach.id)
+    end
+
+    it "does not match when mission_slug differs" do
+      create(:grid_achievement,
+        slug: "specific-mission", trigger_type: "mission_completed",
+        trigger_data: {"mission_slug" => "other-mission"})
+
+      notifs = checker.check(:mission_completed, mission_slug: "first-contact")
+      expect(notifs).to be_empty
+    end
+  end
+end

--- a/spec/services/grid/mission_progressor_spec.rb
+++ b/spec/services/grid/mission_progressor_spec.rb
@@ -1,0 +1,190 @@
+require "rails_helper"
+
+RSpec.describe Grid::MissionProgressor do
+  let(:hackr) { create(:grid_hackr) }
+  let(:mission) { create(:grid_mission) }
+  let!(:hackr_mission) { create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission) }
+  let(:progressor) { described_class.new(hackr) }
+
+  def make_objective(type, **attrs)
+    create(:grid_mission_objective, grid_mission: mission, objective_type: type, **attrs)
+  end
+
+  describe ":visit_room" do
+    it "completes when target_slug matches the room_slug" do
+      objective = make_objective("visit_room", target_slug: "the-blacksite", label: "Reach Blacksite")
+      notifs = progressor.record(:visit_room, room_slug: "the-blacksite")
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj.completed_at).not_to be_nil
+      expect(notifs.join).to include("Reach Blacksite")
+    end
+
+    it "does nothing when target_slug doesn't match" do
+      make_objective("visit_room", target_slug: "other-room", label: "Go elsewhere")
+      notifs = progressor.record(:visit_room, room_slug: "the-blacksite")
+
+      expect(notifs).to be_empty
+      expect(hackr_mission.grid_hackr_mission_objectives.count).to eq(0)
+    end
+
+    it "is silent when an already-complete objective is re-triggered (no duplicate notif)" do
+      make_objective("visit_room", target_slug: "the-blacksite")
+      progressor.record(:visit_room, room_slug: "the-blacksite")
+      second = progressor.record(:visit_room, room_slug: "the-blacksite")
+
+      expect(second).to be_empty
+    end
+  end
+
+  describe ":collect_item (cumulative count)" do
+    it "accumulates progress across multiple takes until target_count is reached" do
+      objective = make_objective("collect_item", target_slug: "Signal Shard", target_count: 3, label: "Collect 3 shards")
+
+      progressor.record(:collect_item, item_name: "Signal Shard")
+      progressor.record(:collect_item, item_name: "Signal Shard")
+      expect(hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective).progress).to eq(2)
+
+      notifs = progressor.record(:collect_item, item_name: "Signal Shard")
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective).reload
+      expect(hobj.progress).to eq(3)
+      expect(hobj.completed_at).not_to be_nil
+      expect(notifs).not_to be_empty
+    end
+  end
+
+  describe ":deliver_item (two-dimensional matching)" do
+    # deliver_item objectives match on BOTH the item name (target_slug)
+    # AND the destination NPC. By convention the destination is the
+    # mission's giver_mob — not a separate column — so a missed-target
+    # deliver doesn't advance the objective.
+    let(:giver_room) { create(:grid_room) }
+    let(:giver_mob) { create(:grid_mob, :quest_giver, name: "Courier", grid_room: giver_room) }
+    let(:other_mob) { create(:grid_mob, name: "Stranger", grid_room: giver_room) }
+    let(:mission) { create(:grid_mission, giver_mob: giver_mob) }
+
+    it "advances when both the item AND the mission giver match" do
+      objective = create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: "Signal Shard", label: "Deliver shard")
+
+      notifs = described_class.new(hackr).record(:deliver_item, item_name: "Signal Shard", npc_name: "Courier")
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj).not_to be_nil
+      expect(hobj.completed_at).not_to be_nil
+      expect(notifs.join).to include("Deliver shard")
+    end
+
+    it "does NOT advance when the item matches but the NPC is not the giver" do
+      create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: "Signal Shard", label: "Deliver shard")
+
+      notifs = described_class.new(hackr).record(:deliver_item, item_name: "Signal Shard", npc_name: "Stranger")
+
+      expect(notifs).to be_empty
+      expect(hackr_mission.grid_hackr_mission_objectives.count).to eq(0)
+    end
+
+    it "does NOT advance when the NPC matches but the item is wrong" do
+      create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: "Signal Shard", label: "Deliver shard")
+
+      notifs = described_class.new(hackr).record(:deliver_item, item_name: "Fake Shard", npc_name: "Courier")
+
+      expect(notifs).to be_empty
+    end
+
+    it "wildcards the item when target_slug is blank (any item delivered to giver)" do
+      objective = create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: nil, label: "Deliver anything")
+
+      described_class.new(hackr).record(:deliver_item, item_name: "Whatever", npc_name: "Courier")
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj&.completed_at).not_to be_nil
+    end
+
+    it "accepts delivery to ANY NPC when the mission has no giver (giver-nil wildcard)" do
+      mission.update!(giver_mob: nil, published: false)
+      objective = create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: "Data Chip", label: "Drop the chip")
+
+      described_class.new(hackr).record(:deliver_item, item_name: "Data Chip", npc_name: "Stranger")
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj&.completed_at).not_to be_nil
+    end
+
+    it "is case-insensitive on both item and NPC names" do
+      objective = create(:grid_mission_objective, :deliver_item,
+        grid_mission: mission, target_slug: "Signal Shard", label: "Deliver shard")
+
+      described_class.new(hackr).record(:deliver_item, item_name: "SIGNAL SHARD", npc_name: "courier")
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj&.completed_at).not_to be_nil
+    end
+  end
+
+  describe ":reach_clearance (threshold)" do
+    it "completes when the provided value reaches target_count" do
+      objective = make_objective("reach_clearance", target_slug: nil, target_count: 3, label: "Hit CL3")
+      notifs = progressor.record(:reach_clearance, clearance: 5)
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj.completed_at).not_to be_nil
+      expect(hobj.progress).to eq(3) # clamped to target
+      expect(notifs).not_to be_empty
+    end
+
+    it "records progress below threshold without completing" do
+      objective = make_objective("reach_clearance", target_count: 5, label: "Hit CL5")
+      notifs = progressor.record(:reach_clearance, clearance: 2)
+
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective)
+      expect(hobj.progress).to eq(2)
+      expect(hobj.completed_at).to be_nil
+      expect(notifs).to be_empty
+    end
+  end
+
+  describe ":spend_cred (accumulator)" do
+    it "accumulates across multiple events" do
+      objective = make_objective("spend_cred", target_count: 200, label: "Spend 200 CRED")
+
+      progressor.record(:spend_cred, amount: 75)
+      progressor.record(:spend_cred, amount: 75)
+      expect(hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective).progress).to eq(150)
+
+      progressor.record(:spend_cred, amount: 50)
+      hobj = hackr_mission.grid_hackr_mission_objectives.find_by(grid_mission_objective: objective).reload
+      expect(hobj.progress).to eq(200)
+      expect(hobj.completed_at).not_to be_nil
+    end
+  end
+
+  describe "READY notification" do
+    it "emits a READY-for-turn-in notification when the last objective completes" do
+      make_objective("visit_room", target_slug: "room-a", label: "A", position: 1)
+      make_objective("visit_room", target_slug: "room-b", label: "B", position: 2)
+
+      first_batch = progressor.record(:visit_room, room_slug: "room-a")
+      expect(first_batch.join).to include("A")
+      expect(first_batch.join).not_to include("READY FOR TURN-IN")
+
+      # Discard progressor so memoized active_hackr_missions reflect the
+      # just-saved objective row; mirrors real per-request lifecycle.
+      final = described_class.new(hackr).record(:visit_room, room_slug: "room-b")
+      expect(final.join).to include("B")
+      expect(final.join).to include("READY FOR TURN-IN")
+    end
+  end
+
+  it "no-ops for completed missions" do
+    make_objective("visit_room", target_slug: "a")
+    hackr_mission.update!(status: "completed", completed_at: Time.current)
+
+    notifs = described_class.new(hackr).record(:visit_room, room_slug: "a")
+    expect(notifs).to be_empty
+  end
+end

--- a/spec/services/grid/mission_reward_granter_spec.rb
+++ b/spec/services/grid/mission_reward_granter_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe Grid::MissionRewardGranter do
+  let(:hackr) { create(:grid_hackr) }
+  let!(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let!(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+  let(:faction) { create(:grid_faction, slug: "hackrcore", name: "Hackrcore") }
+  let(:mission) { create(:grid_mission) }
+  let(:hackr_mission) { create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission) }
+
+  before do
+    # Fund the gameplay pool so mint_gameplay! can succeed.
+    genesis_source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: genesis_source, to_cache: gameplay_pool, amount: 1_000_000,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  describe "#grant!" do
+    it "marks the hackr_mission completed and increments turn_in_count" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 50)
+      described_class.new(hackr, hackr_mission).grant!
+      hackr_mission.reload
+      expect(hackr_mission.status).to eq("completed")
+      expect(hackr_mission.completed_at).not_to be_nil
+      expect(hackr_mission.turn_in_count).to eq(1)
+    end
+
+    it "grants XP via hackr.grant_xp!" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 100)
+      expect {
+        described_class.new(hackr, hackr_mission).grant!
+        hackr.reload
+      }.to change { hackr.stat("xp") }.by(100)
+    end
+
+    it "mints CRED to the default cache" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "cred", amount: 40)
+      expect {
+        described_class.new(hackr, hackr_mission).grant!
+      }.to change { cache.reload.balance }.by(40)
+    end
+
+    it "skips CRED mint when default cache is abandoned (rest still commits)" do
+      cache.update!(status: "abandoned")
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 10)
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "cred", amount: 50)
+
+      expect {
+        described_class.new(hackr, hackr_mission).grant!
+        hackr.reload
+      }.to change { hackr.stat("xp") }.by(10)
+
+      expect(cache.reload.balance).to eq(0)
+    end
+
+    it "grants faction rep via ReputationService" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "faction_rep", amount: 25, target_slug: faction.slug)
+
+      described_class.new(hackr, hackr_mission).grant!
+      rep = hackr.grid_hackr_reputations.find_by(subject: faction)
+      expect(rep.value).to eq(25)
+    end
+
+    it "creates a GridItem for item_grant rewards" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "item_grant", target_slug: "Reward Core", amount: 100, quantity: 2)
+
+      expect {
+        described_class.new(hackr, hackr_mission).grant!
+      }.to change(GridItem, :count).by(1)
+
+      item = hackr.grid_items.last
+      expect(item.name).to eq("Reward Core")
+      expect(item.quantity).to eq(2)
+    end
+
+    it "routes grant_achievement through AchievementAwarder" do
+      ach = create(:grid_achievement, slug: "mission-badge", trigger_type: "manual", xp_reward: 5, cred_reward: 0)
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "grant_achievement", target_slug: ach.slug)
+
+      expect {
+        described_class.new(hackr, hackr_mission).grant!
+      }.to change { hackr.grid_hackr_achievements.count }.by(1)
+    end
+
+    it "broadcasts mission_completed to the AchievementChannel stream" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 10)
+
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "achievement_channel_#{hackr.id}",
+        hash_including(type: "mission_completed")
+      )
+      described_class.new(hackr, hackr_mission).grant!
+    end
+
+    it "advances reach_clearance objectives on OTHER active missions when XP triggers a level-up" do
+      # Mission A: one XP reward that pushes the hackr past CL1 (10 XP).
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 50)
+
+      # Mission B: an independent active mission with a reach_clearance
+      # objective that becomes satisfied once the hackr hits CL1.
+      mission_b = create(:grid_mission, slug: "sibling-mission")
+      obj_b = create(:grid_mission_objective, grid_mission: mission_b,
+        objective_type: "reach_clearance", target_count: 1, label: "Reach CL1")
+      hackr_mission_b = create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission_b)
+
+      outcome = described_class.new(hackr, hackr_mission).grant!
+
+      hackr_obj_b = hackr_mission_b.grid_hackr_mission_objectives.find_by(grid_mission_objective: obj_b)
+      expect(hackr_obj_b).not_to be_nil
+      expect(hackr_obj_b.completed_at).not_to be_nil
+      expect(outcome[:progressor_notifs].join).to include("Reach CL1")
+    end
+
+    it "advances reach_rep objectives on OTHER active missions when the mission grants faction rep" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "faction_rep", amount: 50, target_slug: faction.slug)
+
+      mission_b = create(:grid_mission, slug: "rep-sibling")
+      obj_b = create(:grid_mission_objective, grid_mission: mission_b,
+        objective_type: "reach_rep", target_slug: faction.slug, target_count: 25, label: "Gain 25 rep")
+      hackr_mission_b = create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission_b)
+
+      outcome = described_class.new(hackr, hackr_mission).grant!
+
+      hackr_obj_b = hackr_mission_b.grid_hackr_mission_objectives.find_by(grid_mission_objective: obj_b)
+      expect(hackr_obj_b).not_to be_nil
+      expect(hackr_obj_b.completed_at).not_to be_nil
+      expect(outcome[:progressor_notifs].join).to include("Gain 25 rep")
+    end
+
+    it "returns a notification_html block" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 50)
+      result = described_class.new(hackr, hackr_mission).grant!
+      expect(result[:notification_html]).to include("MISSION COMPLETE")
+      expect(result[:notification_html]).to include(mission.name)
+      expect(result[:notification_html]).to include("+50 XP")
+    end
+  end
+end

--- a/spec/services/grid/mission_service_spec.rb
+++ b/spec/services/grid/mission_service_spec.rb
@@ -1,0 +1,322 @@
+require "rails_helper"
+
+RSpec.describe Grid::MissionService do
+  let(:hackr) { create(:grid_hackr) }
+  let(:giver_room) { create(:grid_room) }
+  let(:other_room) { create(:grid_room) }
+  let(:giver) { create(:grid_mob, :quest_giver, grid_room: giver_room) }
+  let(:mission) { create(:grid_mission, giver_mob: giver) }
+  let(:service) { described_class.new(hackr) }
+
+  before do
+    create(:grid_mission_objective, grid_mission: mission, objective_type: "visit_room", target_slug: "x", label: "Go x")
+  end
+
+  describe "#accept!" do
+    it "creates a GridHackrMission + objective rows in the giver's room" do
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to change(GridHackrMission, :count).by(1)
+        .and change(GridHackrMissionObjective, :count).by(mission.grid_mission_objectives.count)
+    end
+
+    it "raises NotAtGiver when hackr is not in the giver's room" do
+      expect {
+        service.accept!(mission.slug, room: other_room)
+      }.to raise_error(Grid::MissionService::NotAtGiver)
+    end
+
+    it "raises MissionMissing when slug doesn't exist" do
+      expect {
+        service.accept!("bogus-slug", room: giver_room)
+      }.to raise_error(Grid::MissionService::MissionMissing)
+    end
+
+    it "raises ClearanceTooLow when hackr clearance is below requirement" do
+      mission.update!(min_clearance: 5)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::ClearanceTooLow)
+    end
+
+    it "raises AlreadyActive when already working on the mission" do
+      service.accept!(mission.slug, room: giver_room)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::AlreadyActive)
+    end
+
+    it "raises PrereqUnmet when prereq mission hasn't been completed" do
+      prereq = create(:grid_mission)
+      mission.update!(prereq_mission: prereq)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::PrereqUnmet)
+    end
+
+    it "allows accept when prereq has been completed" do
+      prereq = create(:grid_mission)
+      mission.update!(prereq_mission: prereq)
+      create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: prereq)
+
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.not_to raise_error
+    end
+
+    it "raises MissionMissing for an unpublished mission (slug guess leak)" do
+      mission.update!(published: false)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::MissionMissing)
+    end
+
+    it "raises AlreadyCompletedNonRepeatable for a non-repeatable mission" do
+      create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::AlreadyCompletedNonRepeatable)
+    end
+
+    it "allows repeatable missions to be re-accepted after completion" do
+      mission.update!(repeatable: true)
+      create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission)
+
+      expect { service.accept!(mission.slug, room: giver_room) }.not_to raise_error
+    end
+
+    it "does NOT advance sibling missions' threshold objectives on accept" do
+      # Sibling mission B is already accepted with a reach_clearance
+      # objective. The hackr is at CL0, so B's objective is NOT yet
+      # satisfied. Accepting mission A (with its own reach_clearance
+      # objective) should scope its threshold-seeding strictly to A —
+      # B must stay untouched.
+      mission_b = create(:grid_mission, slug: "sibling-threshold")
+      obj_b = create(:grid_mission_objective, :reach_clearance,
+        grid_mission: mission_b, target_count: 1, label: "Hit CL1")
+      hackr_mission_b = create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission_b)
+      hackr_obj_b = create(:grid_hackr_mission_objective,
+        grid_hackr_mission: hackr_mission_b, grid_mission_objective: obj_b, progress: 0)
+
+      # Mission A also has a reach_clearance objective (at a level above
+      # the hackr's current CL) so the seed path runs but doesn't fire
+      # globally.
+      create(:grid_mission_objective, :reach_clearance, grid_mission: mission, target_count: 5)
+
+      service.accept!(mission.slug, room: giver_room)
+
+      hackr_obj_b.reload
+      expect(hackr_obj_b.progress).to eq(0)
+      expect(hackr_obj_b.completed_at).to be_nil
+    end
+
+    it "seeds this mission's threshold objectives with current state" do
+      hackr.grant_xp!(GridHackr::Stats.xp_for_clearance(3))  # push to CL3
+      create(:grid_mission_objective, :reach_clearance,
+        grid_mission: mission, target_count: 2, label: "Hit CL2")
+
+      hackr_mission = service.accept!(mission.slug, room: giver_room)
+
+      obj_row = hackr_mission.grid_hackr_mission_objectives
+        .joins(:grid_mission_objective).where(grid_mission_objectives: {objective_type: "reach_clearance"}).first
+      expect(obj_row.completed_at).not_to be_nil
+    end
+  end
+
+  describe "#accept! rep gate" do
+    it "raises RepTooLow when hackr rep is below min_rep_value" do
+      faction = create(:grid_faction, slug: "acceptgate-faction", name: "Gate Faction")
+      mission.update!(min_rep_faction: faction, min_rep_value: 100)
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::RepTooLow)
+    end
+
+    it "allows accept when rep meets min_rep_value" do
+      faction = create(:grid_faction, slug: "acceptgate-faction-ok", name: "OK Faction")
+      mission.update!(min_rep_faction: faction, min_rep_value: 10)
+      Grid::ReputationService.new(hackr).adjust!(faction, 20, reason: "test:seed")
+
+      expect {
+        service.accept!(mission.slug, room: giver_room)
+      }.not_to raise_error
+    end
+  end
+
+  describe "#turn_in!" do
+    # `turn_in!` is the reward commit path. These specs cover each
+    # failure mode at the service boundary and assert the happy path
+    # delegates to MissionRewardGranter.
+    let!(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+    let!(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+
+    before do
+      # Fund the gameplay pool so any CRED reward can mint.
+      genesis_source = create(:grid_cache)
+      GridTransaction.create!(
+        from_cache: genesis_source, to_cache: gameplay_pool, amount: 1_000_000,
+        tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+      )
+    end
+
+    def accept_and_complete_all_objectives
+      hm = service.accept!(mission.slug, room: giver_room)
+      # Mark every progress row complete so the readiness check passes.
+      hm.grid_hackr_mission_objectives.update_all(
+        progress: 1, completed_at: Time.current
+      )
+      hm.reload
+      hm
+    end
+
+    it "raises NotActive when no active instance exists for the slug" do
+      expect {
+        service.turn_in!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::NotActive)
+    end
+
+    it "raises ObjectivesIncomplete when objectives aren't all done" do
+      service.accept!(mission.slug, room: giver_room)
+      expect {
+        service.turn_in!(mission.slug, room: giver_room)
+      }.to raise_error(Grid::MissionService::ObjectivesIncomplete)
+    end
+
+    it "raises NotAtTurnIn when hackr is not in the giver's room" do
+      accept_and_complete_all_objectives
+      expect {
+        service.turn_in!(mission.slug, room: other_room)
+      }.to raise_error(Grid::MissionService::NotAtTurnIn, /Return to/)
+    end
+
+    it "completes the mission and grants rewards (happy path)" do
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 75)
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "cred", amount: 25)
+      accept_and_complete_all_objectives
+
+      outcome = nil
+      expect {
+        outcome = service.turn_in!(mission.slug, room: giver_room)
+      }.to change { hackr.reload.stat("xp") }.by(75)
+        .and change { cache.reload.balance }.by(25)
+
+      expect(outcome[:notification_html]).to include("MISSION COMPLETE")
+      expect(outcome[:xp_granted]).to eq(75)
+      expect(outcome[:cred_granted]).to eq(25)
+
+      hm = hackr.grid_hackr_missions.find_by(grid_mission: mission)
+      expect(hm.status).to eq("completed")
+      expect(hm.turn_in_count).to eq(1)
+    end
+
+    it "increments turn_in_count on each successful turn-in for repeatables" do
+      mission.update!(repeatable: true)
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 10)
+
+      # First run.
+      accept_and_complete_all_objectives
+      service.turn_in!(mission.slug, room: giver_room)
+
+      # Second run — re-accept and complete again.
+      hm2 = service.accept!(mission.slug, room: giver_room)
+      hm2.grid_hackr_mission_objectives.update_all(progress: 1, completed_at: Time.current)
+      service.turn_in!(mission.slug, room: giver_room)
+
+      # Two completed rows, each with turn_in_count == 1.
+      completed = hackr.grid_hackr_missions.completed.where(grid_mission: mission)
+      expect(completed.count).to eq(2)
+      expect(completed.sum(:turn_in_count)).to eq(2)
+    end
+  end
+
+  describe "#abandon!" do
+    it "destroys the active hackr_mission row (free re-accept)" do
+      hm = service.accept!(mission.slug, room: giver_room)
+
+      expect { service.abandon!(mission.slug) }
+        .to change(GridHackrMission, :count).by(-1)
+      expect(GridHackrMission.find_by(id: hm.id)).to be_nil
+    end
+
+    it "raises NotActive when not currently active" do
+      expect {
+        service.abandon!(mission.slug)
+      }.to raise_error(Grid::MissionService::NotActive)
+    end
+  end
+
+  describe "#active_hackr_missions eager loading" do
+    # Regression: the missions API used to issue 2 extra queries per
+    # active mission (one for mission objectives, one for the progress
+    # rows) via `all_objectives_completed?`. Preloading both
+    # associations means loading 10 active missions + readiness checks
+    # runs in a constant number of queries — not O(N).
+    it "evaluates all_objectives_completed? without per-mission DB queries" do
+      # Seed 3 active missions with 2 objectives each.
+      3.times do |i|
+        m = create(:grid_mission, slug: "eager-m-#{i}")
+        create(:grid_mission_objective, grid_mission: m, objective_type: "visit_room", target_slug: "r-#{i}")
+        create(:grid_mission_objective, grid_mission: m, objective_type: "talk_npc", target_slug: "npc-#{i}")
+        hm = create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: m)
+        m.grid_mission_objectives.each do |obj|
+          create(:grid_hackr_mission_objective, grid_hackr_mission: hm, grid_mission_objective: obj)
+        end
+      end
+
+      preloaded = service.active_hackr_missions.to_a
+
+      # With preloading in place, walking every mission + calling
+      # all_objectives_completed? should issue ZERO additional queries
+      # beyond the association load.
+      queries = []
+      callback = ->(_n, _s, _f, _id, p) { queries << p[:sql] unless p[:sql].include?("sqlite_master") }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        preloaded.each { |hm| hm.all_objectives_completed? }
+      end
+      expect(queries).to be_empty
+    end
+  end
+
+  describe "#available_missions query count" do
+    # Regression: `already_active?` used to fire one EXISTS per candidate
+    # mission. Mirror the memoized `completed_mission_ids` pattern so the
+    # cost scales with hackr state (2 plucks), not candidate count.
+    it "does not scale queries with candidate count" do
+      5.times do |i|
+        create(:grid_mission, slug: "avail-m-#{i}", giver_mob: giver)
+      end
+
+      queries = []
+      callback = ->(_n, _s, _f, _id, p) do
+        queries << p[:sql] unless p[:sql].include?("sqlite_master") || p[:sql].start_with?("SAVEPOINT", "RELEASE")
+      end
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        Grid::MissionService.new(hackr).available_missions(giver_room).to_a
+      end
+
+      # EXISTS-per-candidate was the old bug. Assert specifically that
+      # there is at most ONE `grid_hackr_missions` read (the memoized
+      # active_mission_ids pluck) regardless of candidate count.
+      hackr_mission_reads = queries.count { |q| q.include?("grid_hackr_missions") && q.include?("status") }
+      expect(hackr_mission_reads).to be <= 2 # one for active_mission_ids, one for completed_mission_ids
+    end
+  end
+
+  describe "#available_missions" do
+    it "returns missions from the current room's NPCs with gates met" do
+      mission # ensure created
+      result = service.available_missions(giver_room)
+      expect(result).to include(mission)
+    end
+
+    it "filters out missions with unmet clearance gate" do
+      mission.update!(min_clearance: 10)
+      expect(service.available_missions(giver_room)).not_to include(mission)
+    end
+
+    it "filters out already-active missions" do
+      service.accept!(mission.slug, room: giver_room)
+      expect(service.available_missions(giver_room)).not_to include(mission)
+    end
+  end
+end


### PR DESCRIPTION
  NPC-gated mission system for THE PULSE GRID: accept jobs from quest_giver
  and vendor NPCs, complete multi-objective assignments, turn in for XP,
  CRED, faction rep, item grants, and achievement unlocks.

  Schema: 6 new tables — grid_mission_arcs (storyline grouping),
  grid_missions (definitions with prereq chains, clearance/rep gates),
  grid_mission_objectives (10 extensible types), grid_mission_rewards
  (5 reward types), grid_hackr_missions (per-hackr state with partial
  unique index on active instances), grid_hackr_mission_objectives
  (per-objective progress tracking).

  Services: MissionService (accept/abandon/turn_in lifecycle + gate
  evaluation), MissionProgressor (flat-case trigger dispatch mirroring
  AchievementChecker), MissionRewardGranter (transactional pipeline
  mirroring AchievementAwarder with row-level lock against double
  turn-in).

  Commands: missions, mission <slug>, accept, abandon, turn_in/ti, give
  <item> to <npc>. Progressor hooks wired into go/talk/take/use/salvage/
  buy. ask <npc> about missions/slug intercepts before dialogue lookup.

  Achievement integration: purchase_item trigger bug fixed (was referenced
  in buy_command but missing from TRIGGER_TYPES). New triggers:
  missions_completed_count (cumulative), mission_completed (event-only).

  Admin: full CRUD for missions + arcs at /root/grid_missions, read-only
  hackr mission log. Nested attributes for objectives + rewards.

  Frontend: /missions SPA page (Active/Available/Completed tabs with
  progress bars), mission_completed toast via shared AchievementChannel
  (DOM CustomEvent fan-out, no duplicate subscription), nav links in
  Grid dropdown.

  YAML seed: data/world/missions.yml with 3 starter missions (Signal
  Recovery arc + daily repeatable). data:missions rake task with
  declarative reconcile for objectives, rewards, and prereqs.

  Handbook: /handbook/missions reference article under THE PULSE GRID.

  Review fixes applied: admin slug routing (find_by!), concurrent accept
  race (DB partial unique index + RecordNotUnique rescue), turn-in race
  (row lock), deliver_item NPC constraint (giver-mob convention), gate
  logic dedup (MissionService#gate_status), transaction boundaries
  (seed_threshold_objectives + give_command), YAML reconcile consistency,
  progressor cache invalidation on rollback, N+1 fixes (preloaded
  associations + memoized active/completed ID sets), published-mission
  giver requirement, factory split into per-model files.