### PR TITLE
[TPG] Item Master

### DIFF
--- a/app/controllers/admin/grid_item_definitions_controller.rb
+++ b/app/controllers/admin/grid_item_definitions_controller.rb
@@ -1,0 +1,102 @@
+class Admin::GridItemDefinitionsController < Admin::ApplicationController
+  before_action :set_definition, only: %i[edit update destroy]
+
+  def index
+    scope = GridItemDefinition.all
+    scope = scope.by_item_type(params[:item_type]) if params[:item_type].present? && GridItem::ITEM_TYPES.include?(params[:item_type])
+    @type_filter = params[:item_type]
+    @definitions = scope.ordered
+  end
+
+  def new
+    @definition = GridItemDefinition.new(value: 0, properties: {})
+  end
+
+  def create
+    attrs, json_error = definition_params
+    @definition = GridItemDefinition.new(attrs)
+
+    if json_error
+      @definition.valid?
+      @definition.errors.add(:properties, json_error)
+      flash.now[:error] = @definition.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+      return
+    end
+
+    if @definition.save
+      set_flash_success("Definition '#{@definition.name}' created.")
+      redirect_to admin_grid_item_definitions_path
+    else
+      flash.now[:error] = @definition.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    attrs, json_error = definition_params
+
+    if json_error
+      @definition.assign_attributes(attrs)
+      @definition.errors.add(:properties, json_error)
+      flash.now[:error] = @definition.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
+    if @definition.update(attrs)
+      set_flash_success("Definition '#{@definition.name}' updated.")
+      redirect_to admin_grid_item_definitions_path
+    else
+      flash.now[:error] = @definition.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @definition.grid_items.exists? || @definition.grid_shop_listings.exists?
+      set_flash_error("Cannot delete '#{@definition.name}' — it has live items or shop listings.")
+      redirect_to admin_grid_item_definitions_path
+      return
+    end
+
+    name = @definition.name
+    if @definition.destroy
+      set_flash_success("Definition '#{name}' deleted.")
+    else
+      set_flash_error("Failed to delete '#{name}': #{@definition.errors.full_messages.join(", ")}")
+    end
+    redirect_to admin_grid_item_definitions_path
+  end
+
+  private
+
+  def set_definition
+    @definition = GridItemDefinition.find_by!(slug: params[:id])
+  end
+
+  def definition_params
+    permitted = params.require(:grid_item_definition).permit(
+      :slug, :name, :description, :item_type, :rarity, :value
+    )
+
+    json_source = params[:grid_item_definition][:properties_json]
+    if json_source.blank?
+      permitted[:properties] = {}
+      return [permitted, nil]
+    end
+
+    parsed = JSON.parse(json_source)
+    unless parsed.is_a?(Hash)
+      return [permitted, "must be a JSON object (e.g. {\"slot\": \"gpu\"})"]
+    end
+
+    permitted[:properties] = parsed
+    [permitted, nil]
+  rescue JSON::ParserError => e
+    [permitted, "is not valid JSON: #{e.message}"]
+  end
+end

--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -1,8 +1,11 @@
 class Admin::GridShopListingsController < Admin::ApplicationController
   before_action :set_listing, only: [:edit, :update, :destroy, :restock]
+  before_action :load_selects, only: [:new, :edit]
 
   def index
-    @listings = GridShopListing.includes(:grid_mob).order(:grid_mob_id, :name)
+    @listings = GridShopListing.includes(:grid_mob, :grid_item_definition)
+      .joins(:grid_item_definition)
+      .order(:grid_mob_id, "grid_item_definitions.name")
     @listings = @listings.where(grid_mob_id: params[:mob_id]) if params[:mob_id].present?
     @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
   end
@@ -15,48 +18,30 @@ class Admin::GridShopListingsController < Admin::ApplicationController
       active: true,
       rotation_pool: false
     )
-    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
   end
 
   def create
-    attrs, json_error = listing_params
-    @listing = GridShopListing.new(attrs)
+    @listing = GridShopListing.new(listing_params)
 
-    if json_error.nil? && @listing.save
+    if @listing.save
       set_flash_success("Listing '#{@listing.name}' created for #{@listing.grid_mob.name}.")
       redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
-      return
+    else
+      load_selects
+      flash.now[:error] = @listing.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
     end
-
-    if json_error
-      @listing.valid? # populate other validation errors
-      @listing.errors.add(:properties, json_error)
-    end
-    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
-    flash.now[:error] = @listing.errors.full_messages.join(", ")
-    render :new, status: :unprocessable_entity
   end
 
   def edit
-    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
   end
 
   def update
-    attrs, json_error = listing_params
-    if json_error
-      @listing.assign_attributes(attrs)
-      @listing.errors.add(:properties, json_error)
-      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
-      flash.now[:error] = @listing.errors.full_messages.join(", ")
-      render :edit, status: :unprocessable_entity
-      return
-    end
-
-    if @listing.update(attrs)
+    if @listing.update(listing_params)
       set_flash_success("Listing '#{@listing.name}' updated.")
       redirect_to admin_grid_shop_listings_path(mob_id: @listing.grid_mob_id)
     else
-      @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+      load_selects
       flash.now[:error] = @listing.errors.full_messages.join(", ")
       render :edit, status: :unprocessable_entity
     end
@@ -86,31 +71,17 @@ class Admin::GridShopListingsController < Admin::ApplicationController
     @listing = GridShopListing.find(params[:id])
   end
 
-  # Returns [permitted_attrs, json_error_message_or_nil].
-  # On invalid JSON, :properties is omitted from attrs entirely (preserving
-  # existing values on update) and a human-readable error is returned.
+  def load_selects
+    @vendors = GridMob.where(mob_type: "vendor").includes(:grid_room).order(:name)
+    @definitions = GridItemDefinition.ordered
+  end
+
   def listing_params
-    permitted = params.require(:grid_shop_listing).permit(
-      :grid_mob_id, :name, :description, :item_type, :rarity,
+    params.require(:grid_shop_listing).permit(
+      :grid_mob_id, :grid_item_definition_id,
       :base_price, :sell_price, :stock, :max_stock,
       :restock_amount, :restock_interval_hours,
       :active, :rotation_pool, :min_clearance
     )
-
-    json_source = params[:grid_shop_listing][:properties_json]
-    if json_source.blank?
-      permitted[:properties] = {}
-      return [permitted, nil]
-    end
-
-    parsed = JSON.parse(json_source)
-    unless parsed.is_a?(Hash)
-      return [permitted, "must be a JSON object (e.g. {\"slot\": \"gpu\"})"]
-    end
-
-    permitted[:properties] = parsed
-    [permitted, nil]
-  rescue JSON::ParserError => e
-    [permitted, "is not valid JSON: #{e.message}"]
   end
 end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -128,56 +128,11 @@ class GridHackr < ApplicationRecord
     rig = grid_mining_rig || create_grid_mining_rig!(active: false)
     return if rig.components.any? # Rig already has components
 
-    # Base motherboard: 1 CPU, 2 GPU, 2 RAM slots
-    GridItem.create!(
-      grid_mining_rig: rig,
-      name: "Basic Motherboard",
-      description: "A standard-issue board with minimal expansion. Gets the job done.",
-      item_type: "component",
-      rarity: "common",
-      value: 10,
-      properties: {slot: "motherboard", cpu_slots: 1, gpu_slots: 2, ram_slots: 2, rate_multiplier: 1.0}
-    )
-
-    GridItem.create!(
-      grid_mining_rig: rig,
-      name: "Basic PSU",
-      description: "A reliable power supply. Keeps the lights on.",
-      item_type: "component",
-      rarity: "common",
-      value: 5,
-      properties: {slot: "psu", rate_multiplier: 1.0}
-    )
-
-    GridItem.create!(
-      grid_mining_rig: rig,
-      name: "Basic CPU",
-      description: "A single-core processor. Slow but steady.",
-      item_type: "component",
-      rarity: "common",
-      value: 8,
-      properties: {slot: "cpu", rate_multiplier: 1.0}
-    )
-
-    GridItem.create!(
-      grid_mining_rig: rig,
-      name: "Basic GPU",
-      description: "A standard-issue mining processor. Not fast, but it works.",
-      item_type: "component",
-      rarity: "common",
-      value: 5,
-      properties: {slot: "gpu", rate_multiplier: 1.0}
-    )
-
-    GridItem.create!(
-      grid_mining_rig: rig,
-      name: "Basic RAM",
-      description: "A single stick of memory. Enough to boot.",
-      item_type: "component",
-      rarity: "common",
-      value: 4,
-      properties: {slot: "ram", rate_multiplier: 1.0}
-    )
+    %w[basic-motherboard basic-psu basic-cpu basic-gpu basic-ram].each do |slug|
+      defn = GridItemDefinition.find_by(slug: slug)
+      raise "Item definition '#{slug}' not found — run `rails data:item_definitions` first" unless defn
+      GridItem.create!(defn.item_attributes.merge(grid_mining_rig: rig))
+    end
   end
 
   # Scopes

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -3,23 +3,29 @@
 # Table name: grid_items
 # Database name: primary
 #
-#  id                 :integer          not null, primary key
-#  description        :text
-#  item_type          :string
-#  name               :string
-#  properties         :json
-#  quantity           :integer          default(1), not null
-#  rarity             :string
-#  value              :integer          default(0), not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  grid_hackr_id      :integer
-#  grid_mining_rig_id :integer
-#  room_id            :integer
+#  id                      :integer          not null, primary key
+#  description             :text
+#  item_type               :string
+#  name                    :string
+#  properties              :json
+#  quantity                :integer          default(1), not null
+#  rarity                  :string
+#  value                   :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_hackr_id           :integer
+#  grid_item_definition_id :integer          not null
+#  grid_mining_rig_id      :integer
+#  room_id                 :integer
 #
 # Indexes
 #
-#  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
+#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#
+# Foreign Keys
+#
+#  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 class GridItem < ApplicationRecord
   ITEM_TYPES = %w[tool consumable data faction collectible component].freeze
@@ -43,6 +49,11 @@ class GridItem < ApplicationRecord
     "unicorn" => "#fbbf24"
   }.freeze
 
