### PR TITLE
DB as SoT: seed-only YAML, PaperTrail audit, full admin CRUD

### DIFF
--- a/app/controllers/admin/artists_controller.rb
+++ b/app/controllers/admin/artists_controller.rb
@@ -1,7 +1,60 @@
-# Read-only controller - Artists are managed via YAML files
-# Edit data/catalog/{artist_slug}.yml and run: rails data:catalog
 class Admin::ArtistsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable Artist, find_by: :slug
+
+  before_action :set_artist, only: %i[edit update destroy]
+
   def index
     @artists = Artist.order(:name).includes(:tracks)
+  end
+
+  def new
+    @artist = Artist.new(artist_type: "band")
+  end
+
+  def create
+    @artist = Artist.new(artist_params)
+    if @artist.save
+      set_flash_success("Artist '#{@artist.name}' created.")
+      redirect_to admin_artists_path
+    else
+      flash.now[:error] = @artist.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @artist.update(artist_params)
+      set_flash_success("Artist '#{@artist.name}' updated.")
+      redirect_to admin_artists_path
+    else
+      flash.now[:error] = @artist.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @artist.name
+    if @artist.releases.any? || @artist.tracks.any?
+      set_flash_error("Can't delete '#{name}' — releases or tracks still reference it.")
+    else
+      @artist.destroy!
+      set_flash_success("Artist '#{name}' deleted.")
+    end
+    redirect_to admin_artists_path
+  end
+
+  private
+
+  def set_artist
+    @artist = Artist.find_by!(slug: params[:id])
+  end
+
+  def artist_params
+    params.require(:artist).permit(:name, :slug, :genre, :artist_type)
   end
 end

--- a/app/controllers/admin/codex_entries_controller.rb
+++ b/app/controllers/admin/codex_entries_controller.rb
@@ -1,8 +1,97 @@
-# Read-only controller - Codex entries are managed via YAML files
-# Edit data/content/codex.yml and run: rails data:codex
 class Admin::CodexEntriesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable CodexEntry, find_by: :slug
+
+  before_action :set_entry, only: %i[edit update destroy]
+
   def index
-    @codex_entries = CodexEntry.ordered
-    @codex_entries = @codex_entries.by_type(params[:entry_type]) if params[:entry_type].present?
+    scope = CodexEntry.ordered
+    scope = scope.by_type(params[:entry_type]) if params[:entry_type].present? && CodexEntry::ENTRY_TYPES.include?(params[:entry_type])
+    @type_filter = params[:entry_type]
+    @entries = scope
+  end
+
+  def new
+    @entry = CodexEntry.new(published: false, entry_type: "concept")
+  end
+
+  def create
+    attrs, json_error = entry_params
+    @entry = CodexEntry.new(attrs)
+
+    if json_error
+      @entry.valid?
+      @entry.errors.add(:metadata, json_error)
+      flash.now[:error] = @entry.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+      return
+    end
+
+    if @entry.save
+      set_flash_success("Codex entry '#{@entry.name}' created.")
+      redirect_to admin_codex_entries_path
+    else
+      flash.now[:error] = @entry.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    attrs, json_error = entry_params
+
+    if json_error
+      @entry.assign_attributes(attrs)
+      @entry.errors.add(:metadata, json_error)
+      flash.now[:error] = @entry.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
+    if @entry.update(attrs)
+      set_flash_success("Codex entry '#{@entry.name}' updated.")
+      redirect_to admin_codex_entries_path
+    else
+      flash.now[:error] = @entry.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @entry.name
+    @entry.destroy!
+    set_flash_success("Codex entry '#{name}' deleted.")
+    redirect_to admin_codex_entries_path
+  end
+
+  private
+
+  def set_entry
+    @entry = CodexEntry.find_by!(slug: params[:id])
+  end
+
+  def entry_params
+    permitted = params.require(:codex_entry).permit(
+      :name, :slug, :entry_type, :summary, :content, :position, :published
+    )
+
+    json_source = params[:codex_entry][:metadata_json]
+    if json_source.blank?
+      permitted[:metadata] = {}
+      return [permitted, nil]
+    end
+
+    parsed = JSON.parse(json_source)
+    unless parsed.is_a?(Hash)
+      return [permitted, "must be a JSON object"]
+    end
+
+    permitted[:metadata] = parsed
+    [permitted, nil]
+  rescue JSON::ParserError => e
+    [permitted, "is not valid JSON: #{e.message}"]
   end
 end

--- a/app/controllers/admin/grid_achievements_controller.rb
+++ b/app/controllers/admin/grid_achievements_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridAchievementsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridAchievement
+
   before_action :set_achievement, only: [:edit, :update, :destroy, :award]
 
   def index

--- a/app/controllers/admin/grid_achievements_controller.rb
+++ b/app/controllers/admin/grid_achievements_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridAchievementsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridAchievement
 
   before_action :set_achievement, only: [:edit, :update, :destroy, :award]

--- a/app/controllers/admin/grid_exits_controller.rb
+++ b/app/controllers/admin/grid_exits_controller.rb
@@ -1,0 +1,64 @@
+class Admin::GridExitsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridExit
+
+  before_action :set_exit, only: %i[edit update destroy]
+
+  def index
+    @exits = GridExit.includes(:from_room, :to_room).order(:from_room_id, :direction)
+  end
+
+  def new
+    @exit = GridExit.new(locked: false)
+    load_selects
+  end
+
+  def create
+    @exit = GridExit.new(exit_params)
+    if @exit.save
+      set_flash_success("Exit created: #{@exit.from_room.name} → #{@exit.direction} → #{@exit.to_room.name}")
+      redirect_to admin_grid_exits_path
+    else
+      load_selects
+      flash.now[:error] = @exit.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @exit.update(exit_params)
+      set_flash_success("Exit updated.")
+      redirect_to admin_grid_exits_path
+    else
+      load_selects
+      flash.now[:error] = @exit.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    desc = "#{@exit.from_room.name} → #{@exit.direction} → #{@exit.to_room.name}"
+    @exit.destroy!
+    set_flash_success("Exit '#{desc}' deleted.")
+    redirect_to admin_grid_exits_path
+  end
+
+  private
+
+  def set_exit
+    @exit = GridExit.find(params[:id])
+  end
+
+  def load_selects
+    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+  end
+
+  def exit_params
+    params.require(:grid_exit).permit(:from_room_id, :to_room_id, :direction, :locked, :requires_item_id)
+  end
+end

--- a/app/controllers/admin/grid_factions_controller.rb
+++ b/app/controllers/admin/grid_factions_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridFactionsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridFaction
+
   before_action :set_faction, only: [:edit, :update, :destroy]
 
   def index

--- a/app/controllers/admin/grid_factions_controller.rb
+++ b/app/controllers/admin/grid_factions_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridFactionsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridFaction
 
   before_action :set_faction, only: [:edit, :update, :destroy]

--- a/app/controllers/admin/grid_item_definitions_controller.rb
+++ b/app/controllers/admin/grid_item_definitions_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridItemDefinitionsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridItemDefinition, find_by: :slug, children: [:salvage_yields]
 
   before_action :set_definition, only: %i[edit update destroy]

--- a/app/controllers/admin/grid_item_definitions_controller.rb
+++ b/app/controllers/admin/grid_item_definitions_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridItemDefinitionsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridItemDefinition, find_by: :slug, children: [:salvage_yields]
+
   before_action :set_definition, only: %i[edit update destroy]
 
   def index

--- a/app/controllers/admin/grid_mission_arcs_controller.rb
+++ b/app/controllers/admin/grid_mission_arcs_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridMissionArcsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridMissionArc, find_by: :slug
+
   before_action :set_arc, only: %i[edit update destroy]
 
   def index

--- a/app/controllers/admin/grid_mission_arcs_controller.rb
+++ b/app/controllers/admin/grid_mission_arcs_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridMissionArcsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridMissionArc, find_by: :slug
 
   before_action :set_arc, only: %i[edit update destroy]

--- a/app/controllers/admin/grid_missions_controller.rb
+++ b/app/controllers/admin/grid_missions_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridMissionsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridMission, find_by: :slug, children: [:grid_mission_objectives, :grid_mission_rewards]
 
   before_action :set_mission, only: %i[edit update destroy]

--- a/app/controllers/admin/grid_missions_controller.rb
+++ b/app/controllers/admin/grid_missions_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridMissionsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridMission, find_by: :slug, children: [:grid_mission_objectives, :grid_mission_rewards]
+
   before_action :set_mission, only: %i[edit update destroy]
 
   def index

--- a/app/controllers/admin/grid_mobs_controller.rb
+++ b/app/controllers/admin/grid_mobs_controller.rb
@@ -1,0 +1,83 @@
+class Admin::GridMobsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridMob
+
+  before_action :set_mob, only: %i[edit update destroy]
+
+  def index
+    @mobs = GridMob.includes(:grid_room, :grid_faction).order(:name)
+  end
+
+  def new
+    @mob = GridMob.new
+    load_selects
+  end
+
+  def create
+    @mob = GridMob.new(mob_params)
+    if @mob.save
+      set_flash_success("Mob '#{@mob.name}' created.")
+      redirect_to admin_grid_mobs_path
+    else
+      load_selects
+      flash.now[:error] = @mob.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @mob.update(mob_params)
+      set_flash_success("Mob '#{@mob.name}' updated.")
+      redirect_to admin_grid_mobs_path
+    else
+      load_selects
+      flash.now[:error] = @mob.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @mob.name
+    if @mob.grid_shop_listings.any?
+      set_flash_error("Can't delete '#{name}' — shop listings still reference it.")
+    else
+      @mob.destroy!
+      set_flash_success("Mob '#{name}' deleted.")
+    end
+    redirect_to admin_grid_mobs_path
+  end
+
+  private
+
+  def set_mob
+    @mob = GridMob.find(params[:id])
+  end
+
+  def load_selects
+    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+    @factions = GridFaction.ordered
+  end
+
+  def mob_params
+    permitted = params.require(:grid_mob).permit(
+      :name, :description, :mob_type, :grid_room_id, :grid_faction_id
+    )
+    # Parse JSON fields
+    %w[dialogue_tree vendor_config].each do |json_field|
+      raw = params[:grid_mob][:"#{json_field}_json"]
+      permitted[json_field] = if raw.blank?
+        {}
+      else
+        JSON.parse(raw)
+      end
+    rescue JSON::ParserError
+      permitted[json_field] = {}
+    end
+    permitted
+  end
+end

--- a/app/controllers/admin/grid_rooms_controller.rb
+++ b/app/controllers/admin/grid_rooms_controller.rb
@@ -1,7 +1,73 @@
-# Read-only controller - Grid rooms are managed via YAML files
-# Edit data/world/rooms.yml and run: rails data:rooms
 class Admin::GridRoomsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridRoom
+
+  before_action :set_room, only: %i[edit update destroy]
+
   def index
-    @rooms = GridRoom.includes(:grid_zone, :ambient_playlist).order("grid_zones.name, grid_rooms.name").joins(:grid_zone)
+    @rooms = GridRoom.includes(:grid_zone, :ambient_playlist)
+      .joins(:grid_zone)
+      .order("grid_zones.name, grid_rooms.name")
+  end
+
+  def new
+    @room = GridRoom.new(min_clearance: 0)
+    load_selects
+  end
+
+  def create
+    @room = GridRoom.new(room_params)
+    if @room.save
+      set_flash_success("Room '#{@room.name}' created.")
+      redirect_to admin_grid_rooms_path
+    else
+      load_selects
+      flash.now[:error] = @room.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @room.update(room_params)
+      set_flash_success("Room '#{@room.name}' updated.")
+      redirect_to admin_grid_rooms_path
+    else
+      load_selects
+      flash.now[:error] = @room.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @room.name
+    if @room.grid_mobs.any? || @room.grid_items.any?
+      set_flash_error("Can't delete '#{name}' — mobs or items still reference it.")
+    else
+      @room.destroy!
+      set_flash_success("Room '#{name}' deleted.")
+    end
+    redirect_to admin_grid_rooms_path
+  end
+
+  private
+
+  def set_room
+    @room = GridRoom.find(params[:id])
+  end
+
+  def load_selects
+    @zones = GridZone.order(:name)
+    @playlists = ZonePlaylist.order(:name)
+  end
+
+  def room_params
+    params.require(:grid_room).permit(
+      :name, :slug, :description, :room_type, :min_clearance, :grid_zone_id, :ambient_playlist_id
+    )
   end
 end

--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -1,5 +1,6 @@
 class Admin::GridShopListingsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable GridShopListing
 
   before_action :set_listing, only: [:edit, :update, :destroy, :restock]

--- a/app/controllers/admin/grid_shop_listings_controller.rb
+++ b/app/controllers/admin/grid_shop_listings_controller.rb
@@ -1,4 +1,7 @@
 class Admin::GridShopListingsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable GridShopListing
+
   before_action :set_listing, only: [:edit, :update, :destroy, :restock]
   before_action :load_selects, only: [:new, :edit]
 

--- a/app/controllers/admin/grid_zones_controller.rb
+++ b/app/controllers/admin/grid_zones_controller.rb
@@ -1,7 +1,71 @@
-# Read-only controller - Grid zones are managed via YAML files
-# Edit data/world/zones.yml and run: rails data:zones
 class Admin::GridZonesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridZone
+
+  before_action :set_zone, only: %i[edit update destroy]
+
   def index
-    @zones = GridZone.includes(:ambient_playlist, :grid_faction).order(:name)
+    @zones = GridZone.includes(:ambient_playlist, :grid_faction, :grid_rooms).order(:name)
+  end
+
+  def new
+    @zone = GridZone.new
+    load_selects
+  end
+
+  def create
+    @zone = GridZone.new(zone_params)
+    if @zone.save
+      set_flash_success("Zone '#{@zone.name}' created.")
+      redirect_to admin_grid_zones_path
+    else
+      load_selects
+      flash.now[:error] = @zone.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @zone.update(zone_params)
+      set_flash_success("Zone '#{@zone.name}' updated.")
+      redirect_to admin_grid_zones_path
+    else
+      load_selects
+      flash.now[:error] = @zone.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @zone.name
+    if @zone.grid_rooms.any?
+      set_flash_error("Can't delete '#{name}' — rooms still reference it.")
+    else
+      @zone.destroy!
+      set_flash_success("Zone '#{name}' deleted.")
+    end
+    redirect_to admin_grid_zones_path
+  end
+
+  private
+
+  def set_zone
+    @zone = GridZone.find(params[:id])
+  end
+
+  def load_selects
+    @factions = GridFaction.ordered
+    @playlists = ZonePlaylist.order(:name)
+  end
+
+  def zone_params
+    params.require(:grid_zone).permit(
+      :name, :slug, :description, :zone_type, :color_scheme, :grid_faction_id, :ambient_playlist_id
+    )
   end
 end

--- a/app/controllers/admin/hackr_logs_controller.rb
+++ b/app/controllers/admin/hackr_logs_controller.rb
@@ -1,7 +1,66 @@
-# Read-only controller - HackrLogs are managed via YAML files
-# Edit data/content/hackr_logs.yml and run: rails data:hackr_logs
 class Admin::HackrLogsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable HackrLog, find_by: :slug
+
+  before_action :set_log, only: %i[edit update destroy]
+
   def index
-    @hackr_logs = HackrLog.includes(:grid_hackr).ordered
+    @logs = HackrLog.includes(:grid_hackr).ordered
+  end
+
+  def new
+    @log = HackrLog.new(published: false, timeline: "2120s")
+    load_selects
+  end
+
+  def create
+    @log = HackrLog.new(log_params)
+    if @log.save
+      set_flash_success("Hackr log '#{@log.title}' created.")
+      redirect_to admin_hackr_logs_path
+    else
+      load_selects
+      flash.now[:error] = @log.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @log.update(log_params)
+      set_flash_success("Hackr log '#{@log.title}' updated.")
+      redirect_to admin_hackr_logs_path
+    else
+      load_selects
+      flash.now[:error] = @log.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    title = @log.title
+    @log.destroy!
+    set_flash_success("Hackr log '#{title}' deleted.")
+    redirect_to admin_hackr_logs_path
+  end
+
+  private
+
+  def set_log
+    @log = HackrLog.find_by!(slug: params[:id])
+  end
+
+  def load_selects
+    @hackrs = GridHackr.order(:hackr_alias)
+  end
+
+  def log_params
+    params.require(:hackr_log).permit(
+      :title, :slug, :body, :timeline, :published, :published_at, :grid_hackr_id
+    )
   end
 end

--- a/app/controllers/admin/handbook_articles_controller.rb
+++ b/app/controllers/admin/handbook_articles_controller.rb
@@ -1,5 +1,6 @@
 class Admin::HandbookArticlesController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable HandbookArticle, find_by: :slug
 
   before_action :set_article, only: [:edit, :update, :destroy]

