### PR TITLE
 [TPG] Item Fabrication via Schematics

### DIFF
--- a/app/controllers/admin/grid_item_definitions_controller.rb
+++ b/app/controllers/admin/grid_item_definitions_controller.rb
@@ -82,6 +82,18 @@ class Admin::GridItemDefinitionsController < Admin::ApplicationController
       return
     end
 
+    if @definition.schematics_as_output.exists?
+      set_flash_error("Cannot delete '#{@definition.name}' — it is referenced as a schematic output.")
+      redirect_to admin_grid_item_definitions_path
+      return
+    end
+
+    if @definition.schematic_ingredients.exists?
+      set_flash_error("Cannot delete '#{@definition.name}' — it is used as an ingredient in a schematic.")
+      redirect_to admin_grid_item_definitions_path
+      return
+    end
+
     name = @definition.name
     if @definition.destroy
       set_flash_success("Definition '#{name}' deleted.")

--- a/app/controllers/admin/grid_schematics_controller.rb
+++ b/app/controllers/admin/grid_schematics_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class Admin::GridSchematicsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridSchematic, find_by: :slug, children: [:ingredients]
+
+  before_action :set_schematic, only: %i[edit update destroy]
+
+  def index
+    @schematics = GridSchematic.ordered
+      .includes(:output_definition, ingredients: :input_definition)
+  end
+
+  def new
+    @schematic = GridSchematic.new(
+      published: false, xp_reward: 0, output_quantity: 1,
+      required_clearance: 0,
+      position: (GridSchematic.maximum(:position) || 0) + 1
+    )
+    @schematic.ingredients.build(position: 0)
+    load_selects
+  end
+
+  def create
+    @schematic = GridSchematic.new(schematic_params)
+    if @schematic.save
+      set_flash_success("Schematic '#{@schematic.name}' created.")
+      redirect_to edit_admin_grid_schematic_path(@schematic)
+    else
+      flash.now[:error] = @schematic.errors.full_messages.join(", ")
+      load_selects
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @sorted_ingredients = @schematic.ingredients.ordered.to_a
+    @sorted_ingredients << @schematic.ingredients.build
+    load_selects
+  end
+
+  def update
+    if @schematic.update(schematic_params)
+      set_flash_success("Schematic '#{@schematic.name}' updated.")
+      redirect_to edit_admin_grid_schematic_path(@schematic)
+    else
+      flash.now[:error] = @schematic.errors.full_messages.join(", ")
+      load_selects
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @schematic.name
+    @schematic.destroy!
+    set_flash_success("Schematic '#{name}' deleted.")
+    redirect_to admin_grid_schematics_path
+  end
+
+  private
+
+  def set_schematic
+    @schematic = GridSchematic.find_by!(slug: params[:id])
+  end
+
+  def load_selects
+    @all_definitions = GridItemDefinition.ordered
+  end
+
+  def schematic_params
+    params.require(:grid_schematic).permit(
+      :slug, :name, :description, :output_definition_id, :output_quantity,
+      :xp_reward, :required_clearance, :published, :position,
+      :required_mission_slug, :required_achievement_slug,
+      ingredients_attributes: %i[id input_definition_id quantity position _destroy]
+    )
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,7 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action :require_admin_api, only: [:debit]
 
@@ -67,6 +67,64 @@ class Api::GridController < ApplicationController
       active: active.map { |hm| hackr_mission_json(hm, include_progress: true) },
       completed: completed.map { |hm| hackr_mission_json(hm, include_progress: false) },
       available: available.map { |m| mission_json(m, include_gate_status: true) }