+  # Display fields (name, description, item_type, rarity, value, properties) are
+  # denormalized snapshots copied from the definition at creation time. They are
+  # NOT automatically synced when a definition is updated. To propagate definition
+  # changes to existing items, run: rails data:sync_item_definitions
+  belongs_to :grid_item_definition
   belongs_to :room, class_name: "GridRoom", optional: true
   belongs_to :grid_hackr, optional: true
   belongs_to :grid_mining_rig, optional: true

--- a/app/models/grid_item_definition.rb
+++ b/app/models/grid_item_definition.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_item_definitions
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  item_type   :string           not null
+#  name        :string           not null
+#  properties  :json             not null
+#  rarity      :string           not null
+#  slug        :string           not null
+#  value       :integer          default(0), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_item_definitions_on_item_type  (item_type)
+#  index_grid_item_definitions_on_slug       (slug) UNIQUE
+#
+class GridItemDefinition < ApplicationRecord
+  has_many :grid_items, dependent: :restrict_with_error
+  has_many :grid_shop_listings, dependent: :restrict_with_error
+
+  validates :slug, presence: true, uniqueness: true,
+    format: {with: /\A[a-z0-9-]+\z/, message: "only lowercase letters, numbers, and hyphens"}
+  validates :name, presence: true
+  validates :item_type, presence: true, inclusion: {in: GridItem::ITEM_TYPES}
+  validates :rarity, presence: true, inclusion: {in: GridItem::RARITIES}
+  validates :value, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :ordered, -> { order(:item_type, :name) }
+  scope :by_item_type, ->(t) { where(item_type: t) }
+
+  def to_param
+    slug
+  end
+
+  def rarity_color
+    GridItem::RARITY_COLORS[rarity] || "#9ca3af"
+  end
+
+  def rarity_label
+    GridItem::RARITY_LABELS[rarity] || rarity&.upcase
+  end
+
+  # Build a GridItem attribute hash from this definition.
+  # Callers merge instance-specific fields (grid_hackr, room, quantity, etc.)
+  def item_attributes
+    {
+      grid_item_definition: self,
+      name: name,
+      description: description,
+      item_type: item_type,
+      rarity: rarity,
+      value: value,
+      properties: properties&.deep_dup || {}
+    }
+  end
+end

--- a/app/models/grid_shop_listing.rb
+++ b/app/models/grid_shop_listing.rb
@@ -5,43 +5,43 @@
 # Table name: grid_shop_listings
 # Database name: primary
 #
-#  id                     :integer          not null, primary key
-#  active                 :boolean          default(TRUE), not null
-#  base_price             :integer          not null
-#  description            :text
-#  item_type              :string
-#  max_stock              :integer
-#  min_clearance          :integer          default(0), not null
-#  name                   :string           not null
-#  next_restock_at        :datetime
-#  properties             :json
-#  rarity                 :string
-#  restock_amount         :integer          default(1), not null
-#  restock_interval_hours :integer          default(24), not null
-#  rotation_pool          :boolean          default(FALSE), not null
-#  sell_price             :integer          not null
-#  stock                  :integer
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  grid_mob_id            :integer          not null
+#  id                      :integer          not null, primary key
+#  active                  :boolean          default(TRUE), not null
+#  base_price              :integer          not null
+#  max_stock               :integer
+#  min_clearance           :integer          default(0), not null
+#  next_restock_at         :datetime
+#  restock_amount          :integer          default(1), not null
+#  restock_interval_hours  :integer          default(24), not null
+#  rotation_pool           :boolean          default(FALSE), not null
+#  sell_price              :integer          not null
+#  stock                   :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_item_definition_id :integer          not null
+#  grid_mob_id             :integer          not null
 #
 # Indexes
 #
-#  index_grid_shop_listings_on_grid_mob_id             (grid_mob_id)
-#  index_grid_shop_listings_on_grid_mob_id_and_active  (grid_mob_id,active)
-#  index_grid_shop_listings_on_next_restock_at         (next_restock_at)
+#  index_grid_shop_listings_on_grid_item_definition_id  (grid_item_definition_id)
+#  index_grid_shop_listings_on_grid_mob_id              (grid_mob_id)
+#  index_grid_shop_listings_on_grid_mob_id_and_active   (grid_mob_id,active)
+#  index_grid_shop_listings_on_next_restock_at          (next_restock_at)
 #
 # Foreign Keys
 #
-#  grid_mob_id  (grid_mob_id => grid_mobs.id)
+#  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
+#  grid_mob_id              (grid_mob_id => grid_mobs.id)
 #
 class GridShopListing < ApplicationRecord
   belongs_to :grid_mob
+  belongs_to :grid_item_definition
   has_many :grid_shop_transactions, dependent: :nullify
 
-  validates :name, presence: true
-  validates :item_type, inclusion: {in: GridItem::ITEM_TYPES}, allow_nil: true
-  validates :rarity, inclusion: {in: GridItem::RARITIES}, allow_nil: true
+  delegate :name, :description, :item_type, :rarity, :properties,
+    :rarity_color, :rarity_label,
+    to: :grid_item_definition
+
   validates :base_price, numericality: {only_integer: true, greater_than: 0}
   validates :sell_price, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :stock, numericality: {only_integer: true, greater_than_or_equal_to: 0}, allow_nil: true
@@ -65,14 +65,6 @@ class GridShopListing < ApplicationRecord
 
   def in_stock?
     unlimited_stock? || stock > 0
-  end
-
-  def rarity_color
-    GridItem::RARITY_COLORS[rarity] || "#9ca3af"
-  end
-
-  def rarity_label
-    GridItem::RARITY_LABELS[rarity] || rarity&.upcase
   end
 
   private

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -324,9 +324,11 @@ module Grid
       vendor = room.grid_mobs.find_by(mob_type: "vendor")
       if vendor
         clearance = hackr.stat("clearance")
-        listing = vendor.grid_shop_listings.where(active: true)
+        listing = vendor.grid_shop_listings.includes(:grid_item_definition).joins(:grid_item_definition)
+          .where(active: true)
           .where("min_clearance <= ?", clearance)
-          .find_by("LOWER(name) = ?", target.downcase)
+          .where("LOWER(grid_item_definitions.name) = ?", target.downcase)
+          .first
         if listing
           price = Grid::ShopService.effective_price(listing: listing, mob: vendor, clearance: clearance)
           return examine_listing(listing, price)

--- a/app/services/grid/mission_reward_granter.rb
+++ b/app/services/grid/mission_reward_granter.rb
@@ -145,21 +145,23 @@ module Grid
       end
     end
 
-    # Materialize a new GridItem in the hackr's inventory from the reward
-    # row. `target_slug` may point to an existing shop_listing slug (to
-    # copy its full definition) OR be a bare item name. For v1 we use
-    # target_slug as the name and lean on reward.amount + reward.quantity
-    # for value + stack size. More elaborate templating can extend this.
+    # Materialize a new GridItem in the hackr's inventory from a
+    # GridItemDefinition looked up by reward.target_slug. The definition
+    # supplies name/description/type/rarity/properties; reward.amount and
+    # reward.quantity override value and stack size.
     def build_item_grant(reward)
-      name = reward.target_slug.presence || "Mission Reward"
+      definition = GridItemDefinition.find_by(slug: reward.target_slug)
+      unless definition
+        Rails.logger.warn("[MissionRewardGranter] item_grant skipped: no definition for slug='#{reward.target_slug}'")
+        return nil
+      end
+
       GridItem.create!(
-        grid_hackr: @hackr,
-        name: name,
-        description: "Reward from mission: #{@mission.name}",
-        item_type: "collectible",
-        rarity: "uncommon",
-        value: reward.amount.to_i,
-        quantity: reward.quantity.to_i.clamp(1, 9999)
+        definition.item_attributes.merge(
+          grid_hackr: @hackr,
+          value: [reward.amount.to_i, 0].max,
+          quantity: reward.quantity.to_i.clamp(1, 9999)
+        )
       )
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.warn("[MissionRewardGranter] item grant failed: #{e.message}")

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -12,18 +12,22 @@ module Grid
       clearance = hackr.stat("clearance")
       cache = hackr.default_cache
 
-      mob.grid_shop_listings.where(active: true).order(:rarity, :name).map do |listing|
-        next if listing.min_clearance > clearance
+      mob.grid_shop_listings.includes(:grid_item_definition)
+        .joins(:grid_item_definition)
+        .where(active: true)
+        .order("grid_item_definitions.rarity, grid_item_definitions.name")
+        .map do |listing|
+          next if listing.min_clearance > clearance
 
-        price = effective_price(listing: listing, mob: mob, clearance: clearance)
-        balance = cache&.balance || 0
+          price = effective_price(listing: listing, mob: mob, clearance: clearance)
+          balance = cache&.balance || 0
 
-        {
-          listing: listing,
-          effective_price: price,
-          affordable: balance >= price,
-          out_of_stock: listing.out_of_stock?
-        }
+          {
+            listing: listing,
+            effective_price: price,
+            affordable: balance >= price,
+            out_of_stock: listing.out_of_stock?
+          }
       end.compact
     end
 
@@ -32,8 +36,10 @@ module Grid
       raise AccessDenied, "This vendor doesn't sell anything" unless mob.vendor?
 
       clearance = hackr.stat("clearance")
-      listing = mob.grid_shop_listings.where(active: true)
-        .find_by("LOWER(name) = ?", item_name.downcase)
+      listing = mob.grid_shop_listings.joins(:grid_item_definition)
+        .where(active: true)
+        .where("LOWER(grid_item_definitions.name) = ?", item_name.downcase)
+        .first
 
       raise ItemNotFound, "This vendor doesn't sell '#{item_name}'" unless listing
       raise AccessDenied, "CLEARANCE #{listing.min_clearance}+ required" if clearance < listing.min_clearance