--- a/app/controllers/admin/handbook_articles_controller.rb
+++ b/app/controllers/admin/handbook_articles_controller.rb
@@ -1,4 +1,7 @@
 class Admin::HandbookArticlesController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable HandbookArticle, find_by: :slug
+
   before_action :set_article, only: [:edit, :update, :destroy]
 
   def index

--- a/app/controllers/admin/handbook_sections_controller.rb
+++ b/app/controllers/admin/handbook_sections_controller.rb
@@ -1,5 +1,6 @@
 class Admin::HandbookSectionsController < Admin::ApplicationController
   include Admin::Versionable
+
   versionable HandbookSection, find_by: :slug
 
   before_action :set_section, only: [:edit, :update, :destroy]

--- a/app/controllers/admin/handbook_sections_controller.rb
+++ b/app/controllers/admin/handbook_sections_controller.rb
@@ -1,4 +1,7 @@
 class Admin::HandbookSectionsController < Admin::ApplicationController
+  include Admin::Versionable
+  versionable HandbookSection, find_by: :slug
+
   before_action :set_section, only: [:edit, :update, :destroy]
 
   def index

--- a/app/controllers/admin/releases_controller.rb
+++ b/app/controllers/admin/releases_controller.rb
@@ -1,9 +1,30 @@
 class Admin::ReleasesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable Release, find_by: :slug
+
   before_action :set_release, only: [:edit, :update, :destroy, :purge_cover]
 
   def index
     @releases = Release.includes(:artist, :tracks, cover_image_attachment: :blob)
       .order("artists.name", :release_date)
+  end
+
+  def new
+    @release = Release.new
+    @artists = Artist.order(:name)
+  end
+
+  def create
+    @release = Release.new(release_params)
+    if @release.save
+      set_flash_success("Release '#{@release.name}' created.")
+      redirect_to edit_admin_release_path(@release)
+    else
+      @artists = Artist.order(:name)
+      flash.now[:error] = @release.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -1,8 +1,30 @@
 class Admin::TracksController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable Track, find_by: :slug
+
   before_action :set_track, only: [:edit, :update, :destroy, :purge_audio]
 
   def index
     @tracks = Track.includes(:artist, :release).ordered
+  end
+
+  def new
+    @track = Track.new
+    @releases = Release.includes(:artist).order("artists.name", :name)
+  end
+
+  def create
+    @track = Track.new(track_params)
+    @track.artist = @track.release.artist if @track.release
+    if @track.save
+      set_flash_success("Track '#{@track.title}' created.")
+      redirect_to edit_admin_release_path(@track.release)
+    else
+      @releases = Release.includes(:artist).order("artists.name", :name)
+      flash.now[:error] = @track.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
@@ -43,7 +65,7 @@ class Admin::TracksController < Admin::ApplicationController
 
   def track_params
     params.require(:track).permit(
-      :title, :slug, :track_number, :duration, :featured,
+      :title, :slug, :release_id, :track_number, :duration, :featured,
       :show_in_pulse_vault, :lyrics, :release_date, :audio_file
     )
   end

--- a/app/controllers/concerns/admin/versionable.rb
+++ b/app/controllers/concerns/admin/versionable.rb
@@ -1,0 +1,231 @@
+module Admin::Versionable
+  extend ActiveSupport::Concern
+
+  SKIP_KEYS = %w[id created_at updated_at].freeze
+
+  class_methods do
+    def versionable(model_class, find_by: :id, children: [])
+      define_method(:history) do
+        @record = if find_by == :slug
+          model_class.find_by!(slug: params[:id])
+        else
+          model_class.find(params[:id])
+        end
+
+        @model_name = model_class.model_name.human
+        @model_class = model_class
+        @back_path = url_for(action: :index)
+        @entries = build_timeline(@record, children)
+
+        render "admin/shared/version_history"
+      end
+    end
+  end
+
+  private
+
+  # Returns an array of {version:, source:, changes:} sorted desc by time.
+  def build_timeline(record, child_assocs)
+    entries = []
+
+    # Parent versions
+    record.versions.each do |version|
+      entries << {
+        version: version,
+        source: record.class.model_name.human,
+        changes: compute_diff(record, version)
+      }
+    end
+
+    # Child association versions
+    child_assocs.each do |assoc_name|
+      reflection = record.class.reflect_on_association(assoc_name)
+      next unless reflection
+
+      child_class = reflection.klass
+      # All child record IDs (current + historically deleted)
+      child_ids = child_class.unscoped.where(
+        reflection.foreign_key => record.id
+      ).pluck(:id)
+
+      next if child_ids.empty?
+
+      child_versions = PaperTrail::Version.where(
+        item_type: child_class.name,
+        item_id: child_ids
+      )
+
+      parent_fk = reflection.foreign_key.to_s
+
+      child_versions.each do |version|
+        child_label = child_display_label(child_class, version)
+
+        entries << {
+          version: version,
+          source: child_label,
+          changes: compute_child_diff(child_class, version, parent_fk)
+        }
+      end
+    end
+
+    entries.sort_by { |e| e[:version].created_at }.reverse
+  end
+
+  def child_display_label(child_class, version)
+    human = child_class.model_name.human
+    # Try to get a meaningful identifier from the stored object
+    attrs = safe_load_object(version)
+    if attrs
+      name = attrs["name"] || attrs["label"] || attrs["title"] || attrs["slug"]
+      return "#{human}: #{name}" if name.present?
+
+      # For positional children like objectives/rewards
+      pos = attrs["position"]
+      return "#{human} ##{pos}" if pos.present?
+    end
+
+    # Fallback: try loading the live record
+    live = child_class.find_by(id: version.item_id)
+    if live
+      name = if live.respond_to?(:label)
+        live.label
+      elsif live.respond_to?(:name)
+        live.name
+      end
+      return "#{human}: #{name}" if name.present?
+    end
+
+    "#{human} ##{version.item_id}"
+  end
+
+  def compute_child_diff(child_class, version, parent_fk)
+    # Only skip the FK pointing back to the parent — other FKs are meaningful
+    skip = SKIP_KEYS + [parent_fk]
+
+    case version.event
+    when "create"
+      after = safe_load_object(version.next) || find_live_attrs(child_class, version.item_id)
+      return [] if after.blank?
+
+      after.except(*skip).filter_map do |key, value|
+        next if value.nil? || value == "" || value == 0 || value == false
+        {key: key, from: nil, to: resolve_display(child_class, key, value)}
+      end
+
+    when "update"
+      before = safe_load_object(version)
+      return [] if before.blank?
+
+      after = safe_load_object(version.next) || find_live_attrs(child_class, version.item_id)
+      return [] if after.blank?
+
+      before.except(*skip).filter_map do |key, old_val|
+        new_val = after[key]
+        next if normalize(old_val) == normalize(new_val)
+        {
+          key: key,
+          from: resolve_display(child_class, key, old_val),
+          to: resolve_display(child_class, key, new_val)
+        }
+      end
+
+    when "destroy"
+      before = safe_load_object(version)
+      return [] if before.blank?
+
+      before.except(*skip).filter_map do |key, value|
+        next if value.nil? || value == "" || value == 0 || value == false
+        {key: key, from: resolve_display(child_class, key, value), to: nil}
+      end
+
+    else
+      []
+    end
+  end
+
+  def compute_diff(record, version)
+    case version.event
+    when "create"
+      after = safe_load_object(version.next) || record.attributes
+      return [] if after.blank?
+
+      after.except(*SKIP_KEYS).filter_map do |key, value|
+        next if value.nil? || value == "" || value == 0 || value == false
+        {key: key, from: nil, to: resolve_display(record.class, key, value)}
+      end
+
+    when "update"
+      before = safe_load_object(version)
+      return [] if before.blank?
+
+      after = safe_load_object(version.next) || record.attributes
+      return [] if after.blank?
+
+      before.except(*SKIP_KEYS).filter_map do |key, old_val|
+        new_val = after[key]
+        next if normalize(old_val) == normalize(new_val)
+        {
+          key: key,
+          from: resolve_display(record.class, key, old_val),
+          to: resolve_display(record.class, key, new_val)
+        }
+      end
+
+    when "destroy"
+      before = safe_load_object(version)
+      return [] if before.blank?
+
+      before.except(*SKIP_KEYS).filter_map do |key, value|
+        next if value.nil? || value == "" || value == 0 || value == false
+        {key: key, from: resolve_display(record.class, key, value), to: nil}
+      end
+
+    else
+      []
+    end
+  end
+
+  def safe_load_object(version)
+    return nil if version.blank? || version.object.blank?
+    PaperTrail.serializer.load(version.object)
+  rescue StandardError
+    nil
+  end
+
+  def find_live_attrs(klass, id)
+    klass.find_by(id: id)&.attributes
+  end
+
+  def normalize(value)
+    case value
+    when Hash then value.to_h.transform_keys(&:to_s)
+    when Time, DateTime, ActiveSupport::TimeWithZone then value.to_f.round(3)
+    else value
+    end
+  end
+
+  def resolve_display(model_class, key, value)
+    return value unless key.end_with?("_id") && value.present?
+
+    assoc_name = key.delete_suffix("_id")
+    reflection = model_class.reflect_on_association(assoc_name.to_sym)
+    return value unless reflection
+
+    related = reflection.klass.find_by(id: value)
+    return "#{value} (deleted)" unless related
+
+    label = if related.respond_to?(:hackr_alias)
+      related.hackr_alias
+    elsif related.respond_to?(:name)
+      related.name
+    elsif related.respond_to?(:title)
+      related.title
+    elsif related.respond_to?(:slug)
+      related.slug
+    else
+      "##{related.id}"
+    end
+
+    "#{label} (##{value})"
+  end
+end

--- a/app/controllers/concerns/admin/versionable.rb
+++ b/app/controllers/concerns/admin/versionable.rb
@@ -188,7 +188,7 @@ module Admin::Versionable
   def safe_load_object(version)
     return nil if version.blank? || version.object.blank?
     PaperTrail.serializer.load(version.object)
-  rescue StandardError
+  rescue
     nil
   end
 

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -24,6 +24,8 @@
 #  index_grid_achievements_on_trigger_type  (trigger_type)
 #
 class GridAchievement < ApplicationRecord
+  has_paper_trail
+
   # Naming note: `uplink_packets_count` tracks what players see as
   # Uplink "packets" — an in-world aesthetic alias. The backing model
   # is `ChatMessage`; there is no separate Packet table. Similarly,

--- a/app/models/grid_exit.rb
+++ b/app/models/grid_exit.rb
@@ -18,6 +18,8 @@
 #  index_grid_exits_on_to_room_id    (to_room_id)
 #
 class GridExit < ApplicationRecord
+  has_paper_trail
+
   belongs_to :from_room, class_name: "GridRoom", foreign_key: :from_room_id
   belongs_to :to_room, class_name: "GridRoom", foreign_key: :to_room_id
   belongs_to :requires_item, class_name: "GridItem", optional: true

--- a/app/models/grid_faction.rb
+++ b/app/models/grid_faction.rb
@@ -26,6 +26,8 @@
 #  parent_id  (parent_id => grid_factions.id)
 #
 class GridFaction < ApplicationRecord
+  has_paper_trail
+
   KINDS = %w[collective individual system].freeze
 
   belongs_to :artist, optional: true

--- a/app/models/grid_faction_rep_link.rb
+++ b/app/models/grid_faction_rep_link.rb
@@ -22,6 +22,8 @@
 #  target_faction_id  (target_faction_id => grid_factions.id)
 #
 class GridFactionRepLink < ApplicationRecord