+    }
+  end
+
+  # GET /api/grid/schematics - Published schematics with ingredients,
+  # craftable status, and per-ingredient ownership for the current hackr.
+  def schematics_index
+    schematics = GridSchematic.published.ordered
+      .includes(:output_definition, ingredients: :input_definition)
+
+    # Pre-load hackr state to avoid N+1 on craftable_by? checks
+    inventory_qtys = current_hackr.grid_items
+      .group(:grid_item_definition_id)
+      .sum(:quantity)
+    completed_mission_slugs = current_hackr.grid_hackr_missions
+      .where(status: "completed")
+      .joins(:grid_mission)
+      .pluck("grid_missions.slug").to_set
+    earned_achievement_slugs = current_hackr.grid_hackr_achievements
+      .joins(:grid_achievement)
+      .pluck("grid_achievements.slug").to_set
+
+    render json: {
+      schematics: schematics.map { |s|
+        craftable = s.craftable_by?(current_hackr,
+          completed_mission_slugs: completed_mission_slugs,
+          earned_achievement_slugs: earned_achievement_slugs)
+        has_ingredients = s.ingredients.all? { |i| (inventory_qtys[i.input_definition_id] || 0) >= i.quantity }
+
+        {
+          slug: s.slug,
+          name: s.name,
+          description: s.description,
+          output: {
+            slug: s.output_definition.slug,
+            name: s.output_definition.name,
+            rarity: s.output_definition.rarity,
+            rarity_color: s.output_definition.rarity_color
+          },
+          output_quantity: s.output_quantity,
+          xp_reward: s.xp_reward,
+          required_clearance: s.required_clearance,
+          required_mission_slug: s.required_mission_slug,
+          required_achievement_slug: s.required_achievement_slug,
+          ingredients: s.ingredients.ordered.map { |i|
+            owned = inventory_qtys[i.input_definition_id] || 0
+            {
+              item_slug: i.input_definition.slug,
+              item_name: i.input_definition.name,
+              rarity: i.input_definition.rarity,
+              rarity_color: i.input_definition.rarity_color,
+              required: i.quantity,
+              owned: owned
+            }
+          },
+          craftable: craftable,
+          has_ingredients: has_ingredients
+        }
+      }
     }
   end
 

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -27,6 +27,7 @@ const ReleaseDetailPage = lazy(() => import('~/components/pages/releases/Release
 const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').then(m => ({ default: m.GridGamePage })))
 const AchievementsPage = lazy(() => import('~/components/pages/grid/AchievementsPage'))
 const MissionsPage = lazy(() => import('~/components/pages/grid/MissionsPage'))
+const SchematicsPage = lazy(() => import('~/components/pages/grid/SchematicsPage'))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
@@ -105,6 +106,7 @@ export const AppLayout: React.FC = () => {
           {/* THE PULSE GRID routes */}
           <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
           <Route path="/missions" element={<ProtectedRoute><MissionsPage /></ProtectedRoute>} />
+          <Route path="/schematics" element={<ProtectedRoute><SchematicsPage /></ProtectedRoute>} />
           <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
           <Route path="/grid/login" element={<GridLoginPage />} />
           <Route path="/grid/register" element={<GridRegisterPage />} />

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -291,6 +291,9 @@ export const HeaderMenu: React.FC = () => {
                     <Link to="/missions" className={`mobile-menu-item${isActive('/missions') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>missions
                     </Link>
+                    <Link to="/schematics" className={`mobile-menu-item${isActive('/schematics') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>schematics
+                    </Link>
                     <Link to="/fm/playlists" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>playlists
                     </Link>
@@ -556,7 +559,7 @@ export const HeaderMenu: React.FC = () => {
           </li>
 
           {/* THE PULSE GRID */}
-          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') || isActive('/missions') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
+          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') || isActive('/missions') || isActive('/schematics') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
             <span className="purple-168-text">{isLoggedIn ? '11' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
@@ -594,6 +597,11 @@ export const HeaderMenu: React.FC = () => {
                     <li>
                       <Link to="/missions" onClick={closeDropdown}>
                         <span className="purple-168-text">/</span>missions
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/schematics" onClick={closeDropdown}>
+                        <span className="purple-168-text">/</span>schematics
                       </Link>
                     </li>
                     <li>

--- a/app/javascript/components/pages/grid/SchematicsPage.tsx
+++ b/app/javascript/components/pages/grid/SchematicsPage.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+import type { SchematicsIndexResponse, Schematic, SchematicIngredient } from '~/types/schematic'
+
+type Tab = 'all' | 'ready' | 'available' | 'locked'
+
+const SchematicsPage: React.FC = () => {
+  const [data, setData] = useState<SchematicsIndexResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<Tab>('all')
+
+  useEffect(() => {
+    apiJson<SchematicsIndexResponse>('/api/grid/schematics')
+      .then(json => { setData(json); setLoading(false) })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Failed to load schematics')
+        setLoading(false)
+      })
+  }, [])
+
+  const counts = useMemo(() => {
+    if (!data) return { all: 0, ready: 0, available: 0, locked: 0 }
+    const ready = data.schematics.filter(s => s.craftable && s.has_ingredients).length
+    const available = data.schematics.filter(s => s.craftable && !s.has_ingredients).length
+    const locked = data.schematics.filter(s => !s.craftable).length
+    return { all: data.schematics.length, ready, available, locked }
+  }, [data])
+
+  const filtered = useMemo(() => {
+    if (!data) return []
+    switch (activeTab) {
+    case 'ready': return data.schematics.filter(s => s.craftable && s.has_ingredients)
+    case 'available': return data.schematics.filter(s => s.craftable && !s.has_ingredients)
+    case 'locked': return data.schematics.filter(s => !s.craftable)
+    default: return data.schematics
+    }
+  }, [data, activeTab])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+          <LoadingSpinner message="Loading schematics..." color="cyan-255-text" size="large" />
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto', padding: 40, textAlign: 'center', color: '#f87171' }}>
+          {error || 'Failed to load schematics'}
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+        <div
+          className="tui-window white-text"
+          style={{
+            display: 'block',
+            background: '#0a0a0a',
+            border: '2px solid #a78bfa',
+            boxShadow: '0 0 30px rgba(167, 139, 250, 0.3)'
+          }}
+        >
+          <fieldset style={{ borderColor: '#a78bfa' }}>
+            <legend
+              className="center"
+              style={{ color: '#a78bfa', textShadow: '0 0 15px rgba(167, 139, 250, 0.6)', letterSpacing: 3 }}
+            >
+              FABRICATION SCHEMATICS
+            </legend>
+            <div style={{ padding: 20 }}>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+                <TabButton label={`ALL (${counts.all})`} color="#a78bfa" active={activeTab === 'all'} onClick={() => setActiveTab('all')} />
+                <TabButton label={`READY (${counts.ready})`} color="#34d399" active={activeTab === 'ready'} onClick={() => setActiveTab('ready')} />
+                <TabButton label={`AVAILABLE (${counts.available})`} color="#60a5fa" active={activeTab === 'available'} onClick={() => setActiveTab('available')} />
+                <TabButton label={`LOCKED (${counts.locked})`} color="#6b7280" active={activeTab === 'locked'} onClick={() => setActiveTab('locked')} />
+              </div>
+
+              {filtered.length === 0 ? (
+                <div style={{ padding: 40, textAlign: 'center', color: '#6b7280' }}>
+                  {activeTab === 'ready'
+                    ? 'No schematics ready to fabricate. Gather more materials via salvaging.'
+                    : activeTab === 'available'
+                      ? 'No available schematics missing ingredients.'
+                      : activeTab === 'locked'
+                        ? 'No locked schematics.'
+                        : 'No schematics available. Increase your clearance to unlock more.'}
+                </div>
+              ) : (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: 12 }}>
+                  {filtered.map(s => <SchematicCard key={s.slug} schematic={s} />)}
+                </div>
+              )}
+
+              <div style={{ marginTop: 20, color: '#6b7280', fontSize: '0.8em', textAlign: 'center' }}>
+                Use <code style={{ color: '#a78bfa' }}>schematics</code> in the Terminal to browse.
+                Use <code style={{ color: '#34d399' }}>fab &lt;slug&gt;</code> to fabricate.
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const TabButton: React.FC<{ label: string; color: string; active: boolean; onClick: () => void }> = ({ label, color, active, onClick }) => (
+  <button
+    className="tui-button"
+    onClick={onClick}
+    style={{
+      padding: '6px 14px',
+      background: active ? color : '#222',
+      color: active ? '#000' : color,
+      fontWeight: 'bold',
+      border: `1px solid ${color}`,
+      cursor: 'pointer',
+      boxShadow: 'none',
+      fontFamily: 'monospace'
+    }}
+  >
+    {label}
+  </button>
+)
+
+const SchematicCard: React.FC<{ schematic: Schematic }> = ({ schematic: s }) => {
+  const ready = s.craftable && s.has_ingredients
+  const available = s.craftable && !s.has_ingredients
+  const borderColor = !s.craftable ? '#4b5563' : ready ? '#34d399' : '#60a5fa'
+
+  return (
+    <div style={{ background: '#0f0f0f', border: `1px solid ${borderColor}`, padding: 14, fontFamily: 'monospace' }}>
+      {/* Header */}
+      <div style={{ marginBottom: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+          <span style={{ color: '#a78bfa', fontWeight: 'bold', fontSize: '1.05em' }}>{s.name}</span>
+          {ready && (
+            <span style={{ color: '#34d399', fontSize: '0.7em', background: '#001a10', padding: '2px 6px', border: '1px solid #34d399' }}>
+              READY
+            </span>
+          )}
+          {available && (
+            <span style={{ color: '#60a5fa', fontSize: '0.7em', background: '#001020', padding: '2px 6px', border: '1px solid #60a5fa' }}>
+              AVAILABLE
+            </span>
+          )}
+          {!s.craftable && (
+            <span style={{ color: '#6b7280', fontSize: '0.7em', background: '#1a1a1a', padding: '2px 6px', border: '1px solid #4b5563' }}>
+              LOCKED
+            </span>
+          )}
+        </div>
+        <div style={{ color: '#6b7280', fontSize: '0.75em' }}>{s.slug}</div>
+      </div>
+
+      {/* Description */}
+      {s.description && (
+        <div style={{ color: '#9ca3af', fontSize: '0.85em', marginBottom: 8, lineHeight: 1.4 }}>{s.description}</div>
+      )}
+
+      {/* Output */}
+      <div style={{ marginBottom: 8 }}>
+        <span style={{ color: '#fbbf24', fontSize: '0.8em' }}>Output: </span>
+        <span style={{ color: s.output.rarity_color, fontWeight: 'bold' }}>{s.output.name}</span>
+        {s.output_quantity > 1 && <span style={{ color: '#6b7280' }}> x{s.output_quantity}</span>}
+      </div>
+
+      {/* Ingredients */}
+      <div style={{ marginTop: 8 }}>
+        <div style={{ color: '#fbbf24', fontSize: '0.8em', marginBottom: 4 }}>Ingredients:</div>
+        {s.ingredients.map(i => <IngredientRow key={i.item_slug} ingredient={i} />)}
+      </div>
+
+      {/* Footer */}
+      <div style={{ marginTop: 10, paddingTop: 8, borderTop: '1px solid #2a2a2a', display: 'flex', flexWrap: 'wrap', gap: 10, fontSize: '0.8em' }}>
+        {s.xp_reward > 0 && <span style={{ color: '#a78bfa' }}>+{s.xp_reward} XP</span>}
+        {s.required_clearance > 0 && <span style={{ color: '#d0d0d0' }}>CL{s.required_clearance}+</span>}
+      </div>
+
+      {ready && (
+        <div style={{ marginTop: 8, color: '#6b7280', fontSize: '0.75em' }}>
+          Use <code style={{ color: '#34d399' }}>fab {s.slug}</code> in the Terminal.
+        </div>
+      )}
+    </div>
+  )
+}
+
+const IngredientRow: React.FC<{ ingredient: SchematicIngredient }> = ({ ingredient: i }) => {
+  const met = i.owned >= i.required
+  return (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: '0.9em', color: met ? '#34d399' : '#d0d0d0' }}>
+      <span style={{ color: met ? '#34d399' : '#f87171', minWidth: 12 }}>{met ? '✓' : '✗'}</span>
+      <span style={{ flex: 1 }}>{i.item_name}</span>
+      <span style={{ color: met ? '#34d399' : '#f87171', fontSize: '0.85em' }}>{i.owned}/{i.required}</span>
+    </div>
+  )
+}
+
+export default SchematicsPage

--- a/app/javascript/types/schematic.ts
+++ b/app/javascript/types/schematic.ts
@@ -1,0 +1,34 @@
+export interface SchematicIngredient {
+  item_slug: string
+  item_name: string
+  rarity: string
+  rarity_color: string
+  required: number
+  owned: number
+}
+
+export interface SchematicOutput {
+  slug: string
+  name: string
+  rarity: string
+  rarity_color: string
+}
+
+export interface Schematic {
+  slug: string
+  name: string
+  description: string | null
+  output: SchematicOutput
+  output_quantity: number
+  xp_reward: number
+  required_clearance: number
+  required_mission_slug: string | null
+  required_achievement_slug: string | null
+  ingredients: SchematicIngredient[]
+  craftable: boolean
+  has_ingredients: boolean
+}
+
+export interface SchematicsIndexResponse {
+  schematics: Schematic[]
+}

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -64,6 +64,8 @@ class GridAchievement < ApplicationRecord
     mission_completed
     salvage_yield_received
     salvage_yield_count
+    fabricate_item
+    fabricate_count
   ].freeze
 
   CATEGORIES = %w[grid music social meta progression].freeze
@@ -81,6 +83,7 @@ class GridAchievement < ApplicationRecord
     vods_watched radio_stations_tuned radio_stations_tuned_all
     clearance_level
     missions_completed_count
+    fabricate_count
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy

--- a/app/models/grid_item_definition.rb
+++ b/app/models/grid_item_definition.rb
@@ -29,6 +29,10 @@ class GridItemDefinition < ApplicationRecord
   has_many :salvage_yields, class_name: "GridSalvageYield",
     foreign_key: :source_definition_id, dependent: :destroy
   has_many :output_definitions, through: :salvage_yields, source: :output_definition
+  has_many :schematics_as_output, class_name: "GridSchematic",
+    foreign_key: :output_definition_id, dependent: :restrict_with_error
+  has_many :schematic_ingredients, class_name: "GridSchematicIngredient",
+    foreign_key: :input_definition_id, dependent: :restrict_with_error
 
   accepts_nested_attributes_for :salvage_yields,
     allow_destroy: true,

--- a/app/models/grid_mission.rb
+++ b/app/models/grid_mission.rb
@@ -45,6 +45,7 @@ class GridMission < ApplicationRecord
     visit_room talk_npc collect_item deliver_item
     spend_cred buy_item reach_rep reach_clearance
     use_item salvage_item salvage_yield_received
+    fabricate_item
   ].freeze
 
   # Reward type allowlist. `amount` is the scalar for XP/CRED/rep deltas;

--- a/app/models/grid_schematic.rb
+++ b/app/models/grid_schematic.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_schematics
+# Database name: primary
+#
+#  id                        :integer          not null, primary key
+#  description               :text
+#  name                      :string           not null
+#  output_quantity           :integer          default(1), not null
+#  position                  :integer          default(0), not null
+#  published                 :boolean          default(FALSE), not null
+#  required_achievement_slug :string
+#  required_clearance        :integer          default(0), not null
+#  required_mission_slug     :string
+#  required_room_type        :string
+#  slug                      :string           not null
+#  xp_reward                 :integer          default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  output_definition_id      :integer          not null
+#
+# Indexes
+#
+#  index_grid_schematics_on_output_definition_id  (output_definition_id)
+#  index_grid_schematics_on_slug                  (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  output_definition_id  (output_definition_id => grid_item_definitions.id)
+#
+class GridSchematic < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :output_definition, class_name: "GridItemDefinition"
+  has_many :ingredients, class_name: "GridSchematicIngredient", dependent: :destroy
+  has_many :input_definitions, through: :ingredients
+
+  accepts_nested_attributes_for :ingredients,
+    allow_destroy: true,
+    reject_if: ->(attrs) { attrs["input_definition_id"].blank? }
+
+  validates :slug, presence: true, uniqueness: true,
+    format: {with: /\A[a-z0-9-]+\z/, message: "only lowercase letters, numbers, and hyphens"}
+  validates :name, presence: true
+  validates :output_quantity, numericality: {only_integer: true, greater_than_or_equal_to: 1}
+  validates :xp_reward, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :required_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99}
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(:position, :name) }
+
+  def to_param
+    slug
+  end
+
+  # Check if a hackr meets all visibility/access gates for this schematic.
+  # Clearance is always checked. Mission + achievement gates are optional
+  # (nil = no gate). Returns true if all gates pass.
+  #
+  # For batch checks, pass pre-loaded sets to avoid N+1 queries:
+  #   completed_mission_slugs: Set of slug strings
+  #   earned_achievement_slugs: Set of slug strings
+  def craftable_by?(hackr, completed_mission_slugs: nil, earned_achievement_slugs: nil)
+    return false unless hackr.stat("clearance").to_i >= required_clearance
+
+    if required_mission_slug.present?
+      if completed_mission_slugs
+        return false unless completed_mission_slugs.include?(required_mission_slug)
+      else
+        return false unless hackr.grid_hackr_missions
+          .where(status: "completed")
+          .joins(:grid_mission)
+          .where(grid_missions: {slug: required_mission_slug})
+          .exists?
+      end
+    end
+
+    if required_achievement_slug.present?
+      if earned_achievement_slugs
+        return false unless earned_achievement_slugs.include?(required_achievement_slug)
+      else
+        return false unless hackr.grid_hackr_achievements
+          .joins(:grid_achievement)
+          .where(grid_achievements: {slug: required_achievement_slug})
+          .exists?
+      end
+    end
+
+    true
+  end
+end

--- a/app/models/grid_schematic_ingredient.rb
+++ b/app/models/grid_schematic_ingredient.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_schematic_ingredients
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  position            :integer          default(0), not null
+#  quantity            :integer          default(1), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  grid_schematic_id   :integer          not null
+#  input_definition_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_schematic_ingredients_on_grid_schematic_id    (grid_schematic_id)
+#  index_grid_schematic_ingredients_on_input_definition_id  (input_definition_id)
+#  index_grid_schematic_ingredients_unique                  (grid_schematic_id,input_definition_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_schematic_id    (grid_schematic_id => grid_schematics.id)
+#  input_definition_id  (input_definition_id => grid_item_definitions.id)
+#
+class GridSchematicIngredient < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :grid_schematic
+  belongs_to :input_definition, class_name: "GridItemDefinition"
+
+  validates :quantity, numericality: {only_integer: true, greater_than: 0}
+  validates :input_definition_id, uniqueness: {
+    scope: :grid_schematic_id,
+    message: "already configured as an ingredient for this schematic"
+  }
+  validate :input_and_output_differ
+
+  scope :ordered, -> { order(:position, :id) }
+
+  private
+
+  def input_and_output_differ
+    return unless grid_schematic&.output_definition_id
+    if input_definition_id == grid_schematic.output_definition_id
+      errors.add(:input_definition_id, "cannot be the same as the output")
+    end
+  end
+end

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -104,6 +104,8 @@ module Grid
         derive(@hackr.stat("clearance").to_i, data[:level].to_i)
       when "missions_completed_count"
         derive(missions_completed_count, data[:count].to_i)
+      when "fabricate_count"
+        derive(@hackr.stat("fabricate_count").to_i, data[:count].to_i)
       end
     end
 
@@ -283,6 +285,8 @@ module Grid
         return true
       when "salvage_yield_received"
         return true
+      when "fabricate_item"
+        return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
       when "purchase_item"
         return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
       when "mission_completed"

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -90,6 +90,12 @@ module Grid
         turn_in_command(args.first)
       when "give"
         give_command(args)
+      when "fabricate", "fab"
+        fabricate_command(args.first)
+      when "schematics", "schem", "sch"
+        args.any? ? schematic_detail_command(args.first) : schematics_command
+      when "schematic"
+        schematic_detail_command(args.first)
       when "help", "?"
         help_command
       when "who"
@@ -584,6 +590,11 @@ module Grid
           <span style='color: #34d399;'>abandon &lt;slug&gt;</span>            - Drop an active mission
           <span style='color: #34d399;'>turn_in &lt;slug&gt;, ti</span>        - Turn in a completed mission (must be with giver)
 
+        <span style='color: #fbbf24;'>Fabrication:</span>
+          <span style='color: #34d399;'>schematics, schem, sch</span>     - Browse available schematics
+          <span style='color: #34d399;'>schematic &lt;slug&gt;</span>          - View schematic details &amp; ingredients
+          <span style='color: #34d399;'>fabricate &lt;slug&gt;, fab</span>     - Fabricate an item from a schematic
+
         <span style='color: #fbbf24;'>Commerce:</span>
           <span style='color: #34d399;'>shop, browse</span>              - View vendor inventory &amp; prices
           <span style='color: #34d399;'>buy &lt;item&gt;</span>                - Purchase an item from vendor
@@ -843,6 +854,133 @@ module Grid
       end
 
       output
+    end
+
+    # --- Fabrication commands ---
+
+    def schematics_command
+      all_schematics = GridSchematic.published.ordered
+        .includes(:output_definition, ingredients: :input_definition).to_a
+
+      inventory_qtys = hackr.grid_items.group(:grid_item_definition_id).sum(:quantity)
+      gate_ctx = schematic_gate_context
+
+      available, locked = all_schematics.partition { |s| s.craftable_by?(hackr, **gate_ctx) }
+
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output << "<span style='color: #22d3ee; font-weight: bold;'>FABRICATION SCHEMATICS</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+
+      if all_schematics.empty?
+        output << ""
+        output << "<span style='color: #9ca3af;'>No schematics available.</span>"
+      else
+        if available.any?
+          output << ""
+          output << "<span style='color: #34d399; font-weight: bold;'>[AVAILABLE]</span>"
+          available.each do |s|
+            ingredients_line = s.ingredients.ordered
+              .map { |i| "#{h(i.input_definition.name)} ×#{i.quantity}" }.join(", ")
+            has_mats = s.ingredients.all? { |i| (inventory_qtys[i.input_definition_id] || 0) >= i.quantity }
+            badge = has_mats ? "<span style='color: #34d399;'>✓</span>" : "<span style='color: #f87171;'>✗</span>"
+            output << "  #{badge} <span style='color: #60a5fa;'>#{h(s.slug)}</span> " \
+              "<span style='color: #9ca3af;'>— #{h(s.name)}</span> " \
+              "<span style='color: #6b7280;'>[ #{ingredients_line} ]</span>"
+          end
+        end
+
+        if locked.any?
+          output << ""
+          output << "<span style='color: #6b7280; font-weight: bold;'>[LOCKED]</span>"
+          locked.each do |s|
+            output << "  <span style='color: #4b5563;'>◈ #{h(s.name)}</span>"
+          end
+        end
+      end
+
+      output << ""
+      output << "<span style='color: #6b7280;'>Use 'schematic &lt;slug&gt;' for details. Use 'fab &lt;slug&gt;' to fabricate.</span>"
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output.join("\n")
+    end
+
+    def schematic_detail_command(slug)
+      return "<span style='color: #fbbf24;'>Which schematic? Usage: schematic &lt;slug&gt;</span>" if slug.blank?
+
+      schematic = GridSchematic.published
+        .includes(:output_definition, ingredients: :input_definition)
+        .find_by(slug: slug.downcase)
+      return "<span style='color: #f87171;'>Unknown schematic: #{h(slug)}. Use 'schematics' to browse.</span>" unless schematic
+
+      unless schematic.craftable_by?(hackr, **schematic_gate_context)
+        return "<span style='color: #f87171;'>You don't meet the requirements for this schematic.</span>"
+      end
+
+      output = []
+      output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output << "<span style='color: #60a5fa; font-weight: bold;'>#{h(schematic.name)}</span> <span style='color: #6b7280;'>[#{h(schematic.slug)}]</span>"
+      output << "<span style='color: #9ca3af;'>#{h(schematic.description)}</span>" if schematic.description.present?
+      output << ""
+      output << "<span style='color: #fbbf24;'>OUTPUT:</span> " \
+        "<span style='color: #{schematic.output_definition.rarity_color};'>#{h(schematic.output_definition.name)}</span>" \
+        "#{" <span style='color: #6b7280;'>×#{schematic.output_quantity}</span>" if schematic.output_quantity > 1}"
+      output << "<span style='color: #fbbf24;'>XP REWARD:</span> <span style='color: #a78bfa;'>+#{schematic.xp_reward}</span>" if schematic.xp_reward.positive?
+      if schematic.required_clearance.positive?
+        output << "<span style='color: #fbbf24;'>CLEARANCE:</span> <span style='color: #d0d0d0;'>#{schematic.required_clearance}+</span>"
+      end
+      output << ""
+      output << "<span style='color: #fbbf24;'>INGREDIENTS:</span>"
+      inventory_qtys = hackr.grid_items.group(:grid_item_definition_id).sum(:quantity)
+      can_craft = true
+      schematic.ingredients.ordered.each do |ing|
+        owned = inventory_qtys[ing.input_definition_id] || 0
+        can_craft = false if owned < ing.quantity
+        status = (owned >= ing.quantity) ?
+          "<span style='color: #34d399;'>✓ #{owned}/#{ing.quantity}</span>" :
+          "<span style='color: #f87171;'>✗ #{owned}/#{ing.quantity}</span>"
+        output << "  #{status} <span style='color: #d0d0d0;'>#{h(ing.input_definition.name)}</span>"
+      end
+      output << ""
+      output << (can_craft ?
+        "<span style='color: #34d399;'>★ Ready to fabricate. Use: fab #{h(schematic.slug)}</span>" :
+        "<span style='color: #6b7280;'>Missing ingredients. Gather materials and try again.</span>")
+      output << "<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
+      output.join("\n")
+    end
+
+    def fabricate_command(recipe_slug)
+      return "<span style='color: #fbbf24;'>Fabricate what? Usage: fab &lt;schematic-slug&gt;</span>" if recipe_slug.blank?
+
+      schematic = GridSchematic.published
+        .includes(:output_definition, ingredients: :input_definition)
+        .find_by(slug: recipe_slug.downcase)
+      return "<span style='color: #f87171;'>Unknown schematic: #{h(recipe_slug)}. Use 'schematics' to browse.</span>" unless schematic
+
+      unless schematic.craftable_by?(hackr, **schematic_gate_context)
+        return "<span style='color: #f87171;'>You don't meet the requirements for this schematic.</span>"
+      end
+
+      begin
+        result = Grid::FabricationService.fabricate!(hackr: hackr, schematic: schematic)
+      rescue Grid::FabricationService::IngredientsInsufficient => e
+        return "<span style='color: #f87171;'>#{h(e.message)}</span>"
+      end
+
+      level_msg = result.xp_result[:leveled_up] ?
+        "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{result.xp_result[:new_clearance]}!</span>" : ""
+      qty_display = (result.output_quantity > 1) ? " <span style='color: #6b7280;'>×#{result.output_quantity}</span>" : ""
+      output = "<span style='color: #34d399;'>Fabricated: </span>" \
+        "<span style='color: #60a5fa; font-weight: bold;'>#{h(result.output_item_name)}</span>#{qty_display}" \
+        "<span style='color: #34d399;'>.</span>" \
+        "#{" <span style='color: #a78bfa;'>+#{result.xp_awarded} XP</span>" if result.xp_awarded.positive?}#{level_msg}"
+
+      notifications = achievement_checker.check(:fabricate_item, item_name: result.output_item_name)
+      notifications += achievement_checker.check(:fabricate_count)
+      notifications += mission_progressor.record(:fabricate_item, item_name: result.output_item_name)
+      notifications += mission_progressor.record(:reach_clearance, clearance: hackr.stat("clearance").to_i)
+      output = append_notifications(output, notifications)
+      {output: output, event: nil}
     end
 
     def apply_item_effect(item)
@@ -1617,6 +1755,19 @@ module Grid
 
     def mission_progressor
       @mission_progressor ||= Grid::MissionProgressor.new(hackr)
+    end
+
+    # Pre-loaded gate context for schematic craftable_by? checks.
+    # Memoized per request — safe because CommandParser is single-use.
+    def schematic_gate_context
+      @schematic_gate_context ||= {
+        completed_mission_slugs: hackr.grid_hackr_missions
+          .where(status: "completed").joins(:grid_mission)
+          .pluck("grid_missions.slug").to_set,
+        earned_achievement_slugs: hackr.grid_hackr_achievements
+          .joins(:grid_achievement)
+          .pluck("grid_achievements.slug").to_set
+      }
     end
 
     # --- Mission commands ---

--- a/app/services/grid/fabrication_service.rb
+++ b/app/services/grid/fabrication_service.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Grid
+  class FabricationService
+    Result = Data.define(:xp_awarded, :xp_result, :output_item_name, :output_quantity, :schematic_name)
+
+    class IngredientsInsufficient < StandardError; end
+
+    def self.fabricate!(hackr:, schematic:)
+      new(hackr, schematic).fabricate!
+    end
+
+    def initialize(hackr, schematic)
+      @hackr = hackr
+      @schematic = schematic
+    end
+
+    def fabricate!
+      ingredients = @schematic.ingredients.ordered.includes(:input_definition)
+
+      ActiveRecord::Base.transaction do
+        # Pre-flight check inside the transaction: lock ingredient rows
+        # to prevent a concurrent fabrication from passing the check and
+        # then racing on consumption.
+        ingredients.each do |ing|
+          owned = @hackr.grid_items
+            .where(grid_item_definition_id: ing.input_definition_id)
+            .lock.sum(:quantity)
+          if owned < ing.quantity
+            raise IngredientsInsufficient,
+              "Missing: #{ing.input_definition.name} (need #{ing.quantity}, have #{owned})"
+          end
+        end
+
+        # Consume ingredients
+        ingredients.each { |ing| consume_ingredient!(ing) }
+
+        # Grant output item (stacking via shared module)
+        output_def = @schematic.output_definition
+        Grid::Inventory.grant_item!(
+          hackr: @hackr,
+          definition: output_def,
+          quantity: @schematic.output_quantity
+        )
+
+        # Grant XP
+        xp_result = if @schematic.xp_reward.positive?
+          @hackr.grant_xp!(@schematic.xp_reward)
+        else
+          {leveled_up: false}
+        end
+
+        # Increment stat inside the transaction so it rolls back with
+        # everything else if a later step fails.
+        current = @hackr.stat("fabricate_count") || 0
+        @hackr.set_stat!("fabricate_count", current + 1)
+
+        Result.new(
+          xp_awarded: @schematic.xp_reward,
+          xp_result: xp_result,
+          output_item_name: output_def.name,
+          output_quantity: @schematic.output_quantity,
+          schematic_name: @schematic.name
+        )
+      end
+    end
+
+    private
+
+    # Consume the required quantity from hackr's inventory stacks.
+    # Handles fragmented stacks (multiple rows for the same definition)
+    # by consuming in ID order until the required quantity is met.
+    def consume_ingredient!(ingredient)
+      remaining = ingredient.quantity
+      @hackr.grid_items
+        .where(grid_item_definition_id: ingredient.input_definition_id)
+        .order(:id).lock
+        .each do |stack|
+          break if remaining <= 0
+          if stack.quantity <= remaining
+            remaining -= stack.quantity
+            stack.destroy!
+          else
+            stack.update!(quantity: stack.quantity - remaining)
+            remaining = 0
+          end
+        end
+    end
+  end
+end

--- a/app/services/grid/inventory.rb
+++ b/app/services/grid/inventory.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Grid
+  # Shared item-granting logic for services that add items to a hackr's
+  # inventory. Stacks into an existing item row if the hackr already owns
+  # one with the same definition; otherwise creates a new GridItem from
+  # the definition's template attributes.
+  #
+  # Usage:
+  #   Grid::Inventory.grant_item!(hackr: h, definition: d, quantity: 2)
+  module Inventory
+    module_function
+
+    def grant_item!(hackr:, definition:, quantity: 1)
+      unless ActiveRecord::Base.connection.transaction_open?
+        raise "Grid::Inventory.grant_item! must be called inside a transaction"
+      end
+
+      existing = hackr.grid_items
+        .where(grid_item_definition_id: definition.id)
+        .lock.first
+
+      if existing
+        existing.update!(quantity: existing.quantity + quantity)
+        existing
+      else
+        GridItem.create!(
+          definition.item_attributes.merge(
+            grid_hackr: hackr,
+            quantity: quantity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -33,6 +33,7 @@ module Grid
     #   :use_item         → item_name:
     #   :salvage_item     → item_name:
     #   :salvage_yield_received → item_name: (name of yielded item)
+    #   :fabricate_item   → item_name: (name of crafted output item)
     def record(trigger_type, context = {})
       return [] unless @hackr
 
@@ -114,7 +115,7 @@ module Grid
       case trigger_type.to_s
       when "visit_room"
         target.blank? || target.casecmp?(context[:room_slug].to_s)
-      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item"
+      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item"
         target.blank? || target.casecmp?(name_context(context).to_s)
       when "deliver_item"
         # Convention: `target_slug` holds the item name. The delivery
@@ -148,7 +149,7 @@ module Grid
     # target_count so the `progress >= target_count` completion check fires.
     def next_progress_value(current, trigger_type, context, target_count)
       case trigger_type.to_s
-      when "visit_room", "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "deliver_item"
+      when "visit_room", "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "deliver_item", "fabricate_item"
         [current + 1, target_count].min
       when "spend_cred"
         [current + context[:amount].to_i, target_count].min

--- a/app/services/grid/mission_reward_granter.rb
+++ b/app/services/grid/mission_reward_granter.rb
@@ -156,12 +156,10 @@ module Grid
         return nil
       end
 
-      GridItem.create!(
-        definition.item_attributes.merge(
-          grid_hackr: @hackr,
-          value: [reward.amount.to_i, 0].max,
-          quantity: reward.quantity.to_i.clamp(1, 9999)
-        )
+      Grid::Inventory.grant_item!(
+        hackr: @hackr,
+        definition: definition,
+        quantity: reward.quantity.to_i.clamp(1, 9999)
       )
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.warn("[MissionRewardGranter] item grant failed: #{e.message}")

--- a/app/services/grid/salvage_service.rb
+++ b/app/services/grid/salvage_service.rb
@@ -47,20 +47,11 @@ module Grid
     private
 
     def grant_yield!(yield_row)
-      output_def = yield_row.output_definition
-      existing = @hackr.grid_items.find_by(grid_item_definition_id: output_def.id)
-
-      if existing
-        existing.update!(quantity: existing.quantity + yield_row.quantity)
-        existing
-      else
-        GridItem.create!(
-          output_def.item_attributes.merge(
-            grid_hackr: @hackr,
-            quantity: yield_row.quantity
-          )
-        )
-      end
+      Grid::Inventory.grant_item!(
+        hackr: @hackr,
+        definition: yield_row.output_definition,
+        quantity: yield_row.quantity
+      )
     end
   end
 end

--- a/app/views/admin/grid_schematics/_form.html.erb
+++ b/app/views/admin/grid_schematics/_form.html.erb
@@ -1,0 +1,186 @@
+<%= form_with model: [:admin, schematic], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: SCHEMATIC INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if schematic.errors[:name].any? %>
+        <br><small class="red-255-text"><%= schematic.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">lowercase letters, numbers, hyphens only</small>
+      <% if schematic.errors[:slug].any? %>
+        <br><small class="red-255-text"><%= schematic.errors[:slug].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :output_definition_id, "OUTPUT ITEM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :output_definition_id,
+            @all_definitions.map { |d| ["#{d.name} [#{d.rarity_label}]", d.id] },
+            { include_blank: "Select..." }, class: "tui-input", style: "width: 100%;" %>
+      <% if schematic.errors[:output_definition_id].any? %>
+        <br><small class="red-255-text"><%= schematic.errors[:output_definition_id].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :output_quantity, "OUTPUT QTY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :output_quantity, class: "tui-input", style: "width: 100%;", min: 1 %>
+    </div>
+    <div>
+      <%= f.label :xp_reward, "XP REWARD", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :xp_reward, class: "tui-input", style: "width: 100%;", min: 0 %>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :required_clearance, "REQUIRED CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :required_clearance, class: "tui-input", style: "width: 100%;", min: 0, max: 99 %>
+    </div>
+    <div>
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%;", min: 0 %>
+    </div>
+    <div style="display: flex; align-items: center; padding-top: 25px;">
+      <%= f.check_box :published, style: "margin-right: 8px;" %>
+      <%= f.label :published, "PUBLISHED", class: "white-text", style: "font-weight: bold;" %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: VISIBILITY GATES (Optional) ::]</h3>
+  <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
+    Leave blank for no gate. Slugs are resolved at runtime.
+  </p>
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :required_mission_slug, "REQUIRED MISSION SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :required_mission_slug, class: "tui-input", style: "width: 100%; font-family: monospace;", placeholder: "e.g. signal-recovery" %>
+    </div>
+    <div>
+      <%= f.label :required_achievement_slug, "REQUIRED ACHIEVEMENT SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :required_achievement_slug, class: "tui-input", style: "width: 100%; font-family: monospace;", placeholder: "e.g. first-salvage" %>
+    </div>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: INGREDIENTS ::]</h3>
+  <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
+    Items consumed when this schematic is fabricated.
+  </p>
+  <table id="ingredients-table" class="tui-table" style="width: 100%; margin-bottom: 10px;">
+    <thead>
+      <tr>
+        <th style="text-align: left; width: 70px;">Pos</th>
+        <th style="text-align: left;">Input Item</th>
+        <th style="text-align: center; width: 80px;">Qty</th>
+        <th style="text-align: center; width: 50px;">&times;</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= f.fields_for :ingredients, @sorted_ingredients || schematic.ingredients do |ff| %>
+        <tr>
+          <td><%= ff.number_field :position, class: "tui-input", style: "width: 60px; padding: 4px;", min: 0 %></td>
+          <td>
+            <%= ff.select :input_definition_id,
+                  @all_definitions.map { |d| ["#{d.name} [#{d.rarity_label}]", d.id] },
+                  {include_blank: "— select input —"},
+                  class: "tui-input", style: "width: 100%; padding: 4px;" %>
+          </td>
+          <td style="text-align: center;">
+            <%= ff.number_field :quantity, class: "tui-input", style: "width: 70px; padding: 4px; text-align: center;", min: 1 %>
+          </td>
+          <td style="text-align: center;">
+            <% if ff.object.persisted? %>
+              <%= ff.hidden_field :id %>
+              <%= ff.hidden_field :_destroy, value: "0", class: "destroy-flag" %>
+              <button type="button" class="tui-button red-168 ingredient-destroy-btn" style="padding: 2px 6px; font-size: 0.8em; box-shadow: 4px 4px black;" data-persisted="true">&times;</button>
+            <% else %>
+              <button type="button" class="tui-button red-168 ingredient-destroy-btn" style="padding: 2px 6px; font-size: 0.8em; box-shadow: 4px 4px black;">&times;</button>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <% if schematic.errors[:ingredients].any? %>
+    <small class="red-255-text"><%= schematic.errors[:ingredients].join(", ") %></small>
+  <% end %>
+  <button type="button" id="add-ingredient-btn" class="tui-button green-168" style="padding: 4px 12px; font-size: 0.85em; margin-top: 5px;">+ Add Ingredient</button>
+
+  <template id="ingredient-row-template">
+    <tr>
+      <td>
+        <input type="number" name="grid_schematic[ingredients_attributes][__INDEX__][position]"
+          class="tui-input" style="width: 60px; padding: 4px;" min="0" value="0">
+      </td>
+      <td>
+        <select name="grid_schematic[ingredients_attributes][__INDEX__][input_definition_id]"
+          class="tui-input" style="width: 100%; padding: 4px;">
+          <option value="">— select input —</option>
+          <% @all_definitions.each do |d| %>
+            <option value="<%= d.id %>"><%= d.name %> [<%= d.rarity_label %>]</option>
+          <% end %>
+        </select>
+      </td>
+      <td style="text-align: center;">
+        <input type="number" name="grid_schematic[ingredients_attributes][__INDEX__][quantity]"
+          class="tui-input" style="width: 70px; padding: 4px; text-align: center;" min="1" value="1">
+      </td>
+      <td style="text-align: center;">
+        <button type="button" class="tui-button red-168 ingredient-destroy-btn" style="padding: 2px 6px; font-size: 0.8em; box-shadow: 4px 4px black;">&times;</button>
+      </td>
+    </tr>
+  </template>
+
+  <script nonce="<%= content_security_policy_nonce %>">
+    (function() {
+      var ingredientRowIndex = <%= schematic.ingredients.size + 1000 %>;
+      var table = document.getElementById('ingredients-table');
+
+      table.addEventListener('click', function(e) {
+        var btn = e.target.closest('.ingredient-destroy-btn');
+        if (!btn) return;
+        var row = btn.closest('tr');
+        if (btn.dataset.persisted) {
+          row.querySelector('.destroy-flag').value = '1';
+          row.style.display = 'none';
+        } else {
+          row.remove();
+        }
+      });
+
+      document.getElementById('add-ingredient-btn').addEventListener('click', function() {
+        var template = document.getElementById('ingredient-row-template');
+        var tbody = table.querySelector('tbody');
+        var clone = template.content.cloneNode(true);
+        clone.querySelectorAll('[name]').forEach(function(el) {
+          el.name = el.name.replace('__INDEX__', ingredientRowIndex);
+        });
+        tbody.appendChild(clone);
+        ingredientRowIndex++;
+      });
+    })();
+  </script>
+
+  <div style="margin-top: 30px; display: flex; gap: 10px;">
+    <%= f.submit schematic.persisted? ? "Save Schematic" : "Create Schematic",
+          class: "tui-button purple-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <%= link_to "Cancel", admin_grid_schematics_path,
+          class: "tui-button grey-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% if schematic.persisted? %>
+      <%= link_to "History", history_admin_grid_schematic_path(schematic),
+            class: "tui-button purple-168", style: "padding: 10px 30px; font-size: 1.1em;" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_schematics/edit.html.erb
+++ b/app/views/admin/grid_schematics/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/schematics/<%= @schematic.slug %> :: EDIT SCHEMATIC</legend>
+    <div style="padding: 20px;">
+      <%= render "form", schematic: @schematic %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_schematics/index.html.erb
+++ b/app/views/admin/grid_schematics/index.html.erb
@@ -1,0 +1,69 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/schematics :: FABRICATION SCHEMATICS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Schematic", new_admin_grid_schematic_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 900px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Output</th>
+              <th style="text-align: center;">Qty</th>
+              <th style="text-align: center;">Ingredients</th>
+              <th style="text-align: center;">XP</th>
+              <th style="text-align: center;">CL</th>
+              <th style="text-align: center;">Published</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @schematics.each do |s| %>
+              <tr>
+                <td><%= s.name %></td>
+                <td style="color: #6b7280;"><%= s.slug %></td>
+                <td>
+                  <span style="color: <%= s.output_definition.rarity_color %>;">
+                    <%= s.output_definition.name %>
+                  </span>
+                </td>
+                <td style="text-align: center;"><%= s.output_quantity %></td>
+                <td style="text-align: center;"><%= s.ingredients.size %></td>
+                <td style="text-align: center;"><%= s.xp_reward %></td>
+                <td style="text-align: center;"><%= s.required_clearance %></td>
+                <td style="text-align: center;">
+                  <% if s.published? %>
+                    <span class="green-255-text">✓</span>
+                  <% else %>
+                    <span style="color: #6b7280;">—</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_schematic_path(s), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_schematic_path(s), data: { turbo_method: :delete, turbo_confirm: "Delete schematic '#{s.name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_schematics/new.html.erb
+++ b/app/views/admin/grid_schematics/new.html.erb
@@ -1,0 +1,8 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/schematics/new :: NEW SCHEMATIC</legend>
+    <div style="padding: 20px;">
+      <%= render "form", schematic: @schematic %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -88,6 +88,7 @@
           <%= link_to "Shops", admin_grid_shop_listings_path, class: "green-168-text" %>
           <%= link_to "Achievements", admin_grid_achievements_path, class: "green-168-text" %>
           <%= link_to "Missions", admin_grid_missions_path, class: "green-168-text" %>
+          <%= link_to "Schematics", admin_grid_schematics_path, class: "green-168-text" %>
           <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
           <%= link_to "Zones", admin_grid_zones_path, class: "green-168-text" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
   # the MissionsPage card grid — no dedicated per-slug React route, so
   # we don't expose `/missions/:slug` as a Rails SPA path either.
   get "missions", to: "pages#spa_root", as: :missions
+  get "schematics", to: "pages#spa_root", as: :schematics
 
   # Codex (wiki) routes - SPA
   scope "codex" do
@@ -163,6 +164,7 @@ Rails.application.routes.draw do
     get "grid/current_hackr", to: "grid#current_hackr_info"
     get "grid/achievements", to: "grid#achievements_index"
     get "grid/missions", to: "grid#missions_index"
+    get "grid/schematics", to: "grid#schematics_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
     get "grid/verify/:token", to: "grid#verify_token"
@@ -388,6 +390,13 @@ Rails.application.routes.draw do
       end
     end
     resources :grid_hackr_missions, only: %i[index show]
+
+    # Grid schematics (fabrication recipes)
+    resources :grid_schematics, except: [:show] do
+      member do
+        get :history
+      end
+    end
 
     # Hackr Handbook (docs — full CRUD)
     resources :handbook_sections do

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -1,0 +1,123 @@
+# Fabrication Schematics — crafting recipes for THE PULSE GRID.
+# Loaded by: rails data:schematics (after item_definitions).
+# Idempotent: find_or_initialize_by slug, skip if exists.
+#
+# Ingredients reference item definitions by slug.
+# Output references a single item definition by slug.
+
+schematics:
+
+  # ── Scrap → Basic Rig Components ─────────────────────────────────
+  - slug: fab-basic-cpu
+    name: Fabricate Basic CPU
+    description: "Assemble a functional CPU from salvaged silicon wafers."
+    output_slug: basic-cpu
+    output_quantity: 1
+    xp_reward: 15
+    required_clearance: 0
+    published: true
+    position: 10
+    ingredients:
+      - input_slug: raw-silicon-wafer
+        quantity: 3
+        position: 0
+
+  - slug: fab-basic-gpu
+    name: Fabricate Basic GPU
+    description: "Build a basic mining GPU from reclaimed wafers and shader fragments."
+    output_slug: basic-gpu
+    output_quantity: 1
+    xp_reward: 20
+    required_clearance: 0
+    published: true
+    position: 20
+    ingredients:
+      - input_slug: raw-silicon-wafer
+        quantity: 3
+        position: 0
+      - input_slug: corrupted-shader-fragment
+        quantity: 1
+        position: 1
+
+  - slug: fab-basic-ram
+    name: Fabricate Basic RAM
+    description: "Compile a RAM stick from reclaimed silicon and data shards."
+    output_slug: basic-ram
+    output_quantity: 1
+    xp_reward: 12
+    required_clearance: 0
+    published: true
+    position: 30
+    ingredients:
+      - input_slug: raw-silicon-wafer
+        quantity: 2
+        position: 0
+      - input_slug: data-shard
+        quantity: 1
+        position: 1
+
+  - slug: fab-basic-psu
+    name: Fabricate Basic PSU
+    description: "Wire together a working power supply from scrap cables."
+    output_slug: basic-psu
+    output_quantity: 1
+    xp_reward: 10
+    required_clearance: 0
+    published: true
+    position: 40
+    ingredients:
+      - input_slug: scrap-wire-bundle
+        quantity: 3
+        position: 0
+
+  - slug: fab-basic-motherboard
+    name: Fabricate Basic Motherboard
+    description: "Assemble a motherboard from silicon and wire. The foundation of any rig."
+    output_slug: basic-motherboard
+    output_quantity: 1
+    xp_reward: 25
+    required_clearance: 0
+    published: true
+    position: 50
+    ingredients:
+      - input_slug: raw-silicon-wafer
+        quantity: 2
+        position: 0
+      - input_slug: scrap-wire-bundle
+        quantity: 2
+        position: 1
+
+  # ── Scrap → Basic Consumables ────────────────────────────────────
+  - slug: fab-medpatch
+    name: Fabricate MedPatch
+    description: "Synthesize a basic healing patch from data shards and wire."
+    output_slug: medpatch
+    output_quantity: 1
+    xp_reward: 8
+    required_clearance: 0
+    published: true
+    position: 60
+    ingredients:
+      - input_slug: data-shard
+        quantity: 2
+        position: 0
+      - input_slug: scrap-wire-bundle
+        quantity: 1
+        position: 1
+
+  - slug: fab-stim-shot
+    name: Fabricate Stim Shot
+    description: "Cobble together a stimulant from raw silicon and data fragments."
+    output_slug: stim-shot
+    output_quantity: 1
+    xp_reward: 8
+    required_clearance: 0
+    published: true
+    position: 70
+    ingredients:
+      - input_slug: raw-silicon-wafer
+        quantity: 1
+        position: 0
+      - input_slug: data-shard
+        quantity: 2
+        position: 1

--- a/db/migrate/20260419120001_create_grid_schematic_tables.rb
+++ b/db/migrate/20260419120001_create_grid_schematic_tables.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateGridSchematicTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_schematics do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.text :description
+      t.references :output_definition, null: false, foreign_key: {to_table: :grid_item_definitions}
+      t.integer :output_quantity, null: false, default: 1
+      t.integer :xp_reward, null: false, default: 0
+      t.integer :required_clearance, null: false, default: 0
+      t.boolean :published, null: false, default: false
+      t.integer :position, null: false, default: 0
+      # Visibility gates (all nullable = not required)
+      t.string :required_mission_slug
+      t.string :required_achievement_slug
+      # Future-proofing: room-type restriction (not enforced in v1)
+      t.string :required_room_type
+      t.timestamps
+    end
+    add_index :grid_schematics, :slug, unique: true
+
+    create_table :grid_schematic_ingredients do |t|
+      t.references :grid_schematic, null: false, foreign_key: true, index: true
+      t.references :input_definition, null: false, foreign_key: {to_table: :grid_item_definitions}
+      t.integer :quantity, null: false, default: 1
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_schematic_ingredients,
+      [:grid_schematic_id, :input_definition_id],
+      unique: true, name: :index_grid_schematic_ingredients_unique
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_120004) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_120001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -488,6 +488,37 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_120004) do
     t.index ["output_definition_id"], name: "index_grid_salvage_yields_on_output_definition_id"
     t.index ["source_definition_id", "output_definition_id"], name: "index_grid_salvage_yields_unique", unique: true
     t.index ["source_definition_id"], name: "index_grid_salvage_yields_on_source_definition_id"
+  end
+
+  create_table "grid_schematic_ingredients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_schematic_id", null: false
+    t.integer "input_definition_id", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "quantity", default: 1, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_schematic_id", "input_definition_id"], name: "index_grid_schematic_ingredients_unique", unique: true
+    t.index ["grid_schematic_id"], name: "index_grid_schematic_ingredients_on_grid_schematic_id"
+    t.index ["input_definition_id"], name: "index_grid_schematic_ingredients_on_input_definition_id"
+  end
+
+  create_table "grid_schematics", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.integer "output_definition_id", null: false
+    t.integer "output_quantity", default: 1, null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: false, null: false
+    t.string "required_achievement_slug"
+    t.integer "required_clearance", default: 0, null: false
+    t.string "required_mission_slug"
+    t.string "required_room_type"
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.integer "xp_reward", default: 0, null: false
+    t.index ["output_definition_id"], name: "index_grid_schematics_on_output_definition_id"
+    t.index ["slug"], name: "index_grid_schematics_on_slug", unique: true
   end
 
   create_table "grid_shop_listings", force: :cascade do |t|
@@ -1067,6 +1098,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_120004) do
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_salvage_yields", "grid_item_definitions", column: "output_definition_id"
   add_foreign_key "grid_salvage_yields", "grid_item_definitions", column: "source_definition_id"
+  add_foreign_key "grid_schematic_ingredients", "grid_item_definitions", column: "input_definition_id"
+  add_foreign_key "grid_schematic_ingredients", "grid_schematics"
+  add_foreign_key "grid_schematics", "grid_item_definitions", column: "output_definition_id"
   add_foreign_key "grid_shop_listings", "grid_item_definitions"
   add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -186,7 +186,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, zones, rooms, etc.)"