@@ -56,16 +62,13 @@ module Grid
         # Split CRED: burn 70%, recycle 30% to gameplay pool
         split_purchase!(hackr_cache: cache, amount: price, item_name: listing.name)
 
-        # Create item in hackr's inventory
+        # Create item in hackr's inventory from the definition
         item = GridItem.create!(
-          grid_hackr: hackr,
-          name: listing.name,
-          description: listing.description,
-          item_type: listing.item_type,
-          rarity: listing.rarity,
-          value: listing.base_price,
-          quantity: 1,
-          properties: listing.properties
+          listing.grid_item_definition.item_attributes.merge(
+            grid_hackr: hackr,
+            value: listing.base_price,
+            quantity: 1
+          )
         )
 
         # Record the shop transaction
@@ -93,7 +96,9 @@ module Grid
       raise ItemNotFound, "You don't have '#{item_name}'" unless item
 
       # Find matching listing for sell price, or use item.value * SELL_PRICE_RATIO
-      listing = mob.grid_shop_listings.find_by("LOWER(name) = ?", item_name.downcase)
+      listing = mob.grid_shop_listings.joins(:grid_item_definition)
+        .where("LOWER(grid_item_definitions.name) = ?", item_name.downcase)
+        .first
       sell_price = if listing
         listing.sell_price
       else