+  has_paper_trail
+
   belongs_to :source_faction, class_name: "GridFaction", inverse_of: :outgoing_rep_links
   belongs_to :target_faction, class_name: "GridFaction", inverse_of: :incoming_rep_links
 

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -28,6 +28,8 @@
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 class GridItem < ApplicationRecord
+  has_paper_trail
+
   ITEM_TYPES = %w[tool consumable data faction collectible rig_component material].freeze
   RARITIES = %w[scrap ubiquitous common uncommon rare ultra_rare unicorn].freeze
   RARITY_LABELS = {

--- a/app/models/grid_item_definition.rb
+++ b/app/models/grid_item_definition.rb
@@ -22,6 +22,8 @@
 #  index_grid_item_definitions_on_slug       (slug) UNIQUE
 #
 class GridItemDefinition < ApplicationRecord
+  has_paper_trail
+
   has_many :grid_items, dependent: :restrict_with_error
   has_many :grid_shop_listings, dependent: :restrict_with_error
   has_many :salvage_yields, class_name: "GridSalvageYield",

--- a/app/models/grid_mission.rb
+++ b/app/models/grid_mission.rb
@@ -35,6 +35,8 @@
 #  prereq_mission_id    (prereq_mission_id => grid_missions.id) ON DELETE => nullify
 #
 class GridMission < ApplicationRecord
+  has_paper_trail
+
   # Objective type allowlist. Extending the mission system with a new
   # action verb is a three-line change: add here, add case branch in
   # Grid::MissionProgressor#record, and wire a `progressor.record(:...)`

--- a/app/models/grid_mission_arc.rb
+++ b/app/models/grid_mission_arc.rb
@@ -17,6 +17,8 @@
 #  index_grid_mission_arcs_on_slug  (slug) UNIQUE
 #
 class GridMissionArc < ApplicationRecord
+  has_paper_trail
+
   has_many :grid_missions, dependent: :nullify
 
   validates :slug, presence: true, uniqueness: true

--- a/app/models/grid_mission_objective.rb
+++ b/app/models/grid_mission_objective.rb
@@ -23,6 +23,8 @@
 #  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
 #
 class GridMissionObjective < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_mission
   has_many :grid_hackr_mission_objectives, dependent: :restrict_with_exception
 

--- a/app/models/grid_mission_reward.rb
+++ b/app/models/grid_mission_reward.rb
@@ -22,6 +22,8 @@
 #  grid_mission_id  (grid_mission_id => grid_missions.id) ON DELETE => cascade
 #
 class GridMissionReward < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_mission
 
   validates :reward_type, presence: true, inclusion: {in: GridMission::REWARD_TYPES}

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -15,6 +15,8 @@
 #  grid_room_id    :integer
 #
 class GridMob < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_room
   belongs_to :grid_faction, optional: true
   has_many :grid_shop_listings, dependent: :destroy

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -25,6 +25,8 @@
 #  ambient_playlist_id  (ambient_playlist_id => zone_playlists.id)
 #
 class GridRoom < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_zone
   belongs_to :ambient_playlist, class_name: "ZonePlaylist", optional: true
 

--- a/app/models/grid_salvage_yield.rb
+++ b/app/models/grid_salvage_yield.rb
@@ -25,6 +25,8 @@
 #  source_definition_id  (source_definition_id => grid_item_definitions.id)
 #
 class GridSalvageYield < ApplicationRecord
+  has_paper_trail
+
   belongs_to :source_definition, class_name: "GridItemDefinition"
   belongs_to :output_definition, class_name: "GridItemDefinition"
 

--- a/app/models/grid_shop_listing.rb
+++ b/app/models/grid_shop_listing.rb
@@ -34,6 +34,8 @@
 #  grid_mob_id              (grid_mob_id => grid_mobs.id)
 #
 class GridShopListing < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_mob
   belongs_to :grid_item_definition
   has_many :grid_shop_transactions, dependent: :nullify

--- a/app/models/grid_zone.rb
+++ b/app/models/grid_zone.rb
@@ -23,6 +23,8 @@
 #  ambient_playlist_id  (ambient_playlist_id => zone_playlists.id)
 #
 class GridZone < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_faction, optional: true
   belongs_to :ambient_playlist, class_name: "ZonePlaylist", optional: true
 

--- a/app/models/hackr_log.rb
+++ b/app/models/hackr_log.rb
@@ -25,6 +25,8 @@
 #  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
 #
 class HackrLog < ApplicationRecord
+  has_paper_trail
+
   belongs_to :grid_hackr
 
   validates :title, presence: true

--- a/app/views/admin/artists/_form.html.erb
+++ b/app/views/admin/artists/_form.html.erb
@@ -1,0 +1,37 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @artist.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @artist.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :artist_type, "TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :artist_type, Artist::ARTIST_TYPES.map { |t| [t, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :genre, "GENRE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :genre, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @artist.new_record? ? "Create Artist" : "Update Artist", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_artists_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @artist.persisted? %>
+      <%= link_to "History", history_admin_artist_path(@artist), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/artists/edit.html.erb
+++ b/app/views/admin/artists/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/artists/<%= @artist.slug %> :: EDIT ARTIST</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @artist, url: admin_artist_path(@artist), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/artists/index.html.erb
+++ b/app/views/admin/artists/index.html.erb
@@ -21,9 +21,7 @@
       <!-- Navigation -->
       <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/catalog/{artist_slug}.yml</code> → <code style="color: #888;">rails data:catalog</code>
-        </span>
+        <%= link_to "+ New Artist", new_admin_artist_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
       </div>
 
       <!-- Artists Table -->
@@ -35,14 +33,20 @@
                 <th style="text-align: left;">Name</th>
                 <th style="text-align: left;">Slug</th>
                 <th style="text-align: center;">Tracks</th>
+                <th style="text-align: center;">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <% @artists.each do |artist| %>
-                <tr class="admin-table-row">
+              <% @artists.each_with_index do |artist, i| %>
+                <tr class="admin-table-row" style="<%= " background: #112;" if i.odd? %>">
                   <td><strong><%= artist.name %></strong></td>
                   <td style="font-family: monospace; color: #888;">/<%= artist.slug %></td>
-                  <td style="text-align: center;"><%= artist.tracks.count %></td>
+                  <td style="text-align: center;"><%= artist.tracks.size %></td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_artist_path(artist), class: "tui-button", style: "padding: 4px 10px;" %>
+                    <%= link_to "History", history_admin_artist_path(artist), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+                    <%= button_to "Delete", admin_artist_path(artist), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete artist '#{artist.name}'?" } %>
+                  </td>
                 </tr>
               <% end %>
             </tbody>

--- a/app/views/admin/artists/new.html.erb
+++ b/app/views/admin/artists/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/artists/new :: NEW ARTIST</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @artist, url: admin_artists_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/codex_entries/_form.html.erb
+++ b/app/views/admin/codex_entries/_form.html.erb
@@ -1,0 +1,63 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @entry.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @entry.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+    <div style="flex: 1; min-width: 300px; margin-bottom: 20px;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%;" %>
+    </div>
+    <div style="flex: 1; min-width: 200px; margin-bottom: 20px;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+    <div style="flex: 1; min-width: 200px; margin-bottom: 20px;">
+      <%= f.label :entry_type, "ENTRY TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :entry_type,
+          options_for_select(CodexEntry::ENTRY_TYPES.map { |t| [t.titleize, t] }, @entry.entry_type),
+          {},
+          class: "tui-input", style: "width: 100%;" %>
+    </div>
+    <div style="flex: 1; min-width: 150px; margin-bottom: 20px;">
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%;" %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :summary, "SUMMARY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :summary, class: "tui-input", style: "width: 100%; min-height: 80px;" %>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :content, "CONTENT", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :content, class: "tui-input", style: "width: 100%; min-height: 200px;" %>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :metadata_json, "METADATA", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :metadata_json, value: (@entry.metadata.present? ? JSON.pretty_generate(@entry.metadata) : "{}"), class: "tui-input", style: "width: 100%; min-height: 100px; font-family: monospace;" %>
+    <small style="color: #888;">JSON object</small>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :published, class: "white-text", style: "display: inline-flex; align-items: center; gap: 10px; font-weight: bold; cursor: pointer;" do %>
+      <%= f.check_box :published, style: "width: 20px; height: 20px;" %>
+      <span>PUBLISHED</span>
+    <% end %>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @entry.new_record? ? "Create Entry" : "Update Entry", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_codex_entries_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @entry.persisted? %>
+      <%= link_to "History", history_admin_codex_entry_path(@entry), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/codex_entries/edit.html.erb
+++ b/app/views/admin/codex_entries/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/codex/<%= @entry.slug %> :: EDIT CODEX ENTRY</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @entry, url: admin_codex_entry_path(@entry), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/codex_entries/index.html.erb
+++ b/app/views/admin/codex_entries/index.html.erb
@@ -21,13 +21,11 @@
       <!-- Navigation -->
       <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/content/codex.yml</code> → <code style="color: #888;">rails data:codex</code>
-        </span>
+        <%= link_to "+ New", new_admin_codex_entry_path, class: "tui-button cyan-168", style: "padding: 8px 20px;" %>
       </div>
 
       <!-- Filter by Type -->
-      <% if @codex_entries.any? %>
+      <% if @entries.any? %>
         <div style="margin-bottom: 20px;">
           <label style="color: #888; display: block; margin-bottom: 8px;">
             FILTER BY TYPE
@@ -52,13 +50,13 @@
             style="width: 100%; padding: 10px; background: #0a0a0a; border: 1px solid #444; color: #ccc; font-family: monospace; font-size: 1em;"
           />
           <div style="margin-top: 8px; color: #666; font-size: 0.9em;">
-            <span id="entry-count"><%= @codex_entries.count %></span> / <%= @codex_entries.count %> entries visible
+            <span id="entry-count"><%= @entries.count %></span> / <%= @entries.count %> entries visible
           </div>
         </div>
       <% end %>
 
       <!-- Entries Table -->
-      <% if @codex_entries.any? %>
+      <% if @entries.any? %>
         <div class="tui-window white-text" style="display: block; background: #0a0a0a; margin-top: 20px;">
           <table class="tui-table" style="width: 100%;">
             <thead>
@@ -67,11 +65,13 @@
                 <th style="text-align: left;">Type</th>
                 <th style="text-align: center;">Position</th>
                 <th style="text-align: center;">Published</th>
+                <th style="text-align: center;">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <% @codex_entries.each do |entry| %>
+              <% @entries.each_with_index do |entry, i| %>
                 <tr class="entry-row" class="admin-table-row"
+                    style="<%= " background: #112;" if i.odd? %>"
                     data-entry-name="<%= entry.name.downcase %>"
                     data-entry-summary="<%= entry.summary&.downcase || '' %>">
                   <td>
@@ -96,6 +96,11 @@
                       <span style="color: #f87171;">✗ Draft</span>
                     <% end %>
                   </td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_codex_entry_path(entry), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_codex_entry_path(entry), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_codex_entry_path(entry), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{entry.name}'?" } %>
+                  </td>
                 </tr>
               <% end %>
             </tbody>
@@ -110,7 +115,7 @@
   </fieldset>
 </div>
 
-<% if @codex_entries.any? %>
+<% if @entries.any? %>
   <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener('DOMContentLoaded', function() {
       const searchInput = document.getElementById('entry-search');

--- a/app/views/admin/codex_entries/new.html.erb
+++ b/app/views/admin/codex_entries/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/codex/new :: NEW CODEX ENTRY</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @entry, url: admin_codex_entries_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_achievements/_form.html.erb
+++ b/app/views/admin/grid_achievements/_form.html.erb
@@ -66,5 +66,8 @@
   <div style="margin-top: 20px;">
     <%= f.submit @achievement.new_record? ? "Create Achievement" : "Update Achievement", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
     <%= link_to "Cancel", admin_grid_achievements_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @achievement.persisted? %>
+      <%= link_to "History", history_admin_grid_achievement_path(@achievement), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/grid_achievements/index.html.erb
+++ b/app/views/admin/grid_achievements/index.html.erb
@@ -66,6 +66,7 @@
                 </td>
                 <td style="text-align: right; white-space: nowrap;">
                   <%= link_to "Edit", edit_admin_grid_achievement_path(achievement), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_achievement_path(achievement), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                   <%= button_to "Delete", admin_grid_achievement_path(achievement), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete achievement '#{achievement.name}'?" } %>
                 </td>
               </tr>

--- a/app/views/admin/grid_exits/_form.html.erb
+++ b/app/views/admin/grid_exits/_form.html.erb
@@ -1,0 +1,46 @@
+<% if @exit.errors.any? %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+    <p class="red-255-text">ERRORS:</p>
+    <ul style="margin: 5px 0 0 20px;">
+      <% @exit.errors.full_messages.each do |msg| %>
+        <li class="white-text"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :from_room_id, "FROM ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :from_room_id, options_for_select(@rooms.map { |r| ["#{r.grid_zone.name} — #{r.name}", r.id] }, @exit.from_room_id), { include_blank: "(select room)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :to_room_id, "TO ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :to_room_id, options_for_select(@rooms.map { |r| ["#{r.grid_zone.name} — #{r.name}", r.id] }, @exit.to_room_id), { include_blank: "(select room)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :direction, "DIRECTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :direction,
+          [["North", "north"], ["South", "south"], ["East", "east"], ["West", "west"], ["Up", "up"], ["Down", "down"]],
+          { include_blank: "(select direction)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :locked, "LOCKED", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.check_box :locked, style: "margin-top: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :requires_item_id, "REQUIRES ITEM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :requires_item_id, GridItem.all, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 30px; display: flex; gap: 10px;">
+  <%= f.submit @exit.new_record? ? "Create Exit" : "Update Exit", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+  <%= link_to "Cancel", admin_grid_exits_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% if @exit.persisted? %>
+    <%= link_to "History", history_admin_grid_exit_path(@exit), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% end %>
+</div>

--- a/app/views/admin/grid_exits/edit.html.erb
+++ b/app/views/admin/grid_exits/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/exits/<%= @exit.id %> :: EDIT EXIT</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @exit], url: admin_grid_exit_path(@exit), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_exits/index.html.erb
+++ b/app/views/admin/grid_exits/index.html.erb
@@ -1,0 +1,62 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/exits :: MANAGE GRID EXITS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Exit", new_admin_grid_exit_path, class: "tui-button green-168" %>
+      </div>
+
+      <% if @exits.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">From Room</th>
+                <th style="text-align: center;">Direction</th>
+                <th style="text-align: left;">To Room</th>
+                <th style="text-align: center;">Locked</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @exits.each_with_index do |exit_record, i| %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td class="cyan-255-text"><%= exit_record.from_room&.name || "—" %></td>
+                  <td style="text-align: center; font-weight: bold;"><%= exit_record.direction %></td>
+                  <td class="cyan-255-text"><%= exit_record.to_room&.name || "—" %></td>
+                  <td style="text-align: center;"><%= exit_record.locked? ? "LOCKED" : "—" %></td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_exit_path(exit_record), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_exit_path(exit_record), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_grid_exit_path(exit_record), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete this exit?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+          <%= @exits.count %> exits
+        </p>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No exits yet.</p>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_exits/new.html.erb
+++ b/app/views/admin/grid_exits/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/exits/new :: NEW EXIT</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @exit], url: admin_grid_exits_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_factions/_form.html.erb
+++ b/app/views/admin/grid_factions/_form.html.erb
@@ -50,5 +50,8 @@
   <div style="margin-top: 20px;">
     <%= f.submit @faction.new_record? ? "Create Faction" : "Update Faction", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
     <%= link_to "Cancel", admin_grid_factions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @faction.persisted? %>
+      <%= link_to "History", history_admin_grid_faction_path(@faction), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/grid_factions/index.html.erb
+++ b/app/views/admin/grid_factions/index.html.erb
@@ -45,6 +45,7 @@
                 <td style="text-align: center; color: #888;"><%= faction.position %></td>
                 <td style="text-align: right; white-space: nowrap;">
                   <%= link_to "Edit", edit_admin_grid_faction_path(faction), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_faction_path(faction), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                   <%= button_to "Delete", admin_grid_faction_path(faction), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete faction '#{faction.name}'?" } %>
                 </td>
               </tr>

--- a/app/views/admin/grid_item_definitions/_form.html.erb
+++ b/app/views/admin/grid_item_definitions/_form.html.erb
@@ -166,5 +166,9 @@
           class: "tui-button purple-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
     <%= link_to "Cancel", admin_grid_item_definitions_path,
           class: "tui-button grey-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% if definition.persisted? %>
+      <%= link_to "History", history_admin_grid_item_definition_path(definition),
+            class: "tui-button purple-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/grid_item_definitions/index.html.erb
+++ b/app/views/admin/grid_item_definitions/index.html.erb
@@ -51,6 +51,7 @@
                 <td style="text-align: right; color: #fbbf24;"><%= defn.value %></td>
                 <td style="text-align: center; white-space: nowrap; display: flex; gap: 8px; justify-content: center; align-items: center; padding: 8px 4px;">
                   <%= link_to "Edit", edit_admin_grid_item_definition_path(defn), class: "tui-button cyan-168", style: "padding: 4px 12px; font-size: 0.85em; box-shadow: none; line-height: 1;" %>
+                  <%= link_to "History", history_admin_grid_item_definition_path(defn), class: "tui-button purple-168", style: "padding: 4px 12px; font-size: 0.85em; box-shadow: none; line-height: 1;" %>
                   <%= button_to "Delete", admin_grid_item_definition_path(defn), method: :delete,
                         data: {confirm: "Delete '#{defn.name}'? This will fail if any items or listings reference it."},
                         class: "tui-button red-168", style: "padding: 4px 12px; font-size: 0.85em; box-shadow: none; line-height: 1;",

--- a/app/views/admin/grid_mission_arcs/_form.html.erb
+++ b/app/views/admin/grid_mission_arcs/_form.html.erb
@@ -36,5 +36,8 @@
   <div style="margin-top: 20px;">
     <%= f.submit @arc.new_record? ? "Create Arc" : "Update Arc", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
     <%= link_to "Cancel", admin_grid_mission_arcs_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @arc.persisted? %>
+      <%= link_to "History", history_admin_grid_mission_arc_path(@arc), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/grid_mission_arcs/index.html.erb
+++ b/app/views/admin/grid_mission_arcs/index.html.erb
@@ -47,6 +47,7 @@
                 </td>
                 <td style="text-align: right; white-space: nowrap;">
                   <%= link_to "Edit", edit_admin_grid_mission_arc_path(arc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_mission_arc_path(arc), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                   <%= button_to "Delete", admin_grid_mission_arc_path(arc), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete arc '#{arc.name}'?" } %>
                 </td>
               </tr>

--- a/app/views/admin/grid_missions/_form.html.erb
+++ b/app/views/admin/grid_missions/_form.html.erb
@@ -170,5 +170,8 @@
   <div style="margin-top: 25px;">
     <%= f.submit @mission.new_record? ? "Create Mission" : "Update Mission", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
     <%= link_to "Cancel", admin_grid_missions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @mission.persisted? %>
+      <%= link_to "History", history_admin_grid_mission_path(@mission), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/grid_missions/index.html.erb
+++ b/app/views/admin/grid_missions/index.html.erb
@@ -69,6 +69,7 @@
                 </td>
                 <td style="text-align: right; white-space: nowrap;">
                   <%= link_to "Edit", edit_admin_grid_mission_path(mission), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_mission_path(mission), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                   <%= button_to "Delete", admin_grid_mission_path(mission), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete mission '#{mission.name}'?" } %>
                 </td>
               </tr>

--- a/app/views/admin/grid_mobs/_form.html.erb
+++ b/app/views/admin/grid_mobs/_form.html.erb
@@ -1,0 +1,57 @@
+<% if @mob.errors.any? %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+    <p class="red-255-text">ERRORS:</p>
+    <ul style="margin: 5px 0 0 20px;">
+      <% @mob.errors.full_messages.each do |msg| %>
+        <li class="white-text"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :mob_type, "MOB TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :mob_type,
+          [["Quest Giver", "quest_giver"], ["Vendor", "vendor"], ["Lore", "lore"], ["Special", "special"]],
+          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 15px;">
+  <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+  <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :grid_room_id, "ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :grid_room_id, options_for_select(@rooms.map { |r| ["#{r.grid_zone.name} — #{r.name}", r.id] }, @mob.grid_room_id), { include_blank: "(select room)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :grid_faction_id, "FACTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :grid_faction_id, @factions, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: DIALOGUE TREE (JSON) ::]</h3>
+<div style="margin-bottom: 15px;">
+  <%= text_area_tag "grid_mob[dialogue_tree_json]", (@mob.dialogue_tree || {}).to_json, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 100px; font-family: monospace;" %>
+</div>
+
+<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: VENDOR CONFIG (JSON) ::]</h3>
+<div style="margin-bottom: 15px;">
+  <%= text_area_tag "grid_mob[vendor_config_json]", (@mob.vendor_config || {}).to_json, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 100px; font-family: monospace;" %>
+</div>
+
+<div style="margin-top: 30px; display: flex; gap: 10px;">
+  <%= f.submit @mob.new_record? ? "Create Mob" : "Update Mob", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+  <%= link_to "Cancel", admin_grid_mobs_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% if @mob.persisted? %>
+    <%= link_to "History", history_admin_grid_mob_path(@mob), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% end %>
+</div>

--- a/app/views/admin/grid_mobs/edit.html.erb
+++ b/app/views/admin/grid_mobs/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mobs/<%= @mob.id %> :: EDIT MOB</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @mob], url: admin_grid_mob_path(@mob), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_mobs/index.html.erb
+++ b/app/views/admin/grid_mobs/index.html.erb
@@ -1,0 +1,62 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mobs :: MANAGE GRID MOBS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Mob", new_admin_grid_mob_path, class: "tui-button green-168" %>
+      </div>
+
+      <% if @mobs.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Name</th>
+                <th style="text-align: left;">Mob Type</th>
+                <th style="text-align: left;">Room</th>
+                <th style="text-align: left;">Faction</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @mobs.each_with_index do |mob, i| %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td class="cyan-255-text"><strong><%= mob.name %></strong></td>
+                  <td><%= mob.mob_type || "—" %></td>
+                  <td><%= mob.grid_room&.name || "—" %></td>
+                  <td><%= mob.grid_faction&.name || "—" %></td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_mob_path(mob), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_mob_path(mob), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_grid_mob_path(mob), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{mob.name}'?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+          <%= @mobs.count %> mobs
+        </p>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No mobs yet.</p>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_mobs/new.html.erb
+++ b/app/views/admin/grid_mobs/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mobs/new :: NEW MOB</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @mob], url: admin_grid_mobs_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_rooms/_form.html.erb
+++ b/app/views/admin/grid_rooms/_form.html.erb
@@ -1,0 +1,58 @@
+<% if @room.errors.any? %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+    <p class="red-255-text">ERRORS:</p>
+    <ul style="margin: 5px 0 0 20px;">
+      <% @room.errors.full_messages.each do |msg| %>
+        <li class="white-text"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 15px;">
+  <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+  <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :room_type, "ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :room_type,
+          [["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Prism", "prism"], ["Dream", "dream"]],
+          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0 %>
+  </div>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :grid_zone_id, "ZONE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :grid_zone_id, @zones, :id, :name, { include_blank: "(select zone)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :ambient_playlist_id, "AMBIENT PLAYLIST", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :ambient_playlist_id, @playlists, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 30px; display: flex; gap: 10px;">
+  <%= f.submit @room.new_record? ? "Create Room" : "Update Room", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+  <%= link_to "Cancel", admin_grid_rooms_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% if @room.persisted? %>
+    <%= link_to "History", history_admin_grid_room_path(@room), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% end %>
+</div>