-  task world: [:factions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions]
+  task world: [:factions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -1941,6 +1941,64 @@ namespace :data do
 
     puts "Arcs: #{arc_created} created, #{GridMissionArc.count} total"
     puts "Missions: #{mission_created} created, #{GridMission.count} total"
+  end
+
+  desc "Load fabrication schematics from YAML"
+  task schematics: :environment do
+    puts "\n--- Loading Fabrication Schematics ---"
+    yaml_file = Rails.root.join("data", "world", "schematics.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    schematics_data = data["schematics"] || []
+    created = 0
+
+    schematics_data.each do |attrs|
+      output_def = GridItemDefinition.find_by(slug: attrs["output_slug"])
+      unless output_def
+        puts "  ✗ Output definition not found: #{attrs["output_slug"]}"
+        next
+      end
+
+      schematic = GridSchematic.find_or_initialize_by(slug: attrs["slug"])
+      next unless schematic.new_record?
+
+      schematic.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"],
+        output_definition: output_def,
+        output_quantity: attrs["output_quantity"] || 1,
+        xp_reward: attrs["xp_reward"] || 0,
+        required_clearance: attrs["required_clearance"] || 0,
+        published: attrs["published"] != false,
+        position: attrs["position"] || 0,
+        required_mission_slug: attrs["required_mission_slug"],
+        required_achievement_slug: attrs["required_achievement_slug"]
+      )
+
+      (attrs["ingredients"] || []).each_with_index do |ing_attrs, idx|
+        input_def = GridItemDefinition.find_by(slug: ing_attrs["input_slug"])
+        unless input_def
+          puts "  ✗ Ingredient definition not found: #{ing_attrs["input_slug"]} (schematic: #{attrs["slug"]})"
+          next
+        end
+        schematic.ingredients.build(
+          input_definition: input_def,
+          quantity: ing_attrs["quantity"] || 1,
+          position: ing_attrs["position"] || idx
+        )
+      end
+
+      schematic.save!
+      created += 1
+      puts "  ✓ Created: #{schematic.name} → #{output_def.name}"
+    end
+
+    puts "Schematics: #{created} created, #{GridSchematic.count} total"
   end
 end
 

--- a/spec/factories/grid_schematic_ingredients.rb
+++ b/spec/factories/grid_schematic_ingredients.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :grid_schematic_ingredient do
+    association :grid_schematic
+    association :input_definition, factory: :grid_item_definition
+    quantity { 1 }
+    position { 0 }
+  end
+end

--- a/spec/factories/grid_schematics.rb
+++ b/spec/factories/grid_schematics.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :grid_schematic do
+    sequence(:slug) { |n| "schematic-#{n}" }
+    sequence(:name) { |n| "Schematic #{n}" }
+    description { "A fabrication schematic" }
+    association :output_definition, factory: :grid_item_definition
+    output_quantity { 1 }
+    xp_reward { 10 }
+    required_clearance { 0 }
+    published { true }
+    position { 0 }
+
+    trait :unpublished do
+      published { false }
+    end
+
+    trait :clearance_gated do
+      required_clearance { 5 }
+    end
+  end
+end

--- a/spec/models/grid_schematic_ingredient_spec.rb
+++ b/spec/models/grid_schematic_ingredient_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe GridSchematicIngredient do
+  let(:output_def) { create(:grid_item_definition, slug: "output-item") }
+  let(:input_def) { create(:grid_item_definition, slug: "input-item") }
+  let(:schematic) do
+    GridSchematic.create!(slug: "test-sch", name: "Test", output_definition: output_def)
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      ingredient = described_class.new(
+        grid_schematic: schematic, input_definition: input_def, quantity: 2
+      )
+      expect(ingredient).to be_valid
+    end
+
+    it "requires quantity > 0" do
+      ingredient = described_class.new(
+        grid_schematic: schematic, input_definition: input_def, quantity: 0
+      )
+      expect(ingredient).not_to be_valid
+      expect(ingredient.errors[:quantity]).to be_present
+    end
+
+    it "enforces unique input per schematic" do
+      described_class.create!(grid_schematic: schematic, input_definition: input_def)
+      duplicate = described_class.new(grid_schematic: schematic, input_definition: input_def)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:input_definition_id]).to include(
+        "already configured as an ingredient for this schematic"
+      )
+    end
+
+    it "prevents input same as output" do
+      ingredient = described_class.new(
+        grid_schematic: schematic, input_definition: output_def, quantity: 1
+      )
+      expect(ingredient).not_to be_valid
+      expect(ingredient.errors[:input_definition_id]).to include("cannot be the same as the output")
+    end
+  end
+
+  describe ".ordered" do
+    it "orders by position then id" do
+      i2 = described_class.create!(grid_schematic: schematic, input_definition: input_def, position: 1)
+      input2 = create(:grid_item_definition, slug: "input-2")
+      i1 = described_class.create!(grid_schematic: schematic, input_definition: input2, position: 0)
+
+      expect(described_class.ordered.to_a).to eq([i1, i2])
+    end
+  end
+
+  describe "dependent destroy" do
+    it "is destroyed when schematic is destroyed" do
+      described_class.create!(grid_schematic: schematic, input_definition: input_def)
+      expect { schematic.destroy! }.to change(described_class, :count).by(-1)
+    end
+  end
+end