--- a/app/views/admin/grid_item_definitions/_form.html.erb
+++ b/app/views/admin/grid_item_definitions/_form.html.erb
@@ -1,0 +1,69 @@
+<%= form_with model: [:admin, definition], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: DEFINITION INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if definition.errors[:name].any? %>
+        <br><small class="red-255-text"><%= definition.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">lowercase letters, numbers, hyphens only</small>
+      <% if definition.errors[:slug].any? %>
+        <br><small class="red-255-text"><%= definition.errors[:slug].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :item_type, "ITEM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :item_type,
+            GridItem::ITEM_TYPES.map { |t| [t.titleize, t] },
+            { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
+      <% if definition.errors[:item_type].any? %>
+        <br><small class="red-255-text"><%= definition.errors[:item_type].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :rarity, "RARITY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :rarity,
+            GridItem::RARITIES.map { |r| [GridItem::RARITY_LABELS[r] || r.upcase, r] },
+            { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
+      <% if definition.errors[:rarity].any? %>
+        <br><small class="red-255-text"><%= definition.errors[:rarity].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :value, "BASE VALUE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :value, class: "tui-input", style: "width: 100%;", min: 0 %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: PROPERTIES (JSON) ::]</h3>
+  <div style="margin-bottom: 20px;">
+    <%= text_area_tag "grid_item_definition[properties_json]",
+          (definition.properties.present? ? JSON.pretty_generate(definition.properties) : "{}"),
+          class: "tui-input", style: "width: 100%; font-family: monospace; height: 120px;" %>
+    <small style="color: #888;">JSON object. Components: {"slot": "gpu", "rate_multiplier": 1.5}. Consumables: {"effect_type": "heal", "amount": 30}</small>
+    <% if definition.errors[:properties].any? %>
+      <br><small class="red-255-text"><%= definition.errors[:properties].join(", ") %></small>
+    <% end %>
+  </div>
+
+  <div style="margin-top: 30px; display: flex; gap: 10px;">
+    <%= f.submit definition.persisted? ? "Save Definition" : "Create Definition",
+          class: "tui-button purple-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <%= link_to "Cancel", admin_grid_item_definitions_path,
+          class: "tui-button grey-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_item_definitions/edit.html.erb
+++ b/app/views/admin/grid_item_definitions/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/items :: EDIT — <%= @definition.slug %></legend>
+    <div style="padding: 20px;">
+      <%= render "form", definition: @definition %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_item_definitions/index.html.erb
+++ b/app/views/admin/grid_item_definitions/index.html.erb
@@ -1,0 +1,69 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/items :: ITEM DEFINITIONS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Definition", new_admin_grid_item_definition_path, class: "tui-button green-168" %>
+
+        <%= form_with url: admin_grid_item_definitions_path, method: :get, local: true, style: "display: inline-flex; gap: 8px; align-items: center; margin-left: 20px;" do %>
+          <label class="white-text" style="font-weight: bold;">TYPE:</label>
+          <%= select_tag :item_type,
+                options_for_select([["ALL", ""]] + GridItem::ITEM_TYPES.map { |t| [t.titleize, t] }, @type_filter),
+                class: "tui-input", style: "padding: 4px 8px;", onchange: "this.form.submit()" %>
+          <% if @type_filter.present? %>
+            <%= link_to "× clear", admin_grid_item_definitions_path, class: "tui-button", style: "padding: 4px 10px; font-size: 0.8em;" %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Type</th>
+              <th style="text-align: left;">Rarity</th>
+              <th style="text-align: right;">Value</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @definitions.each do |defn| %>
+              <tr>
+                <td class="cyan-255-text"><%= defn.name %></td>
+                <td style="color: #666; font-family: monospace;"><%= defn.slug %></td>
+                <td style="color: #9ca3af;"><%= defn.item_type %></td>
+                <td style="color: <%= defn.rarity_color %>;"><%= defn.rarity_label %></td>
+                <td style="text-align: right; color: #fbbf24;"><%= defn.value %></td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_item_definition_path(defn), class: "tui-button", style: "padding: 3px 10px; font-size: 0.85em;" %>
+                  <%= button_to "Delete", admin_grid_item_definition_path(defn), method: :delete,
+                        data: { confirm: "Delete '#{defn.name}'? This will fail if any items or listings reference it." },
+                        class: "tui-button red-168", style: "padding: 3px 10px; font-size: 0.85em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+        <%= @definitions.count %> definitions
+      </p>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_item_definitions/new.html.erb
+++ b/app/views/admin/grid_item_definitions/new.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/items :: NEW DEFINITION</legend>
+    <div style="padding: 20px;">
+      <%= render "form", definition: @definition %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_shop_listings/_form.html.erb
+++ b/app/views/admin/grid_shop_listings/_form.html.erb
@@ -17,37 +17,20 @@
     </div>
 
     <div>
-      <%= f.label :name, "ITEM NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
-      <% if listing.errors[:name].any? %>
-        <br><small class="red-255-text"><%= listing.errors[:name].join(", ") %></small>
+      <%= f.label :grid_item_definition_id, "ITEM DEFINITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_item_definition_id,
+          @definitions.map { |d| ["#{d.name} [#{d.item_type} / #{d.rarity_label}]", d.id] },
+          { include_blank: "Select definition..." }, class: "tui-input", style: "width: 100%;" %>
+      <% if listing.errors[:grid_item_definition].any? %>
+        <br><small class="red-255-text"><%= listing.errors[:grid_item_definition].join(", ") %></small>
       <% end %>
     </div>
   </div>
 
-  <div style="margin-top: 15px;">
-    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
-  </div>
-
-  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
-    <div>
-      <%= f.label :item_type, "ITEM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-      <%= f.select :item_type,
-          GridItem::ITEM_TYPES.map { |t| [t.titleize, t] },
-          { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
-    </div>
-
-    <div>
-      <%= f.label :rarity, "RARITY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-      <%= f.select :rarity,
-          GridItem::RARITIES.map { |r| [r.titleize.gsub("_", "-"), r] },
-          { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
-    </div>
-
+  <div style="display: grid; grid-template-columns: 1fr; gap: 20px; margin-top: 15px;">
     <div>
       <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%;", min: 0 %>
+      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 200px;", min: 0 %>
     </div>
   </div>
 
@@ -101,15 +84,6 @@
     <label class="white-text" style="display: flex; align-items: center; gap: 8px;">
       <%= f.check_box :rotation_pool, style: "width: auto;" %> Rotation Pool
     </label>
-  </div>
-
-  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: PROPERTIES (JSON) ::]</h3>
-
-  <div style="margin-bottom: 20px;">
-    <%= text_area_tag "grid_shop_listing[properties_json]",
-        (listing.properties.present? ? JSON.pretty_generate(listing.properties) : "{}"),
-        class: "tui-input", style: "width: 100%; font-family: monospace; height: 120px;" %>
-    <small style="color: #888;">JSON object. For components: {"slot": "gpu", "rate_multiplier": 1.5}. For consumables: {"effect_type": "heal", "amount": 30}</small>
   </div>
 
   <div style="margin-top: 30px; display: flex; gap: 10px;">

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -84,6 +84,7 @@
         <div class="admin-nav-dropdown-menu">
           <%= link_to "Dashboard", admin_grid_path, class: "green-168-text" %>
           <%= link_to "Economy", admin_grid_economy_path, class: "green-168-text" %>
+          <%= link_to "Item Defs", admin_grid_item_definitions_path, class: "green-168-text" %>
           <%= link_to "Shops", admin_grid_shop_listings_path, class: "green-168-text" %>
           <%= link_to "Achievements", admin_grid_achievements_path, class: "green-168-text" %>
           <%= link_to "Missions", admin_grid_missions_path, class: "green-168-text" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,6 +310,9 @@ Rails.application.routes.draw do
     # Grid reputation event log (read-only)
     resources :grid_reputation_events, only: [:index]
 
+    # Grid item definitions (item master catalog)
+    resources :grid_item_definitions, except: [:show]
+
     # Grid shops (runtime CRUD + stock management)
     resources :grid_shop_listings do
       member do

--- a/data/catalog/wavelength-zero.yml
+++ b/data/catalog/wavelength-zero.yml
@@ -469,15 +469,15 @@ releases:
           I am free
           I can see
 
-  - slug: prism-break-live
-    title: "Prism Break [LIVE at #BlackShadez (TCPU 2126)]"
-    release_type: single
-    label: "hackr.fm"
-    release_date: "2127-01-23"
-    cover_image: "prism_break_live.jpg"
-    coming_soon: true
-    tracks:
-      - title: "Prism Break [LIVE at #BlackShadez (TCPU 2126)]"
-        slug: prism-break-live
-        track_number: 1
-        audio_file: prism-break-live.ogg
+  # - slug: prism-break-live
+  #   title: "Prism Break [LIVE at #BlackShadez (TCPU 2126)]"
+  #   release_type: single
+  #   label: "hackr.fm"
+  #   release_date: "2127-01-23"
+  #   cover_image: "prism_break_live.jpg"
+  #   coming_soon: true
+  #   tracks:
+  #     - title: "Prism Break [LIVE at #BlackShadez (TCPU 2126)]"
+  #       slug: prism-break-live
+  #       track_number: 1
+  #       audio_file: prism-break-live.ogg

--- a/data/world/item_definitions.yml
+++ b/data/world/item_definitions.yml
@@ -1,0 +1,309 @@
+# Item Definitions — the canonical item catalog for THE PULSE GRID.
+# Loaded by: rails data:item_definitions (before items and shop_listings).
+# Idempotent: upsert by slug.
+#
+# item_type: tool | consumable | data | faction | collectible | component
+# rarity:    scrap | ubiquitous | common | uncommon | rare | ultra_rare | unicorn
+
+item_definitions:
+
+  # ── Starter Components ─────────────────────────────────────────
+  - slug: basic-motherboard
+    name: Basic Motherboard
+    description: "A standard-issue board with minimal expansion. Gets the job done."
+    item_type: component
+    rarity: common
+    value: 10
+    properties:
+      slot: motherboard
+      cpu_slots: 1
+      gpu_slots: 2
+      ram_slots: 2
+      rate_multiplier: 1.0
+
+  - slug: basic-psu
+    name: Basic PSU
+    description: "A reliable power supply. Keeps the lights on."
+    item_type: component
+    rarity: common
+    value: 5
+    properties:
+      slot: psu
+      rate_multiplier: 1.0
+
+  - slug: basic-cpu
+    name: Basic CPU
+    description: "A single-core processor. Slow but steady."
+    item_type: component
+    rarity: common
+    value: 8
+    properties:
+      slot: cpu
+      rate_multiplier: 1.0
+
+  - slug: basic-gpu
+    name: Basic GPU
+    description: "A standard-issue mining processor. Not fast, but it works."
+    item_type: component
+    rarity: common
+    value: 5
+    properties:
+      slot: gpu
+      rate_multiplier: 1.0
+
+  - slug: basic-ram
+    name: Basic RAM
+    description: "A single stick of memory. Enough to boot."
+    item_type: component
+    rarity: common
+    value: 4
+    properties:
+      slot: ram
+      rate_multiplier: 1.0
+
+  # ── Shop Components (Codec) ────────────────────────────────────
+  - slug: enhanced-gpu
+    name: Enhanced GPU
+    description: "A mid-tier graphics processor. Decent hash rate, reasonable power draw."
+    item_type: component
+    rarity: uncommon
+    value: 300
+    properties:
+      slot: gpu
+      rate_multiplier: 1.3
+
+  - slug: enhanced-cpu
+    name: Enhanced CPU
+    description: "Dual-core processor salvaged from decommissioned GovCorp terminals. Still kicks."
+    item_type: component
+    rarity: uncommon
+    value: 300
+    properties:
+      slot: cpu
+      rate_multiplier: 1.3
+
+  - slug: enhanced-ram-module
+    name: Enhanced RAM Module
+    description: "High-bandwidth memory module. Makes everything snappier."
+    item_type: component
+    rarity: uncommon
+    value: 250
+    properties:
+      slot: ram
+      rate_multiplier: 1.25
+
+  - slug: hardened-psu
+    name: Hardened PSU
+    description: "Surge-protected power supply. Won't fry when the grid spikes."
+    item_type: component
+    rarity: uncommon
+    value: 200
+    properties:
+      slot: psu
+      rate_multiplier: 1.2
+
+  # ── Black Market Components (GHOST) ────────────────────────────
+  - slug: milspec-gpu
+    name: Milspec GPU
+    description: "Military-specification graphics processor. Stolen from a GovCorp mining facility. The serial numbers have been... removed."
+    item_type: component
+    rarity: rare
+    value: 800
+    properties:
+      slot: gpu
+      rate_multiplier: 1.8
+
+  - slug: milspec-cpu
+    name: Milspec CPU
+    description: "Quad-core processor with hardened encryption coprocessor. Falls off a GovCorp truck every now and then."
+    item_type: component
+    rarity: rare
+    value: 800
+    properties:
+      slot: cpu
+      rate_multiplier: 1.8
+
+  - slug: overclocked-ram-array
+    name: Overclocked RAM Array
+    description: "Eight high-density modules wired in parallel. Runs hot. Runs fast. Don't ask where it came from."
+    item_type: component
+    rarity: rare
+    value: 650
+    properties:
+      slot: ram
+      rate_multiplier: 1.7
+
+  - slug: quantum-flux-capacitor
+    name: Quantum Flux Capacitor
+    description: "Experimental power supply that harnesses quantum fluctuations. Theoretically impossible. Practically devastating."
+    item_type: component
+    rarity: ultra_rare
+    value: 2500
+    properties:
+      slot: psu
+      rate_multiplier: 2.5
+
+  - slug: neural-cortex-board
+    name: Neural Cortex Board
+    description: "A motherboard that interfaces directly with neural tissue. Three times the slots of anything on the market. The installation process is... unpleasant."
+    item_type: component
+    rarity: ultra_rare
+    value: 5000
+    properties:
+      slot: motherboard
+      cpu_slots: 2
+      gpu_slots: 4
+      ram_slots: 4
+      rate_multiplier: 2.0
+
+  # ── Consumables ────────────────────────────────────────────────
+  - slug: medpatch
+    name: MedPatch
+    description: "A standard-issue dermal adhesive infused with nanite healing agents. Slap it on, feel the burn, feel better."
+    item_type: consumable
+    rarity: common
+    value: 50
+    properties:
+      effect_type: heal
+      amount: 30
+
+  - slug: stim-shot
+    name: Stim Shot
+    description: "A cocktail of synthetic adrenaline and nootropics. Your hands will shake, but you'll get things done."
+    item_type: consumable
+    rarity: common
+    value: 50
+    properties:
+      effect_type: energize
+      amount: 30
+
+  - slug: neural-patch
+    name: Neural Patch
+    description: "Firmware patch that temporarily boosts cognitive throughput. Side effects include vivid dreams and a mild taste of copper."
+    item_type: consumable
+    rarity: uncommon
+    value: 150
+    properties:
+      effect_type: psyche_boost
+      amount: 40
+
+  - slug: muse-chip
+    name: Muse Chip
+    description: "A micro-implant that stimulates the creative cortex. Popular among artists, musicians, and the dangerously unhinged."
+    item_type: consumable
+    rarity: uncommon
+    value: 150
+    properties:
+      effect_type: inspire
+      amount: 40
+
+  - slug: black-ice-injector
+    name: Black ICE Injector
+    description: "Military-grade psyche stimulant. Sharpens the mind to a razor edge. The comedown is legendary. Handle with extreme care."
+    item_type: consumable
+    rarity: rare
+    value: 500
+    properties:
+      effect_type: psyche_boost
+      amount: 80
+
+  # ── Tools ──────────────────────────────────────────────────────
+  - slug: basic-decryption-key
+    name: Basic Decryption Key
+    description: "Opens standard-grade encrypted containers. Disposable — one use, then it fries itself."
+    item_type: tool
+    rarity: common
+    value: 75
+    properties: {}
+
+  - slug: signal-analyzer
+    name: Signal Analyzer
+    description: "Portable frequency scanner. Useful for detecting hidden transmissions and anomalies."
+    item_type: tool
+    rarity: uncommon
+    value: 200
+    properties: {}
+
+  - slug: deep-scan-array
+    name: Deep Scan Array
+    description: "Military-grade network scanner. Reads encrypted traffic, identifies hidden nodes, maps surveillance blind spots."
+    item_type: tool
+    rarity: rare
+    value: 1000
+    properties: {}
+
+  - slug: govcorp-access-spoofcard
+    name: GovCorp Access Spoofcard
+    description: "Spoofs GovCorp network credentials. Burns out after a single use. Don't get caught with one."
+    item_type: tool
+    rarity: rare
+    value: 1200
+    properties: {}
+
+  # ── Data ───────────────────────────────────────────────────────
+  - slug: fracture-network-data-chip
+    name: Fracture Network Data Chip
+    description: "A small chip containing encrypted Fracture Network communications."
+    item_type: data
+    rarity: rare
+    value: 50
+    properties: {}
+
+  - slug: faction-data-shard
+    name: Faction Data Shard
+    description: "A data fragment of unknown origin. The encryption is beyond standard tools. Someone will want this."
+    item_type: data
+    rarity: uncommon
+    value: 200
+    properties: {}
+
+  - slug: phantom-drive
+    name: Phantom Drive
+    description: "Untraceable storage device with quantum-encrypted partitions. What's stored on it is between you and the universe."
+    item_type: data
+    rarity: rare
+    value: 900
+    properties: {}
+
+  # ── Tools (world-placed) ───────────────────────────────────────
+  - slug: frequency-modulator
+    name: Frequency Modulator
+    description: "A device for tuning into Synthia's signal. Essential for PRISM communication."
+    item_type: tool
+    rarity: uncommon
+    value: 30
+    properties: {}
+
+  - slug: govcorp-access-keycard
+    name: GovCorp Access Keycard
+    description: "Stolen keycard providing access to restricted areas. Handle with care."
+    item_type: tool
+    rarity: rare
+    value: 75
+    properties: {}
+
+  # ── Collectibles ───────────────────────────────────────────────
+  - slug: chronology-shard
+    name: Chronology Shard
+    description: "A fragment of crystallized time from the moment of the Fracture. It hums with impossible frequencies — echoes of 9/9. Those who hold it report dreams of futures that never happened. It shouldn't exist."
+    item_type: collectible
+    rarity: unicorn
+    value: 999
+    properties: {}
+
+  - slug: temporal-resonance-crystal
+    name: Temporal Resonance Crystal
+    description: "A byproduct of Chronology Fracture research. It hums at a frequency that shouldn't exist. Collectors pay a fortune for these."
+    item_type: collectible
+    rarity: ultra_rare
+    value: 3000
+    properties: {}
+
+  # ── Faction Items ──────────────────────────────────────────────
+  - slug: fracture-beacon
+    name: Fracture Beacon
+    description: "Emits a signal recognizable only to Fracture Network operatives across temporal boundaries. Possession alone is a statement."
+    item_type: faction
+    rarity: ultra_rare
+    value: 5000
+    properties: {}

--- a/data/world/items.yml
+++ b/data/world/items.yml
@@ -1,29 +1,15 @@
-# Grid Items
+# Grid Items — world-placed item instances.
+# Each entry references a definition by slug.
+# Loaded by: rails data:items (after item_definitions and rooms).
 items:
-  - name: fracture network data chip
-    description: "A small chip containing encrypted Fracture Network communications."
-    item_type: data
+  - definition_slug: fracture-network-data-chip
     room_slug: hackr-tv-broadcast-station
-    rarity: rare
-    value: 50
 
-  - name: frequency modulator
-    description: "A device for tuning into Synthia's signal. Essential for PRISM communication."
-    item_type: tool
+  - definition_slug: frequency-modulator
     room_slug: hackr-tv-broadcast-station
-    rarity: uncommon
-    value: 30
 
-  - name: GovCorp access keycard
-    description: "Stolen keycard providing access to restricted areas. Handle with care."
-    item_type: tool
+  - definition_slug: govcorp-access-keycard
     room_slug: xeraen-operations-center
-    rarity: rare
-    value: 75
 
-  - name: Chronology Shard
-    description: "A fragment of crystallized time from the moment of the Fracture. It hums with impossible frequencies — echoes of 9/9. Those who hold it report dreams of futures that never happened. It shouldn't exist."
-    item_type: collectible
+  - definition_slug: chronology-shard
     room_slug: hackr-tv-broadcast-station
-    rarity: unicorn
-    value: 999

--- a/data/world/shop_listings.yml
+++ b/data/world/shop_listings.yml
@@ -1,5 +1,6 @@
-# Shop Listings — vendor inventory definitions
-# Loaded by: rails data:shop_listings (after mobs)
+# Shop Listings — vendor inventory definitions.
+# Each entry references a definition by slug. Item display fields come from the definition.
+# Loaded by: rails data:shop_listings (after item_definitions and mobs).
 shop_listings:
 
   # ══════════════════════════════════════════
@@ -9,143 +10,83 @@ shop_listings:
   # Consumables
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: MedPatch
-    description: "A standard-issue dermal adhesive infused with nanite healing agents. Slap it on, feel the burn, feel better."
-    item_type: consumable
-    rarity: common
+    definition_slug: medpatch
     base_price: 50
     max_stock: 10
     restock_amount: 3
-    properties:
-      effect_type: heal
-      amount: 30
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Stim Shot
-    description: "A cocktail of synthetic adrenaline and nootropics. Your hands will shake, but you'll get things done."
-    item_type: consumable
-    rarity: common
+    definition_slug: stim-shot
     base_price: 50
     max_stock: 10
     restock_amount: 3
-    properties:
-      effect_type: energize
-      amount: 30
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Neural Patch
-    description: "Firmware patch that temporarily boosts cognitive throughput. Side effects include vivid dreams and a mild taste of copper."
-    item_type: consumable
-    rarity: uncommon
+    definition_slug: neural-patch
     base_price: 150
     max_stock: 5
     restock_amount: 2
-    properties:
-      effect_type: psyche_boost
-      amount: 40
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Muse Chip
-    description: "A micro-implant that stimulates the creative cortex. Popular among artists, musicians, and the dangerously unhinged."
-    item_type: consumable
-    rarity: uncommon
+    definition_slug: muse-chip
     base_price: 150
     max_stock: 5
     restock_amount: 2
-    properties:
-      effect_type: inspire
-      amount: 40
 
   # Tools
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Basic Decryption Key
-    description: "Opens standard-grade encrypted containers. Disposable — one use, then it fries itself."
-    item_type: tool
-    rarity: common
+    definition_slug: basic-decryption-key
     base_price: 75
     max_stock: 20
     restock_amount: 5
-    properties: {}
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Signal Analyzer
-    description: "Portable frequency scanner. Useful for detecting hidden transmissions and anomalies."
-    item_type: tool
-    rarity: uncommon
+    definition_slug: signal-analyzer
     base_price: 200
     max_stock: 3
     restock_amount: 1
-    properties: {}
 
-  # Components (up to uncommon, rarely rare)
+  # Components
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Enhanced GPU
-    description: "A mid-tier graphics processor. Decent hash rate, reasonable power draw."
-    item_type: component
-    rarity: uncommon
+    definition_slug: enhanced-gpu
     base_price: 300
     max_stock: 3
     restock_amount: 1
-    properties:
-      slot: gpu
-      rate_multiplier: 1.3
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Enhanced CPU
-    description: "Dual-core processor salvaged from decommissioned GovCorp terminals. Still kicks."
-    item_type: component
-    rarity: uncommon
+    definition_slug: enhanced-cpu
     base_price: 300
     max_stock: 3
     restock_amount: 1
-    properties:
-      slot: cpu
-      rate_multiplier: 1.3
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Enhanced RAM Module
-    description: "High-bandwidth memory module. Makes everything snappier."
-    item_type: component
-    rarity: uncommon
+    definition_slug: enhanced-ram-module
     base_price: 250
     max_stock: 3
     restock_amount: 1
-    properties:
-      slot: ram
-      rate_multiplier: 1.25
 
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Hardened PSU
-    description: "Surge-protected power supply. Won't fry when the grid spikes."
-    item_type: component
-    rarity: uncommon
+    definition_slug: hardened-psu
     base_price: 200
     max_stock: 4
     restock_amount: 1
-    properties:
-      slot: psu
-      rate_multiplier: 1.2
 
   # Data
   - vendor_name: Codec
     room_slug: the-signal-bazaar
-    name: Faction Data Shard
-    description: "A data fragment of unknown origin. The encryption is beyond standard tools. Someone will want this."
-    item_type: data
-    rarity: uncommon
+    definition_slug: faction-data-shard
     base_price: 200
     max_stock: 3
     restock_amount: 1
-    properties: {}
 
   # ══════════════════════════════════════════
   # THE BLACKSITE — Black market (GHOST)
@@ -156,169 +97,110 @@ shop_listings:
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Milspec GPU
-    description: "Military-specification graphics processor. Stolen from a GovCorp mining facility. The serial numbers have been... removed."
-    item_type: component
-    rarity: rare
+    definition_slug: milspec-gpu
     base_price: 800
     max_stock: 2
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties:
-      slot: gpu
-      rate_multiplier: 1.8
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Milspec CPU
-    description: "Quad-core processor with hardened encryption coprocessor. Falls off a GovCorp truck every now and then."
-    item_type: component
-    rarity: rare
+    definition_slug: milspec-cpu
     base_price: 800
     max_stock: 2
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties:
-      slot: cpu
-      rate_multiplier: 1.8
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Overclocked RAM Array
-    description: "Eight high-density modules wired in parallel. Runs hot. Runs fast. Don't ask where it came from."
-    item_type: component
-    rarity: rare
+    definition_slug: overclocked-ram-array
     base_price: 650
     max_stock: 2
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties:
-      slot: ram
-      rate_multiplier: 1.7
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Quantum Flux Capacitor
-    description: "Experimental power supply that harnesses quantum fluctuations. Theoretically impossible. Practically devastating."
-    item_type: component
-    rarity: ultra_rare
+    definition_slug: quantum-flux-capacitor
     base_price: 2500
     max_stock: 1
     restock_amount: 1
     restock_interval_hours: 336
     rotation_pool: true
     min_clearance: 15
-    properties:
-      slot: psu
-      rate_multiplier: 2.5
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Neural Cortex Board
-    description: "A motherboard that interfaces directly with neural tissue. Three times the slots of anything on the market. The installation process is... unpleasant."
-    item_type: component
-    rarity: ultra_rare
+    definition_slug: neural-cortex-board
     base_price: 5000
     max_stock: 1
     restock_amount: 1
     restock_interval_hours: 336
     rotation_pool: true
     min_clearance: 20
-    properties:
-      slot: motherboard
-      cpu_slots: 2
-      gpu_slots: 4
-      ram_slots: 4
-      rate_multiplier: 2.0
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Deep Scan Array
-    description: "Military-grade network scanner. Reads encrypted traffic, identifies hidden nodes, maps surveillance blind spots."
-    item_type: tool
-    rarity: rare
+    definition_slug: deep-scan-array
     base_price: 1000
     max_stock: 2
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties: {}
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: GovCorp Access Spoofcard
-    description: "Spoofs GovCorp network credentials. Burns out after a single use. Don't get caught with one."
-    item_type: tool
-    rarity: rare
+    definition_slug: govcorp-access-spoofcard
     base_price: 1200
     max_stock: 1
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties: {}
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Temporal Resonance Crystal
-    description: "A byproduct of Chronology Fracture research. It hums at a frequency that shouldn't exist. Collectors pay a fortune for these."
-    item_type: collectible
-    rarity: ultra_rare
+    definition_slug: temporal-resonance-crystal
     base_price: 3000
     max_stock: 1
     restock_amount: 1
     restock_interval_hours: 336
     rotation_pool: true
     min_clearance: 10
-    properties: {}
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Fracture Beacon
-    description: "Emits a signal recognizable only to Fracture Network operatives across temporal boundaries. Possession alone is a statement."
-    item_type: faction
-    rarity: ultra_rare
+    definition_slug: fracture-beacon
     base_price: 5000
     max_stock: 1
     restock_amount: 1
     restock_interval_hours: 336
     rotation_pool: true
     min_clearance: 25
-    properties: {}
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Phantom Drive
-    description: "Untraceable storage device with quantum-encrypted partitions. What's stored on it is between you and the universe."
-    item_type: data
-    rarity: rare
+    definition_slug: phantom-drive
     base_price: 900
     max_stock: 3
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties: {}
 
   - vendor_name: GHOST
     room_slug: the-blacksite
-    name: Black ICE Injector
-    description: "Military-grade psyche stimulant. Sharpens the mind to a razor edge. The comedown is legendary. Handle with extreme care."
-    item_type: consumable
-    rarity: rare
+    definition_slug: black-ice-injector
     base_price: 500
     max_stock: 2
     restock_amount: 1
     restock_interval_hours: 168
     rotation_pool: true
     min_clearance: 10
-    properties:
-      effect_type: psyche_boost
-      amount: 80

--- a/db/migrate/20260416120001_create_grid_item_definitions.rb
+++ b/db/migrate/20260416120001_create_grid_item_definitions.rb
@@ -1,0 +1,17 @@
+class CreateGridItemDefinitions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_item_definitions do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :item_type, null: false
+      t.string :rarity, null: false
+      t.integer :value, null: false, default: 0
+      t.json :properties, null: false, default: {}
+      t.timestamps
+    end
+
+    add_index :grid_item_definitions, :slug, unique: true
+    add_index :grid_item_definitions, :item_type
+  end
+end

--- a/db/migrate/20260416120002_add_definition_to_grid_items.rb
+++ b/db/migrate/20260416120002_add_definition_to_grid_items.rb
@@ -1,0 +1,27 @@
+class AddDefinitionToGridItems < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :grid_items, :grid_item_definition, null: true, foreign_key: true, index: true
+
+    # Backfill: create definitions from existing items, link them
+    if GridItem.any?
+      GridItem.find_each do |item|
+        slug = item.name.parameterize
+        defn = GridItemDefinition.find_or_create_by!(slug: slug) do |d|
+          d.name = item.name
+          d.description = item.description
+          d.item_type = item.item_type || "tool"
+          d.rarity = item.rarity || "common"
+          d.value = item.value || 0
+          d.properties = item.properties || {}
+        end
+        item.update_column(:grid_item_definition_id, defn.id)
+      end
+    end
+
+    change_column_null :grid_items, :grid_item_definition_id, false
+  end
+
+  def down
+    remove_reference :grid_items, :grid_item_definition
+  end
+end

--- a/db/migrate/20260416120003_refactor_grid_shop_listings_for_definition.rb
+++ b/db/migrate/20260416120003_refactor_grid_shop_listings_for_definition.rb
@@ -1,0 +1,54 @@
+class RefactorGridShopListingsForDefinition < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :grid_shop_listings, :grid_item_definition, null: true, foreign_key: true, index: true
+
+    # Backfill: match listings to definitions by name, creating if needed
+    if GridShopListing.any?
+      GridShopListing.find_each do |listing|
+        slug = listing.read_attribute(:name)&.parameterize || "listing-#{listing.id}"
+        defn = GridItemDefinition.find_or_create_by!(slug: slug) do |d|
+          d.name = listing.read_attribute(:name)
+          d.description = listing.read_attribute(:description)
+          d.item_type = listing.read_attribute(:item_type) || "tool"
+          d.rarity = listing.read_attribute(:rarity) || "common"
+          d.value = listing.base_price || 0
+          d.properties = listing.read_attribute(:properties) || {}
+        end
+        listing.update_column(:grid_item_definition_id, defn.id)
+      end
+    end
+
+    change_column_null :grid_shop_listings, :grid_item_definition_id, false
+
+    remove_column :grid_shop_listings, :name, :string
+    remove_column :grid_shop_listings, :description, :text
+    remove_column :grid_shop_listings, :item_type, :string
+    remove_column :grid_shop_listings, :rarity, :string
+    remove_column :grid_shop_listings, :properties, :json
+  end
+
+  def down
+    add_column :grid_shop_listings, :name, :string
+    add_column :grid_shop_listings, :description, :text
+    add_column :grid_shop_listings, :item_type, :string
+    add_column :grid_shop_listings, :rarity, :string
+    add_column :grid_shop_listings, :properties, :json
+
+    # Restore columns from definitions
+    if GridShopListing.any?
+      GridShopListing.includes(:grid_item_definition).find_each do |listing|
+        defn = listing.grid_item_definition
+        next unless defn
+        listing.update_columns(
+          name: defn.name,
+          description: defn.description,
+          item_type: defn.item_type,
+          rarity: defn.rarity,
+          properties: defn.properties
+        )
+      end
+    end
+
+    remove_reference :grid_shop_listings, :grid_item_definition
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_120003) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -307,10 +307,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
     t.index ["role"], name: "index_grid_hackrs_on_role"
   end
 
+  create_table "grid_item_definitions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "item_type", null: false
+    t.string "name", null: false
+    t.json "properties", default: {}, null: false
+    t.string "rarity", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.integer "value", default: 0, null: false
+    t.index ["item_type"], name: "index_grid_item_definitions_on_item_type"
+    t.index ["slug"], name: "index_grid_item_definitions_on_slug", unique: true
+  end
+
   create_table "grid_items", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "grid_hackr_id"
+    t.integer "grid_item_definition_id", null: false
     t.integer "grid_mining_rig_id"
     t.string "item_type"
     t.string "name"
@@ -320,6 +335,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
     t.integer "room_id"
     t.datetime "updated_at", null: false
     t.integer "value", default: 0, null: false
+    t.index ["grid_item_definition_id"], name: "index_grid_items_on_grid_item_definition_id"
     t.index ["grid_mining_rig_id"], name: "index_grid_items_on_grid_mining_rig_id"
   end
 
@@ -460,21 +476,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
     t.boolean "active", default: true, null: false
     t.integer "base_price", null: false
     t.datetime "created_at", null: false
-    t.text "description"
+    t.integer "grid_item_definition_id", null: false
     t.integer "grid_mob_id", null: false
-    t.string "item_type"
     t.integer "max_stock"
     t.integer "min_clearance", default: 0, null: false
-    t.string "name", null: false
     t.datetime "next_restock_at"
-    t.json "properties", default: {}
-    t.string "rarity"
     t.integer "restock_amount", default: 1, null: false
     t.integer "restock_interval_hours", default: 24, null: false
     t.boolean "rotation_pool", default: false, null: false
     t.integer "sell_price", null: false
     t.integer "stock"
     t.datetime "updated_at", null: false
+    t.index ["grid_item_definition_id"], name: "index_grid_shop_listings_on_grid_item_definition_id"
     t.index ["grid_mob_id", "active"], name: "index_grid_shop_listings_on_grid_mob_id_and_active"
     t.index ["grid_mob_id"], name: "index_grid_shop_listings_on_grid_mob_id"
     t.index ["next_restock_at"], name: "index_grid_shop_listings_on_next_restock_at"
@@ -1025,6 +1038,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
   add_foreign_key "grid_hackr_reputations", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "tracks"
+  add_foreign_key "grid_items", "grid_item_definitions"
   add_foreign_key "grid_mission_objectives", "grid_missions", on_delete: :cascade
   add_foreign_key "grid_mission_rewards", "grid_missions", on_delete: :cascade
   add_foreign_key "grid_missions", "grid_factions", column: "min_rep_faction_id", on_delete: :nullify
@@ -1033,6 +1047,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120002) do
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
+  add_foreign_key "grid_shop_listings", "grid_item_definitions"
   add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -192,7 +192,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, zones, rooms, etc.)"