--- a/app/views/admin/grid_rooms/edit.html.erb
+++ b/app/views/admin/grid_rooms/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/rooms/<%= @room.id %> :: EDIT ROOM</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @room], url: admin_grid_room_path(@room), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_rooms/index.html.erb
+++ b/app/views/admin/grid_rooms/index.html.erb
@@ -1,75 +1,68 @@
-<div class="tui-window white-text admin-panel" style="display: block; max-width: 1600px; margin: 30px auto; padding: 20px;">
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
   <fieldset class="admin-panel-border">
-    <legend class="center">/root/grid_rooms :: MANAGE GRID ROOMS</legend>
+    <legend class="center">/root/grid/rooms :: MANAGE GRID ROOMS</legend>
 
     <div style="padding: 20px;">
-      <!-- Flash Messages -->
       <% if flash[:success] %>
         <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
-          <p class="green-255-text">✓ SUCCESS</p>
-          <p class="white-text"><%= flash[:success] %></p>
+          <p class="green-255-text"><%= flash[:success] %></p>
         </div>
       <% end %>
 
       <% if flash[:error] %>
         <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
-          <p class="red-255-text">⚠ ERROR</p>
-          <p class="white-text"><%= flash[:error] %></p>
+          <p class="red-255-text"><%= flash[:error] %></p>
         </div>
       <% end %>
 
-      <!-- Navigation -->
-      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
-        <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/world/rooms.yml</code> → <code style="color: #888;">rails data:rooms</code>
-        </span>
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
+        <%= link_to "+ New Room", new_admin_grid_room_path, class: "tui-button green-168" %>
       </div>
 
-      <!-- Rooms Table -->
       <% if @rooms.any? %>
-        <div class="tui-window white-text" style="display: block; background: #0a0a0a; margin-top: 20px;">
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
           <table class="tui-table" style="width: 100%;">
             <thead>
               <tr>
-                <th style="text-align: left;">Room Name</th>
+                <th style="text-align: left;">Name</th>
+                <th style="text-align: left;">Slug</th>
                 <th style="text-align: left;">Zone</th>
                 <th style="text-align: left;">Type</th>
-                <th style="text-align: left;">Room Playlist</th>
-                <th style="text-align: left;">Effective Playlist</th>
+                <th style="text-align: center;">Clearance</th>
+                <th style="text-align: left;">Ambient Playlist</th>
+                <th style="text-align: right;">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <% @rooms.each do |room| %>
-                <% effective_playlist = room.ambient_playlist || room.grid_zone.ambient_playlist %>
-                <tr>
-                  <td><strong><%= room.name %></strong></td>
+              <% @rooms.each_with_index do |room, i| %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td class="cyan-255-text"><strong><%= room.name %></strong></td>
+                  <td style="font-family: monospace; color: #666;">/<%= room.slug %></td>
                   <td style="color: #22d3ee;"><%= room.grid_zone.name %></td>
                   <td><%= room.room_type || "—" %></td>
+                  <td style="text-align: center;"><%= room.min_clearance %></td>
                   <td>
                     <% if room.ambient_playlist %>
-                      <span class="purple-255-text">🎵 <%= room.ambient_playlist.name %></span>
+                      <span class="purple-255-text"><%= room.ambient_playlist.name %></span>
                     <% else %>
                       <span style="color: #666;">—</span>
                     <% end %>
                   </td>
-                  <td>
-                    <% if effective_playlist %>
-                      <span class="<%= room.ambient_playlist ? 'purple-255-text' : 'cyan-255-text' %>">
-                        🎵 <%= effective_playlist.name %>
-                        <% unless room.ambient_playlist %>
-                          <small style="color: #666;">(from zone)</small>
-                        <% end %>
-                      </span>
-                    <% else %>
-                      <span style="color: #666;">None</span>
-                    <% end %>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_room_path(room), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_room_path(room), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_grid_room_path(room), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{room.name}'?" } %>
                   </td>
                 </tr>
               <% end %>
             </tbody>
           </table>
         </div>
+
+        <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+          <%= @rooms.count %> rooms
+        </p>
       <% else %>
         <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
           <p style="color: #666; font-size: 1.2em;">No rooms yet.</p>

--- a/app/views/admin/grid_rooms/new.html.erb
+++ b/app/views/admin/grid_rooms/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/rooms/new :: NEW ROOM</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @room], url: admin_grid_rooms_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_shop_listings/_form.html.erb
+++ b/app/views/admin/grid_shop_listings/_form.html.erb
@@ -93,5 +93,10 @@
     <%= link_to "Cancel", admin_grid_shop_listings_path,
         class: "tui-button grey-168",
         style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% if listing.persisted? %>
+      <%= link_to "History", history_admin_grid_shop_listing_path(listing),
+          class: "tui-button purple-168",
+          style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/grid_shop_listings/index.html.erb
+++ b/app/views/admin/grid_shop_listings/index.html.erb
@@ -87,6 +87,7 @@
                   <td style="text-align: center; color: #888;"><%= listing.min_clearance > 0 ? listing.min_clearance : "-" %></td>
                   <td style="text-align: right; white-space: nowrap;">
                     <%= link_to "Edit", edit_admin_grid_shop_listing_path(listing), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_shop_listing_path(listing), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <% if listing.max_stock.present? %>
                       <%= button_to "Restock", restock_admin_grid_shop_listing_path(listing), method: :post, form: { style: "display: inline;" }, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <% end %>

--- a/app/views/admin/grid_zones/_form.html.erb
+++ b/app/views/admin/grid_zones/_form.html.erb
@@ -1,0 +1,58 @@
+<% if @zone.errors.any? %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+    <p class="red-255-text">ERRORS:</p>
+    <ul style="margin: 5px 0 0 20px;">
+      <% @zone.errors.full_messages.each do |msg| %>
+        <li class="white-text"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 15px;">
+  <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+  <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :zone_type, "ZONE TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.select :zone_type,
+          [["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Residential", "residential"], ["Transit", "transit"], ["Special", "special"], ["Danger Zone", "danger_zone"]],
+          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :color_scheme, "COLOR SCHEME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :color_scheme, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :grid_faction_id, "FACTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :grid_faction_id, @factions, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :ambient_playlist_id, "AMBIENT PLAYLIST", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :ambient_playlist_id, @playlists, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 30px; display: flex; gap: 10px;">
+  <%= f.submit @zone.new_record? ? "Create Zone" : "Update Zone", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+  <%= link_to "Cancel", admin_grid_zones_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% if @zone.persisted? %>
+    <%= link_to "History", history_admin_grid_zone_path(@zone), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% end %>
+</div>

--- a/app/views/admin/grid_zones/edit.html.erb
+++ b/app/views/admin/grid_zones/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/zones/<%= @zone.id %> :: EDIT ZONE</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @zone], url: admin_grid_zone_path(@zone), local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_zones/index.html.erb
+++ b/app/views/admin/grid_zones/index.html.erb
@@ -1,65 +1,68 @@
 <div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
   <fieldset class="admin-panel-border">
-    <legend class="center">/root/grid_zones :: MANAGE GRID ZONES</legend>
+    <legend class="center">/root/grid/zones :: MANAGE GRID ZONES</legend>
 
     <div style="padding: 20px;">
-      <!-- Flash Messages -->
       <% if flash[:success] %>
         <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
-          <p class="green-255-text">✓ SUCCESS</p>
-          <p class="white-text"><%= flash[:success] %></p>
+          <p class="green-255-text"><%= flash[:success] %></p>
         </div>
       <% end %>
 
       <% if flash[:error] %>
         <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
-          <p class="red-255-text">⚠ ERROR</p>
-          <p class="white-text"><%= flash[:error] %></p>
+          <p class="red-255-text"><%= flash[:error] %></p>
         </div>
       <% end %>
 
-      <!-- Navigation -->
-      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
-        <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/world/zones.yml</code> → <code style="color: #888;">rails data:zones</code>
-        </span>
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
+        <%= link_to "+ New Zone", new_admin_grid_zone_path, class: "tui-button green-168" %>
       </div>
 
-      <!-- Zones Table -->
       <% if @zones.any? %>
-        <div class="tui-window white-text" style="display: block; background: #0a0a0a; margin-top: 20px;">
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
           <table class="tui-table" style="width: 100%;">
             <thead>
               <tr>
-                <th style="text-align: left;">Zone Name</th>
+                <th style="text-align: left;">Name</th>
                 <th style="text-align: left;">Slug</th>
                 <th style="text-align: left;">Type</th>
                 <th style="text-align: left;">Faction</th>
                 <th style="text-align: left;">Ambient Playlist</th>
                 <th style="text-align: center;">Rooms</th>
+                <th style="text-align: right;">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <% @zones.each do |zone| %>
-                <tr>
-                  <td><strong><%= zone.name %></strong></td>
+              <% @zones.each_with_index do |zone, i| %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td class="cyan-255-text"><strong><%= zone.name %></strong></td>
                   <td style="font-family: monospace; color: #666;">/<%= zone.slug %></td>
                   <td><%= zone.zone_type || "—" %></td>
                   <td><%= zone.grid_faction&.name || "—" %></td>
                   <td>
                     <% if zone.ambient_playlist %>
-                      <span class="purple-255-text">🎵 <%= zone.ambient_playlist.name %></span>
+                      <span class="purple-255-text"><%= zone.ambient_playlist.name %></span>
                     <% else %>
                       <span style="color: #666;">—</span>
                     <% end %>
                   </td>
-                  <td style="text-align: center;"><%= zone.grid_rooms.count %></td>
+                  <td style="text-align: center;"><%= zone.grid_rooms.size %></td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_zone_path(zone), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_zone_path(zone), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_grid_zone_path(zone), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{zone.name}'?" } %>
+                  </td>
                 </tr>
               <% end %>
             </tbody>
           </table>
         </div>
+
+        <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+          <%= @zones.count %> zones
+        </p>
       <% else %>
         <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
           <p style="color: #666; font-size: 1.2em;">No zones yet.</p>

--- a/app/views/admin/grid_zones/new.html.erb
+++ b/app/views/admin/grid_zones/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/zones/new :: NEW ZONE</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @zone], url: admin_grid_zones_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/hackr_logs/_form.html.erb
+++ b/app/views/admin/hackr_logs/_form.html.erb
@@ -1,0 +1,57 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @log.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @log.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+    <div style="flex: 1; min-width: 300px; margin-bottom: 20px;">
+      <%= f.label :title, "TITLE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :title, class: "tui-input", style: "width: 100%;" %>
+    </div>
+    <div style="flex: 1; min-width: 200px; margin-bottom: 20px;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+    <div style="flex: 1; min-width: 200px; margin-bottom: 20px;">
+      <%= f.label :grid_hackr_id, "AUTHOR", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.collection_select :grid_hackr_id, @hackrs, :id, :hackr_alias,
+          { include_blank: "— Select Author —" },
+          class: "tui-input", style: "width: 100%;" %>
+    </div>
+    <div style="flex: 1; min-width: 150px; margin-bottom: 20px;">
+      <%= f.label :timeline, "TIMELINE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :timeline, class: "tui-input", style: "width: 100%;" %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :body, "BODY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :body, class: "tui-input", style: "width: 100%; min-height: 300px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; flex-wrap: wrap; align-items: center;">
+    <div style="margin-bottom: 20px;">
+      <%= f.label :published, class: "white-text", style: "display: inline-flex; align-items: center; gap: 10px; font-weight: bold; cursor: pointer;" do %>
+        <%= f.check_box :published, style: "width: 20px; height: 20px;" %>
+        <span>PUBLISHED</span>
+      <% end %>
+    </div>
+    <div style="flex: 1; min-width: 200px; margin-bottom: 20px;">
+      <%= f.label :published_at, "PUBLISHED AT", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.datetime_field :published_at, class: "tui-input", style: "width: 100%;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @log.new_record? ? "Create Log" : "Update Log", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_hackr_logs_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @log.persisted? %>
+      <%= link_to "History", history_admin_hackr_log_path(@log), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/hackr_logs/edit.html.erb
+++ b/app/views/admin/hackr_logs/edit.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackr_logs/<%= @log.slug %> :: EDIT HACKR LOG</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @log, url: admin_hackr_log_path(@log), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/hackr_logs/index.html.erb
+++ b/app/views/admin/hackr_logs/index.html.erb
@@ -19,15 +19,13 @@
       <% end %>
 
       <!-- Navigation -->
-      <div style="margin-bottom: 20px;">
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/content/hackr_logs.yml</code> → <code style="color: #888;">rails data:hackr_logs</code>
-        </span>
+        <%= link_to "+ New", new_admin_hackr_log_path, class: "tui-button cyan-168", style: "padding: 8px 20px;" %>
       </div>
 
       <!-- Logs Table -->
-      <% if @hackr_logs.any? %>
+      <% if @logs.any? %>
         <div class="tui-window white-text" style="display: block; background: #0a0a0a; margin-top: 20px;">
           <table class="tui-table" style="width: 100%;">
             <thead>
@@ -36,17 +34,18 @@
                 <th style="text-align: left;">Author</th>
                 <th style="text-align: center;">Status</th>
                 <th style="text-align: center;">Published</th>
+                <th style="text-align: center;">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <% @hackr_logs.each do |log| %>
-                <tr class="admin-table-row">
+              <% @logs.each_with_index do |log, i| %>
+                <tr class="admin-table-row" style="<%= " background: #112;" if i.odd? %>">
                   <td>
                     <strong><%= log.title %></strong>
                     <br>
                     <small style="color: #666; font-family: monospace;">/<%= log.slug %></small>
                   </td>
-                  <td><%= log.grid_hackr.hackr_alias %></td>
+                  <td><%= log.grid_hackr&.hackr_alias %></td>
                   <td style="text-align: center;">
                     <% if log.published? %>
                       <span class="green-255-text">✓ Published</span>
@@ -56,6 +55,11 @@
                   </td>
                   <td style="text-align: center;">
                     <%= log.published_at&.strftime("%Y-%m-%d %H:%M") || "—" %>
+                  </td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_hackr_log_path(log), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_hackr_log_path(log), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_hackr_log_path(log), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{log.title}'?" } %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/admin/hackr_logs/new.html.erb
+++ b/app/views/admin/hackr_logs/new.html.erb
@@ -1,0 +1,10 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackr_logs/new :: NEW HACKR LOG</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @log, url: admin_hackr_logs_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/handbook_articles/_form.html.erb
+++ b/app/views/admin/handbook_articles/_form.html.erb
@@ -82,5 +82,10 @@
     <%= link_to "Cancel", admin_handbook_articles_path,
         class: "tui-button grey-168",
         style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% if article.persisted? %>
