### PR TITLE
TOTP two-factor authentication + account disable controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@
 # Generate at: https://github.com/settings/tokens → "Generate new token (classic)"
 # HACKRTV_GITHUB_TOKEN=ghp_...
 
+# Active Record Encryption (TOTP secret storage)
+# Generate with: bin/rails db:encryption:init
+# ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
+# ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=
+# ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=
+
 # GridHackr account passwords (used in seeds)
 # XERAEN_PASSWORD=
 # RYKER_PASSWORD=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
           bin/rails db:migrate
 
       - name: Run RSpec tests
+        env:
+          ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY: ci-test-primary-key-not-real
+          ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY: ci-test-deterministic-key-00
+          ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: ci-test-derivation-salt-000
         run: bundle exec rspec
 
   test_frontend:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem "jbuilder"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.22"
 
+# TOTP two-factor authentication
+gem "rotp", "~> 6.3"
+gem "rqrcode", "~> 2.2"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       racc
     browser (6.2.0)
     builder (3.3.0)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -300,6 +301,11 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
+    rotp (6.3.0)
+    rqrcode (2.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -448,6 +454,8 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rails-controller-testing
   redcarpet
+  rotp (~> 6.3)
+  rqrcode (~> 2.2)
   rspec-rails (~> 8.0)
   shoulda-matchers (~> 7.0)
   solid_cable

--- a/app/controllers/admin/grid_controller.rb
+++ b/app/controllers/admin/grid_controller.rb
@@ -19,6 +19,42 @@ class Admin::GridController < Admin::ApplicationController
     redirect_to admin_grid_path
   end
 
+  def disable_login
+    hackr = GridHackr.find(params[:hackr_id])
+    if hackr.id == current_hackr.id
+      set_flash_error("Cannot disable your own login.")
+      return redirect_to admin_grid_path
+    end
+    hackr.update!(login_disabled: true)
+    set_flash_success("Login disabled for #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
+  end
+
+  def enable_login
+    hackr = GridHackr.find(params[:hackr_id])
+    hackr.update!(login_disabled: false)
+    set_flash_success("Login re-enabled for #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
+  end
+
+  def toggle_service_account
+    hackr = GridHackr.find(params[:hackr_id])
+    hackr.update!(service_account: !hackr.service_account?)
+    status = hackr.service_account? ? "enabled" : "disabled"
+    set_flash_success("Service account #{status} for #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
+  end
+
+  def reset_totp
+    hackr = GridHackr.find(params[:hackr_id])
+    Grid::TotpService.new(hackr).disable_admin!(acting_admin: current_hackr)
+    set_flash_success("2FA disabled for #{hackr.hackr_alias}.")
+    redirect_to admin_grid_path
+  rescue Grid::TotpService::NotEnabled
+    set_flash_error("#{hackr.hackr_alias} does not have 2FA enabled.")
+    redirect_to admin_grid_path
+  end
+
   def broadcast
     message = params[:message].to_s.strip
 

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -1,5 +1,6 @@
 class Api::GridController < ApplicationController
   include GridAuthentication
+  include GridSerialization
 
   before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
@@ -73,14 +74,7 @@ class Api::GridController < ApplicationController
   def current_hackr_info
     render json: {
       logged_in: true,
-      hackr: {
-        id: current_hackr.id,
-        hackr_alias: current_hackr.hackr_alias,
-        email: current_hackr.email,
-        role: current_hackr.role,
-        current_room: current_hackr.current_room ? room_json(current_hackr.current_room) : nil,
-        features: current_hackr.admin? ? [FeatureGrant::PULSE_GRID] : current_hackr.feature_grants.pluck(:feature)
-      }
+      hackr: auth_hackr_json(current_hackr)
     }
   end
 
@@ -89,15 +83,20 @@ class Api::GridController < ApplicationController
     hackr = GridHackr.find_by(hackr_alias: params[:hackr_alias])
 
     if hackr&.authenticate(params[:password])
-      # Ensure hackr has a current room (spawn point if missing)
-      if hackr.current_room.nil?
-        starting_room = GridRoom.joins(:grid_zone)
-          .where(grid_zones: {slug: "hackr-tv-central"})
-          .where(room_type: "hub")
-          .first
-        hackr.update!(current_room: starting_room) if starting_room
+      if hackr.login_disabled?
+        Rails.logger.warn("[AUTH] Login blocked (disabled): hackr_alias=#{hackr.hackr_alias} ip=#{request.remote_ip}")
+        return render json: {success: false, error: "This account has been disabled."}, status: :forbidden
       end
 
+      # 2FA gate: if TOTP enabled, defer login until code is verified
+      if hackr.otp_required_for_login?
+        session[:pending_2fa_hackr_id] = hackr.id
+        session[:pending_2fa_at] = Time.current.to_i
+        Rails.logger.info("[AUTH] 2FA required: hackr_alias=#{hackr.hackr_alias} ip=#{request.remote_ip}")
+        return render json: {success: true, requires_totp: true}
+      end
+
+      hackr.ensure_current_room!
       log_in(hackr)
       hackr.touch_activity!
       Grid::AchievementSweepJob.perform_later(hackr.id)
@@ -105,14 +104,7 @@ class Api::GridController < ApplicationController
       render json: {
         success: true,
         message: "Welcome back to THE PULSE GRID, #{hackr.hackr_alias}.",
-        hackr: {
-          id: hackr.id,
-          hackr_alias: hackr.hackr_alias,
-          email: hackr.email,
-          role: hackr.role,
-          current_room: hackr.current_room ? room_json(hackr.current_room) : nil,
-          features: hackr.admin? ? [FeatureGrant::PULSE_GRID] : hackr.feature_grants.pluck(:feature)
-        }
+        hackr: auth_hackr_json(hackr)
       }
     else
       attempted_alias = params[:hackr_alias].to_s.truncate(50)
@@ -224,19 +216,11 @@ class Api::GridController < ApplicationController
       password_confirmation: params[:password_confirmation]
     )
     @hackr.enforce_alias_length = true
-
-    # Set starting room (hackr.tv Broadcast Station)
-    starting_room = GridRoom.joins(:grid_zone)
-      .where(grid_zones: {slug: "hackr-tv-central"})
-      .where(room_type: "hub")
-      .first
-
-    @hackr.current_room = starting_room
-
     @hackr.registration_ip = request.remote_ip
 
     ActiveRecord::Base.transaction do
       if @hackr.save
+        @hackr.ensure_current_room!
         token.mark_used!
         @hackr.provision_economy!
         log_in(@hackr)
@@ -245,13 +229,7 @@ class Api::GridController < ApplicationController
         render json: {
           success: true,
           message: "Welcome to THE PULSE GRID, #{@hackr.hackr_alias}. Your journey with the Fracture Network begins now.",
-          hackr: {
-            id: @hackr.id,
-            hackr_alias: @hackr.hackr_alias,
-            role: @hackr.role,
-            current_room: @hackr.current_room ? room_json(@hackr.current_room) : nil,
-            features: @hackr.admin? ? [FeatureGrant::PULSE_GRID] : @hackr.feature_grants.pluck(:feature)
-          }
+          hackr: auth_hackr_json(@hackr)
         }, status: :created
       else
         Rails.logger.warn("[AUTH] Registration completion failed: email=#{token.email} errors=#{@hackr.errors.full_messages.join("; ")} ip=#{request.remote_ip}")

--- a/app/controllers/api/totp_controller.rb
+++ b/app/controllers/api/totp_controller.rb
@@ -1,0 +1,133 @@
+class Api::TotpController < ApplicationController
+  include GridAuthentication
+  include GridSerialization
+
+  before_action :require_login_api, only: %i[status setup enable disable regenerate_backup_codes]
+  before_action :require_admin_api, only: [:admin_reset]
+
+  # GET /api/totp/status
+  def status
+    service = Grid::TotpService.new(current_hackr)
+    render json: service.status
+  end
+
+  # POST /api/totp/setup
+  # Generates a new OTP secret + QR code. Does NOT persist or enable 2FA.
+  def setup
+    service = Grid::TotpService.new(current_hackr)
+    data = service.generate_setup_data
+
+    Rails.logger.info("[2FA] TOTP setup initiated: hackr_alias=#{current_hackr.hackr_alias} ip=#{request.remote_ip}")
+    render json: {
+      success: true,
+      secret: data[:secret],
+      qr_svg: data[:qr_svg]
+    }
+  rescue Grid::TotpService::AlreadyEnabled => e
+    render json: {success: false, error: e.message}, status: :unprocessable_entity
+  end
+
+  # POST /api/totp/enable
+  # Verifies a TOTP code against the staged secret, enables 2FA, returns backup codes.
+  def enable
+    service = Grid::TotpService.new(current_hackr)
+    backup_codes = service.enable!(
+      password: params[:password],
+      otp_secret: params[:otp_secret],
+      totp_code: params[:code]
+    )
+
+    Rails.logger.info("[2FA] TOTP enabled: hackr_alias=#{current_hackr.hackr_alias} ip=#{request.remote_ip}")
+    render json: {
+      success: true,
+      message: "Two-factor authentication enabled.",
+      backup_codes: backup_codes
+    }
+  rescue Grid::TotpService::InvalidPassword => e
+    render json: {success: false, error: e.message}, status: :unauthorized
+  rescue Grid::TotpService::InvalidCode, Grid::TotpService::AlreadyEnabled => e
+    render json: {success: false, error: e.message}, status: :unprocessable_entity
+  end
+
+  # POST /api/totp/verify
+  # Accepts a TOTP or backup code for pending-2FA session. Completes login.
+  def verify
+    hackr = pending_2fa_hackr
+    unless hackr
+      return render json: {success: false, error: "No pending authentication session."}, status: :unauthorized
+    end
+
+    if hackr.login_disabled?
+      clear_pending_2fa
+      return render json: {success: false, error: "This account has been disabled."}, status: :forbidden
+    end
+
+    service = Grid::TotpService.new(hackr)
+    method = service.verify!(params[:code])
+
+    clear_pending_2fa
+
+    hackr.ensure_current_room!
+    log_in(hackr)
+    hackr.touch_activity!
+    Grid::AchievementSweepJob.perform_later(hackr.id)
+
+    Rails.logger.info("[2FA] Login completed (#{method}): hackr_alias=#{hackr.hackr_alias} ip=#{request.remote_ip}")
+    render json: {
+      success: true,
+      message: "Welcome back to THE PULSE GRID, #{hackr.hackr_alias}.",
+      hackr: auth_hackr_json(hackr)
+    }
+  rescue Grid::TotpService::InvalidCode
+    Rails.logger.warn("[2FA] TOTP verify failed: ip=#{request.remote_ip}")
+    render json: {success: false, error: "Invalid code. Access denied."}, status: :unauthorized
+  end
+
+  # DELETE /api/totp/disable
+  # Requires password + valid TOTP code.
+  def disable
+    service = Grid::TotpService.new(current_hackr)
+    service.disable!(password: params[:password], totp_code: params[:code])
+
+    Rails.logger.info("[2FA] TOTP disabled: hackr_alias=#{current_hackr.hackr_alias} ip=#{request.remote_ip}")
+    render json: {success: true, message: "Two-factor authentication disabled."}
+  rescue Grid::TotpService::InvalidPassword => e
+    render json: {success: false, error: e.message}, status: :unauthorized
+  rescue Grid::TotpService::InvalidCode, Grid::TotpService::NotEnabled => e
+    render json: {success: false, error: e.message}, status: :unprocessable_entity
+  end
+
+  # POST /api/totp/regenerate_backup_codes
+  # Requires password + valid TOTP code. Flushes old codes.
+  def regenerate_backup_codes
+    service = Grid::TotpService.new(current_hackr)
+    backup_codes = service.regenerate_backup_codes!(password: params[:password], totp_code: params[:code])
+
+    Rails.logger.info("[2FA] Backup codes regenerated: hackr_alias=#{current_hackr.hackr_alias} ip=#{request.remote_ip}")
+    render json: {
+      success: true,
+      message: "Backup codes regenerated. Old codes are now invalid.",
+      backup_codes: backup_codes
+    }
+  rescue Grid::TotpService::InvalidPassword => e
+    render json: {success: false, error: e.message}, status: :unauthorized
+  rescue Grid::TotpService::InvalidCode, Grid::TotpService::NotEnabled => e
+    render json: {success: false, error: e.message}, status: :unprocessable_entity
+  end
+
+  # POST /api/totp/admin_reset
+  # Admin-only: clears 2FA for a target hackr.
+  def admin_reset
+    target = GridHackr.find_by(hackr_alias: params[:hackr_alias])
+    unless target
+      return render json: {success: false, error: "Hackr not found."}, status: :not_found
+    end
+
+    service = Grid::TotpService.new(target)
+    service.disable_admin!(acting_admin: current_hackr)
+
+    render json: {success: true, message: "2FA cleared for #{target.hackr_alias}."}
+  rescue Grid::TotpService::NotEnabled => e
+    render json: {success: false, error: e.message}, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/concerns/grid_authentication.rb
+++ b/app/controllers/concerns/grid_authentication.rb
@@ -31,12 +31,25 @@ module GridAuthentication
     if hackr.nil?
       token_prefix = (token.length > 8) ? "#{token[0, 8]}..." : token
       Rails.logger.warn("[AUTH] Invalid API token: alias=#{hackr_alias} token_prefix=#{token_prefix} ip=#{request.remote_ip}")
+      return nil
     end
+
+    if hackr.login_disabled? && !hackr.service_account?
+      Rails.logger.warn("[AUTH] API token rejected (disabled): alias=#{hackr_alias} ip=#{request.remote_ip}")
+      return nil
+    end
+
     hackr
   end
 
   def session_hackr
-    GridHackr.find_by(id: session[:grid_hackr_id]) if session[:grid_hackr_id]
+    return nil unless session[:grid_hackr_id]
+    hackr = GridHackr.find_by(id: session[:grid_hackr_id])
+    if hackr&.login_disabled?
+      log_out
+      return nil
+    end
+    hackr
   end
 
   public
@@ -57,8 +70,25 @@ module GridAuthentication
 
   def log_out
     session.delete(:grid_hackr_id)
+    session.delete(:pending_2fa_hackr_id)
     cookies.delete(:grid_hackr_id)
     @current_hackr = nil
+  end
+
+  PENDING_2FA_EXPIRY = 10.minutes
+
+  def pending_2fa_hackr
+    return nil unless session[:pending_2fa_hackr_id]
+    if session[:pending_2fa_at] && Time.current.to_i - session[:pending_2fa_at].to_i > PENDING_2FA_EXPIRY.to_i
+      clear_pending_2fa
+      return nil
+    end
+    GridHackr.find_by(id: session[:pending_2fa_hackr_id])
+  end
+
+  def clear_pending_2fa
+    session.delete(:pending_2fa_hackr_id)
+    session.delete(:pending_2fa_at)
   end
 
   # Authorization filters

--- a/app/controllers/concerns/grid_serialization.rb
+++ b/app/controllers/concerns/grid_serialization.rb
@@ -1,0 +1,25 @@
+module GridSerialization
+  extend ActiveSupport::Concern
+
+  private
+
+  def auth_hackr_json(hackr)
+    {
+      id: hackr.id,
+      hackr_alias: hackr.hackr_alias,
+      email: hackr.email,
+      role: hackr.role,
+      current_room: hackr.current_room ? auth_room_json(hackr.current_room) : nil,
+      features: hackr.admin? ? [FeatureGrant::PULSE_GRID] : hackr.feature_grants.pluck(:feature),
+      otp_enabled: hackr.otp_required_for_login?
+    }
+  end
+
+  def auth_room_json(room)
+    {
+      id: room.id,
+      name: room.name,
+      description: room.description
+    }
+  end
+end

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -32,6 +32,7 @@ const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegister
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
 const ForgotPasswordPage = lazy(() => import('~/components/pages/grid/ForgotPasswordPage').then(m => ({ default: m.ForgotPasswordPage })))
 const IdentityPage = lazy(() => import('~/components/pages/grid/IdentityPage').then(m => ({ default: m.IdentityPage })))
+const TwoFactorPage = lazy(() => import('~/components/pages/grid/TwoFactorPage'))
 const ResetPasswordPage = lazy(() => import('~/components/pages/grid/ResetPasswordPage').then(m => ({ default: m.ResetPasswordPage })))
 const GridConfirmEmailChangePage = lazy(() => import('~/components/pages/grid/GridConfirmEmailChangePage').then(m => ({ default: m.GridConfirmEmailChangePage })))
 const LogsIndexPage = lazy(() => import('~/components/pages/logs/LogsIndexPage').then(m => ({ default: m.LogsIndexPage })))
@@ -110,6 +111,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/grid/forgot_password" element={<ForgotPasswordPage />} />
           <Route path="/grid/verify/:token" element={<GridVerifyPage />} />
           <Route path="/grid/identity" element={<ProtectedRoute><IdentityPage /></ProtectedRoute>} />
+          <Route path="/grid/identity/two-factor" element={<ProtectedRoute><TwoFactorPage /></ProtectedRoute>} />
           <Route path="/grid/reset_password/:token" element={<ResetPasswordPage />} />
           <Route path="/grid/confirm_email_change/:token" element={<GridConfirmEmailChangePage />} />
           {/* Hackr Logs routes */}

--- a/app/javascript/components/pages/grid/GridLoginPage.tsx
+++ b/app/javascript/components/pages/grid/GridLoginPage.tsx
@@ -2,13 +2,17 @@ import React, { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { GridLayout } from '~/components/layouts/GridLayout'
 import { useGridAuth } from '~/hooks/useGridAuth'
+import { useGridAuthContext } from '~/contexts/GridAuthContext'
 
 export const GridLoginPage: React.FC = () => {
   const [hackrAlias, setHackrAlias] = useState('')
   const [password, setPassword] = useState('')
+  const [totpCode, setTotpCode] = useState('')
+  const [totpRequired, setTotpRequired] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const { login } = useGridAuth()
+  const { verifyTotp } = useGridAuthContext()
   const navigate = useNavigate()
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -18,10 +22,28 @@ export const GridLoginPage: React.FC = () => {
 
     const result = await login(hackrAlias, password)
 
-    if (result.success) {
+    if (result.requires_totp) {
+      setTotpRequired(true)
+    } else if (result.success) {
       navigate('/grid')
     } else {
       setError(result.error || 'Login failed')
+    }
+
+    setLoading(false)
+  }
+
+  const handleTotpSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const result = await verifyTotp(totpCode)
+
+    if (result.success) {
+      navigate('/grid')
+    } else {
+      setError(result.error || 'Invalid code')
     }
 
     setLoading(false)
@@ -44,56 +66,96 @@ export const GridLoginPage: React.FC = () => {
             <h1 className="cyan-255-text" style={{ fontSize: '2.5em', letterSpacing: '0.1em', margin: 0 }}>
               THE PULSE GRID
             </h1>
-            <p style={{ margin: '10px 0', fontSize: '1.2em' }}>FRACTURE NETWORK LOGIN</p>
+            <p style={{ margin: '10px 0', fontSize: '1.2em' }}>
+              {totpRequired ? 'TWO-FACTOR VERIFICATION' : 'FRACTURE NETWORK LOGIN'}
+            </p>
           </div>
 
-          <form onSubmit={handleSubmit}>
-            <div style={{ marginBottom: '20px' }}>
-              <label htmlFor="hackr_alias" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
-                HACKR ALIAS
-              </label>
-              <input
-                type="text"
-                id="hackr_alias"
-                value={hackrAlias}
-                onChange={(e) => setHackrAlias(e.target.value)}
-                className="tui-input"
-                placeholder="Enter your alias"
-                required
-                autoFocus
-                disabled={loading}
-                style={{ width: '100%' }}
-              />
-            </div>
+          {totpRequired ? (
+            <form onSubmit={handleTotpSubmit}>
+              <div style={{ marginBottom: '20px' }}>
+                <label htmlFor="totp_code" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                  AUTHENTICATION CODE
+                </label>
+                <input
+                  type="text"
+                  id="totp_code"
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value)}
+                  className="tui-input"
+                  placeholder="6-digit code or backup code"
+                  maxLength={10}
+                  autoComplete="one-time-code"
+                  autoFocus
+                  required
+                  disabled={loading}
+                  style={{ width: '100%' }}
+                />
+                <p style={{ margin: '8px 0 0 0', fontSize: '0.85em', color: '#888' }}>
+                  Enter the code from your authenticator app, or a backup code.
+                </p>
+              </div>
 
-            <div style={{ marginBottom: '20px' }}>
-              <label htmlFor="password" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
-                PASSWORD
-              </label>
-              <input
-                type="password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="tui-input"
-                placeholder="Enter password"
-                required
-                disabled={loading}
-                style={{ width: '100%' }}
-              />
-            </div>
+              <div className="center" style={{ margin: '30px 0' }}>
+                <button
+                  type="submit"
+                  className="tui-button purple-168"
+                  disabled={loading}
+                  style={{ fontSize: '1.1em', padding: '10px 30px' }}
+                >
+                  {loading ? 'VERIFYING...' : 'VERIFY'}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <form onSubmit={handleSubmit}>
+              <div style={{ marginBottom: '20px' }}>
+                <label htmlFor="hackr_alias" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                  HACKR ALIAS
+                </label>
+                <input
+                  type="text"
+                  id="hackr_alias"
+                  value={hackrAlias}
+                  onChange={(e) => setHackrAlias(e.target.value)}
+                  className="tui-input"
+                  placeholder="Enter your alias"
+                  required
+                  autoFocus
+                  disabled={loading}
+                  style={{ width: '100%' }}
+                />
+              </div>
 
-            <div className="center" style={{ margin: '30px 0' }}>
-              <button
-                type="submit"
-                className="tui-button purple-168"
-                disabled={loading}
-                style={{ fontSize: '1.1em', padding: '10px 30px' }}
-              >
-                {loading ? 'CONNECTING...' : 'CONNECT'}
-              </button>
-            </div>
-          </form>
+              <div style={{ marginBottom: '20px' }}>
+                <label htmlFor="password" className="white-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+                  PASSWORD
+                </label>
+                <input
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="tui-input"
+                  placeholder="Enter password"
+                  required
+                  disabled={loading}
+                  style={{ width: '100%' }}
+                />
+              </div>
+
+              <div className="center" style={{ margin: '30px 0' }}>
+                <button
+                  type="submit"
+                  className="tui-button purple-168"
+                  disabled={loading}
+                  style={{ fontSize: '1.1em', padding: '10px 30px' }}
+                >
+                  {loading ? 'CONNECTING...' : 'CONNECT'}
+                </button>
+              </div>
+            </form>
+          )}
 
           <hr style={{ borderColor: '#00ffff', margin: '30px 0' }} />
 

--- a/app/javascript/components/pages/grid/IdentityPage.tsx
+++ b/app/javascript/components/pages/grid/IdentityPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { GridLayout } from '~/components/layouts/GridLayout'
 import { useGridAuth } from '~/hooks/useGridAuth'
 import { useGridAuthContext } from '~/contexts/GridAuthContext'
@@ -122,6 +123,34 @@ export const IdentityPage: React.FC = () => {
                 {emailMessage}
               </p>
             )}
+          </div>
+
+          <div style={{ margin: '20px 0', padding: '15px', border: '1px solid #4a4a6a' }}>
+            <p className="cyan-255-text" style={{ margin: '0 0 15px 0', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+              TWO-FACTOR AUTHENTICATION
+            </p>
+            <p style={{ margin: '0 0 15px 0' }}>
+              {hackr?.otp_enabled
+                ? <span style={{ color: '#00ff00' }}>[ ACTIVE ]</span>
+                : <span style={{ color: '#888' }}>[ INACTIVE ]</span>
+              }
+            </p>
+            <Link
+              to="/grid/identity/two-factor"
+              className="tui-button"
+              style={{
+                background: '#00ff00',
+                color: '#0a0a0a',
+                border: 'none',
+                padding: '10px 20px',
+                fontFamily: '\'Courier New\', monospace',
+                fontWeight: 'bold',
+                textDecoration: 'none',
+                display: 'inline-block'
+              }}
+            >
+              MANAGE 2FA
+            </Link>
           </div>
 
           <div className="center" style={{ margin: '30px 0' }}>

--- a/app/javascript/components/pages/grid/TwoFactorPage.tsx
+++ b/app/javascript/components/pages/grid/TwoFactorPage.tsx
@@ -1,0 +1,552 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { GridLayout } from '~/components/layouts/GridLayout'
+import { useGridAuthContext } from '~/contexts/GridAuthContext'
+
+type Phase = 'loading' | 'disabled' | 'setup' | 'confirm' | 'backup_codes' | 'enabled' | 'disable' | 'regenerate'
+
+export const TwoFactorPage: React.FC = () => {
+  const { hackr, totpSetup, totpEnable, totpDisable, totpStatus, checkAuth, regenerateBackupCodes } = useGridAuthContext()
+
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  // Setup phase state
+  const [secret, setSecret] = useState('')
+  const [qrSvg, setQrSvg] = useState('')
+  const [password, setPassword] = useState('')
+  const [code, setCode] = useState('')
+
+  // Backup codes (shown once)
+  const [backupCodes, setBackupCodes] = useState<string[]>([])
+  const [backupCodesRemaining, setBackupCodesRemaining] = useState(0)
+
+  // Disable phase state
+  const [disablePassword, setDisablePassword] = useState('')
+  const [disableCode, setDisableCode] = useState('')
+
+  // Regenerate phase state
+  const [regenPassword, setRegenPassword] = useState('')
+  const [regenCode, setRegenCode] = useState('')
+
+  useEffect(() => {
+    totpStatus().then(status => {
+      if (status.enabled) {
+        setBackupCodesRemaining(status.backup_codes_remaining)
+        setPhase('enabled')
+      } else {
+        setPhase('disabled')
+      }
+    })
+  }, [totpStatus])
+
+  const handleSetup = async () => {
+    setError(null)
+    setLoading(true)
+
+    const result = await totpSetup()
+    if (result.success && result.secret && result.qr_svg) {
+      setSecret(result.secret)
+      setQrSvg(result.qr_svg)
+      setPhase('setup')
+    } else {
+      setError(result.error || 'Setup failed.')
+    }
+
+    setLoading(false)
+  }
+
+  const handleEnable = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const result = await totpEnable(password, secret, code)
+    if (result.success && result.backup_codes) {
+      setBackupCodes(result.backup_codes)
+      setPhase('backup_codes')
+      setPassword('')
+      setCode('')
+    } else {
+      setError(result.error || 'Enable failed.')
+    }
+
+    setLoading(false)
+  }
+
+  const handleBackupCodesSaved = async () => {
+    setBackupCodes([])
+    await checkAuth()
+    const status = await totpStatus()
+    setBackupCodesRemaining(status.backup_codes_remaining)
+    setPhase('enabled')
+  }
+
+  const handleDisable = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const result = await totpDisable(disablePassword, disableCode)
+    if (result.success) {
+      setMessage('Two-factor authentication disabled.')
+      setDisablePassword('')
+      setDisableCode('')
+      await checkAuth()
+      setPhase('disabled')
+    } else {
+      setError(result.error || 'Disable failed.')
+    }
+
+    setLoading(false)
+  }
+
+  const handleRegenerate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    const result = await regenerateBackupCodes(regenPassword, regenCode)
+    if (result.success && result.backup_codes) {
+      setBackupCodes(result.backup_codes)
+      setRegenPassword('')
+      setRegenCode('')
+      setPhase('backup_codes')
+    } else {
+      setError(result.error || 'Regeneration failed.')
+    }
+
+    setLoading(false)
+  }
+
+  return (
+    <GridLayout>
+      <div className="tui-window white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block', background: '#1a1a2e', border: '1px solid #4a4a6a' }}>
+        <fieldset style={{ borderColor: '#4a4a6a' }}>
+          <legend className="center">TWO-FACTOR AUTH</legend>
+
+          <div className="center" style={{ margin: '30px 0' }}>
+            <h1 className="cyan-255-text" style={{ fontSize: '2em', letterSpacing: '0.1em', margin: 0 }}>
+              TWO-FACTOR AUTHENTICATION
+            </h1>
+            <p style={{ margin: '10px 0', fontSize: '1em' }}>
+              HACKR: {hackr?.hackr_alias}
+            </p>
+          </div>
+
+          {error && (
+            <div style={{ background: '#330000', border: '1px solid #ff4444', padding: '10px', margin: '0 0 20px 0' }}>
+              <p style={{ margin: 0, color: '#ff4444' }}>{error}</p>
+            </div>
+          )}
+
+          {message && (
+            <p style={{ color: '#00ff00', margin: '0 0 20px 0' }}>{message}</p>
+          )}
+
+          {/* --- LOADING --- */}
+          {phase === 'loading' && (
+            <div className="center" style={{ padding: '30px 0' }}>
+              <p>Loading 2FA status...</p>
+            </div>
+          )}
+
+          {/* --- DISABLED: Show enable button --- */}
+          {phase === 'disabled' && (
+            <div style={{ padding: '15px', border: '1px solid #4a4a6a', margin: '20px 0' }}>
+              <p style={{ margin: '0 0 15px 0' }}>
+                <span className="cyan-255-text">STATUS:</span> INACTIVE
+              </p>
+              <p style={{ margin: '0 0 20px 0', color: '#aaa', fontSize: '0.9em' }}>
+                Add an extra layer of security to your account. You will need an authenticator app
+                (Google Authenticator, Authy, or similar).
+              </p>
+              <div className="center">
+                <button
+                  onClick={handleSetup}
+                  disabled={loading}
+                  className="tui-button"
+                  style={{
+                    background: '#00ff00',
+                    color: '#0a0a0a',
+                    border: 'none',
+                    padding: '10px 30px',
+                    fontFamily: '\'Courier New\', monospace',
+                    fontWeight: 'bold',
+                    cursor: loading ? 'not-allowed' : 'pointer',
+                    opacity: loading ? 0.6 : 1
+                  }}
+                >
+                  {loading ? 'GENERATING...' : 'ENABLE TWO-FACTOR AUTH'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* --- SETUP: Show QR code and secret --- */}
+          {phase === 'setup' && (
+            <div style={{ padding: '15px', border: '1px solid #4a4a6a', margin: '20px 0' }}>
+              <p className="cyan-255-text" style={{ margin: '0 0 15px 0', fontWeight: 'bold' }}>
+                STEP 1: SCAN QR CODE
+              </p>
+              <p style={{ margin: '0 0 15px 0', color: '#aaa', fontSize: '0.9em' }}>
+                Scan this QR code with your authenticator app:
+              </p>
+
+              <div className="center" style={{ margin: '20px 0', background: '#fff', padding: '15px', display: 'inline-block' }}>
+                <div dangerouslySetInnerHTML={{ __html: qrSvg }} style={{ lineHeight: 0 }} />
+              </div>
+
+              <p style={{ margin: '20px 0 5px 0', color: '#aaa', fontSize: '0.85em' }}>
+                Or enter this secret manually:
+              </p>
+              <div style={{ background: '#0a0a1a', padding: '10px', border: '1px solid #4a4a6a', fontFamily: '\'Courier New\', monospace', letterSpacing: '0.15em', wordBreak: 'break-all' }}>
+                {secret}
+              </div>
+
+              <p className="cyan-255-text" style={{ margin: '25px 0 15px 0', fontWeight: 'bold' }}>
+                STEP 2: VERIFY CODE
+              </p>
+
+              <form onSubmit={handleEnable}>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="2fa_password" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    CONFIRM PASSWORD
+                  </label>
+                  <input
+                    type="password"
+                    id="2fa_password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="tui-input"
+                    placeholder="Enter your password"
+                    required
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="2fa_code" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    AUTHENTICATOR CODE
+                  </label>
+                  <input
+                    type="text"
+                    id="2fa_code"
+                    value={code}
+                    onChange={(e) => setCode(e.target.value)}
+                    className="tui-input"
+                    placeholder="6-digit code"
+                    maxLength={6}
+                    autoComplete="one-time-code"
+                    required
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div className="center" style={{ margin: '20px 0' }}>
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="tui-button"
+                    style={{
+                      background: '#00ff00',
+                      color: '#0a0a0a',
+                      border: 'none',
+                      padding: '10px 30px',
+                      fontFamily: '\'Courier New\', monospace',
+                      fontWeight: 'bold',
+                      cursor: loading ? 'not-allowed' : 'pointer',
+                      opacity: loading ? 0.6 : 1
+                    }}
+                  >
+                    {loading ? 'VERIFYING...' : 'ACTIVATE 2FA'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setPhase('disabled'); setError(null) }}
+                    style={{
+                      background: 'transparent',
+                      color: '#888',
+                      border: '1px solid #4a4a6a',
+                      padding: '10px 20px',
+                      fontFamily: '\'Courier New\', monospace',
+                      cursor: 'pointer',
+                      marginLeft: '10px'
+                    }}
+                  >
+                    CANCEL
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          {/* --- BACKUP CODES: Show once after enable --- */}
+          {phase === 'backup_codes' && (
+            <div style={{ padding: '15px', border: '1px solid #4a4a6a', margin: '20px 0' }}>
+              <div style={{ background: '#331100', border: '1px solid #ff8800', padding: '10px', marginBottom: '20px' }}>
+                <p style={{ margin: 0, color: '#ff8800', fontWeight: 'bold' }}>
+                  ⚠ SAVE THESE BACKUP CODES — SHOWN ONCE ONLY
+                </p>
+                <p style={{ margin: '5px 0 0 0', color: '#ffaa44', fontSize: '0.85em' }}>
+                  If you lose access to your authenticator app, use these codes to log in.
+                  Each code can only be used once.
+                </p>
+              </div>
+
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '8px',
+                background: '#0a0a1a',
+                padding: '15px',
+                border: '1px solid #4a4a6a',
+                fontFamily: '\'Courier New\', monospace',
+                fontSize: '1.1em',
+                letterSpacing: '0.1em'
+              }}>
+                {backupCodes.map((code, i) => (
+                  <div key={i} style={{ padding: '5px 0' }}>
+                    {code}
+                  </div>
+                ))}
+              </div>
+
+              <div className="center" style={{ margin: '25px 0 10px 0' }}>
+                <button
+                  onClick={handleBackupCodesSaved}
+                  className="tui-button"
+                  style={{
+                    background: '#00ff00',
+                    color: '#0a0a0a',
+                    border: 'none',
+                    padding: '10px 30px',
+                    fontFamily: '\'Courier New\', monospace',
+                    fontWeight: 'bold',
+                    cursor: 'pointer'
+                  }}
+                >
+                  I HAVE SAVED THESE CODES
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* --- ENABLED: Show status + disable option --- */}
+          {phase === 'enabled' && (
+            <div style={{ padding: '15px', border: '1px solid #4a4a6a', margin: '20px 0' }}>
+              <p style={{ margin: '0 0 10px 0' }}>
+                <span className="cyan-255-text">STATUS:</span>{' '}
+                <span style={{ color: '#00ff00' }}>ACTIVE</span>
+              </p>
+              <p style={{ margin: '0 0 20px 0' }}>
+                <span className="cyan-255-text">BACKUP CODES REMAINING:</span> {backupCodesRemaining}
+              </p>
+
+              <div className="center" style={{ display: 'flex', gap: '10px', justifyContent: 'center', flexWrap: 'wrap' }}>
+                <button
+                  onClick={() => { setPhase('regenerate'); setError(null); setMessage(null) }}
+                  style={{
+                    background: 'transparent',
+                    color: '#00ffff',
+                    border: '1px solid #00ffff',
+                    padding: '10px 20px',
+                    fontFamily: '\'Courier New\', monospace',
+                    fontWeight: 'bold',
+                    cursor: 'pointer'
+                  }}
+                >
+                  REGENERATE BACKUP CODES
+                </button>
+                <button
+                  onClick={() => { setPhase('disable'); setError(null); setMessage(null) }}
+                  style={{
+                    background: 'transparent',
+                    color: '#ff4444',
+                    border: '1px solid #ff4444',
+                    padding: '10px 20px',
+                    fontFamily: '\'Courier New\', monospace',
+                    fontWeight: 'bold',
+                    cursor: 'pointer'
+                  }}
+                >
+                  DISABLE TWO-FACTOR AUTH
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* --- REGENERATE: Password + TOTP confirmation --- */}
+          {phase === 'regenerate' && (
+            <div style={{ padding: '15px', border: '1px solid #00ffff', margin: '20px 0' }}>
+              <p className="cyan-255-text" style={{ margin: '0 0 10px 0', fontWeight: 'bold' }}>
+                REGENERATE BACKUP CODES
+              </p>
+              <p style={{ margin: '0 0 15px 0', color: '#aaa', fontSize: '0.9em' }}>
+                This will invalidate all existing backup codes and generate 8 new ones.
+              </p>
+              <form onSubmit={handleRegenerate}>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="regen_password" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    PASSWORD
+                  </label>
+                  <input
+                    type="password"
+                    id="regen_password"
+                    value={regenPassword}
+                    onChange={(e) => setRegenPassword(e.target.value)}
+                    className="tui-input"
+                    placeholder="Enter your password"
+                    required
+                    autoFocus
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="regen_code" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    AUTHENTICATOR CODE
+                  </label>
+                  <input
+                    type="text"
+                    id="regen_code"
+                    value={regenCode}
+                    onChange={(e) => setRegenCode(e.target.value)}
+                    className="tui-input"
+                    placeholder="6-digit code"
+                    maxLength={6}
+                    autoComplete="one-time-code"
+                    required
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div className="center" style={{ margin: '20px 0' }}>
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    className="tui-button"
+                    style={{
+                      background: '#00ffff',
+                      color: '#0a0a0a',
+                      border: 'none',
+                      padding: '10px 30px',
+                      fontFamily: '\'Courier New\', monospace',
+                      fontWeight: 'bold',
+                      cursor: loading ? 'not-allowed' : 'pointer',
+                      opacity: loading ? 0.6 : 1
+                    }}
+                  >
+                    {loading ? 'REGENERATING...' : 'REGENERATE CODES'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setPhase('enabled'); setError(null) }}
+                    style={{
+                      background: 'transparent',
+                      color: '#888',
+                      border: '1px solid #4a4a6a',
+                      padding: '10px 20px',
+                      fontFamily: '\'Courier New\', monospace',
+                      cursor: 'pointer',
+                      marginLeft: '10px'
+                    }}
+                  >
+                    CANCEL
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          {/* --- DISABLE: Password + TOTP confirmation --- */}
+          {phase === 'disable' && (
+            <div style={{ padding: '15px', border: '1px solid #ff4444', margin: '20px 0' }}>
+              <p className="cyan-255-text" style={{ margin: '0 0 15px 0', fontWeight: 'bold' }}>
+                DISABLE TWO-FACTOR AUTHENTICATION
+              </p>
+              <form onSubmit={handleDisable}>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="disable_password" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    PASSWORD
+                  </label>
+                  <input
+                    type="password"
+                    id="disable_password"
+                    value={disablePassword}
+                    onChange={(e) => setDisablePassword(e.target.value)}
+                    className="tui-input"
+                    placeholder="Enter your password"
+                    required
+                    autoFocus
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div style={{ marginBottom: '15px' }}>
+                  <label htmlFor="disable_code" className="white-text" style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold', fontSize: '0.9em' }}>
+                    AUTHENTICATOR CODE
+                  </label>
+                  <input
+                    type="text"
+                    id="disable_code"
+                    value={disableCode}
+                    onChange={(e) => setDisableCode(e.target.value)}
+                    className="tui-input"
+                    placeholder="6-digit code"
+                    maxLength={6}
+                    autoComplete="one-time-code"
+                    required
+                    disabled={loading}
+                    style={{ width: '100%' }}
+                  />
+                </div>
+                <div className="center" style={{ margin: '20px 0' }}>
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    style={{
+                      background: '#ff4444',
+                      color: '#fff',
+                      border: 'none',
+                      padding: '10px 30px',
+                      fontFamily: '\'Courier New\', monospace',
+                      fontWeight: 'bold',
+                      cursor: loading ? 'not-allowed' : 'pointer',
+                      opacity: loading ? 0.6 : 1
+                    }}
+                  >
+                    {loading ? 'DISABLING...' : 'CONFIRM DISABLE'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setPhase('enabled'); setError(null) }}
+                    style={{
+                      background: 'transparent',
+                      color: '#888',
+                      border: '1px solid #4a4a6a',
+                      padding: '10px 20px',
+                      fontFamily: '\'Courier New\', monospace',
+                      cursor: 'pointer',
+                      marginLeft: '10px'
+                    }}
+                  >
+                    CANCEL
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          <div className="center" style={{ margin: '20px 0' }}>
+            <Link to="/grid/identity" style={{ color: '#00ffff' }}>← BACK TO IDENTITY</Link>
+          </div>
+        </fieldset>
+      </div>
+    </GridLayout>
+  )
+}
+
+export default TwoFactorPage

--- a/app/javascript/contexts/GridAuthContext.tsx
+++ b/app/javascript/contexts/GridAuthContext.tsx
@@ -8,6 +8,7 @@ export interface GridHackr {
   role: string
   current_room: GridRoom | null
   features: string[]
+  otp_enabled?: boolean
 }
 
 export interface GridRoom {
@@ -21,6 +22,26 @@ interface LoginResponse {
   message?: string
   error?: string
   hackr?: GridHackr
+  requires_totp?: boolean
+}
+
+interface TotpSetupResponse {
+  success: boolean
+  secret?: string
+  qr_svg?: string
+  error?: string
+}
+
+interface TotpEnableResponse {
+  success: boolean
+  backup_codes?: string[]
+  message?: string
+  error?: string
+}
+
+interface TotpStatusResponse {
+  enabled: boolean
+  backup_codes_remaining: number
 }
 
 interface RegisterResponse {
@@ -102,6 +123,12 @@ interface GridAuthContextType {
   disconnect: () => Promise<{ success: boolean; error?: string }>
   checkAuth: () => Promise<void>
   hasFeature: (feature: string) => boolean
+  totpSetup: () => Promise<TotpSetupResponse>
+  totpEnable: (password: string, otp_secret: string, code: string) => Promise<TotpEnableResponse>
+  totpDisable: (password: string, code: string) => Promise<{ success: boolean; error?: string; message?: string }>
+  verifyTotp: (code: string) => Promise<LoginResponse>
+  totpStatus: () => Promise<TotpStatusResponse>
+  regenerateBackupCodes: (password: string, code: string) => Promise<TotpEnableResponse>
 }
 
 const GridAuthContext = createContext<GridAuthContextType | null>(null)
@@ -392,6 +419,79 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     }
   }, [])
 
+  const totpSetup = useCallback(async (): Promise<TotpSetupResponse> => {
+    try {
+      return await apiJson<TotpSetupResponse>('/api/totp/setup', { method: 'POST' })
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Setup failed.'
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const totpEnable = useCallback(async (password: string, otp_secret: string, code: string): Promise<TotpEnableResponse> => {
+    try {
+      return await apiJson<TotpEnableResponse>('/api/totp/enable', {
+        method: 'POST',
+        body: JSON.stringify({ password, otp_secret, code })
+      })
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Enable failed.'
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const totpDisable = useCallback(async (password: string, code: string): Promise<{ success: boolean; error?: string; message?: string }> => {
+    try {
+      return await apiJson<{ success: boolean; error?: string; message?: string }>('/api/totp/disable', {
+        method: 'DELETE',
+        body: JSON.stringify({ password, code })
+      })
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Disable failed.'
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const verifyTotp = useCallback(async (code: string): Promise<LoginResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<LoginResponse>('/api/totp/verify', {
+        method: 'POST',
+        body: JSON.stringify({ code })
+      })
+      if (data.success && data.hackr) {
+        setHackr(data.hackr)
+        return data
+      }
+      setError(data.error || 'Verification failed')
+      return data
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Verification failed.'
+      setError(errorMsg)
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const regenerateBackupCodes = useCallback(async (password: string, code: string): Promise<TotpEnableResponse> => {
+    try {
+      return await apiJson<TotpEnableResponse>('/api/totp/regenerate_backup_codes', {
+        method: 'POST',
+        body: JSON.stringify({ password, code })
+      })
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Regeneration failed.'
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
+  const totpStatus = useCallback(async (): Promise<TotpStatusResponse> => {
+    try {
+      return await apiJson<TotpStatusResponse>('/api/totp/status')
+    } catch {
+      return { enabled: false, backup_codes_remaining: 0 }
+    }
+  }, [])
+
   const value: GridAuthContextType = {
     hackr,
     loading,
@@ -409,7 +509,13 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     confirmEmailChange,
     disconnect,
     checkAuth,
-    hasFeature
+    hasFeature,
+    totpSetup,
+    totpEnable,
+    totpDisable,
+    verifyTotp,
+    totpStatus,
+    regenerateBackupCodes
   }
 
   return (

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -3,18 +3,24 @@
 # Table name: grid_hackrs
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  api_token_digest :string
-#  email            :string
-#  hackr_alias      :string
-#  last_activity_at :datetime
-#  password_digest  :string
-#  registration_ip  :string
-#  role             :string
-#  stats            :json
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  current_room_id  :integer
+#  id                      :integer          not null, primary key
+#  api_token_digest        :string
+#  email                   :string
+#  hackr_alias             :string
+#  last_activity_at        :datetime
+#  login_disabled          :boolean          default(FALSE), not null
+#  otp_backup_code_digests :json
+#  otp_last_used_at        :integer
+#  otp_required_for_login  :boolean          default(FALSE), not null
+#  otp_secret              :string
+#  password_digest         :string
+#  registration_ip         :string
+#  role                    :string
+#  service_account         :boolean          default(FALSE), not null
+#  stats                   :json
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  current_room_id         :integer
 #
 # Indexes
 #
@@ -27,9 +33,13 @@ class GridHackr < ApplicationRecord
   include ProfanityFilterable
   include GridHackr::Stats
 
-  has_paper_trail ignore: %i[password_digest api_token_digest last_activity_at stats]
+  has_paper_trail ignore: %i[
+    password_digest api_token_digest last_activity_at stats
+    otp_secret otp_backup_code_digests otp_last_used_at
+  ]
 
   has_secure_password
+  encrypts :otp_secret
 
   filter_profanity :hackr_alias
 
@@ -175,6 +185,16 @@ class GridHackr < ApplicationRecord
     admin? || feature_grants.exists?(feature: feature_name)
   end
 
+  # Ensure hackr has a current room, spawning in the starting hub if needed.
+  def ensure_current_room!
+    return if current_room.present?
+    starting_room = GridRoom.joins(:grid_zone)
+      .where(grid_zones: {slug: "hackr-tv-central"})
+      .where(room_type: "hub")
+      .first
+    update!(current_room: starting_room) if starting_room
+  end
+
   # Update last activity timestamp without triggering callbacks
   def touch_activity!
     update_column(:last_activity_at, Time.current)
@@ -186,6 +206,56 @@ class GridHackr < ApplicationRecord
     token = SecureRandom.hex(32)
     update_column(:api_token_digest, Digest::SHA256.hexdigest(token))
     token
+  end
+
+  # --- TOTP Two-Factor Authentication ---
+
+  TOTP_ISSUER = "hackr.tv"
+  TOTP_BACKUP_CODE_COUNT = 8
+  TOTP_BACKUP_CODE_LENGTH = 10
+
+  def totp
+    return nil unless otp_secret.present?
+    ROTP::TOTP.new(otp_secret, issuer: TOTP_ISSUER)
+  end
+
+  def verify_otp(code)
+    return false unless totp
+    timestamp = totp.verify(code.to_s.strip, drift_behind: 30, drift_ahead: 30, after: otp_last_used_at)
+    return false unless timestamp
+    update_column(:otp_last_used_at, timestamp)
+    true
+  end
+
+  def otp_provisioning_uri
+    totp&.provisioning_uri(hackr_alias)
+  end
+
+  def generate_backup_codes!
+    raw_codes = Array.new(TOTP_BACKUP_CODE_COUNT) { SecureRandom.alphanumeric(TOTP_BACKUP_CODE_LENGTH).upcase }
+    self.otp_backup_code_digests = raw_codes.map { |c| BCrypt::Password.create(c) }
+    save!(validate: false)
+    raw_codes
+  end
+
+  def consume_backup_code!(raw_code)
+    digests = otp_backup_code_digests.to_a
+    idx = digests.index { |d| BCrypt::Password.new(d) == raw_code.to_s.strip.upcase }
+    return false if idx.nil?
+    digests.delete_at(idx)
+    update_column(:otp_backup_code_digests, digests)
+    true
+  end
+
+  # NOTE: update_columns bypasses AR Encryption but is safe here since
+  # we're only writing nils. Do NOT write non-nil otp_secret this way.
+  def clear_totp!
+    update_columns(
+      otp_required_for_login: false,
+      otp_secret: nil,
+      otp_backup_code_digests: nil,
+      otp_last_used_at: nil
+    )
   end
 
   # Authenticate a hackr by alias and raw token.

--- a/app/services/grid/totp_service.rb
+++ b/app/services/grid/totp_service.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Grid
+  class TotpService
+    class Error < StandardError; end
+    class InvalidPassword < Error; end
+    class InvalidCode < Error; end
+    class AlreadyEnabled < Error; end
+    class NotEnabled < Error; end
+
+    ISSUER = "hackr.tv"
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Generate a fresh TOTP secret and return setup data.
+    # Does NOT persist anything — secret is only saved on enable.
+    def generate_setup_data
+      raise AlreadyEnabled, "2FA is already enabled." if @hackr.otp_required_for_login?
+
+      secret = ROTP::Base32.random
+      totp = ROTP::TOTP.new(secret, issuer: ISSUER)
+      uri = totp.provisioning_uri(@hackr.hackr_alias)
+
+      qr = RQRCode::QRCode.new(uri)
+      svg = qr.as_svg(module_size: 4, standalone: true, use_path: true)
+
+      {secret: secret, provisioning_uri: uri, qr_svg: svg}
+    end
+
+    # Verify a TOTP code against a staged (not yet persisted) secret,
+    # then enable 2FA and generate backup codes.
+    def enable!(password:, otp_secret:, totp_code:)
+      raise AlreadyEnabled, "2FA is already enabled." if @hackr.otp_required_for_login?
+      raise InvalidPassword, "Password incorrect." unless @hackr.authenticate(password)
+
+      totp = ROTP::TOTP.new(otp_secret, issuer: ISSUER)
+      unless totp.verify(totp_code.to_s.strip, drift_behind: 30, drift_ahead: 30)
+        raise InvalidCode, "Invalid TOTP code. Try again."
+      end
+
+      backup_codes = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.otp_secret = otp_secret
+        @hackr.otp_required_for_login = true
+        @hackr.save!(validate: false)
+        backup_codes = @hackr.generate_backup_codes!
+      end
+
+      backup_codes
+    end
+
+    # Verify a TOTP code or backup code for a pending login.
+    # Returns :totp or :backup_code indicating which succeeded.
+    def verify!(code)
+      code = code.to_s.strip
+      raise NotEnabled, "2FA is not enabled." unless @hackr.otp_required_for_login?
+
+      return :totp if @hackr.verify_otp(code)
+      return :backup_code if @hackr.consume_backup_code!(code)
+
+      raise InvalidCode, "Invalid code. Access denied."
+    end
+
+    # Regenerate backup codes. Requires password and valid TOTP code.
+    # Flushes old codes entirely.
+    def regenerate_backup_codes!(password:, totp_code:)
+      raise NotEnabled, "2FA is not enabled." unless @hackr.otp_required_for_login?
+      raise InvalidPassword, "Password incorrect." unless @hackr.authenticate(password)
+      raise InvalidCode, "Invalid TOTP code." unless @hackr.verify_otp(totp_code.to_s.strip)
+
+      @hackr.generate_backup_codes!
+    end
+
+    # Disable 2FA. Requires password and valid TOTP code.
+    def disable!(password:, totp_code:)
+      raise NotEnabled, "2FA is not enabled." unless @hackr.otp_required_for_login?
+      raise InvalidPassword, "Password incorrect." unless @hackr.authenticate(password)
+      raise InvalidCode, "Invalid TOTP code." unless @hackr.verify_otp(totp_code.to_s.strip)
+
+      @hackr.clear_totp!
+    end
+
+    # Admin recovery — no credentials required from target hackr.
+    def disable_admin!(acting_admin:)
+      raise NotEnabled, "2FA is not enabled for #{@hackr.hackr_alias}." unless @hackr.otp_required_for_login?
+
+      @hackr.clear_totp!
+      Rails.logger.info("[2FA] Admin TOTP reset: target=#{@hackr.hackr_alias} admin=#{acting_admin.hackr_alias} ip=n/a")
+    end
+
+    def status
+      {
+        enabled: @hackr.otp_required_for_login?,
+        backup_codes_remaining: @hackr.otp_backup_code_digests.to_a.length
+      }
+    end
+  end
+end

--- a/app/views/admin/grid/index.html.erb
+++ b/app/views/admin/grid/index.html.erb
@@ -119,6 +119,7 @@
                 <th style="text-align: center;">CLR</th>
                 <th style="text-align: center;">XP</th>
                 <th style="text-align: center;">Grid Access</th>
+                <th style="text-align: center;">Login</th>
                 <th style="text-align: center;">Status</th>
                 <th style="text-align: center;">Created</th>
               </tr>
@@ -127,7 +128,15 @@
               <% @all_hackrs.each do |hackr| %>
                 <tr>
                   <td style="font-family: monospace; color: #666;"><%= hackr.id %></td>
-                  <td><%= hackr.hackr_alias %></td>
+                  <td style="white-space: nowrap;">
+                    <%= hackr.hackr_alias %>
+                    <% if hackr.service_account? %>
+                      <span style="color: #ff8800; font-size: 0.8em;">[SVC]</span>
+                      <%= button_to "✕", admin_grid_toggle_service_account_path(hackr_id: hackr.id), method: :post, form: { style: "display: inline;" }, class: "tui-button", style: "padding: 1px 5px; font-size: 0.7em; margin-left: 3px; background: transparent; color: #ff8800; border: 1px solid #ff8800;", data: { confirm: "Remove service account flag from #{hackr.hackr_alias}?" } %>
+                    <% else %>
+                      <%= button_to "SVC", admin_grid_toggle_service_account_path(hackr_id: hackr.id), method: :post, form: { style: "display: inline;" }, class: "tui-button", style: "padding: 1px 5px; font-size: 0.7em; margin-left: 3px; background: transparent; color: #666; border: 1px solid #444;", data: { confirm: "Mark #{hackr.hackr_alias} as a service account? API tokens will bypass login-disabled." } %>
+                    <% end %>
+                  </td>
                   <td>
                     <% if hackr.admin? %>
                       <span class="red-255-text">[ADMIN]</span>
@@ -146,6 +155,17 @@
                     <% else %>
                       <span style="color: #666;">NONE</span>
                       <%= button_to "Grant", admin_grid_grant_feature_path(hackr_id: hackr.id, feature: FeatureGrant::PULSE_GRID), method: :post, form: { style: "display: inline;" }, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 5px;", data: { confirm: "Grant grid access to #{hackr.hackr_alias}?" } %>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <% if hackr.login_disabled? %>
+                      <span class="red-255-text">DISABLED</span>
+                      <%= button_to "Enable", admin_grid_enable_login_path(hackr_id: hackr.id), method: :post, form: { style: "display: inline;" }, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 5px;", data: { confirm: "Re-enable login for #{hackr.hackr_alias}?" } %>
+                    <% else %>
+                      <span class="green-255-text">ENABLED</span>
+                      <% unless hackr.id == current_hackr.id %>
+                        <%= button_to "Disable", admin_grid_disable_login_path(hackr_id: hackr.id), method: :post, form: { style: "display: inline;" }, class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 5px; background: #ff4444; color: #fff;", data: { confirm: "Disable login for #{hackr.hackr_alias}? They will be logged out immediately." } %>
+                      <% end %>
                     <% end %>
                   </td>
                   <td style="text-align: center;">

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,11 @@ module HackrRails
     # config.eager_load_paths << Rails.root.join("extras")
     config.autoload_paths << Rails.root.join("app/observers")
 
+    # Active Record Encryption (used for TOTP secret storage)
+    config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
+    config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
+    config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -81,6 +81,23 @@ class Rack::Attack
     end
   end
 
+  ### Throttle TOTP verification ###
+
+  # 5 TOTP verify attempts per 2 minutes per IP (brute-force protection)
+  throttle("totp_verify/ip", limit: 5, period: 2.minutes) do |req|
+    if req.path == "/api/totp/verify" && req.post?
+      req.ip
+    end
+  end
+
+  # 5 TOTP setup/enable/disable attempts per 15 minutes per IP
+  throttle("totp_manage/ip", limit: 5, period: 15.minutes) do |req|
+    if (%w[/api/totp/setup /api/totp/enable].include?(req.path) && req.post?) ||
+        (req.path == "/api/totp/disable" && req.delete?)
+      req.ip
+    end
+  end
+
   ### Throttle token verification ###
 
   # 10 token verifications per IP per minute

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     get "verify/:token", to: "pages#spa_root", as: :grid_verify
     get "forgot_password", to: "pages#spa_root", as: :grid_forgot_password
     get "identity", to: "pages#spa_root", as: :grid_identity
+    get "identity/two-factor", to: "pages#spa_root", as: :grid_two_factor
     get "reset_password/:token", to: "pages#spa_root", as: :grid_password_reset
     get "confirm_email_change/:token", to: "pages#spa_root", as: :grid_confirm_email_change
   end
@@ -174,6 +175,15 @@ Rails.application.routes.draw do
     post "grid/reset_password", to: "grid#reset_password"
     post "grid/request_email_change", to: "grid#request_email_change"
     post "grid/confirm_email_change", to: "grid#confirm_email_change"
+
+    # TOTP two-factor authentication
+    get "totp/status", to: "totp#status"
+    post "totp/setup", to: "totp#setup"
+    post "totp/enable", to: "totp#enable"
+    post "totp/verify", to: "totp#verify"
+    delete "totp/disable", to: "totp#disable"
+    post "totp/regenerate_backup_codes", to: "totp#regenerate_backup_codes"
+    post "totp/admin_reset", to: "totp#admin_reset"
 
     # Code browser API routes
     get "code", to: "code#index"
@@ -312,6 +322,10 @@ Rails.application.routes.draw do
     # Grid management (still functional - runtime operations)
     get "grid", to: "grid#index", as: :grid
     post "grid/broadcast", to: "grid#broadcast", as: :grid_broadcast
+    post "grid/hackrs/:hackr_id/reset_totp", to: "grid#reset_totp", as: :grid_reset_totp
+    post "grid/hackrs/:hackr_id/disable_login", to: "grid#disable_login", as: :grid_disable_login
+    post "grid/hackrs/:hackr_id/enable_login", to: "grid#enable_login", as: :grid_enable_login
+    post "grid/hackrs/:hackr_id/toggle_service_account", to: "grid#toggle_service_account", as: :grid_toggle_service_account
     post "grid/grant_feature", to: "grid#grant_feature", as: :grid_grant_feature
     delete "grid/revoke_feature", to: "grid#revoke_feature", as: :grid_revoke_feature
 

--- a/data/system/hackrs.yml
+++ b/data/system/hackrs.yml
@@ -43,6 +43,7 @@ hackrs:
     starting_room: hackr-tv-broadcast-station
     env_password_key: RELAY_PASSWORD
     default_password: relaystream
+    service_account: true
 
   # Expansion characters — hackr log authors
   - hackr_alias: Vex

--- a/db/migrate/20260418120001_add_totp_to_grid_hackrs.rb
+++ b/db/migrate/20260418120001_add_totp_to_grid_hackrs.rb
@@ -1,0 +1,7 @@
+class AddTotpToGridHackrs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackrs, :otp_secret, :string
+    add_column :grid_hackrs, :otp_required_for_login, :boolean, null: false, default: false
+    add_column :grid_hackrs, :otp_backup_code_digests, :json
+  end
+end

--- a/db/migrate/20260418120002_add_otp_last_used_at_to_grid_hackrs.rb
+++ b/db/migrate/20260418120002_add_otp_last_used_at_to_grid_hackrs.rb
@@ -1,0 +1,5 @@
+class AddOtpLastUsedAtToGridHackrs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackrs, :otp_last_used_at, :integer
+  end
+end

--- a/db/migrate/20260418120003_add_login_disabled_to_grid_hackrs.rb
+++ b/db/migrate/20260418120003_add_login_disabled_to_grid_hackrs.rb
@@ -1,0 +1,5 @@
+class AddLoginDisabledToGridHackrs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackrs, :login_disabled, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260418120004_add_service_account_to_grid_hackrs.rb
+++ b/db/migrate/20260418120004_add_service_account_to_grid_hackrs.rb
@@ -1,0 +1,5 @@
+class AddServiceAccountToGridHackrs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackrs, :service_account, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_213400) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_120004) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -296,9 +296,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_213400) do
     t.string "email"
     t.string "hackr_alias"
     t.datetime "last_activity_at"
+    t.boolean "login_disabled", default: false, null: false
+    t.json "otp_backup_code_digests"
+    t.integer "otp_last_used_at"
+    t.boolean "otp_required_for_login", default: false, null: false
+    t.string "otp_secret"
     t.string "password_digest"
     t.string "registration_ip"
     t.string "role"
+    t.boolean "service_account", default: false, null: false
     t.json "stats"
     t.datetime "updated_at", null: false
     t.index ["api_token_digest"], name: "index_grid_hackrs_on_api_token_digest", unique: true

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -288,11 +288,15 @@ namespace :data do
         email: attrs["email"],
         role: attrs["role"],
         password: password,
-        skip_reserved_check: true
+        skip_reserved_check: true,
+        login_disabled: attrs["hackr_alias"] != "XERAEN",
+        service_account: attrs["service_account"] == true
       )
       hackr.save!
       created += 1
-      puts "  ✓ Created: #{hackr.hackr_alias} (#{hackr.role})"
+      flags = [hackr.login_disabled? ? "login_disabled" : nil, hackr.service_account? ? "service_account" : nil].compact
+      flag_str = flags.any? ? " [#{flags.join(", ")}]" : ""
+      puts "  ✓ Created: #{hackr.hackr_alias} (#{hackr.role})#{flag_str}"
     end
 
     puts "Hackrs: #{created} created, #{GridHackr.count} total"

--- a/spec/controllers/concerns/grid_authentication_spec.rb
+++ b/spec/controllers/concerns/grid_authentication_spec.rb
@@ -115,6 +115,32 @@ RSpec.describe GridAuthentication, type: :controller do
         expect(controller.send(:current_hackr)).to be_nil
       end
     end
+
+    context "when hackr has login_disabled" do
+      before { session[:grid_hackr_id] = operative.id }
+
+      it "returns nil and clears session" do
+        operative.update!(login_disabled: true)
+        expect(controller.send(:current_hackr)).to be_nil
+        expect(session[:grid_hackr_id]).to be_nil
+      end
+    end
+
+    context "when hackr has login_disabled and uses API token" do
+      it "returns nil for non-service accounts" do
+        operative.update!(login_disabled: true)
+        token = operative.generate_api_token!
+        request.headers["Authorization"] = "Bearer #{operative.hackr_alias}:#{token}"
+        expect(controller.send(:current_hackr)).to be_nil
+      end
+
+      it "returns hackr for service accounts" do
+        operative.update!(login_disabled: true, service_account: true)
+        token = operative.generate_api_token!
+        request.headers["Authorization"] = "Bearer #{operative.hackr_alias}:#{token}"
+        expect(controller.send(:current_hackr)).to eq(operative)
+      end
+    end
   end
 
   describe "#api_token_request?" do

--- a/spec/factories/grid_hackrs.rb
+++ b/spec/factories/grid_hackrs.rb
@@ -3,18 +3,24 @@
 # Table name: grid_hackrs
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  api_token_digest :string
-#  email            :string
-#  hackr_alias      :string
-#  last_activity_at :datetime
-#  password_digest  :string
-#  registration_ip  :string
-#  role             :string
-#  stats            :json
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  current_room_id  :integer
+#  id                      :integer          not null, primary key
+#  api_token_digest        :string
+#  email                   :string
+#  hackr_alias             :string
+#  last_activity_at        :datetime
+#  login_disabled          :boolean          default(FALSE), not null
+#  otp_backup_code_digests :json
+#  otp_last_used_at        :integer
+#  otp_required_for_login  :boolean          default(FALSE), not null
+#  otp_secret              :string
+#  password_digest         :string
+#  registration_ip         :string
+#  role                    :string
+#  service_account         :boolean          default(FALSE), not null
+#  stats                   :json
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  current_room_id         :integer
 #
 # Indexes
 #

--- a/spec/models/grid_hackr_spec.rb
+++ b/spec/models/grid_hackr_spec.rb
@@ -3,18 +3,24 @@
 # Table name: grid_hackrs
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  api_token_digest :string
-#  email            :string
-#  hackr_alias      :string
-#  last_activity_at :datetime
-#  password_digest  :string
-#  registration_ip  :string
-#  role             :string
-#  stats            :json
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  current_room_id  :integer
+#  id                      :integer          not null, primary key
+#  api_token_digest        :string
+#  email                   :string
+#  hackr_alias             :string
+#  last_activity_at        :datetime
+#  login_disabled          :boolean          default(FALSE), not null
+#  otp_backup_code_digests :json
+#  otp_last_used_at        :integer
+#  otp_required_for_login  :boolean          default(FALSE), not null
+#  otp_secret              :string
+#  password_digest         :string
+#  registration_ip         :string
+#  role                    :string
+#  service_account         :boolean          default(FALSE), not null
+#  stats                   :json
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  current_room_id         :integer
 #
 # Indexes
 #

--- a/spec/requests/api/login_disabled_spec.rb
+++ b/spec/requests/api/login_disabled_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "Login disabled accounts", type: :request do
+  let(:hackr) { create(:grid_hackr, password: "hackthegrid") }
+
+  describe "POST /api/grid/login" do
+    it "blocks login for disabled accounts" do
+      hackr.update!(login_disabled: true)
+
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body["error"]).to include("disabled")
+    end
+
+    it "allows login for enabled accounts" do
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be true
+    end
+  end
+
+  describe "session rehydration" do
+    it "logs out disabled hackr on next request" do
+      # Log in normally
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+      expect(response.parsed_body["success"]).to be true
+
+      # Verify session works
+      get "/api/grid/current_hackr", as: :json
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["logged_in"]).to be true
+
+      # Admin disables the account
+      hackr.update!(login_disabled: true)
+
+      # Next request should fail auth
+      get "/api/grid/current_hackr", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/totp/verify" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.otp_secret = secret
+      hackr.otp_required_for_login = true
+      hackr.save!(validate: false)
+      hackr.generate_backup_codes!
+    end
+
+    it "blocks disabled hackr during 2FA verification" do
+      # Start login (sets pending session)
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+      expect(response.parsed_body["requires_totp"]).to be true
+
+      # Admin disables account between password and TOTP steps
+      hackr.update!(login_disabled: true)
+
+      # TOTP verify should reject
+      code = ROTP::TOTP.new(secret).now
+      post "/api/totp/verify", params: {code: code}, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body["error"]).to include("disabled")
+    end
+  end
+end

--- a/spec/requests/api/totp_controller_spec.rb
+++ b/spec/requests/api/totp_controller_spec.rb
@@ -1,0 +1,207 @@
+require "rails_helper"
+
+RSpec.describe "Api::TotpController", type: :request do
+  let(:hackr) { create(:grid_hackr, password: "hackthegrid") }
+
+  def login_as(h)
+    post "/api/grid/login", params: {hackr_alias: h.hackr_alias, password: "hackthegrid"}, as: :json
+  end
+
+  describe "GET /api/totp/status" do
+    it "returns 401 when not logged in" do
+      get "/api/totp/status", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns disabled status for hackr without 2FA" do
+      login_as(hackr)
+      get "/api/totp/status", as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["enabled"]).to be false
+      expect(body["backup_codes_remaining"]).to eq(0)
+    end
+  end
+
+  describe "POST /api/totp/setup" do
+    it "returns secret and QR SVG" do
+      login_as(hackr)
+      post "/api/totp/setup", as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to be true
+      expect(body["secret"]).to be_present
+      expect(body["qr_svg"]).to include("<svg")
+    end
+
+    it "returns 401 when not logged in" do
+      post "/api/totp/setup", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/totp/enable" do
+    it "enables 2FA and returns backup codes" do
+      login_as(hackr)
+      post "/api/totp/setup", as: :json
+      secret = response.parsed_body["secret"]
+
+      totp = ROTP::TOTP.new(secret)
+      post "/api/totp/enable", params: {
+        password: "hackthegrid",
+        otp_secret: secret,
+        code: totp.now
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to be true
+      expect(body["backup_codes"].length).to eq(8)
+      expect(hackr.reload.otp_required_for_login?).to be true
+    end
+
+    it "rejects wrong password" do
+      login_as(hackr)
+      post "/api/totp/setup", as: :json
+      secret = response.parsed_body["secret"]
+
+      post "/api/totp/enable", params: {
+        password: "wrong",
+        otp_secret: secret,
+        code: ROTP::TOTP.new(secret).now
+      }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/totp/verify" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.otp_secret = secret
+      hackr.otp_required_for_login = true
+      hackr.save!(validate: false)
+      hackr.generate_backup_codes!
+    end
+
+    it "completes login with valid TOTP code" do
+      # Login sets pending session
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+      expect(response.parsed_body["requires_totp"]).to be true
+
+      # Verify TOTP
+      code = ROTP::TOTP.new(secret).now
+      post "/api/totp/verify", params: {code: code}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to be true
+      expect(body["hackr"]["hackr_alias"]).to eq(hackr.hackr_alias)
+    end
+
+    it "completes login with valid backup code" do
+      codes = hackr.generate_backup_codes!
+
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+      post "/api/totp/verify", params: {code: codes.first}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be true
+    end
+
+    it "rejects invalid code" do
+      post "/api/grid/login", params: {hackr_alias: hackr.hackr_alias, password: "hackthegrid"}, as: :json
+      post "/api/totp/verify", params: {code: "000000"}, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "rejects when no pending session" do
+      post "/api/totp/verify", params: {code: "123456"}, as: :json
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body["error"]).to include("No pending")
+    end
+  end
+
+  describe "DELETE /api/totp/disable" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.otp_secret = secret
+      hackr.otp_required_for_login = true
+      hackr.save!(validate: false)
+      @backup_codes = hackr.generate_backup_codes!
+      login_as(hackr)
+      # Complete 2FA verification using a backup code to preserve TOTP freshness
+      post "/api/totp/verify", params: {code: @backup_codes.first}, as: :json
+    end
+
+    it "disables 2FA with valid password and code" do
+      code = ROTP::TOTP.new(secret).now
+      delete "/api/totp/disable", params: {password: "hackthegrid", code: code}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["success"]).to be true
+      expect(hackr.reload.otp_required_for_login?).to be false
+    end
+  end
+
+  describe "POST /api/totp/regenerate_backup_codes" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.otp_secret = secret
+      hackr.otp_required_for_login = true
+      hackr.save!(validate: false)
+      @backup_codes = hackr.generate_backup_codes!
+      login_as(hackr)
+      post "/api/totp/verify", params: {code: @backup_codes.first}, as: :json
+    end
+
+    it "returns new backup codes" do
+      code = ROTP::TOTP.new(secret).now
+      post "/api/totp/regenerate_backup_codes", params: {password: "hackthegrid", code: code}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["success"]).to be true
+      expect(body["backup_codes"].length).to eq(8)
+    end
+
+    it "rejects wrong password" do
+      code = ROTP::TOTP.new(secret).now
+      post "/api/totp/regenerate_backup_codes", params: {password: "wrong", code: code}, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /api/totp/admin_reset" do
+    let(:admin) { create(:grid_hackr, :admin, password: "hackthegrid") }
+    let(:target) { create(:grid_hackr, password: "hackthegrid") }
+
+    before do
+      target.update_columns(otp_required_for_login: true)
+      target.otp_secret = ROTP::Base32.random
+      target.save!(validate: false)
+    end
+
+    it "clears 2FA for target hackr" do
+      login_as(admin)
+      post "/api/totp/admin_reset", params: {hackr_alias: target.hackr_alias}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(target.reload.otp_required_for_login?).to be false
+    end
+
+    it "rejects non-admin" do
+      login_as(hackr)
+      post "/api/totp/admin_reset", params: {hackr_alias: target.hackr_alias}, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/services/grid/totp_service_spec.rb
+++ b/spec/services/grid/totp_service_spec.rb
@@ -1,0 +1,220 @@
+require "rails_helper"
+
+RSpec.describe Grid::TotpService do
+  let(:hackr) { create(:grid_hackr, password: "hackthegrid") }
+  let(:service) { described_class.new(hackr) }
+
+  describe "#generate_setup_data" do
+    it "returns secret, provisioning_uri, and qr_svg" do
+      data = service.generate_setup_data
+
+      expect(data[:secret]).to be_present
+      expect(data[:provisioning_uri]).to include("otpauth://totp/")
+      expect(data[:provisioning_uri]).to include(hackr.hackr_alias)
+      expect(data[:qr_svg]).to include("<svg")
+    end
+
+    it "raises AlreadyEnabled when 2FA is active" do
+      hackr.update_columns(otp_required_for_login: true)
+
+      expect { service.generate_setup_data }
+        .to raise_error(Grid::TotpService::AlreadyEnabled)
+    end
+  end
+
+  describe "#enable!" do
+    it "enables 2FA with valid password and TOTP code" do
+      data = service.generate_setup_data
+      totp = ROTP::TOTP.new(data[:secret])
+      code = totp.now
+
+      backup_codes = service.enable!(
+        password: "hackthegrid",
+        otp_secret: data[:secret],
+        totp_code: code
+      )
+
+      expect(backup_codes).to be_an(Array)
+      expect(backup_codes.length).to eq(8)
+      expect(hackr.reload.otp_required_for_login?).to be true
+      expect(hackr.otp_secret).to eq(data[:secret])
+    end
+
+    it "raises InvalidPassword with wrong password" do
+      data = service.generate_setup_data
+      totp = ROTP::TOTP.new(data[:secret])
+
+      expect {
+        service.enable!(password: "wrong", otp_secret: data[:secret], totp_code: totp.now)
+      }.to raise_error(Grid::TotpService::InvalidPassword)
+    end
+
+    it "raises InvalidCode with wrong TOTP code" do
+      data = service.generate_setup_data
+
+      expect {
+        service.enable!(password: "hackthegrid", otp_secret: data[:secret], totp_code: "000000")
+      }.to raise_error(Grid::TotpService::InvalidCode)
+    end
+
+    it "raises AlreadyEnabled when called twice" do
+      data = service.generate_setup_data
+      totp = ROTP::TOTP.new(data[:secret])
+      service.enable!(password: "hackthegrid", otp_secret: data[:secret], totp_code: totp.now)
+
+      expect {
+        service.enable!(password: "hackthegrid", otp_secret: data[:secret], totp_code: totp.now)
+      }.to raise_error(Grid::TotpService::AlreadyEnabled)
+    end
+  end
+
+  describe "#verify!" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.update_columns(otp_required_for_login: true)
+      hackr.otp_secret = secret
+      hackr.save!(validate: false)
+      hackr.generate_backup_codes!
+    end
+
+    it "returns :totp for valid TOTP code" do
+      code = ROTP::TOTP.new(secret).now
+      expect(service.verify!(code)).to eq(:totp)
+    end
+
+    it "returns :backup_code for valid backup code" do
+      codes = hackr.generate_backup_codes!
+      expect(service.verify!(codes.first)).to eq(:backup_code)
+    end
+
+    it "consumes backup code on use" do
+      codes = hackr.generate_backup_codes!
+      service.verify!(codes.first)
+
+      expect(hackr.reload.otp_backup_code_digests.length).to eq(7)
+    end
+
+    it "raises InvalidCode for wrong code" do
+      expect { service.verify!("000000") }
+        .to raise_error(Grid::TotpService::InvalidCode)
+    end
+
+    it "raises NotEnabled when 2FA is off" do
+      hackr.update_columns(otp_required_for_login: false)
+
+      expect { service.verify!("123456") }
+        .to raise_error(Grid::TotpService::NotEnabled)
+    end
+  end
+
+  describe "#disable!" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.update_columns(otp_required_for_login: true)
+      hackr.otp_secret = secret
+      hackr.save!(validate: false)
+      hackr.generate_backup_codes!
+    end
+
+    it "disables 2FA with valid password and TOTP code" do
+      code = ROTP::TOTP.new(secret).now
+      service.disable!(password: "hackthegrid", totp_code: code)
+
+      hackr.reload
+      expect(hackr.otp_required_for_login?).to be false
+      expect(hackr.otp_secret).to be_nil
+      expect(hackr.otp_backup_code_digests).to be_nil
+    end
+
+    it "raises InvalidPassword with wrong password" do
+      code = ROTP::TOTP.new(secret).now
+
+      expect { service.disable!(password: "wrong", totp_code: code) }
+        .to raise_error(Grid::TotpService::InvalidPassword)
+    end
+
+    it "raises InvalidCode with wrong TOTP code" do
+      expect { service.disable!(password: "hackthegrid", totp_code: "000000") }
+        .to raise_error(Grid::TotpService::InvalidCode)
+    end
+  end
+
+  describe "#regenerate_backup_codes!" do
+    let(:secret) { ROTP::Base32.random }
+
+    before do
+      hackr.update_columns(otp_required_for_login: true)
+      hackr.otp_secret = secret
+      hackr.save!(validate: false)
+      hackr.generate_backup_codes!
+    end
+
+    it "generates new codes and flushes old ones" do
+      old_digests = hackr.otp_backup_code_digests.dup
+      code = ROTP::TOTP.new(secret).now
+
+      new_codes = service.regenerate_backup_codes!(password: "hackthegrid", totp_code: code)
+
+      expect(new_codes.length).to eq(8)
+      expect(hackr.reload.otp_backup_code_digests).not_to eq(old_digests)
+    end
+
+    it "raises InvalidPassword with wrong password" do
+      code = ROTP::TOTP.new(secret).now
+
+      expect { service.regenerate_backup_codes!(password: "wrong", totp_code: code) }
+        .to raise_error(Grid::TotpService::InvalidPassword)
+    end
+
+    it "raises NotEnabled when 2FA is off" do
+      hackr.update_columns(otp_required_for_login: false)
+
+      expect { service.regenerate_backup_codes!(password: "hackthegrid", totp_code: "123456") }
+        .to raise_error(Grid::TotpService::NotEnabled)
+    end
+  end
+
+  describe "#disable_admin!" do
+    let(:admin) { create(:grid_hackr, :admin) }
+
+    before do
+      hackr.update_columns(otp_required_for_login: true)
+      hackr.otp_secret = ROTP::Base32.random
+      hackr.save!(validate: false)
+    end
+
+    it "disables 2FA without requiring target credentials" do
+      service.disable_admin!(acting_admin: admin)
+
+      hackr.reload
+      expect(hackr.otp_required_for_login?).to be false
+      expect(hackr.otp_secret).to be_nil
+    end
+
+    it "raises NotEnabled when 2FA is not active" do
+      hackr.update_columns(otp_required_for_login: false)
+
+      expect { service.disable_admin!(acting_admin: admin) }
+        .to raise_error(Grid::TotpService::NotEnabled)
+    end
+  end
+
+  describe "#status" do
+    it "returns disabled status for new hackr" do
+      result = service.status
+      expect(result[:enabled]).to be false
+      expect(result[:backup_codes_remaining]).to eq(0)
+    end
+
+    it "returns enabled status with backup code count" do
+      hackr.update_columns(otp_required_for_login: true)
+      hackr.generate_backup_codes!
+
+      result = service.status
+      expect(result[:enabled]).to be true
+      expect(result[:backup_codes_remaining]).to eq(8)
+    end
+  end
+end


### PR DESCRIPTION
  Add optional TOTP-based 2FA for all GridHackr accounts using rotp/rqrcode.
  Hackrs enable 2FA from /grid/identity/two-factor — scan QR code with
  authenticator app, confirm with code + password, receive 8 one-time backup
  codes. Login flow gains a second step: password → TOTP code entry.

  2FA architecture:
  - Grid::TotpService handles all TOTP logic (setup, enable, verify, disable, admin reset, backup code regeneration)
  - Api::TotpController with 7 endpoints under /api/totp/
  - OTP secret encrypted at rest via Rails AR Encryption
  - Backup codes stored as BCrypt digests in JSON column
  - Replay prevention via otp_last_used_at timestamp
  - Pending 2FA session expires after 10 minutes
  - Rack::Attack rate limiting on all TOTP endpoints
  - Bearer token auth bypasses 2FA by design

  Account controls:
  - login_disabled column blocks web login + session rehydration + 2FA verify
  - service_account column allows API token usage when login is disabled (e.g., relay chat middleware)
  - Admin panel at /root/grid has toggle buttons for both flags
  - Self-disable guard prevents admins from locking themselves out
  - Seeded hackrs default to login_disabled except XERAEN; relay gets service_account flag

  Refactors:
  - GridSerialization concern extracts auth hackr/room JSON (was 3 copies)
  - GridHackr#ensure_current_room! extracts spawn logic (was 3 copies)