-  task world: [:factions, :zones, :rooms, :exits, :mobs, :items, :achievements, :shop_listings, :missions]
+  task world: [:factions, :zones, :rooms, :exits, :mobs, :item_definitions, :items, :achievements, :shop_listings, :missions]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -697,6 +697,43 @@ namespace :data do
     puts "Mobs: #{created} created, #{updated} updated, #{GridMob.count} total"
   end
 
+  desc "Load item definitions from YAML"
+  task item_definitions: :environment do
+    puts "\n--- Loading Item Definitions ---"
+    yaml_file = Rails.root.join("data", "world", "item_definitions.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    defs_data = data["item_definitions"]
+    created = updated = 0
+
+    defs_data.each do |attrs|
+      defn = GridItemDefinition.find_or_initialize_by(slug: attrs["slug"])
+      was_new = defn.new_record?
+
+      defn.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"],
+        item_type: attrs["item_type"],
+        rarity: attrs["rarity"],
+        value: attrs["value"] || 0,
+        properties: attrs["properties"] || {}
+      )
+
+      if defn.changed?
+        defn.save!
+        was_new ? (created += 1) : (updated += 1)
+        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{defn.name} (#{defn.slug})"
+      end
+    end
+
+    puts "Item Definitions: #{created} created, #{updated} updated, #{GridItemDefinition.count} total"
+  end
+
   desc "Load items from YAML"
   task items: :environment do
     puts "\n--- Loading Items ---"
@@ -718,17 +755,22 @@ namespace :data do
         next
       end
 
-      item = GridItem.find_or_initialize_by(name: attrs["name"], room: room)
+      defn = GridItemDefinition.find_by(slug: attrs["definition_slug"])
+      unless defn
+        puts "  ✗ Definition not found: #{attrs["definition_slug"]}"
+        next
+      end
+
+      item = GridItem.find_or_initialize_by(grid_item_definition: defn, room: room, grid_hackr: nil)
       was_new = item.new_record?
 
       item.assign_attributes(
-        description: attrs["description"],
-        item_type: attrs["item_type"],
-        rarity: attrs["rarity"],
-        value: attrs["value"] || 0,
-        quantity: attrs["quantity"] || 1,
-        properties: attrs["properties"]
+        defn.item_attributes.merge(
+          room: room,
+          quantity: attrs["quantity"] || 1
+        )
       )
+      item.value = attrs["value"] if attrs.key?("value")
 
       if item.changed?
         item.save!
@@ -738,6 +780,25 @@ namespace :data do
     end
 
     puts "Items: #{created} created, #{updated} updated, #{GridItem.count} total"
+  end
+
+  desc "Sync existing grid_items with their current definitions"
+  task sync_item_definitions: :environment do
+    puts "\n--- Syncing Item Definitions → Items ---"
+    synced = 0
+
+    GridItem.includes(:grid_item_definition).find_each do |item|
+      defn = item.grid_item_definition
+      attrs = defn.item_attributes.except(:grid_item_definition)
+      changes = attrs.select { |k, v| item.read_attribute(k) != v }
+      next if changes.empty?
+
+      item.update_columns(changes)
+      synced += 1
+      puts "  ↻ #{item.name} (id=#{item.id}): #{changes.keys.join(", ")}"
+    end
+
+    puts "Synced #{synced} items, #{GridItem.count} total"
   end
 
   desc "Load achievements from YAML"
@@ -810,7 +871,13 @@ namespace :data do
         next
       end
 
-      listing = GridShopListing.find_or_initialize_by(name: attrs["name"], grid_mob: mob)
+      defn = GridItemDefinition.find_by(slug: attrs["definition_slug"])
+      unless defn
+        puts "  ✗ Definition not found: #{attrs["definition_slug"]}"
+        next
+      end
+
+      listing = GridShopListing.find_or_initialize_by(grid_item_definition: defn, grid_mob: mob)
       was_new = listing.new_record?
 
       base_price = attrs["base_price"]
@@ -818,19 +885,15 @@ namespace :data do
       rotation_pool = attrs.fetch("rotation_pool", false)
       restock_hours = attrs["restock_interval_hours"] || mob.restock_interval_hours
 
-      # Definition fields — always updated from YAML (source of truth)
+      # Shop-specific fields — always updated from YAML (source of truth)
       listing.assign_attributes(
-        description: attrs["description"],
-        item_type: attrs["item_type"],
-        rarity: attrs["rarity"],
         base_price: base_price,
         sell_price: sell_price,
         max_stock: attrs["max_stock"],
         restock_amount: attrs["restock_amount"] || 1,
         restock_interval_hours: restock_hours,
         rotation_pool: rotation_pool,
-        min_clearance: attrs["min_clearance"] || 0,
-        properties: attrs["properties"] || {}
+        min_clearance: attrs["min_clearance"] || 0
       )
 
       # Runtime state — only set on creation. Preserves live stock, active flag,

--- a/lib/tasks/economy.rake
+++ b/lib/tasks/economy.rake
@@ -84,29 +84,16 @@ namespace :data do
     incomplete_rigs = GridMiningRig.includes(:grid_items, :grid_hackr).select { |rig| !rig.functional? }
     if incomplete_rigs.any?
       puts "\n  Backfilling #{incomplete_rigs.count} incomplete rigs..."
-      base_components = [
-        {name: "Basic Motherboard", description: "A standard-issue board with minimal expansion. Gets the job done.", slot: "motherboard", rate_multiplier: 1.0, value: 10, extra: {cpu_slots: 1, gpu_slots: 2, ram_slots: 2}},
-        {name: "Basic PSU", description: "A reliable power supply. Keeps the lights on.", slot: "psu", rate_multiplier: 1.0, value: 5},
-        {name: "Basic CPU", description: "A single-core processor. Slow but steady.", slot: "cpu", rate_multiplier: 1.0, value: 8},
-        {name: "Basic GPU", description: "A standard-issue mining processor. Not fast, but it works.", slot: "gpu", rate_multiplier: 1.0, value: 5},
-        {name: "Basic RAM", description: "A single stick of memory. Enough to boot.", slot: "ram", rate_multiplier: 1.0, value: 4}
-      ]
+      base_slugs = %w[basic-motherboard basic-psu basic-cpu basic-gpu basic-ram]
+      definitions = GridItemDefinition.where(slug: base_slugs).index_by(&:slug)
 
       incomplete_rigs.each do |rig|
         installed_slots = rig.components.map(&:slot)
-        base_components.each do |comp|
-          next if installed_slots.include?(comp[:slot])
-          props = {slot: comp[:slot], rate_multiplier: comp[:rate_multiplier]}
-          props.merge!(comp[:extra]) if comp[:extra]
-          GridItem.create!(
-            grid_mining_rig: rig,
-            name: comp[:name],
-            description: comp[:description],
-            item_type: "component",
-            rarity: "common",
-            value: comp[:value],
-            properties: props
-          )
+        base_slugs.each do |slug|
+          defn = definitions[slug]
+          next unless defn
+          next if installed_slots.include?(defn.properties["slot"])
+          GridItem.create!(defn.item_attributes.merge(grid_mining_rig: rig))
         end
         puts "    #{rig.grid_hackr.hackr_alias}: backfilled to #{rig.reload.components.count} components (functional=#{rig.functional?})"
       end

--- a/spec/controllers/api/grid_controller_spec.rb
+++ b/spec/controllers/api/grid_controller_spec.rb
@@ -142,6 +142,16 @@ RSpec.describe Api::GridController, type: :controller do
     let!(:room) { create(:grid_room, grid_zone: zone, room_type: "hub") }
     let!(:token) { GridRegistrationToken.create!(email: "test@example.com", ip_address: "127.0.0.1") }
 
+    before do
+      # provision_economy! needs base component definitions
+      %w[basic-motherboard basic-psu basic-cpu basic-gpu basic-ram].each_with_index do |slug, i|
+        slots = %w[motherboard psu cpu gpu ram]
+        props = {"slot" => slots[i], "rate_multiplier" => 1.0}
+        props.merge!("cpu_slots" => 1, "gpu_slots" => 2, "ram_slots" => 2) if slug == "basic-motherboard"
+        create(:grid_item_definition, slug: slug, name: "Basic #{slots[i].capitalize}", item_type: "component", properties: props)
+      end
+    end
+
     context "with valid token and valid params" do
       it "creates a new GridHackr" do
         expect {

--- a/spec/factories/grid_item_definitions.rb
+++ b/spec/factories/grid_item_definitions.rb
@@ -1,0 +1,50 @@
+# == Schema Information
+#
+# Table name: grid_item_definitions
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  item_type   :string           not null
+#  name        :string           not null
+#  properties  :json             not null
+#  rarity      :string           not null
+#  slug        :string           not null
+#  value       :integer          default(0), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_item_definitions_on_item_type  (item_type)
+#  index_grid_item_definitions_on_slug       (slug) UNIQUE
+#
+FactoryBot.define do
+  factory :grid_item_definition do
+    sequence(:slug) { |n| "item-def-#{n}" }
+    sequence(:name) { |n| "Item Definition #{n}" }
+    description { "A catalog item definition" }
+    item_type { "tool" }
+    rarity { "common" }
+    value { 10 }
+    properties { {} }
+
+    trait :component do
+      item_type { "component" }
+      properties { {"slot" => "gpu", "rate_multiplier" => 1.0} }
+    end
+
+    trait :consumable do
+      item_type { "consumable" }
+      properties { {"effect_type" => "heal", "amount" => 25} }
+    end
+
+    trait :rare do
+      rarity { "rare" }
+    end
+
+    trait :unicorn do
+      rarity { "unicorn" }
+    end
+  end
+end

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -3,33 +3,43 @@
 # Table name: grid_items
 # Database name: primary
 #
-#  id                 :integer          not null, primary key
-#  description        :text
-#  item_type          :string
-#  name               :string
-#  properties         :json
-#  quantity           :integer          default(1), not null
-#  rarity             :string
-#  value              :integer          default(0), not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  grid_hackr_id      :integer
-#  grid_mining_rig_id :integer
-#  room_id            :integer
+#  id                      :integer          not null, primary key
+#  description             :text
+#  item_type               :string
+#  name                    :string
+#  properties              :json
+#  quantity                :integer          default(1), not null
+#  rarity                  :string
+#  value                   :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_hackr_id           :integer
+#  grid_item_definition_id :integer          not null
+#  grid_mining_rig_id      :integer
+#  room_id                 :integer
 #
 # Indexes
 #
-#  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
+#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#
+# Foreign Keys
+#
+#  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 FactoryBot.define do
   factory :grid_item do
-    sequence(:name) { |n| "Item #{n}" }
-    description { "A grid item" }
-    item_type { "tool" }
-    rarity { "common" }
-    value { 10 }
+    association :grid_item_definition
+
+    # Denormalized fields derived from the definition to stay in sync.
+    # Explicit overrides (e.g. `create(:grid_item, name: "Custom")`) still work.
+    name { grid_item_definition.name }
+    description { grid_item_definition.description }
+    item_type { grid_item_definition.item_type }
+    rarity { grid_item_definition.rarity }
+    value { grid_item_definition.value }
+    properties { grid_item_definition.properties&.deep_dup || {} }
     quantity { 1 }
-    properties { {} }
 
     # By default, items are in a room
     association :room, factory: :grid_room
@@ -40,13 +50,11 @@ FactoryBot.define do
     end
 
     trait :component do
-      item_type { "component" }
-      properties { {"slot" => "gpu", "rate_multiplier" => 1.0} }
+      association :grid_item_definition, factory: [:grid_item_definition, :component]
     end
 
     trait :consumable do
-      item_type { "consumable" }
-      properties { {"effect_type" => "heal", "amount" => 25} }
+      association :grid_item_definition, factory: [:grid_item_definition, :consumable]
     end
   end
 end

--- a/spec/factories/grid_shop_listings.rb
+++ b/spec/factories/grid_shop_listings.rb
@@ -3,43 +3,39 @@
 # Table name: grid_shop_listings
 # Database name: primary
 #
-#  id                     :integer          not null, primary key
-#  active                 :boolean          default(TRUE), not null
-#  base_price             :integer          not null
-#  description            :text
-#  item_type              :string
-#  max_stock              :integer
-#  min_clearance          :integer          default(0), not null
-#  name                   :string           not null
-#  next_restock_at        :datetime
-#  properties             :json
-#  rarity                 :string
-#  restock_amount         :integer          default(1), not null
-#  restock_interval_hours :integer          default(24), not null
-#  rotation_pool          :boolean          default(FALSE), not null
-#  sell_price             :integer          not null
-#  stock                  :integer
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  grid_mob_id            :integer          not null
+#  id                      :integer          not null, primary key
+#  active                  :boolean          default(TRUE), not null
+#  base_price              :integer          not null
+#  max_stock               :integer
+#  min_clearance           :integer          default(0), not null
+#  next_restock_at         :datetime
+#  restock_amount          :integer          default(1), not null
+#  restock_interval_hours  :integer          default(24), not null
+#  rotation_pool           :boolean          default(FALSE), not null
+#  sell_price              :integer          not null
+#  stock                   :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_item_definition_id :integer          not null
+#  grid_mob_id             :integer          not null
 #
 # Indexes
 #
-#  index_grid_shop_listings_on_grid_mob_id             (grid_mob_id)
-#  index_grid_shop_listings_on_grid_mob_id_and_active  (grid_mob_id,active)
-#  index_grid_shop_listings_on_next_restock_at         (next_restock_at)
+#  index_grid_shop_listings_on_grid_item_definition_id  (grid_item_definition_id)
+#  index_grid_shop_listings_on_grid_mob_id              (grid_mob_id)
+#  index_grid_shop_listings_on_grid_mob_id_and_active   (grid_mob_id,active)
+#  index_grid_shop_listings_on_next_restock_at          (next_restock_at)
 #
 # Foreign Keys
 #
-#  grid_mob_id  (grid_mob_id => grid_mobs.id)
+#  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
+#  grid_mob_id              (grid_mob_id => grid_mobs.id)
 #
 FactoryBot.define do
   factory :grid_shop_listing do
-    sequence(:name) { |n| "Shop Item #{n}" }
-    description { "An item for sale" }
     association :grid_mob, :vendor
-    item_type { "consumable" }
-    rarity { "common" }
+    association :grid_item_definition
+
     base_price { 100 }
     sell_price { 50 }
     stock { 10 }
@@ -49,7 +45,6 @@ FactoryBot.define do
     active { true }
     rotation_pool { false }
     min_clearance { 0 }
-    properties { {} }
 
     trait :unlimited do
       stock { nil }
@@ -66,20 +61,18 @@ FactoryBot.define do
 
     trait :black_market do
       min_clearance { 10 }
-      rarity { "rare" }
       base_price { 800 }
       sell_price { 400 }
       association :grid_mob, :vendor, vendor_config: {"shop_type" => "black_market"}
+      association :grid_item_definition, :rare
     end
 
     trait :component do
-      item_type { "component" }
-      properties { {"slot" => "gpu", "rate_multiplier" => 1.5} }
+      association :grid_item_definition, factory: [:grid_item_definition, :component]
     end
 
     trait :consumable do
-      item_type { "consumable" }
-      properties { {"effect_type" => "heal", "amount" => 30} }
+      association :grid_item_definition, factory: [:grid_item_definition, :consumable]
     end
   end
 end

--- a/spec/models/grid_item_spec.rb
+++ b/spec/models/grid_item_spec.rb
@@ -3,23 +3,29 @@
 # Table name: grid_items
 # Database name: primary
 #
-#  id                 :integer          not null, primary key
-#  description        :text
-#  item_type          :string
-#  name               :string
-#  properties         :json
-#  quantity           :integer          default(1), not null
-#  rarity             :string
-#  value              :integer          default(0), not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  grid_hackr_id      :integer
-#  grid_mining_rig_id :integer
-#  room_id            :integer
+#  id                      :integer          not null, primary key
+#  description             :text
+#  item_type               :string
+#  name                    :string
+#  properties              :json
+#  quantity                :integer          default(1), not null
+#  rarity                  :string
+#  value                   :integer          default(0), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_hackr_id           :integer
+#  grid_item_definition_id :integer          not null
+#  grid_mining_rig_id      :integer
+#  room_id                 :integer
 #
 # Indexes
 #
-#  index_grid_items_on_grid_mining_rig_id  (grid_mining_rig_id)
+#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#
+# Foreign Keys
+#
+#  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 require "rails_helper"
 

--- a/spec/models/grid_mining_rig_spec.rb
+++ b/spec/models/grid_mining_rig_spec.rb
@@ -22,10 +22,8 @@ RSpec.describe GridMiningRig, type: :model do
 
   def install_component(rig, slot:, name: "Test #{slot}", rate_multiplier: 1.0, extra_props: {})
     props = {slot: slot, rate_multiplier: rate_multiplier}.merge(extra_props)
-    GridItem.create!(
-      grid_mining_rig: rig, name: name, item_type: "component",
-      rarity: "common", value: 1, properties: props
-    )
+    defn = create(:grid_item_definition, :component, properties: props, name: name)
+    GridItem.create!(defn.item_attributes.merge(grid_mining_rig: rig))
   end
 
   def install_base_rig(rig)

--- a/spec/services/grid/mining_service_spec.rb
+++ b/spec/services/grid/mining_service_spec.rb
@@ -22,10 +22,8 @@ RSpec.describe Grid::MiningService do
       {slot: "ram", name: "RAM"}
     ].each do |comp|
       props = {slot: comp[:slot], rate_multiplier: 1.0}.merge(comp[:extra] || {})
-      GridItem.create!(
-        grid_mining_rig: rig, name: comp[:name], item_type: "component",
-        rarity: "common", value: 1, properties: props
-      )
+      defn = create(:grid_item_definition, :component, properties: props, name: comp[:name])
+      GridItem.create!(defn.item_attributes.merge(grid_mining_rig: rig))
     end
   end
 

--- a/spec/services/grid/mission_reward_granter_spec.rb
+++ b/spec/services/grid/mission_reward_granter_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Grid::MissionRewardGranter do
     end
 
     it "creates a GridItem for item_grant rewards" do
-      create(:grid_mission_reward, grid_mission: mission, reward_type: "item_grant", target_slug: "Reward Core", amount: 100, quantity: 2)
+      create(:grid_item_definition, slug: "reward-core", name: "Reward Core", item_type: "collectible", rarity: "uncommon")
+      create(:grid_mission_reward, grid_mission: mission, reward_type: "item_grant", target_slug: "reward-core", amount: 100, quantity: 2)
 
       expect {
         described_class.new(hackr, hackr_mission).grant!

--- a/spec/services/grid/shop_service_spec.rb
+++ b/spec/services/grid/shop_service_spec.rb
@@ -9,10 +9,14 @@ RSpec.describe Grid::ShopService do
   let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
   let(:burn_cache) { create(:grid_cache, :burn) }
 
+  let(:medpatch_def) do
+    create(:grid_item_definition, :consumable, slug: "medpatch", name: "MedPatch")
+  end
+
   let!(:listing) do
-    create(:grid_shop_listing, :consumable,
+    create(:grid_shop_listing,
+      grid_item_definition: medpatch_def,
       grid_mob: vendor,
-      name: "MedPatch",
       base_price: 100,
       sell_price: 50,
       stock: 5,
@@ -144,11 +148,11 @@ RSpec.describe Grid::ShopService do
     end
 
     let!(:item) do
-      create(:grid_item,
+      create(:grid_item, :consumable,
+        grid_item_definition: medpatch_def,
         grid_hackr: hackr,
         room: nil,
         name: "MedPatch",
-        item_type: "consumable",
         rarity: "common",
         value: 100)
     end
@@ -206,7 +210,7 @@ RSpec.describe Grid::ShopService do
     end
 
     let(:bm_listing) do
-      create(:grid_shop_listing, grid_mob: bm_vendor, base_price: 1000)
+      create(:grid_shop_listing, grid_mob: bm_vendor, base_price: 1000, sell_price: 500)
     end
 
     it "returns base_price for standard vendors" do
@@ -287,9 +291,10 @@ RSpec.describe Grid::ShopService do
 
     let!(:rot_listings) do
       5.times.map do |i|
+        defn = create(:grid_item_definition, slug: "rot-item-#{i}", name: "Rotation Item #{i}")
         create(:grid_shop_listing,
+          grid_item_definition: defn,
           grid_mob: bm_vendor,
-          name: "Rotation Item #{i}",
           rotation_pool: true,
           active: false)
       end


### PR DESCRIPTION
Introduces a canonical item catalog table with slug-based identity. All 6 item creation paths (shop buy, mission reward, rig provisioning, economy backfill, world seed, shop listing seed) now derive from definitions via item_attributes. GridShopListing refactored to FK + delegation, removing 5 duplicated columns.

  - Schema: grid_item_definitions table, FK on grid_items and grid_shop_listings
  - Migrations handle both fresh and populated DBs
    - (nullable → backfill → constrain)
  - 33 definitions in item_definitions.yml
    - (components, consumables, tools, data, collectibles, faction)
  - YAML seeds (items.yml, shop_listings.yml) reference definitions by slug
  - Admin CRUD at /admin/grid_item_definitions with type filter and properties JSON editor
  - Shop listings admin simplified to definition dropdown + shop-specific fields
  - data:sync_item_definitions rake task for propagating definition changes to live items
  - ShopService queries join through definitions for name lookups
  - Full CI: 1853 RSpec (0 failures), StandardRB + ESLint + Brakeman clean