+      <%= link_to "History", history_admin_handbook_article_path(article),
+          class: "tui-button purple-168",
+          style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/handbook_articles/index.html.erb
+++ b/app/views/admin/handbook_articles/index.html.erb
@@ -68,6 +68,7 @@
                   </td>
                   <td style="text-align: right; white-space: nowrap;">
                     <%= link_to "Edit", edit_admin_handbook_article_path(article), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_handbook_article_path(article), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= button_to "Delete", admin_handbook_article_path(article), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete article '#{article.title}'?" } %>
                   </td>
                 </tr>

--- a/app/views/admin/handbook_sections/_form.html.erb
+++ b/app/views/admin/handbook_sections/_form.html.erb
@@ -38,5 +38,8 @@
   <div style="margin-top: 20px;">
     <%= f.submit section.persisted? ? "Save Section" : "Create Section", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
     <%= link_to "Cancel", admin_handbook_sections_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if section.persisted? %>
+      <%= link_to "History", history_admin_handbook_section_path(section), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/handbook_sections/index.html.erb
+++ b/app/views/admin/handbook_sections/index.html.erb
@@ -52,6 +52,7 @@
                   <td style="text-align: right; white-space: nowrap;">
                     <%= link_to "Articles", admin_handbook_articles_path(section_id: section.id), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
                     <%= link_to "Edit", edit_admin_handbook_section_path(section), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= link_to "History", history_admin_handbook_section_path(section), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= button_to "Delete", admin_handbook_section_path(section), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete section '#{section.name}' and all #{section.articles.size} articles?" } %>
                   </td>
                 </tr>

--- a/app/views/admin/releases/_form.html.erb
+++ b/app/views/admin/releases/_form.html.erb
@@ -129,5 +129,10 @@
     <%= link_to "Cancel", admin_releases_path,
         class: "tui-button grey-168",
         style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% if release.persisted? %>
+      <%= link_to "History", history_admin_release_path(release),
+          class: "tui-button purple-168",
+          style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/releases/index.html.erb
+++ b/app/views/admin/releases/index.html.erb
@@ -21,6 +21,7 @@
       <!-- Navigation -->
       <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "+ New Release", new_admin_release_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
       </div>
 
       <!-- Releases Table -->
@@ -74,6 +75,7 @@
                   </td>
                   <td style="text-align: center; white-space: nowrap;">
                     <%= link_to "Edit", edit_admin_release_path(release), class: "tui-button cyan-168", style: "padding: 4px 12px; font-size: 0.85em;" %>
+                    <%= link_to "History", history_admin_release_path(release), class: "tui-button purple-168", style: "padding: 4px 12px; font-size: 0.85em;" %>
                     <%= button_to "Delete", admin_release_path(release), method: :delete,
                         class: "tui-button red-168",
                         style: "padding: 4px 12px; font-size: 0.85em;",

--- a/app/views/admin/releases/new.html.erb
+++ b/app/views/admin/releases/new.html.erb
@@ -1,0 +1,13 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/releases/new :: NEW RELEASE</legend>
+
+    <div style="padding: 20px;">
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
+        <%= link_to "← All Releases", admin_releases_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+      </div>
+
+      <%= render "form", release: @release %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -90,6 +90,10 @@
           <%= link_to "Missions", admin_grid_missions_path, class: "green-168-text" %>
           <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
+          <%= link_to "Zones", admin_grid_zones_path, class: "green-168-text" %>
+          <%= link_to "Rooms", admin_grid_rooms_path, class: "green-168-text" %>
+          <%= link_to "Mobs", admin_grid_mobs_path, class: "green-168-text" %>
+          <%= link_to "Exits", admin_grid_exits_path, class: "green-168-text" %>
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
         </div>
       </div>

--- a/app/views/admin/shared/version_history.html.erb
+++ b/app/views/admin/shared/version_history.html.erb
@@ -1,0 +1,106 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/history :: <%= @model_name.upcase %> VERSION HISTORY</legend>
+
+    <div style="padding: 20px;">
+      <div style="margin-bottom: 20px;">
+        <span class="cyan-255-text" style="font-size: 1.1em;"><%= @record.respond_to?(:name) ? @record.name : @record.respond_to?(:title) ? @record.title : "##{@record.id}" %></span>
+        <% if @record.respond_to?(:slug) %>
+          <span style="color: #666; font-family: monospace; margin-left: 10px;"><%= @record.slug %></span>
+        <% end %>
+      </div>
+
+      <% if @entries.empty? %>
+        <div style="padding: 20px; color: #666;">
+          No version history recorded for this record.
+        </div>
+      <% else %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Event</th>
+                <th style="text-align: left;">Source</th>
+                <th style="text-align: left;">Changed By</th>
+                <th style="text-align: left;">Changed At</th>
+                <th style="text-align: left;">Changes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @entries.each_with_index do |entry, i| %>
+                <% version = entry[:version] %>
+                <% changes = entry[:changes] %>
+                <% is_child = entry[:source] != @model_name %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td style="padding: 8px 4px;">
+                    <% case version.event %>
+                    <% when "create" %>
+                      <span class="green-255-text">CREATE</span>
+                    <% when "update" %>
+                      <span class="yellow-168-text">UPDATE</span>
+                    <% when "destroy" %>
+                      <span class="red-255-text">DESTROY</span>
+                    <% end %>
+                  </td>
+                  <td style="padding: 8px 4px; white-space: nowrap;">
+                    <% if is_child %>
+                      <span style="color: #22d3ee; font-size: 0.85em;"><%= entry[:source] %></span>
+                    <% else %>
+                      <span style="color: #888;"><%= entry[:source] %></span>
+                    <% end %>
+                  </td>
+                  <td style="padding: 8px 4px;">
+                    <% if version.whodunnit.present? %>
+                      <% hackr = GridHackr.find_by(id: version.whodunnit) %>
+                      <span class="cyan-255-text"><%= hackr&.hackr_alias || "hackr##{version.whodunnit}" %></span>
+                    <% else %>
+                      <span style="color: #666;">system</span>
+                    <% end %>
+                  </td>
+                  <td style="padding: 8px 4px; color: #888; font-family: monospace; white-space: nowrap;">
+                    <%= version.created_at.strftime("%Y-%m-%d %H:%M:%S") %>
+                  </td>
+                  <td style="padding: 8px 4px; max-width: 500px;">
+                    <% if changes.any? %>
+                      <% changes.first(8).each do |change| %>
+                        <div style="margin-bottom: 4px;">
+                          <span style="color: #a78bfa; font-family: monospace;"><%= change[:key].delete_suffix("_id") %></span>
+                          <% if change[:from].present? && change[:to].present? %>
+                            <span style="color: #666;"> : </span>
+                            <span class="red-255-text" style="font-family: monospace; font-size: 0.85em; text-decoration: line-through;"><%= truncate(change[:from].to_s, length: 60) %></span>
+                            <span style="color: #666;"> &rarr; </span>
+                            <span class="green-255-text" style="font-family: monospace; font-size: 0.85em;"><%= truncate(change[:to].to_s, length: 60) %></span>
+                          <% elsif change[:to].present? %>
+                            <span style="color: #666;"> : </span>
+                            <span class="green-255-text" style="font-family: monospace; font-size: 0.85em;"><%= truncate(change[:to].to_s, length: 60) %></span>
+                          <% elsif change[:from].present? %>
+                            <span style="color: #666;"> : </span>
+                            <span class="red-255-text" style="font-family: monospace; font-size: 0.85em; text-decoration: line-through;"><%= truncate(change[:from].to_s, length: 60) %></span>
+                            <span style="color: #666;"> &rarr; </span>
+                            <span style="color: #666;">null</span>
+                          <% end %>
+                        </div>
+                      <% end %>
+                      <% if changes.size > 8 %>
+                        <span style="color: #666;">+<%= changes.size - 8 %> more</span>
+                      <% end %>
+                    <% elsif version.event == "create" && !is_child %>
+                      <span style="color: #666;">initial creation</span>
+                    <% else %>
+                      <span style="color: #666;">—</span>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333; display: flex; gap: 10px;">
+        <%= link_to "<- Back", @back_path, class: "tui-button green-168" %>
+        <%= link_to "Edit", url_for(action: :edit, id: @record), class: "tui-button cyan-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/tracks/edit.html.erb
+++ b/app/views/admin/tracks/edit.html.erb
@@ -142,6 +142,9 @@
           <%= link_to "Cancel", edit_admin_release_path(@release),
               class: "tui-button grey-168",
               style: "padding: 10px 30px; font-size: 1.1em;" %>
+          <%= link_to "History", history_admin_track_path(@track),
+              class: "tui-button purple-168",
+              style: "padding: 10px 30px; font-size: 1.1em;" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/tracks/index.html.erb
+++ b/app/views/admin/tracks/index.html.erb
@@ -21,9 +21,7 @@
       <!-- Navigation -->
       <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/catalog/{artist_slug}.yml</code> → <code style="color: #888;">rails data:catalog</code>
-        </span>
+        <%= link_to "+ New Track", new_admin_track_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
       </div>
 
       <!-- Search Filter -->

--- a/app/views/admin/tracks/new.html.erb
+++ b/app/views/admin/tracks/new.html.erb
@@ -1,0 +1,67 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/tracks/new :: NEW TRACK</legend>
+
+    <div style="padding: 20px;">
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
+        <%= link_to "← All Tracks", admin_tracks_path, class: "tui-button green-168", style: "padding: 8px 20px;" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+        <% if @track.errors.any? %>
+          <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+            <p class="red-255-text"><%= @track.errors.full_messages.join(", ") %></p>
+          </div>
+        <% end %>
+
+        <%= form_with model: [:admin, @track], local: true do |f| %>
+          <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+            <div style="flex: 1;">
+              <%= f.label :title, "TITLE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.text_field :title, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+            </div>
+            <div style="flex: 1;">
+              <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+            </div>
+          </div>
+
+          <div style="margin-bottom: 15px;">
+            <%= f.label :release_id, "RELEASE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+            <%= f.select :release_id, options_for_select(@releases.map { |r| ["#{r.artist.name} — #{r.name}", r.id] }, @track.release_id), {include_blank: "(select release)"}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+            <small style="color: #666;">Artist is derived from the release.</small>
+          </div>
+
+          <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+            <div style="flex: 1;">
+              <%= f.label :track_number, "TRACK #", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.number_field :track_number, class: "tui-input", style: "width: 100%; padding: 8px;", min: 1 %>
+            </div>
+            <div style="flex: 1;">
+              <%= f.label :duration, "DURATION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.text_field :duration, class: "tui-input", style: "width: 100%; padding: 8px;", placeholder: "3:45" %>
+            </div>
+          </div>
+
+          <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+            <div style="flex: 1;">
+              <%= f.label :featured, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+                <%= f.check_box :featured, style: "margin-right: 8px;" %> FEATURED
+              <% end %>
+            </div>
+            <div style="flex: 1;">
+              <%= f.label :show_in_pulse_vault, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+                <%= f.check_box :show_in_pulse_vault, style: "margin-right: 8px;" %> SHOW IN PULSE VAULT
+              <% end %>
+            </div>
+          </div>
+
+          <div style="margin-top: 20px;">
+            <%= f.submit "Create Track", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+            <%= link_to "Cancel", admin_tracks_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,30 +252,62 @@ Rails.application.routes.draw do
   namespace :admin, path: "root" do
     root "dashboard#index"
 
-    # Catalog resources
-    resources :artists, only: [:index]
-    resources :releases, only: %i[index edit update destroy] do
+    # Catalog resources (full CRUD)
+    resources :artists do
+      member do
+        get :history
+      end
+    end
+    resources :releases do
       member do
         delete :purge_cover, to: "releases#purge_cover"
+        get :history
       end
     end
-    resources :tracks, only: %i[index edit update destroy] do
+    resources :tracks do
       member do
         delete :purge_audio, to: "tracks#purge_audio"
+        get :history
       end
     end
 
-    # Read-only content resources (managed via data/content/*.yml)
-    resources :codex_entries, only: [:index]
-    resources :hackr_logs, only: [:index]
+    # Content resources (full CRUD)
+    resources :codex_entries do
+      member do
+        get :history
+      end
+    end
+    resources :hackr_logs do
+      member do
+        get :history
+      end
+    end
 
-    # Read-only system resources (managed via data/system/*.yml)
+    # System resources (read-only)
     resources :radio_stations, only: %i[index show]
     resources :zone_playlists, only: %i[index show]
 
-    # Read-only world resources (managed via data/world/*.yml)
-    resources :grid_zones, only: [:index]
-    resources :grid_rooms, only: [:index]
+    # World resources (full CRUD)
+    resources :grid_zones do
+      member do
+        get :history
+      end
+    end
+    resources :grid_rooms do
+      member do
+        get :history
+      end
+    end
+    resources :grid_mobs do
+      member do
+        get :history
+      end
+    end
+    resources :grid_exits do
+      member do
+        get :history
+      end
+    end
 
     # Grid management (still functional - runtime operations)
     get "grid", to: "grid#index", as: :grid
@@ -290,11 +322,15 @@ Rails.application.routes.draw do
     resources :grid_achievements do
       member do
         post :award
+        get :history
       end
     end
 
     # Grid factions (full CRUD + rep-link management)
     resources :grid_factions do
+      member do
+        get :history
+      end
       collection do
         post :update_rep_links
       end
@@ -311,24 +347,45 @@ Rails.application.routes.draw do
     resources :grid_reputation_events, only: [:index]
 
     # Grid item definitions (item master catalog)
-    resources :grid_item_definitions, except: [:show]
+    resources :grid_item_definitions, except: [:show] do
+      member do
+        get :history
+      end
+    end
 
     # Grid shops (runtime CRUD + stock management)
     resources :grid_shop_listings do
       member do
         post :restock
+        get :history
       end
     end
     resources :grid_shop_transactions, only: [:index]
 
-    # Grid missions (runtime CRUD + YAML-seedable)
-    resources :grid_mission_arcs
-    resources :grid_missions
+    # Grid missions (runtime CRUD)
+    resources :grid_mission_arcs do
+      member do
+        get :history
+      end
+    end
+    resources :grid_missions do
+      member do
+        get :history
+      end
+    end
     resources :grid_hackr_missions, only: %i[index show]
 
-    # Hackr Handbook (docs — full CRUD, YAML-seedable)
-    resources :handbook_sections
-    resources :handbook_articles
+    # Hackr Handbook (docs — full CRUD)
+    resources :handbook_sections do
+      member do
+        get :history
+      end
+    end
+    resources :handbook_articles do
+      member do
+        get :history
+      end
+    end
 
     # PulseWire moderation (still functional - runtime operations)
     resources :pulse_wire, only: %i[index destroy] do

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,6 @@
-# Unified Data Loading System
-# YAML files are the single source of truth for all seeded content
+# Unified Data Seeding System
+# YAML files provide initial seed data. The database is the source of truth.
+# Existing records are never overwritten — only new records are created.
 #
 # Import Order (respecting dependencies):
 # 1. catalog           (artists, releases, tracks from per-artist YAML files)
@@ -29,10 +30,10 @@
 
 namespace :data do
   # === Master Tasks ===
-  desc "Load all data from YAML (full fresh load). Set S3_BUCKET to also load audio from S3."
+  desc "Seed data from YAML (creates missing records only). Set S3_BUCKET to also load audio from S3."
   task load: :environment do
     puts "\n" + "=" * 80
-    puts "LOADING ALL DATA FROM YAML FILES"
+    puts "SEEDING DATA FROM YAML FILES (new records only)"
     puts "=" * 80 + "\n"
 
     Rake::Task["data:catalog"].invoke
@@ -54,7 +55,7 @@ namespace :data do
     Rake::Task["data:economy"].invoke
 
     puts "\n" + "=" * 80
-    puts "DATA LOAD COMPLETE"
+    puts "DATA SEED COMPLETE"
     puts "=" * 80 + "\n"
   end
 
@@ -83,9 +84,9 @@ namespace :data do
       next
     end
 
-    artists_created = artists_updated = 0
-    releases_created = releases_updated = 0
-    tracks_created = tracks_updated = 0
+    artists_created = 0
+    releases_created = 0
+    tracks_created = 0
 
     artist_files.each do |file|
       data = YAML.load_file(file)
@@ -97,23 +98,21 @@ namespace :data do
         next
       end
 
-      # Upsert artist
+      # Seed artist (skip if exists)
       artist = Artist.find_or_initialize_by(slug: artist_slug)
-      was_new = artist.new_record?
 
-      artist.assign_attributes(
-        name: artist_data["name"],
-        genre: artist_data["genre"],
-        artist_type: artist_data["artist_type"] || "band"
-      )
-
-      if artist.changed?
+      if artist.new_record?
+        artist.assign_attributes(
+          name: artist_data["name"],
+          genre: artist_data["genre"],
+          artist_type: artist_data["artist_type"] || "band"
+        )
         artist.save!