--- a/spec/models/grid_schematic_spec.rb
+++ b/spec/models/grid_schematic_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe GridSchematic do
+  let(:output_def) { create(:grid_item_definition, slug: "output-item") }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      schematic = described_class.new(
+        slug: "test-schematic", name: "Test", output_definition: output_def
+      )
+      expect(schematic).to be_valid
+    end
+
+    it "requires slug" do
+      schematic = described_class.new(name: "Test", output_definition: output_def)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:slug]).to be_present
+    end
+
+    it "requires unique slug" do
+      described_class.create!(slug: "taken", name: "First", output_definition: output_def)
+      duplicate = described_class.new(slug: "taken", name: "Second", output_definition: output_def)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:slug]).to be_present
+    end
+
+    it "validates slug format" do
+      schematic = described_class.new(slug: "INVALID SLUG!", name: "Test", output_definition: output_def)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:slug]).to include("only lowercase letters, numbers, and hyphens")
+    end
+
+    it "requires name" do
+      schematic = described_class.new(slug: "test", output_definition: output_def, name: nil)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:name]).to be_present
+    end
+
+    it "requires output_quantity >= 1" do
+      schematic = described_class.new(slug: "test", name: "Test", output_definition: output_def, output_quantity: 0)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:output_quantity]).to be_present
+    end
+
+    it "requires xp_reward >= 0" do
+      schematic = described_class.new(slug: "test", name: "Test", output_definition: output_def, xp_reward: -1)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:xp_reward]).to be_present
+    end
+
+    it "requires required_clearance 0-99" do
+      schematic = described_class.new(slug: "test", name: "Test", output_definition: output_def, required_clearance: 100)
+      expect(schematic).not_to be_valid
+      expect(schematic.errors[:required_clearance]).to be_present
+    end
+  end
+
+  describe "#to_param" do
+    it "returns slug" do
+      schematic = described_class.new(slug: "my-schematic")
+      expect(schematic.to_param).to eq("my-schematic")
+    end
+  end
+
+  describe ".published" do
+    it "returns only published schematics" do
+      pub = described_class.create!(slug: "pub", name: "Pub", output_definition: output_def, published: true)
+      described_class.create!(slug: "draft", name: "Draft", output_definition: output_def, published: false)
+
+      expect(described_class.published).to eq([pub])
+    end
+  end
+
+  describe ".ordered" do
+    it "orders by position then name" do
+      s2 = described_class.create!(slug: "b", name: "Beta", output_definition: output_def, position: 1)
+      s1 = described_class.create!(slug: "a", name: "Alpha", output_definition: output_def, position: 0)
+
+      expect(described_class.ordered.to_a).to eq([s1, s2])
+    end
+  end
+
+  describe "#craftable_by?" do
+    let(:zone) { create(:grid_zone) }
+    let(:room) { create(:grid_room, grid_zone: zone) }
+    let(:hackr) { create(:grid_hackr, current_room: room) }
+
+    context "clearance gate" do
+      it "returns true when hackr meets clearance" do
+        hackr.set_stat!("clearance", 5)
+        schematic = described_class.create!(
+          slug: "gated", name: "Gated", output_definition: output_def, required_clearance: 5
+        )
+        expect(schematic.craftable_by?(hackr)).to be true
+      end
+
+      it "returns false when hackr below clearance" do
+        hackr.set_stat!("clearance", 2)
+        schematic = described_class.create!(
+          slug: "gated", name: "Gated", output_definition: output_def, required_clearance: 5
+        )
+        expect(schematic.craftable_by?(hackr)).to be false
+      end
+    end
+
+    context "mission gate" do
+      let(:mission) do
+        mob = create(:grid_mob, grid_room: room)
+        create(:grid_mission, slug: "required-mission", giver_mob: mob, published: true)
+      end
+
+      it "returns true when mission completed" do
+        create(:grid_hackr_mission, :completed, grid_hackr: hackr, grid_mission: mission)
+        schematic = described_class.create!(
+          slug: "mission-gated", name: "Mission Gated",
+          output_definition: output_def, required_mission_slug: "required-mission"
+        )
+        expect(schematic.craftable_by?(hackr)).to be true
+      end
+
+      it "returns false when mission not completed" do
+        schematic = described_class.create!(
+          slug: "mission-gated", name: "Mission Gated",
+          output_definition: output_def, required_mission_slug: "required-mission"
+        )
+        expect(schematic.craftable_by?(hackr)).to be false
+      end
+    end
+
+    context "achievement gate" do
+      let(:achievement) do
+        create(:grid_achievement, slug: "required-achievement",
+          trigger_type: "manual", category: "grid")
+      end
+
+      it "returns true when achievement earned" do
+        create(:grid_hackr_achievement, grid_hackr: hackr, grid_achievement: achievement)
+        schematic = described_class.create!(
+          slug: "ach-gated", name: "Achievement Gated",
+          output_definition: output_def, required_achievement_slug: "required-achievement"
+        )
+        expect(schematic.craftable_by?(hackr)).to be true
+      end
+
+      it "returns false when achievement not earned" do
+        achievement # ensure it exists
+        schematic = described_class.create!(
+          slug: "ach-gated", name: "Achievement Gated",
+          output_definition: output_def, required_achievement_slug: "required-achievement"
+        )
+        expect(schematic.craftable_by?(hackr)).to be false
+      end
+    end
+
+    context "no gates" do
+      it "returns true with all nil gates" do
+        schematic = described_class.create!(
+          slug: "open", name: "Open", output_definition: output_def
+        )
+        expect(schematic.craftable_by?(hackr)).to be true
+      end
+    end
+  end
+end