-        was_new ? (artists_created += 1) : (artists_updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"} artist: #{artist.name}"
+        artists_created += 1
+        puts "  ✓ Created artist: #{artist.name}"
       end
 
-      # Upsert releases and tracks
+      # Seed releases and tracks (skip existing)
       (data["releases"] || []).each do |release_data|
         next unless release_data["title"].present? && release_data["slug"].present?
 
@@ -123,35 +122,33 @@ namespace :data do
         end
 
         release = Release.find_or_initialize_by(artist: artist, slug: release_data["slug"])
-        was_new = release.new_record?
 
-        release_date = DataLoaderHelpers.parse_date(release_data["release_date"])
+        if release.new_record?
+          release_date = DataLoaderHelpers.parse_date(release_data["release_date"])
 
-        release.assign_attributes(
-          name: release_data["title"],
-          release_type: release_data["release_type"],
-          release_date: release_date,
-          description: release_data["description"],
-          catalog_number: release_data["catalog_number"],
-          media_format: release_data["media_format"],
-          classification: release_data["classification"],
-          label: release_data["label"],
-          credits: release_data["credits"],
-          notes: release_data["notes"],
-          streaming_links: DataLoaderHelpers.normalize_json(release_data["streaming_links"]),
-          coming_soon: release_data.fetch("coming_soon", false)
-        )
-
-        if release.changed?
+          release.assign_attributes(
+            name: release_data["title"],
+            release_type: release_data["release_type"],
+            release_date: release_date,
+            description: release_data["description"],
+            catalog_number: release_data["catalog_number"],
+            media_format: release_data["media_format"],
+            classification: release_data["classification"],
+            label: release_data["label"],
+            credits: release_data["credits"],
+            notes: release_data["notes"],
+            streaming_links: DataLoaderHelpers.normalize_json(release_data["streaming_links"]),
+            coming_soon: release_data.fetch("coming_soon", false)
+          )
           release.save!
-          was_new ? (releases_created += 1) : (releases_updated += 1)
-          puts "  #{was_new ? "✓ Created" : "↻ Updated"} release: #{release.name} (#{artist.name})"
+          releases_created += 1
+          puts "  ✓ Created release: #{release.name} (#{artist.name})"
+
+          # Attach cover image on creation
+          DataLoaderHelpers.attach_cover_image(release, release_data["cover_image"], artist_slug) if release_data["cover_image"].present?
         end
 
-        # Attach cover image if specified
-        DataLoaderHelpers.attach_cover_image(release, release_data["cover_image"], artist_slug) if release_data["cover_image"].present?
-
-        # Upsert tracks
+        # Seed tracks (skip existing)
         (release_data["tracks"] || []).each do |track_data|
           if track_data["skip"]
             puts "    ⊘ Skipped track: #{track_data["title"]}"
@@ -159,7 +156,7 @@ namespace :data do
           end
 
           track = artist.tracks.find_or_initialize_by(slug: track_data["slug"])
-          was_new = track.new_record?
+          next unless track.new_record?
 
           track.assign_attributes(
             title: track_data["title"],
@@ -173,19 +170,16 @@ namespace :data do
             videos: DataLoaderHelpers.normalize_json(track_data["videos"]),
             lyrics: track_data["lyrics"]
           )
-
-          if track.changed?
-            track.save!
-            was_new ? (tracks_created += 1) : (tracks_updated += 1)
-            puts "    #{was_new ? "✓ Created" : "↻ Updated"} track: #{track.title}"
-          end
+          track.save!
+          tracks_created += 1
+          puts "    ✓ Created track: #{track.title}"
         end
       end
     end
 
-    puts "Artists: #{artists_created} created, #{artists_updated} updated, #{Artist.count} total"
-    puts "Releases: #{releases_created} created, #{releases_updated} updated, #{Release.count} total"
-    puts "Tracks: #{tracks_created} created, #{tracks_updated} updated, #{Track.count} total"
+    puts "Artists: #{artists_created} created, #{Artist.count} total"
+    puts "Releases: #{releases_created} created, #{Release.count} total"
+    puts "Tracks: #{tracks_created} created, #{Track.count} total"
   end
 
   desc "Load system data (hackrs, channels, radio stations, etc.)"
@@ -277,11 +271,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     hackrs_data = data["hackrs"]
-    created = updated = 0
+    created = 0
 
     hackrs_data.each do |attrs|
       hackr = GridHackr.find_or_initialize_by(hackr_alias: attrs["hackr_alias"])
-      was_new = hackr.new_record?
+      next unless hackr.new_record?
 
       # Get password from env or use default
       password = if Rails.env.production?
@@ -293,22 +287,15 @@ namespace :data do
       hackr.assign_attributes(
         email: attrs["email"],
         role: attrs["role"],
+        password: password,
         skip_reserved_check: true
       )
-
-      # Only set password on new records or if explicitly changed
-      if was_new
-        hackr.password = password
-      end
-
-      if hackr.changed? || was_new
-        hackr.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{hackr.hackr_alias} (#{hackr.role})"
-      end
+      hackr.save!
+      created += 1
+      puts "  ✓ Created: #{hackr.hackr_alias} (#{hackr.role})"
     end
 
-    puts "Hackrs: #{created} created, #{updated} updated, #{GridHackr.count} total"
+    puts "Hackrs: #{created} created, #{GridHackr.count} total"
   end
 
   desc "Load channels from YAML"
@@ -323,11 +310,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     channels_data = data["channels"]
-    created = updated = 0
+    created = 0
 
     channels_data.each do |attrs|
       channel = ChatChannel.find_or_initialize_by(slug: attrs["slug"])
-      was_new = channel.new_record?
+      next unless channel.new_record?
 
       channel.assign_attributes(
         name: attrs["name"],
@@ -337,15 +324,12 @@ namespace :data do
         slow_mode_seconds: attrs["slow_mode_seconds"],
         minimum_role: attrs["minimum_role"]
       )
-
-      if channel.changed?
-        channel.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{channel.name}"
-      end
+      channel.save!
+      created += 1
+      puts "  ✓ Created: #{channel.name}"
     end
 
-    puts "Channels: #{created} created, #{updated} updated, #{ChatChannel.count} total"
+    puts "Channels: #{created} created, #{ChatChannel.count} total"
   end
 
   desc "Load radio stations from YAML"
@@ -361,11 +345,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     stations_data = data["stations"]
-    created = updated = 0
+    created = 0
 
     stations_data.each do |attrs|
       station = RadioStation.find_or_initialize_by(slug: attrs["slug"])
-      was_new = station.new_record?
+      next unless station.new_record?
 
       station.assign_attributes(
         name: attrs["name"],
@@ -376,15 +360,12 @@ namespace :data do
         position: attrs["position"] || 0,
         hidden: attrs.fetch("hidden", false)
       )
-
-      if station.changed?
-        station.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{station.name}"
-      end
+      station.save!
+      created += 1
+      puts "  ✓ Created: #{station.name}"
     end
 
-    puts "Radio Stations: #{created} created, #{updated} updated, #{RadioStation.count} total"
+    puts "Radio Stations: #{created} created, #{RadioStation.count} total"
   end
 
   desc "Load zone playlists from YAML"
@@ -399,53 +380,41 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     playlists_data = data["zone_playlists"]
-    created = updated = 0
+    created = 0
 
     playlists_data.each do |attrs|
       playlist = ZonePlaylist.find_or_initialize_by(slug: attrs["slug"])
       was_new = playlist.new_record?
 
-      playlist.assign_attributes(
-        name: attrs["name"],
-        description: attrs["description"],
-        crossfade_duration_ms: attrs["crossfade_duration_ms"],
-        default_volume: attrs["default_volume"]
-      )
-
-      if playlist.changed? || was_new
+      if was_new
+        playlist.assign_attributes(
+          name: attrs["name"],
+          description: attrs["description"],
+          crossfade_duration_ms: attrs["crossfade_duration_ms"],
+          default_volume: attrs["default_volume"]
+        )
         playlist.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{playlist.name}"
-      end
+        created += 1
+        puts "  ✓ Created: #{playlist.name}"
 
-      # Sync tracks from artist
-      if attrs["artist_tracks"].present?
-        artist = Artist.find_by(slug: attrs["artist_tracks"])
-        if artist
-          desired_track_ids = artist.tracks.pluck(:id).to_set
-
-          # Remove stale tracks
-          playlist.zone_playlist_tracks.each do |zpt|
-            unless desired_track_ids.include?(zpt.track_id)
-              zpt.destroy!
+        # Seed tracks from artist (only on new playlists)
+        if attrs["artist_tracks"].present?
+          artist = Artist.find_by(slug: attrs["artist_tracks"])
+          if artist
+            artist.tracks.each_with_index do |track, index|
+              ZonePlaylistTrack.create!(
+                zone_playlist: playlist,
+                track: track,
+                position: index + 1
+              )
             end
+            puts "    → Seeded #{artist.tracks.count} tracks from #{artist.name}"
           end
-
-          # Add/update track positions
-          artist.tracks.each_with_index do |track, index|
-            zpt = ZonePlaylistTrack.find_or_initialize_by(
-              zone_playlist: playlist,
-              track: track
-            )
-            zpt.position = index + 1
-            zpt.save! if zpt.new_record? || zpt.changed?
-          end
-          puts "    → Synced #{artist.tracks.count} tracks from #{artist.name}"
         end
       end
     end
 
-    puts "Zone Playlists: #{created} created, #{updated} updated, #{ZonePlaylist.count} total"
+    puts "Zone Playlists: #{created} created, #{ZonePlaylist.count} total"
   end
 
   desc "Load factions from YAML"
@@ -461,13 +430,14 @@ namespace :data do
     data = YAML.load_file(yaml_file)
     factions_data = data["factions"] || []
     links_data = data["rep_links"] || []
-    created = updated = 0
+    created = 0
+    new_faction_slugs = Set.new
 
-    # Pass 1: upsert factions without parent FK (parents may be defined later
+    # Pass 1: seed factions without parent FK (parents may be defined later
     # in the YAML than their children; resolve on pass 2).
     factions_data.each do |attrs|
       faction = GridFaction.find_or_initialize_by(slug: attrs["slug"])
-      was_new = faction.new_record?
+      next unless faction.new_record?
 
       artist = attrs["artist_slug"].present? ? Artist.find_by(slug: attrs["artist_slug"]) : nil
 
@@ -479,28 +449,26 @@ namespace :data do
         position: attrs["position"] || 0,
         artist: artist
       )
-
-      if faction.changed?
-        faction.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{faction.name}"
-      end
+      faction.save!
+      created += 1
+      new_faction_slugs << attrs["slug"]
+      puts "  ✓ Created: #{faction.name}"
     end
 
-    # Pass 2: resolve parent_slug → parent_id. Only writes when changed.
+    # Pass 2: resolve parent_slug → parent_id (only for newly created factions).
     factions_data.each do |attrs|
+      next unless new_faction_slugs.include?(attrs["slug"])
+      next unless attrs["parent_slug"].present?
+
       faction = GridFaction.find_by(slug: attrs["slug"])
       next unless faction
-      parent_id = attrs["parent_slug"].present? ? GridFaction.where(slug: attrs["parent_slug"]).pick(:id) : nil
-      if faction.parent_id != parent_id
-        faction.update!(parent_id: parent_id)
-      end
+
+      parent_id = GridFaction.where(slug: attrs["parent_slug"]).pick(:id)
+      faction.update!(parent_id: parent_id) if parent_id
     end
 
-    # Pass 3: rep-link graph. Idempotent — we fully reconcile to match YAML so
-    # removing a link from YAML removes it from DB (unlike other tasks here,
-    # because the link graph is small and fully declarative).
-    desired_keys = Set.new
+    # Pass 3: seed rep-link graph (only create missing links, never delete).
+    links_created = 0
     links_data.each do |attrs|
       source = GridFaction.find_by(slug: attrs["source_slug"])
       target = GridFaction.find_by(slug: attrs["target_slug"])
@@ -512,21 +480,15 @@ namespace :data do
       link = GridFactionRepLink.find_or_initialize_by(
         source_faction_id: source.id, target_faction_id: target.id
       )
-      link.weight = attrs["weight"]
-      link.save! if link.new_record? || link.changed?
-      desired_keys << [source.id, target.id]
-    end
-
-    removed = 0
-    GridFactionRepLink.find_each do |existing|
-      unless desired_keys.include?([existing.source_faction_id, existing.target_faction_id])
-        existing.destroy!
-        removed += 1
+      if link.new_record?
+        link.weight = attrs["weight"]
+        link.save!
+        links_created += 1
       end
     end
 
-    puts "Factions: #{created} created, #{updated} updated, #{GridFaction.count} total"
-    puts "Rep links: #{GridFactionRepLink.count} active, #{removed} removed"
+    puts "Factions: #{created} created, #{GridFaction.count} total"
+    puts "Rep links: #{links_created} created, #{GridFactionRepLink.count} total"
   end
 
   desc "Load zones from YAML"
@@ -541,11 +503,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     zones_data = data["zones"]
-    created = updated = 0
+    created = 0
 
     zones_data.each do |attrs|
       zone = GridZone.find_or_initialize_by(slug: attrs["slug"])
-      was_new = zone.new_record?
+      next unless zone.new_record?
 
       faction = attrs["faction_slug"].present? ? GridFaction.find_by(slug: attrs["faction_slug"]) : nil
       playlist = attrs["ambient_playlist_slug"].present? ? ZonePlaylist.find_by(slug: attrs["ambient_playlist_slug"]) : nil
@@ -558,15 +520,12 @@ namespace :data do
         grid_faction: faction,
         ambient_playlist: playlist
       )
-
-      if zone.changed?
-        zone.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{zone.name}"
-      end
+      zone.save!
+      created += 1
+      puts "  ✓ Created: #{zone.name}"
     end
 
-    puts "Zones: #{created} created, #{updated} updated, #{GridZone.count} total"
+    puts "Zones: #{created} created, #{GridZone.count} total"
   end
 
   desc "Load rooms from YAML"
@@ -581,11 +540,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     rooms_data = data["rooms"]
-    created = updated = 0
+    created = 0
 
     rooms_data.each do |attrs|
       room = GridRoom.find_or_initialize_by(slug: attrs["slug"])
-      was_new = room.new_record?
+      next unless room.new_record?
 
       zone = GridZone.find_by(slug: attrs["zone_slug"])
       unless zone
@@ -600,15 +559,12 @@ namespace :data do
         room_type: attrs["room_type"],
         min_clearance: attrs["min_clearance"] || 0
       )
-
-      if room.changed?
-        room.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{room.name}"
-      end
+      room.save!
+      created += 1
+      puts "  ✓ Created: #{room.name}"
     end
 
-    puts "Rooms: #{created} created, #{updated} updated, #{GridRoom.count} total"
+    puts "Rooms: #{created} created, #{GridRoom.count} total"
   end
 
   desc "Load exits from YAML"
@@ -623,7 +579,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     exits_data = data["exits"]
-    created = updated = 0
+    created = 0
 
     exits_data.each do |attrs|
       from_room = GridRoom.find_by(slug: attrs["from_room_slug"])
@@ -639,18 +595,15 @@ namespace :data do
         to_room: to_room,
         direction: attrs["direction"]
       )
-      was_new = exit_record.new_record?
+      next unless exit_record.new_record?
 
       exit_record.locked = attrs["locked"] || false
-
-      if exit_record.changed?
-        exit_record.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{from_room.name} -> #{attrs["direction"]} -> #{to_room.name}"
-      end
+      exit_record.save!
+      created += 1
+      puts "  ✓ Created: #{from_room.name} -> #{attrs["direction"]} -> #{to_room.name}"
     end
 
-    puts "Exits: #{created} created, #{updated} updated, #{GridExit.count} total"
+    puts "Exits: #{created} created, #{GridExit.count} total"
   end
 
   desc "Load mobs from YAML"
@@ -665,7 +618,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     mobs_data = data["mobs"]
-    created = updated = 0
+    created = 0
 
     mobs_data.each do |attrs|
       room = GridRoom.find_by(slug: attrs["room_slug"])
@@ -677,7 +630,7 @@ namespace :data do
       end
 
       mob = GridMob.find_or_initialize_by(name: attrs["name"], grid_room: room)
-      was_new = mob.new_record?
+      next unless mob.new_record?
 
       mob.assign_attributes(
         description: attrs["description"],
@@ -686,15 +639,12 @@ namespace :data do
         dialogue_tree: attrs["dialogue_tree"],
         vendor_config: attrs["vendor_config"]
       )
-
-      if mob.changed?
-        mob.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{mob.name}"
-      end
+      mob.save!
+      created += 1
+      puts "  ✓ Created: #{mob.name}"
     end
 
-    puts "Mobs: #{created} created, #{updated} updated, #{GridMob.count} total"
+    puts "Mobs: #{created} created, #{GridMob.count} total"
   end
 
   desc "Load item definitions from YAML"
@@ -709,11 +659,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     defs_data = data["item_definitions"]
-    created = updated = 0
+    created = 0
 
     defs_data.each do |attrs|
       defn = GridItemDefinition.find_or_initialize_by(slug: attrs["slug"])
-      was_new = defn.new_record?
+      next unless defn.new_record?
 
       defn.assign_attributes(
         name: attrs["name"],
@@ -723,15 +673,12 @@ namespace :data do
         value: attrs["value"] || 0,
         properties: attrs["properties"] || {}
       )
-
-      if defn.changed?
-        defn.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{defn.name} (#{defn.slug})"
-      end
+      defn.save!
+      created += 1
+      puts "  ✓ Created: #{defn.name} (#{defn.slug})"
     end
 
-    puts "Item Definitions: #{created} created, #{updated} updated, #{GridItemDefinition.count} total"
+    puts "Item Definitions: #{created} created, #{GridItemDefinition.count} total"
   end
 
   desc "Load salvage yield definitions from YAML"
@@ -746,7 +693,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     yields_data = data["salvage_yields"] || []
-    created = updated = 0
+    created = 0
 
     yields_data.each do |attrs|
       source = GridItemDefinition.find_by(slug: attrs["source_slug"])
@@ -765,21 +712,18 @@ namespace :data do
         source_definition: source,
         output_definition: output
       )
-      was_new = yield_row.new_record?
+      next unless yield_row.new_record?
 
       yield_row.assign_attributes(
         quantity: attrs["quantity"] || 1,
         position: attrs["position"] || 0
       )
-
-      if yield_row.changed?
-        yield_row.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{source.name} → #{output.name} ×#{yield_row.quantity}"
-      end
+      yield_row.save!
+      created += 1
+      puts "  ✓ Created: #{source.name} → #{output.name} ×#{yield_row.quantity}"
     end
 
-    puts "Salvage Yields: #{created} created, #{updated} updated, #{GridSalvageYield.count} total"
+    puts "Salvage Yields: #{created} created, #{GridSalvageYield.count} total"
   end
 
   desc "Load items from YAML"
@@ -794,7 +738,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     items_data = data["items"]
-    created = updated = 0
+    created = 0
 
     items_data.each do |attrs|
       room = GridRoom.find_by(slug: attrs["room_slug"])
@@ -810,7 +754,7 @@ namespace :data do
       end
 
       item = GridItem.find_or_initialize_by(grid_item_definition: defn, room: room, grid_hackr: nil)
-      was_new = item.new_record?
+      next unless item.new_record?
 
       item.assign_attributes(
         defn.item_attributes.merge(
@@ -819,15 +763,12 @@ namespace :data do
         )
       )
       item.value = attrs["value"] if attrs.key?("value")
-
-      if item.changed?
-        item.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{item.name}"
-      end
+      item.save!
+      created += 1
+      puts "  ✓ Created: #{item.name}"
     end
 
-    puts "Items: #{created} created, #{updated} updated, #{GridItem.count} total"
+    puts "Items: #{created} created, #{GridItem.count} total"
   end
 
   desc "Sync existing grid_items with their current definitions"
@@ -861,11 +802,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     achievements_data = data["achievements"]
-    created = updated = 0
+    created = 0
 
     achievements_data.each do |attrs|
       achievement = GridAchievement.find_or_initialize_by(slug: attrs["slug"])
-      was_new = achievement.new_record?
+      next unless achievement.new_record?
 
       achievement.assign_attributes(
         name: attrs["name"],
@@ -878,15 +819,12 @@ namespace :data do
         category: attrs["category"] || "grid",
         hidden: attrs["hidden"] || false
       )
-
-      if achievement.changed?
-        achievement.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{achievement.name}"
-      end
+      achievement.save!
+      created += 1
+      puts "  ✓ Created: #{achievement.name}"
     end
 
-    puts "Achievements: #{created} created, #{updated} updated, #{GridAchievement.count} total"
+    puts "Achievements: #{created} created, #{GridAchievement.count} total"
   end
 
   desc "Load shop listings from YAML"
@@ -901,7 +839,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     listings_data = data["shop_listings"]
-    created = updated = 0
+    created = 0
 
     # Vendors that need initial rotation seeding (first-time black market creation).
     vendors_needing_rotation = Set.new
@@ -926,14 +864,13 @@ namespace :data do
       end
 
       listing = GridShopListing.find_or_initialize_by(grid_item_definition: defn, grid_mob: mob)
-      was_new = listing.new_record?
+      next unless listing.new_record?
 
       base_price = attrs["base_price"]
       sell_price = attrs["sell_price"] || (base_price / 2.0).ceil
       rotation_pool = attrs.fetch("rotation_pool", false)
       restock_hours = attrs["restock_interval_hours"] || mob.restock_interval_hours
 
-      # Shop-specific fields — always updated from YAML (source of truth)
       listing.assign_attributes(
         base_price: base_price,
         sell_price: sell_price,
@@ -941,24 +878,16 @@ namespace :data do
         restock_amount: attrs["restock_amount"] || 1,
         restock_interval_hours: restock_hours,
         rotation_pool: rotation_pool,
-        min_clearance: attrs["min_clearance"] || 0
+        min_clearance: attrs["min_clearance"] || 0,
+        stock: attrs["max_stock"],
+        next_restock_at: Time.current + restock_hours.hours,
+        active: attrs.fetch("active", !rotation_pool)
       )
+      listing.save!
+      created += 1
+      puts "  ✓ Created: #{listing.name} (#{mob.name})"
 
-      # Runtime state — only set on creation. Preserves live stock, active flag,
-      # and restock timer on re-import. Rotation pool items start inactive so the
-      # rotation job (or the initial seed below) controls which are visible.
-      if was_new
-        listing.stock = attrs["max_stock"]
-        listing.next_restock_at = Time.current + restock_hours.hours
-        listing.active = attrs.fetch("active", !rotation_pool)
-        vendors_needing_rotation << mob if rotation_pool
-      end
-
-      if listing.changed?
-        listing.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{listing.name} (#{mob.name})"
-      end
+      vendors_needing_rotation << mob if rotation_pool
     end
 
     # Seed initial rotation for any vendor with a freshly-created rotation pool
@@ -970,7 +899,7 @@ namespace :data do
       puts "  ⟳ Seeded initial rotation: #{mob.name}"
     end
 
-    puts "Shop Listings: #{created} created, #{updated} updated, #{GridShopListing.count} total"
+    puts "Shop Listings: #{created} created, #{GridShopListing.count} total"
   end
 
   desc "Load key playlists from YAML"
@@ -986,79 +915,51 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     playlists_data = data["playlists"]
-    created = updated = 0
+    created = 0
 
     playlists_data.each do |attrs|
+      playlist = Playlist.find_or_initialize_by(name: attrs["name"])
+      next unless playlist.new_record?
+
       owner = GridHackr.find_by(hackr_alias: attrs["owner"])
       radio_station = attrs["radio_station"].present? ? RadioStation.find_by(slug: attrs["radio_station"]) : nil
-
-      playlist = Playlist.find_or_initialize_by(name: attrs["name"])
-      was_new = playlist.new_record?
 
       playlist.assign_attributes(
         description: attrs["description"],
         grid_hackr: owner,
         is_public: attrs["is_public"] || false
       )
+      playlist.save!
+      created += 1
+      puts "  ✓ Created: #{playlist.name}"
 
-      if playlist.changed? || was_new
-        playlist.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{playlist.name}"
-      end
-
-      # Sync radio station link
+      # Seed radio station link
       if radio_station
         RadioStationPlaylist.find_or_create_by!(
           radio_station: radio_station,
           playlist: playlist
         )
         puts "    → Linked to radio station: #{radio_station.name}"
-      else
-        # Remove stale radio station links for this playlist
-        playlist.radio_station_playlists.destroy_all
       end
 
-      # Sync tracks
+      # Seed tracks
       if attrs["tracks"].present?
-        desired_tracks = []
-        attrs["tracks"].each do |track_ref|
+        attrs["tracks"].each_with_index do |track_ref, index|
           artist_slug, track_slug = track_ref.split("/")
           artist = Artist.find_by(slug: artist_slug)
           track = artist&.tracks&.find_by(slug: track_slug)
 
           if track
-            desired_tracks << track
+            PlaylistTrack.create!(playlist: playlist, track: track, position: index + 1)
           else
             puts "    ✗ Track not found: #{track_ref}"
           end
         end
-
-        desired_track_ids = desired_tracks.map(&:id).to_set
-
-        # Remove stale tracks
-        playlist.playlist_tracks.each do |pt|
-          unless desired_track_ids.include?(pt.track_id)
-            pt.destroy!
-            puts "    - Removed stale track from playlist"
-          end
-        end
-
-        # Add/update track positions
-        desired_tracks.each_with_index do |track, index|
-          pt = PlaylistTrack.find_or_initialize_by(playlist: playlist, track: track)
-          pt.position = index + 1
-          pt.save! if pt.new_record? || pt.changed?
-        end
-        puts "    → Synced #{desired_tracks.size} tracks"
-      else
-        # No tracks specified — clear any existing
-        removed = playlist.playlist_tracks.destroy_all.size
-        puts "    - Removed #{removed} stale tracks" if removed > 0
+        puts "    → Seeded #{playlist.playlist_tracks.count} tracks"
       end
     end
 
-    puts "Key Playlists: #{created} created, #{updated} updated, #{Playlist.count} total"
+    puts "Key Playlists: #{created} created, #{Playlist.count} total"
   end
 
   desc "Load codex entries from YAML"
@@ -1073,11 +974,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     entries_data = data["codex_entries"]
-    created = updated = 0
+    created = 0
 
     entries_data.each do |attrs|
       entry = CodexEntry.find_or_initialize_by(slug: attrs["slug"])
-      was_new = entry.new_record?
+      next unless entry.new_record?
 
       entry.assign_attributes(
         name: attrs["name"],
@@ -1088,15 +989,12 @@ namespace :data do
         position: attrs["position"],
         metadata: attrs["metadata"]
       )
-
-      if entry.changed?
-        entry.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{entry.name} (#{entry.entry_type})"
-      end
+      entry.save!
+      created += 1
+      puts "  ✓ Created: #{entry.name} (#{entry.entry_type})"
     end
 
-    puts "Codex Entries: #{created} created, #{updated} updated, #{CodexEntry.count} total"
+    puts "Codex Entries: #{created} created, #{CodexEntry.count} total"
   end
 
   desc "Load handbook sections and articles from YAML"
@@ -1112,30 +1010,28 @@ namespace :data do
     data = YAML.load_file(yaml_file)
     sections_data = data["handbook_sections"] || []
 
-    sections_created = sections_updated = 0
-    articles_created = articles_updated = 0
+    sections_created = 0
+    articles_created = 0
 
     sections_data.each do |section_attrs|
       section = HandbookSection.find_or_initialize_by(slug: section_attrs["slug"])
-      was_new = section.new_record?
 
-      section.assign_attributes(
-        name: section_attrs["name"],
-        icon: section_attrs["icon"],
-        summary: section_attrs["summary"],
-        position: section_attrs["position"] || 0,
-        published: section_attrs.fetch("published", true)
-      )
-
-      if section.changed?
+      if section.new_record?
+        section.assign_attributes(
+          name: section_attrs["name"],
+          icon: section_attrs["icon"],
+          summary: section_attrs["summary"],
+          position: section_attrs["position"] || 0,
+          published: section_attrs.fetch("published", true)
+        )
         section.save!
-        was_new ? (sections_created += 1) : (sections_updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"} section: #{section.name}"
+        sections_created += 1
+        puts "  ✓ Created section: #{section.name}"
       end
 
       (section_attrs["articles"] || []).each do |article_attrs|
         article = HandbookArticle.find_or_initialize_by(slug: article_attrs["slug"])
-        article_was_new = article.new_record?
+        next unless article.new_record?
 
         article.assign_attributes(
           handbook_section: section,
@@ -1148,17 +1044,14 @@ namespace :data do
           published: article_attrs.fetch("published", true),
           metadata: article_attrs["metadata"] || {}
         )
-
-        if article.changed?
-          article.save!
-          article_was_new ? (articles_created += 1) : (articles_updated += 1)
-          puts "    #{article_was_new ? "✓ Created" : "↻ Updated"} article: #{article.title}"
-        end
+        article.save!
+        articles_created += 1
+        puts "    ✓ Created article: #{article.title}"
       end
     end
 
-    puts "Handbook Sections: #{sections_created} created, #{sections_updated} updated, #{HandbookSection.count} total"
-    puts "Handbook Articles: #{articles_created} created, #{articles_updated} updated, #{HandbookArticle.count} total"
+    puts "Handbook Sections: #{sections_created} created, #{HandbookSection.count} total"
+    puts "Handbook Articles: #{articles_created} created, #{HandbookArticle.count} total"
   end
 
   desc "Load hackr logs from YAML"
@@ -1173,7 +1066,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     logs_data = data["hackr_logs"]
-    created = updated = 0
+    created = 0
 
     logs_data.each do |attrs|
       grid_hackr = GridHackr.find_by(hackr_alias: attrs["author"])
@@ -1183,7 +1076,7 @@ namespace :data do
       end
 
       log = HackrLog.find_or_initialize_by(slug: attrs["slug"])
-      was_new = log.new_record?
+      next unless log.new_record?
 
       # Parse lore date (subtract 100 years for database storage)
       published_at = nil
@@ -1200,15 +1093,12 @@ namespace :data do
         published: true,
         published_at: published_at
       )
-
-      if log.changed?
-        log.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{log.title}"
-      end
+      log.save!
+      created += 1
+      puts "  ✓ Created: #{log.title}"
     end
 
-    puts "Hackr Logs: #{created} created, #{updated} updated, #{HackrLog.count} total"
+    puts "Hackr Logs: #{created} created, #{HackrLog.count} total"
   end
 
   desc "Load wire (pulses and echoes) from YAML"
@@ -1313,25 +1203,22 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     elements_data = data["elements"]
-    created = updated = 0
+    created = 0
 
     elements_data.each do |attrs|
       element = OverlayElement.find_or_initialize_by(slug: attrs["slug"])
-      was_new = element.new_record?
+      next unless element.new_record?
 
       element.assign_attributes(
         name: attrs["name"],
         element_type: attrs["element_type"]
       )
-
-      if element.changed?
-        element.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{element.name}"
-      end
+      element.save!
+      created += 1
+      puts "  ✓ Created: #{element.name}"
     end
 
-    puts "Overlay Elements: #{created} created, #{updated} updated, #{OverlayElement.count} total"
+    puts "Overlay Elements: #{created} created, #{OverlayElement.count} total"
   end
 
   desc "Load overlay tickers from YAML"
@@ -1346,11 +1233,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     tickers_data = data["tickers"]
-    created = updated = 0
+    created = 0
 
     tickers_data.each do |attrs|
       ticker = OverlayTicker.find_or_initialize_by(slug: attrs["slug"])
-      was_new = ticker.new_record?
+      next unless ticker.new_record?
 
       ticker.assign_attributes(
         name: attrs["name"],
@@ -1359,15 +1246,12 @@ namespace :data do
         speed: attrs["speed"],
         active: attrs["active"]
       )
-
-      if ticker.changed?
-        ticker.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{ticker.name}"
-      end
+      ticker.save!
+      created += 1
+      puts "  ✓ Created: #{ticker.name}"
     end
 
-    puts "Overlay Tickers: #{created} created, #{updated} updated, #{OverlayTicker.count} total"
+    puts "Overlay Tickers: #{created} created, #{OverlayTicker.count} total"
   end
 
   desc "Load overlay lower thirds from YAML"
@@ -1382,11 +1266,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     lower_thirds_data = data["lower_thirds"]
-    created = updated = 0
+    created = 0
 
     lower_thirds_data.each do |attrs|
       lt = OverlayLowerThird.find_or_initialize_by(slug: attrs["slug"])
-      was_new = lt.new_record?
+      next unless lt.new_record?
 
       lt.assign_attributes(
         name: attrs["name"],
@@ -1394,15 +1278,12 @@ namespace :data do
         secondary_text: attrs["secondary_text"],
         active: attrs["active"]
       )
-
-      if lt.changed?
-        lt.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{lt.name}"
-      end
+      lt.save!
+      created += 1
+      puts "  ✓ Created: #{lt.name}"
     end
 
-    puts "Overlay Lower Thirds: #{created} created, #{updated} updated, #{OverlayLowerThird.count} total"
+    puts "Overlay Lower Thirds: #{created} created, #{OverlayLowerThird.count} total"
   end
 
   desc "Load overlay scenes from YAML"
@@ -1417,11 +1298,11 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     scenes_data = data["scenes"]
-    created = updated = 0
+    created = 0
 
     scenes_data.each do |attrs|
       scene = OverlayScene.find_or_initialize_by(slug: attrs["slug"])
-      was_new = scene.new_record?
+      next unless scene.new_record?
 
       scene.assign_attributes(
         name: attrs["name"],
@@ -1429,15 +1310,12 @@ namespace :data do
         width: attrs["width"],
         height: attrs["height"]
       )
-
-      if scene.changed?
-        scene.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{scene.name}"
-      end
+      scene.save!
+      created += 1
+      puts "  ✓ Created: #{scene.name}"
     end
 
-    puts "Overlay Scenes: #{created} created, #{updated} updated, #{OverlayScene.count} total"
+    puts "Overlay Scenes: #{created} created, #{OverlayScene.count} total"
   end
 
   desc "Load overlay scene elements from YAML"
@@ -1452,7 +1330,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     scene_elements_data = data["scene_elements"]
-    created = updated = 0
+    created = 0
 
     scene_elements_data.each do |attrs|
       scene = OverlayScene.find_by(slug: attrs["scene_slug"])
@@ -1467,7 +1345,7 @@ namespace :data do
         overlay_scene: scene,
         overlay_element: element
       )
-      was_new = se.new_record?
+      next unless se.new_record?
 
       se.assign_attributes(
         x: attrs["x"],
@@ -1476,15 +1354,12 @@ namespace :data do
         height: attrs["height"],
         z_index: attrs["z_index"]
       )
-
-      if se.changed?
-        se.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{element.name} in #{scene.name}"
-      end
+      se.save!
+      created += 1
+      puts "  ✓ Created: #{element.name} in #{scene.name}"
     end
 
-    puts "Overlay Scene Elements: #{created} created, #{updated} updated, #{OverlaySceneElement.count} total"
+    puts "Overlay Scene Elements: #{created} created, #{OverlaySceneElement.count} total"
   end
 
   desc "Load overlay scene groups from YAML"
@@ -1505,53 +1380,37 @@ namespace :data do
       next
     end
 
-    created = updated = 0
+    created = 0
     groups_data.each do |attrs|
       group = OverlaySceneGroup.find_or_initialize_by(slug: attrs["slug"])
       was_new = group.new_record?
 
-      group.assign_attributes(
-        name: attrs["name"],
-        description: attrs["description"]
-      )
-
-      if group.changed?
-        group.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{group.name}"
-      end
-
-      # Sync scenes in group
-      scene_slugs = attrs["scenes"] || []
-      desired_scenes = scene_slugs.filter_map { |slug| OverlayScene.find_by(slug: slug) }
-      desired_scene_ids = desired_scenes.map(&:id).to_set
-
-      existing = group.overlay_scene_group_scenes.includes(:overlay_scene).to_a
-      existing_scene_ids = existing.map(&:overlay_scene_id).to_set
-
-      # Remove stale
-      existing.each do |sgs|
-        unless desired_scene_ids.include?(sgs.overlay_scene_id)
-          sgs.destroy!
-          puts "    - Removed scene: #{sgs.overlay_scene.name}"
-        end
-      end
-
-      # Add/update positions
-      desired_scenes.each_with_index do |scene, index|
-        sgs = OverlaySceneGroupScene.find_or_initialize_by(
-          overlay_scene_group: group,
-          overlay_scene: scene
+      if was_new
+        group.assign_attributes(
+          name: attrs["name"],
+          description: attrs["description"]
         )
-        sgs.position = index + 1
-        if sgs.new_record? || sgs.changed?
-          sgs.save!
-          puts "    + Added scene: #{scene.name}" if !existing_scene_ids.include?(scene.id)
+        group.save!
+        created += 1
+        puts "  ✓ Created: #{group.name}"
+
+        # Seed scenes in group (only on new groups)
+        scene_slugs = attrs["scenes"] || []
+        scene_slugs.each_with_index do |slug, index|
+          scene = OverlayScene.find_by(slug: slug)
+          next unless scene
+
+          OverlaySceneGroupScene.create!(
+            overlay_scene_group: group,
+            overlay_scene: scene,
+            position: index + 1
+          )
+          puts "    + Added scene: #{scene.name}"
         end
       end
     end
 
-    puts "Overlay Scene Groups: #{created} created, #{updated} updated"
+    puts "Overlay Scene Groups: #{created} created"
   end
 
   desc "Load redirects from YAML"
@@ -1566,7 +1425,7 @@ namespace :data do
 
     data = YAML.load_file(yaml_file)
     mirror_groups = data["mirrors"] || []
-    created = updated = 0
+    created = 0
 
     # Build mirror lookup: primary_domain => [mirror_domains]
     mirror_map = {}
@@ -1590,18 +1449,15 @@ namespace :data do
         domain: attrs["domain"],
         path: attrs["path"]
       )
-      was_new = redirect.new_record?
+      next unless redirect.new_record?
 
       redirect.destination_url = attrs["destination_url"]
-
-      if redirect.changed?
-        redirect.save!
-        was_new ? (created += 1) : (updated += 1)
-        puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{attrs["domain"]}#{attrs["path"]} → #{attrs["destination_url"]}"
-      end
+      redirect.save!
+      created += 1
+      puts "  ✓ Created: #{attrs["domain"]}#{attrs["path"]} → #{attrs["destination_url"]}"
     end
 
-    puts "Redirects: #{created} created, #{updated} updated, #{Redirect.count} total"
+    puts "Redirects: #{created} created, #{Redirect.count} total"
   end
 
   desc "Load vidz (VODs/streams) from YAML"
@@ -1622,7 +1478,7 @@ namespace :data do
       next
     end
 
-    created = updated = skipped = 0
+    created = skipped = 0
 
     vidz_data.each do |attrs|
       artist = Artist.find_by("LOWER(name) = ?", attrs["artist"].to_s.downcase)
@@ -1632,16 +1488,15 @@ namespace :data do
         next
       end
 
-      started_at = attrs["started_at"].present? ? Time.parse(attrs["started_at"]) : nil
-      ended_at = attrs["ended_at"].present? ? Time.parse(attrs["ended_at"]) : nil
-
       # Pre-convert YouTube URL to embed format to match what the model stores
       # (HackrStream.before_validation converts watch/live URLs to embed URLs)
       vod_url = DataLoaderHelpers.youtube_embed_url(attrs["vod_url"])
 
       stream = HackrStream.find_or_initialize_by(vod_url: vod_url, artist: artist)
-      was_new = stream.new_record?
+      next unless stream.new_record?
 
+      started_at = attrs["started_at"].present? ? Time.parse(attrs["started_at"]) : nil
+      ended_at = attrs["ended_at"].present? ? Time.parse(attrs["ended_at"]) : nil
       live_url = DataLoaderHelpers.youtube_embed_url(attrs["live_url"])
 
       stream.assign_attributes(
@@ -1652,22 +1507,15 @@ namespace :data do
         started_at: started_at,
         ended_at: ended_at
       )
-
-      if was_new
-        stream.save!
-        created += 1
-        puts "  ✓ Created: #{stream.title} (#{artist.name})"
-      elsif stream.changed?
-        stream.save!
-        updated += 1
-        puts "  ↻ Updated: #{stream.title} (#{artist.name})"
-      end
+      stream.save!
+      created += 1
+      puts "  ✓ Created: #{stream.title} (#{artist.name})"
     rescue => e
       puts "  ✗ Error processing '#{attrs["title"]}': #{e.message}"
       skipped += 1
     end
 
-    puts "Vidz: #{created} created, #{updated} updated, #{skipped} skipped, #{HackrStream.count} total"
+    puts "Vidz: #{created} created, #{skipped} skipped, #{HackrStream.count} total"
   end
 
   desc "Create TCP Livestream Archive playlist from tracks with audio"
@@ -1705,19 +1553,17 @@ namespace :data do
     puts "  Found #{tracks_with_audio.count} tracks with audio"
 
     playlist = xeraen.playlists.find_or_initialize_by(name: "TCP Livestream Archive")
-    was_new = playlist.new_record?
 
-    playlist.assign_attributes(
-      description: "Archived recordings from The.CyberPul.se live trans-temporal broadcasts.",
-      is_public: false
-    )
-
-    if playlist.changed? || was_new
+    if playlist.new_record?
+      playlist.assign_attributes(
+        description: "Archived recordings from The.CyberPul.se live trans-temporal broadcasts.",
+        is_public: false
+      )
       playlist.save!
-      puts "  #{was_new ? "✓ Created" : "↻ Updated"}: #{playlist.name}"
+      puts "  ✓ Created: #{playlist.name}"
     end
 
-    # Add tracks to playlist
+    # Add new tracks to playlist (always — new audio may be attached after initial seed)
     added = 0
     tracks_with_audio.each do |track|
       pt = PlaylistTrack.find_or_initialize_by(playlist: playlist, track: track)
@@ -1992,30 +1838,30 @@ namespace :data do
     arcs_data = data["arcs"] || []
     missions_data = data["missions"] || []
 
-    # Pass 1: upsert arcs
-    arc_created = arc_updated = 0
+    # Pass 1: seed arcs (skip existing)
+    arc_created = 0
     arcs_data.each do |attrs|
       arc = GridMissionArc.find_or_initialize_by(slug: attrs["slug"])
-      was_new = arc.new_record?
+      next unless arc.new_record?
+
       arc.assign_attributes(
         name: attrs["name"],
         description: attrs["description"],
         position: attrs["position"] || 0,
         published: attrs.fetch("published", true)
       )
-      if arc.new_record? || arc.changed?
-        arc.save!
-        was_new ? (arc_created += 1) : (arc_updated += 1)
-        puts "  #{was_new ? "✓ Arc Created" : "↻ Arc Updated"}: #{arc.name}"
-      end
+      arc.save!
+      arc_created += 1
+      puts "  ✓ Arc Created: #{arc.name}"
     end
 
-    # Pass 2: upsert missions WITHOUT prereq (resolved in pass 3 so order
+    # Pass 2: seed missions WITHOUT prereq (resolved in pass 3 so order
     # in YAML doesn't matter — a mission can prereq a later-declared one).
-    mission_created = mission_updated = 0
+    mission_created = 0
+    new_mission_slugs = Set.new
     missions_data.each do |attrs|
       mission = GridMission.find_or_initialize_by(slug: attrs["slug"])
-      was_new = mission.new_record?
+      next unless mission.new_record?
 
       giver = if attrs["giver_mob_name"].present?
         query = GridMob.where("LOWER(name) = ?", attrs["giver_mob_name"].to_s.downcase)
@@ -2044,75 +1890,53 @@ namespace :data do
         position: attrs["position"] || 0,
         published: attrs.fetch("published", true)
       )