--- a/spec/services/grid/command_parser_spec.rb
+++ b/spec/services/grid/command_parser_spec.rb
@@ -391,5 +391,267 @@ RSpec.describe Grid::CommandParser do
         end
       end
     end
+
+    # --- Fabrication commands ---
+
+    describe "schematics command" do
+      let(:cpu_def) do
+        create(:grid_item_definition, :component, slug: "basic-cpu", name: "Basic CPU", value: 8)
+      end
+      let(:wafer_def) do
+        create(:grid_item_definition, slug: "raw-silicon-wafer",
+          name: "Raw Silicon Wafer", item_type: "material", rarity: "scrap", value: 2)
+      end
+
+      context "with available schematics" do
+        let(:input) { "schematics" }
+
+        before do
+          s = create(:grid_schematic, slug: "fab-cpu", name: "Fabricate CPU",
+            output_definition: cpu_def, xp_reward: 10)
+          create(:grid_schematic_ingredient, grid_schematic: s, input_definition: wafer_def, quantity: 3)
+        end
+
+        it "lists available schematics" do
+          result = parser.execute
+          expect(result[:output]).to include("FABRICATION SCHEMATICS")
+          expect(result[:output]).to include("fab-cpu")
+          expect(result[:output]).to include("Fabricate CPU")
+        end
+      end
+
+      context "with no schematics" do
+        let(:input) { "schematics" }
+
+        it "shows empty message" do
+          result = parser.execute
+          expect(result[:output]).to include("No schematics available")
+        end
+      end
+
+      context "with clearance-locked schematic" do
+        let(:input) { "schematics" }
+
+        before do
+          create(:grid_schematic, :clearance_gated, slug: "locked-sch", name: "Locked",
+            output_definition: cpu_def, required_clearance: 99)
+        end
+
+        it "shows schematic in locked section" do
+          result = parser.execute
+          expect(result[:output]).to include("[LOCKED]")
+          expect(result[:output]).to include("Locked")
+        end
+      end
+
+      context "aliases" do
+        let(:input) { "schem" }
+
+        it "works with schem alias" do
+          result = parser.execute
+          expect(result[:output]).to include("FABRICATION SCHEMATICS")
+        end
+      end
+
+      context "schem with slug argument" do
+        let(:input) { "schem fab-cpu" }
+
+        before do
+          s = create(:grid_schematic, slug: "fab-cpu", name: "Fabricate CPU",
+            output_definition: cpu_def, xp_reward: 10)
+          create(:grid_schematic_ingredient, grid_schematic: s, input_definition: wafer_def, quantity: 3)
+        end
+
+        it "shows schematic detail instead of list" do
+          result = parser.execute
+          expect(result[:output]).to include("Fabricate CPU")
+          expect(result[:output]).to include("INGREDIENTS")
+        end
+      end
+
+      context "sch with slug argument" do
+        let(:input) { "sch fab-cpu" }
+
+        before do
+          s = create(:grid_schematic, slug: "fab-cpu", name: "Fabricate CPU",
+            output_definition: cpu_def, xp_reward: 10)
+          create(:grid_schematic_ingredient, grid_schematic: s, input_definition: wafer_def, quantity: 3)
+        end
+
+        it "shows schematic detail instead of list" do
+          result = parser.execute
+          expect(result[:output]).to include("Fabricate CPU")
+          expect(result[:output]).to include("INGREDIENTS")
+        end
+      end
+    end
+
+    describe "schematic detail command" do
+      let(:cpu_def) do
+        create(:grid_item_definition, :component, slug: "basic-cpu", name: "Basic CPU", value: 8)
+      end
+      let(:wafer_def) do
+        create(:grid_item_definition, slug: "raw-silicon-wafer",
+          name: "Raw Silicon Wafer", item_type: "material", rarity: "scrap", value: 2)
+      end
+
+      let!(:schematic) do
+        s = create(:grid_schematic, slug: "fab-cpu", name: "Fabricate CPU",
+          description: "Build a CPU", output_definition: cpu_def, xp_reward: 15, output_quantity: 1)
+        create(:grid_schematic_ingredient, grid_schematic: s, input_definition: wafer_def, quantity: 3)
+        s
+      end
+
+      context "with valid slug" do
+        let(:input) { "schematic fab-cpu" }
+
+        it "shows schematic details" do
+          result = parser.execute
+          expect(result[:output]).to include("Fabricate CPU")
+          expect(result[:output]).to include("Build a CPU")
+          expect(result[:output]).to include("Raw Silicon Wafer")
+          expect(result[:output]).to include("+15")
+        end
+
+        it "shows ingredient ownership status" do
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+          result = parser.execute
+          expect(result[:output]).to include("5/3")
+          expect(result[:output]).to include("Ready to fabricate")
+        end
+
+        it "shows missing ingredient status" do
+          result = parser.execute
+          expect(result[:output]).to include("0/3")
+          expect(result[:output]).to include("Missing ingredients")
+        end
+      end
+
+      context "with unknown slug" do
+        let(:input) { "schematic nonexistent" }
+
+        it "returns error" do
+          result = parser.execute
+          expect(result[:output]).to include("Unknown schematic")
+        end
+      end
+
+      context "with no slug" do
+        let(:input) { "schematic" }
+
+        it "shows usage hint" do
+          result = parser.execute
+          expect(result[:output]).to include("Usage:")
+        end
+      end
+    end
+
+    describe "fabricate command" do
+      let(:cpu_def) do
+        create(:grid_item_definition, :component, slug: "basic-cpu", name: "Basic CPU", value: 8)
+      end
+      let(:wafer_def) do
+        create(:grid_item_definition, slug: "raw-silicon-wafer",
+          name: "Raw Silicon Wafer", item_type: "material", rarity: "scrap", value: 2)
+      end
+
+      let!(:schematic) do
+        s = create(:grid_schematic, slug: "fab-cpu", name: "Fabricate CPU",
+          output_definition: cpu_def, xp_reward: 15)
+        create(:grid_schematic_ingredient, grid_schematic: s, input_definition: wafer_def, quantity: 3)
+        s
+      end
+
+      context "happy path" do
+        let(:input) { "fab fab-cpu" }
+
+        before do
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        end
+
+        it "fabricates the item and shows success" do
+          result = parser.execute
+          expect(result[:output]).to include("Fabricated:")
+          expect(result[:output]).to include("Basic CPU")
+          expect(result[:output]).to include("+15 XP")
+        end
+
+        it "consumes ingredients" do
+          parser.execute
+          wafer = hackr.grid_items.find_by(grid_item_definition: wafer_def)
+          expect(wafer.quantity).to eq(2)
+        end
+
+        it "creates output item" do
+          parser.execute
+          cpu = hackr.grid_items.find_by(grid_item_definition: cpu_def)
+          expect(cpu).to be_present
+        end
+
+        it "increments fabricate_count stat" do
+          parser.execute
+          expect(hackr.stat("fabricate_count")).to eq(1)
+        end
+      end
+
+      context "insufficient ingredients" do
+        let(:input) { "fab fab-cpu" }
+
+        before do
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 1))
+        end
+
+        it "returns error message" do
+          result = parser.execute
+          expect(result[:output]).to include("Missing:")
+          expect(result[:output]).to include("Raw Silicon Wafer")
+        end
+      end
+
+      context "unknown schematic" do
+        let(:input) { "fab nonexistent" }
+
+        it "returns error" do
+          result = parser.execute
+          expect(result[:output]).to include("Unknown schematic")
+        end
+      end
+
+      context "empty input" do
+        let(:input) { "fabricate" }
+
+        it "shows usage hint" do
+          result = parser.execute
+          expect(result[:output]).to include("Usage:")
+        end
+      end
+
+      context "clearance blocked" do
+        let(:input) { "fab fab-cpu" }
+
+        before do
+          schematic.update!(required_clearance: 99)
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        end
+
+        it "returns requirements error" do
+          result = parser.execute
+          expect(result[:output]).to include("don't meet the requirements")
+        end
+      end
+
+      context "fabricate alias" do
+        let(:input) { "fabricate fab-cpu" }
+
+        before do
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        end
+
+        it "works with full command name" do
+          result = parser.execute
+          expect(result[:output]).to include("Fabricated:")
+        end
+      end
+    end
   end
 end