+      mission.save!
+      mission_created += 1
+      new_mission_slugs << attrs["slug"]
+      puts "  ✓ Mission Created: #{mission.name}"
 
-      if mission.new_record? || mission.changed?
-        mission.save!
-        was_new ? (mission_created += 1) : (mission_updated += 1)
-        puts "  #{was_new ? "✓ Mission Created" : "↻ Mission Updated"}: #{mission.name}"
-      end
-
-      # Reconcile objectives declaratively by position. Objectives not in
-      # YAML are removed (including the "empty list" case — fully
-      # clearing objectives from YAML deletes all existing rows so
-      # authors see the change reflected).
-      desired_obj_positions = (attrs["objectives"] || []).map { |o| o["position"].to_i }
-      mission.grid_mission_objectives.where.not(position: desired_obj_positions).destroy_all
-
+      # Seed objectives
       (attrs["objectives"] || []).each do |o|
-        pos = o["position"].to_i
-        objective = mission.grid_mission_objectives.find_or_initialize_by(position: pos)
-        objective.assign_attributes(
+        mission.grid_mission_objectives.create!(
+          position: o["position"].to_i,
           objective_type: o["objective_type"],
           label: o["label"],
           target_slug: o["target_slug"],
           target_count: o["target_count"] || 1
         )
-        objective.save! if objective.new_record? || objective.changed?
       end
 
-      # Rewards: same declarative reconcile by position. Matches
-      # factions/objectives idiom — upsert on `changed?`, destroy
-      # rows no longer in YAML. Avoids churn on idempotent re-runs.
-      desired_reward_positions = (attrs["rewards"] || []).each_with_index.map { |r, i| r["position"] || (i + 1) }
-      mission.grid_mission_rewards.where.not(position: desired_reward_positions).destroy_all
-
+      # Seed rewards
       (attrs["rewards"] || []).each_with_index do |r, i|
-        pos = r["position"] || (i + 1)
-        reward = mission.grid_mission_rewards.find_or_initialize_by(position: pos)
-        reward.assign_attributes(
+        mission.grid_mission_rewards.create!(
+          position: r["position"] || (i + 1),
           reward_type: r["reward_type"],
           amount: r["amount"] || 0,
           target_slug: r["target_slug"],
           quantity: r["quantity"] || 1
         )
-        reward.save! if reward.new_record? || reward.changed?
       end
     end
 
-    # Pass 3: reconcile prereq_mission_slug → prereq_mission_id declaratively.
-    # Handles three cases per mission:
-    #   1. YAML adds/changes prereq → resolve slug → set FK
-    #   2. YAML removes prereq → null out the FK (prevents stale prereq drift)
-    #   3. YAML references an unknown prereq slug → warn, leave existing FK
+    # Pass 3: resolve prereq_mission_slug → prereq_mission_id (only for newly created missions).
     missions_data.each do |attrs|
+      next unless new_mission_slugs.include?(attrs["slug"])
+      next unless attrs["prereq_mission_slug"].present?
+
       mission = GridMission.find_by(slug: attrs["slug"])
       next unless mission
 
-      desired_prereq_id = if attrs["prereq_mission_slug"].present?
-        prereq = GridMission.find_by(slug: attrs["prereq_mission_slug"])
-        unless prereq
-          puts "  ⚠ Mission '#{attrs["slug"]}': prereq '#{attrs["prereq_mission_slug"]}' not found — leaving existing FK"
-          next
-        end
-        prereq.id
+      prereq = GridMission.find_by(slug: attrs["prereq_mission_slug"])
+      unless prereq
+        puts "  ⚠ Mission '#{attrs["slug"]}': prereq '#{attrs["prereq_mission_slug"]}' not found"
+        next
       end
 
-      next if mission.prereq_mission_id == desired_prereq_id
-      mission.update!(prereq_mission_id: desired_prereq_id)
+      mission.update!(prereq_mission_id: prereq.id)
     end
 
-    puts "Arcs: #{arc_created} created, #{arc_updated} updated, #{GridMissionArc.count} total"
-    puts "Missions: #{mission_created} created, #{mission_updated} updated, #{GridMission.count} total"
+    puts "Arcs: #{arc_created} created, #{GridMissionArc.count} total"
+    puts "Missions: #{mission_created} created, #{GridMission.count} total"
   end
 end
 


### PR DESCRIPTION
  Stop YAML from clobbering admin edits; make the database the authoritative
  source for all entity data. YAML files remain as initial seed data for fresh
  environments but never overwrite existing records.

  data.rake → seed-only
  - All upsert patterns converted to skip existing records (find_or_initialize_by + new_record? guard). Join-table reconcile and stale-deletion sweeps removed.
  - Rep-link graph, mission objectives/rewards only seeded on new parent creation.
  - Header/descriptions updated from "Loading" to "Seeding".

  PaperTrail audit trail (replaces YAML version control)
  - Added has_paper_trail to 16 models (GridAchievement, GridFaction, GridFactionRepLink, GridItemDefinition, GridItem, GridSalvageYield, GridMission, GridMissionArc, GridMissionObjective, GridMissionReward, GridMob, GridRoom, GridZone, GridExit, GridShopListing, HackrLog). Total: 24 models now tracked. whodunnit already wired via current_hackr.

  Version history UI
  - Admin::Versionable concern with versionable class macro — adds history action with FK resolution, child association interleaving, and diff display.
  - Shared view at admin/shared/version_history.html.erb with TUI styling, striped rows, old→new diffs with color coding.
  - History buttons on all CRUD index pages and edit forms. Edit button on history page for quick navigation.

  Full admin CRUD (9 resources)
  - Upgraded from read-only: Artists, CodexEntries, HackrLogs, GridZones, GridRooms.
  - Added new/create: Releases, Tracks.
  - Brand new controllers + views: GridMobs, GridExits.
  - All wired with Versionable, history routes, destroy guards, nav links.