--- a/spec/services/grid/fabrication_service_spec.rb
+++ b/spec/services/grid/fabrication_service_spec.rb
@@ -1,0 +1,226 @@
+require "rails_helper"
+
+RSpec.describe Grid::FabricationService do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:wafer_def) do
+    create(:grid_item_definition, slug: "raw-silicon-wafer",
+      name: "Raw Silicon Wafer", item_type: "material", rarity: "scrap", value: 2)
+  end
+
+  let(:fragment_def) do
+    create(:grid_item_definition, slug: "corrupted-shader-fragment",
+      name: "Corrupted Shader Fragment", item_type: "material", rarity: "scrap", value: 2)
+  end
+
+  let(:cpu_def) do
+    create(:grid_item_definition, :component,
+      slug: "basic-cpu", name: "Basic CPU", value: 8)
+  end
+
+  let(:schematic) do
+    s = GridSchematic.create!(
+      slug: "fab-basic-cpu", name: "Fabricate Basic CPU",
+      output_definition: cpu_def, output_quantity: 1, xp_reward: 15
+    )
+    GridSchematicIngredient.create!(grid_schematic: s, input_definition: wafer_def, quantity: 3, position: 0)
+    GridSchematicIngredient.create!(grid_schematic: s, input_definition: fragment_def, quantity: 1, position: 1)
+    s
+  end
+
+  describe ".fabricate!" do
+    context "happy path" do
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+      end
+
+      it "consumes ingredients and grants output" do
+        result = described_class.fabricate!(hackr: hackr, schematic: schematic)
+
+        expect(result.xp_awarded).to eq(15)
+        expect(result.output_item_name).to eq("Basic CPU")
+        expect(result.output_quantity).to eq(1)
+        expect(result.schematic_name).to eq("Fabricate Basic CPU")
+
+        # Ingredients consumed
+        wafer = hackr.grid_items.find_by(grid_item_definition: wafer_def)
+        expect(wafer.quantity).to eq(2) # 5 - 3
+
+        fragment = hackr.grid_items.find_by(grid_item_definition: fragment_def)
+        expect(fragment.quantity).to eq(1) # 2 - 1
+
+        # Output created
+        cpu = hackr.grid_items.find_by(grid_item_definition: cpu_def)
+        expect(cpu).to be_present
+        expect(cpu.quantity).to eq(1)
+      end
+
+      it "grants XP" do
+        old_xp = hackr.stat("xp").to_i
+        described_class.fabricate!(hackr: hackr, schematic: schematic)
+        expect(hackr.stat("xp").to_i).to eq(old_xp + 15)
+      end
+    end
+
+    context "stacking output" do
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+        GridItem.create!(cpu_def.item_attributes.merge(grid_hackr: hackr, quantity: 1))
+      end
+
+      it "stacks output into existing inventory" do
+        described_class.fabricate!(hackr: hackr, schematic: schematic)
+
+        cpu = hackr.grid_items.find_by(grid_item_definition: cpu_def)
+        expect(cpu.quantity).to eq(2) # 1 + 1
+        expect(hackr.grid_items.where(grid_item_definition: cpu_def).count).to eq(1)
+      end
+    end
+
+    context "multi-quantity output" do
+      let(:multi_schematic) do
+        s = GridSchematic.create!(
+          slug: "fab-multi", name: "Fab Multi",
+          output_definition: cpu_def, output_quantity: 3, xp_reward: 0
+        )
+        GridSchematicIngredient.create!(grid_schematic: s, input_definition: wafer_def, quantity: 1, position: 0)
+        s
+      end
+
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+      end
+
+      it "grants output_quantity items" do
+        result = described_class.fabricate!(hackr: hackr, schematic: multi_schematic)
+
+        expect(result.output_quantity).to eq(3)
+        cpu = hackr.grid_items.find_by(grid_item_definition: cpu_def)
+        expect(cpu.quantity).to eq(3)
+      end
+    end
+
+    context "insufficient ingredients" do
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 1)) # need 3
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+      end
+
+      it "raises IngredientsInsufficient" do
+        expect {
+          described_class.fabricate!(hackr: hackr, schematic: schematic)
+        }.to raise_error(
+          Grid::FabricationService::IngredientsInsufficient,
+          /Raw Silicon Wafer.*need 3.*have 1/
+        )
+      end
+
+      it "does not consume any ingredients" do
+        begin
+          described_class.fabricate!(hackr: hackr, schematic: schematic)
+        rescue Grid::FabricationService::IngredientsInsufficient
+          nil
+        end
+
+        wafer = hackr.grid_items.find_by(grid_item_definition: wafer_def)
+        expect(wafer.quantity).to eq(1) # unchanged
+      end
+    end
+
+    context "missing ingredient entirely" do
+      before do
+        # Only have wafers, no fragments at all
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+      end
+
+      it "raises IngredientsInsufficient" do
+        expect {
+          described_class.fabricate!(hackr: hackr, schematic: schematic)
+        }.to raise_error(
+          Grid::FabricationService::IngredientsInsufficient,
+          /Corrupted Shader Fragment.*need 1.*have 0/
+        )
+      end
+    end
+
+    context "ingredient consumed to zero destroys the row" do
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 3)) # exact match
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 1)) # exact match
+      end
+
+      it "destroys ingredient items consumed entirely" do
+        described_class.fabricate!(hackr: hackr, schematic: schematic)
+
+        expect(hackr.grid_items.find_by(grid_item_definition: wafer_def)).to be_nil
+        expect(hackr.grid_items.find_by(grid_item_definition: fragment_def)).to be_nil
+      end
+    end
+
+    context "fragmented stacks" do
+      before do
+        # Two separate stacks of wafers: 2 + 2 = 4, need 3
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 1))
+      end
+
+      it "consumes across stacks correctly" do
+        described_class.fabricate!(hackr: hackr, schematic: schematic)
+
+        wafers = hackr.grid_items.where(grid_item_definition: wafer_def)
+        total_qty = wafers.sum(:quantity)
+        expect(total_qty).to eq(1) # 4 - 3 = 1
+      end
+    end
+
+    context "zero XP reward" do
+      let(:no_xp_schematic) do
+        s = GridSchematic.create!(
+          slug: "no-xp", name: "No XP",
+          output_definition: cpu_def, output_quantity: 1, xp_reward: 0
+        )
+        GridSchematicIngredient.create!(grid_schematic: s, input_definition: wafer_def, quantity: 1, position: 0)
+        s
+      end
+
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+      end
+
+      it "skips XP grant and returns leveled_up: false" do
+        old_xp = hackr.stat("xp").to_i
+        result = described_class.fabricate!(hackr: hackr, schematic: no_xp_schematic)
+
+        expect(result.xp_awarded).to eq(0)
+        expect(result.xp_result[:leveled_up]).to be false
+        expect(hackr.stat("xp").to_i).to eq(old_xp)
+      end
+    end
+
+    context "transaction safety" do
+      before do
+        GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        GridItem.create!(fragment_def.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+      end
+
+      it "rolls back ingredient consumption if output creation fails" do
+        allow(Grid::Inventory).to receive(:grant_item!).and_raise(ActiveRecord::RecordInvalid)
+
+        expect {
+          begin
+            described_class.fabricate!(hackr: hackr, schematic: schematic)
+          rescue ActiveRecord::RecordInvalid
+            nil
+          end
+        }.not_to change {
+          hackr.grid_items.find_by(grid_item_definition: wafer_def).quantity
+        }
+      end
+    end
+  end
+end

--- a/spec/services/grid/inventory_spec.rb
+++ b/spec/services/grid/inventory_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Grid::Inventory do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:definition) { create(:grid_item_definition, slug: "test-item", name: "Test Item") }
+
+  describe ".grant_item!" do
+    context "when hackr has no existing item" do
+      it "creates a new item" do
+        expect {
+          described_class.grant_item!(hackr: hackr, definition: definition, quantity: 3)
+        }.to change { hackr.grid_items.count }.by(1)
+
+        item = hackr.grid_items.find_by(grid_item_definition: definition)
+        expect(item.name).to eq("Test Item")
+        expect(item.quantity).to eq(3)
+      end
+    end
+
+    context "when hackr already has the item" do
+      let!(:existing) do
+        GridItem.create!(definition.item_attributes.merge(grid_hackr: hackr, quantity: 2))
+      end
+
+      it "stacks into existing item" do
+        expect {
+          described_class.grant_item!(hackr: hackr, definition: definition, quantity: 5)
+        }.not_to change { hackr.grid_items.count }
+
+        expect(existing.reload.quantity).to eq(7)
+      end
+    end
+
+    context "with default quantity" do
+      it "grants 1 by default" do
+        described_class.grant_item!(hackr: hackr, definition: definition)
+        item = hackr.grid_items.find_by(grid_item_definition: definition)
+        expect(item.quantity).to eq(1)
+      end
+    end
+
+    context "transaction guard" do
+      it "raises if called outside a transaction" do
+        # RSpec's use_transactional_fixtures wraps each example in a
+        # transaction, so we need to explicitly test without one.
+        # Temporarily stub transaction_open? to simulate no transaction.
+        allow(ActiveRecord::Base.connection).to receive(:transaction_open?).and_return(false)
+
+        expect {
+          described_class.grant_item!(hackr: hackr, definition: definition)
+        }.to raise_error(RuntimeError, /must be called inside a transaction/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  Many-to-one crafting system for THE PULSE GRID. Hackrs gather materials via
  salvaging, then combine them into items using schematics.

  Schema: grid_schematics (recipe definitions with slug, output, XP reward,
  clearance/mission/achievement gates) + grid_schematic_ingredients
  (input items + quantities). required_room_type column reserved for future
  hackr den feature.

  Service: Grid::FabricationService — single-transaction fabrication with locked
  pre-flight ingredient check, fragmented-stack consumption, output stacking via
  shared Grid::Inventory module, XP grant, and atomic stat increment.

  Shared abstraction: Extracted Grid::Inventory.grant_item! from duplicated
  stacking logic in SalvageService + MissionRewardGranter. Includes
  transaction-open assertion and row-level locking.

  Terminal commands: schematics/schem/sch (browse, or detail with slug arg),
  schematic <slug> (ingredient check), fabricate/fab <slug> (craft). Pre-loaded
  gate context and inventory quantities eliminate N+1 queries.

  Achievement/Mission integration: fabricate_item (event) + fabricate_count
  (cumulative) triggers. fabricate_item mission objective type.

  Admin: Full CRUD at /root/grid_schematics with Versionable, nested ingredient
  form, PaperTrail. Destroy guards on item definitions referencing schematics.

  Frontend: /schematics SPA page with 4 tabs (All/Ready/Available/Locked),
  per-ingredient ownership display, rarity-colored output.
  Nav links (desktop + mobile).

  Seed data: 7 starter schematics — 5 rig components + 2 consumables from scrap materials.