### PR TITLE
[TPG] Restrict fabrication and rig modification to Hackr Den

### DIFF
--- a/app/controllers/admin/grid_schematics_controller.rb
+++ b/app/controllers/admin/grid_schematics_controller.rb
@@ -72,7 +72,7 @@ class Admin::GridSchematicsController < Admin::ApplicationController
     params.require(:grid_schematic).permit(
       :slug, :name, :description, :output_definition_id, :output_quantity,
       :xp_reward, :required_clearance, :published, :position,
-      :required_mission_slug, :required_achievement_slug,
+      :required_mission_slug, :required_achievement_slug, :required_room_type,
       ingredients_attributes: %i[id input_definition_id quantity position _destroy]
     )
   end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -88,11 +88,14 @@ class Api::GridController < ApplicationController
       .joins(:grid_achievement)
       .pluck("grid_achievements.slug").to_set
 
+    current_room = current_hackr.current_room
+
     render json: {
       schematics: schematics.map { |s|
         craftable = s.craftable_by?(current_hackr,
           completed_mission_slugs: completed_mission_slugs,
-          earned_achievement_slugs: earned_achievement_slugs)
+          earned_achievement_slugs: earned_achievement_slugs,
+          current_room: current_room)
         has_ingredients = s.ingredients.all? { |i| (inventory_qtys[i.input_definition_id] || 0) >= i.quantity }
 
         {
@@ -110,6 +113,8 @@ class Api::GridController < ApplicationController
           required_clearance: s.required_clearance,
           required_mission_slug: s.required_mission_slug,
           required_achievement_slug: s.required_achievement_slug,
+          required_room_type: s.required_room_type,
+          required_room_type_label: s.room_type_label,
           ingredients: s.ingredients.ordered.map { |i|
             owned = inventory_qtys[i.input_definition_id] || 0
             {

--- a/app/javascript/components/pages/grid/SchematicsPage.tsx
+++ b/app/javascript/components/pages/grid/SchematicsPage.tsx
@@ -185,6 +185,9 @@ const SchematicCard: React.FC<{ schematic: Schematic }> = ({ schematic: s }) => 
       <div style={{ marginTop: 10, paddingTop: 8, borderTop: '1px solid #2a2a2a', display: 'flex', flexWrap: 'wrap', gap: 10, fontSize: '0.8em' }}>
         {s.xp_reward > 0 && <span style={{ color: '#a78bfa' }}>+{s.xp_reward} XP</span>}
         {s.required_clearance > 0 && <span style={{ color: '#d0d0d0' }}>CL{s.required_clearance}+</span>}
+        {s.required_room_type_label && (
+          <span style={{ color: '#fbbf24' }}>Requires {s.required_room_type_label}</span>
+        )}
       </div>
 
       {ready && (

--- a/app/javascript/types/schematic.ts
+++ b/app/javascript/types/schematic.ts
@@ -24,6 +24,8 @@ export interface Schematic {
   required_clearance: number
   required_mission_slug: string | null
   required_achievement_slug: string | null
+  required_room_type: string | null
+  required_room_type_label: string | null
   ingredients: SchematicIngredient[]
   craftable: boolean
   has_ingredients: boolean

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -66,6 +66,10 @@ class GridRoom < ApplicationRecord
     room_type == "den"
   end
 
+  def owned_den_of?(hackr)
+    den? && owner_id == hackr.id
+  end
+
   def den_floor_items
     grid_items.where(grid_hackr_id: nil, grid_mining_rig_id: nil)
   end

--- a/app/models/grid_schematic.rb
+++ b/app/models/grid_schematic.rb
@@ -33,6 +33,10 @@
 class GridSchematic < ApplicationRecord
   has_paper_trail
 
+  ROOM_TYPE_LABELS = {
+    "den" => "the Workbench in your Den"
+  }.freeze
+
   belongs_to :output_definition, class_name: "GridItemDefinition"
   has_many :ingredients, class_name: "GridSchematicIngredient", dependent: :destroy
   has_many :input_definitions, through: :ingredients
@@ -47,6 +51,7 @@ class GridSchematic < ApplicationRecord
   validates :output_quantity, numericality: {only_integer: true, greater_than_or_equal_to: 1}
   validates :xp_reward, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :required_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 99}
+  validates :required_room_type, inclusion: {in: ROOM_TYPE_LABELS.keys, allow_nil: true}
 
   scope :published, -> { where(published: true) }
   scope :ordered, -> { order(:position, :name) }
@@ -62,8 +67,16 @@ class GridSchematic < ApplicationRecord
   # For batch checks, pass pre-loaded sets to avoid N+1 queries:
   #   completed_mission_slugs: Set of slug strings
   #   earned_achievement_slugs: Set of slug strings
-  def craftable_by?(hackr, completed_mission_slugs: nil, earned_achievement_slugs: nil)
+  #   current_room: GridRoom or nil — checked against required_room_type
+  NOT_PROVIDED = Object.new.freeze
+  private_constant :NOT_PROVIDED
+
+  def craftable_by?(hackr, completed_mission_slugs: nil, earned_achievement_slugs: nil, current_room: NOT_PROVIDED)
     return false unless hackr.stat("clearance").to_i >= required_clearance
+
+    if required_room_type.present? && current_room != NOT_PROVIDED
+      return false unless room_type_satisfied?(hackr, current_room)
+    end
 
     if required_mission_slug.present?
       if completed_mission_slugs
@@ -89,5 +102,24 @@ class GridSchematic < ApplicationRecord
     end
 
     true
+  end
+
+  # Human-readable label for the room type requirement.
+  def room_type_label
+    return nil unless required_room_type.present?
+    ROOM_TYPE_LABELS[required_room_type] || "a #{required_room_type.titleize}"
+  end
+
+  private
+
+  # Check if hackr's current room satisfies the required_room_type.
+  def room_type_satisfied?(hackr, current_room)
+    return false unless current_room
+
+    if required_room_type == "den"
+      current_room.owned_den_of?(hackr)
+    else
+      current_room.room_type == required_room_type
+    end
   end
 end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -1008,7 +1008,7 @@ module Grid
       inventory_qtys = hackr.grid_items.group(:grid_item_definition_id).sum(:quantity)
       gate_ctx = schematic_gate_context
 
-      available, locked = all_schematics.partition { |s| s.craftable_by?(hackr, **gate_ctx) }
+      available, locked = all_schematics.partition { |s| s.craftable_by?(hackr, **gate_ctx, current_room: hackr.current_room) }
 
       output = []
       output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
@@ -1056,8 +1056,8 @@ module Grid
         .find_by(slug: slug.downcase)
       return "<span style='color: #f87171;'>Unknown schematic: #{h(slug)}. Use 'schematics' to browse.</span>" unless schematic
 
-      unless schematic.craftable_by?(hackr, **schematic_gate_context)
-        return "<span style='color: #f87171;'>You don't meet the requirements for this schematic.</span>"
+      unless schematic.craftable_by?(hackr, **schematic_gate_context, current_room: hackr.current_room)
+        return craftability_error_for(schematic)
       end
 
       output = []
@@ -1100,8 +1100,8 @@ module Grid
         .find_by(slug: recipe_slug.downcase)
       return "<span style='color: #f87171;'>Unknown schematic: #{h(recipe_slug)}. Use 'schematics' to browse.</span>" unless schematic
 
-      unless schematic.craftable_by?(hackr, **schematic_gate_context)
-        return "<span style='color: #f87171;'>You don't meet the requirements for this schematic.</span>"
+      unless schematic.craftable_by?(hackr, **schematic_gate_context, current_room: hackr.current_room)
+        return craftability_error_for(schematic)
       end
 
       begin
@@ -1740,6 +1740,7 @@ module Grid
 
     def rig_install_command(rig, item_name)
       return "<span style='color: #fbbf24;'>Install what? Usage: rig install &lt;item&gt;</span>" if item_name.blank?
+      return "<span style='color: #f87171;'>Your rig isn't here. It's in your Den.</span>" unless in_own_den?
       return "<span style='color: #f87171;'>Your rig must be powered down before modifying components. Use 'rig off' first.</span>" if rig.active?
 
       item = hackr.grid_items.where(grid_mining_rig_id: nil).find_by("LOWER(name) = ?", item_name.downcase)
@@ -1773,6 +1774,7 @@ module Grid
 
     def rig_uninstall_command(rig, item_name)
       return "<span style='color: #fbbf24;'>Uninstall what? Usage: rig uninstall &lt;component&gt;</span>" if item_name.blank?
+      return "<span style='color: #f87171;'>Your rig isn't here. It's in your Den.</span>" unless in_own_den?
       return "<span style='color: #f87171;'>Your rig must be powered down before modifying components. Use 'rig off' first.</span>" if rig.active?
 
       item = rig.components.find_by("LOWER(name) = ?", item_name.downcase)
@@ -1921,6 +1923,18 @@ module Grid
 
     def mission_progressor
       @mission_progressor ||= Grid::MissionProgressor.new(hackr)
+    end
+
+    def in_own_den?
+      hackr.current_room&.owned_den_of?(hackr)
+    end
+
+    def craftability_error_for(schematic)
+      if schematic.required_room_type.present? && schematic.craftable_by?(hackr, **schematic_gate_context)
+        "<span style='color: #f87171;'>You can only fabricate this item at #{schematic.room_type_label}.</span>"
+      else
+        "<span style='color: #f87171;'>You don't meet the requirements for this schematic.</span>"
+      end
     end
 
     # Pre-loaded gate context for schematic craftable_by? checks.

--- a/app/views/admin/grid_schematics/_form.html.erb
+++ b/app/views/admin/grid_schematics/_form.html.erb
@@ -63,7 +63,7 @@
   <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
     Leave blank for no gate. Slugs are resolved at runtime.
   </p>
-  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px;">
     <div>
       <%= f.label :required_mission_slug, "REQUIRED MISSION SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
       <%= f.text_field :required_mission_slug, class: "tui-input", style: "width: 100%; font-family: monospace;", placeholder: "e.g. signal-recovery" %>
@@ -71,6 +71,14 @@
     <div>
       <%= f.label :required_achievement_slug, "REQUIRED ACHIEVEMENT SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
       <%= f.text_field :required_achievement_slug, class: "tui-input", style: "width: 100%; font-family: monospace;", placeholder: "e.g. first-salvage" %>
+    </div>
+    <div>
+      <%= f.label :required_room_type, "REQUIRED ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :required_room_type,
+            [["Den (own)", "den"]],
+            { include_blank: "None (craft anywhere)" },
+            class: "tui-input", style: "width: 100%;" %>
+      <small style="color: #888;">Location required to fabricate</small>
     </div>
   </div>
 

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -15,6 +15,7 @@ schematics:
     output_quantity: 1
     xp_reward: 15
     required_clearance: 0
+    required_room_type: den
     published: true
     position: 10
     ingredients:
@@ -29,6 +30,7 @@ schematics:
     output_quantity: 1
     xp_reward: 20
     required_clearance: 0
+    required_room_type: den
     published: true
     position: 20
     ingredients:
@@ -46,6 +48,7 @@ schematics:
     output_quantity: 1
     xp_reward: 12
     required_clearance: 0
+    required_room_type: den
     published: true
     position: 30
     ingredients:
@@ -63,6 +66,7 @@ schematics:
     output_quantity: 1
     xp_reward: 10
     required_clearance: 0
+    required_room_type: den
     published: true
     position: 40
     ingredients:
@@ -77,6 +81,7 @@ schematics:
     output_quantity: 1
     xp_reward: 25
     required_clearance: 0
+    required_room_type: den
     published: true
     position: 50
     ingredients:

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1977,7 +1977,8 @@ namespace :data do
         published: attrs["published"] != false,
         position: attrs["position"] || 0,
         required_mission_slug: attrs["required_mission_slug"],
-        required_achievement_slug: attrs["required_achievement_slug"]
+        required_achievement_slug: attrs["required_achievement_slug"],
+        required_room_type: attrs["required_room_type"]
       )
 
       (attrs["ingredients"] || []).each_with_index do |ing_attrs, idx|

--- a/lib/tasks/grant_cred.rake
+++ b/lib/tasks/grant_cred.rake
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+namespace :grid do
+  desc "Grant CRED to a hackr's default cache. Usage: rake grid:grant_cred[AMOUNT,ALIAS,pool]"
+  task :grant_cred, [:amount, :alias, :pool] => :environment do |_t, args|
+    abort "ERROR: This task can only be run in development." unless Rails.env.development?
+
+    amount = (args[:amount] || abort("ERROR: amount required.")).to_i
+    hackr_alias = args[:alias] || "XERAEN"
+    abort "ERROR: amount must be positive." unless amount > 0
+
+    pool_key = (args[:pool] || "mine").downcase
+    abort "ERROR: pool must be 'play' or 'mine'." unless %w[play mine].include?(pool_key)
+
+    hackr = GridHackr.find_by!(hackr_alias: hackr_alias)
+    cache = GridCache.where(grid_hackr: hackr, is_default: true).first ||
+            GridCache.where(grid_hackr: hackr).active.first
+    abort "ERROR: No active cache found for #{hackr_alias}." unless cache
+
+    pool = (pool_key == "play") ? GridCache.gameplay_pool : GridCache.mining_pool
+
+    prev_hash = GridTransaction.order(created_at: :desc, id: :desc).first&.tx_hash
+
+    tx = GridTransaction.new(
+      from_cache: pool,
+      to_cache: cache,
+      amount: amount,
+      tx_type: (pool_key == "play") ? "gameplay_reward" : "mining_reward",
+      memo: "Dev grant: #{amount} CRED from #{pool_key} pool",
+      previous_tx_hash: prev_hash,
+      created_at: Time.current
+    )
+    tx.tx_hash = tx.compute_hash
+    tx.save!
+
+    puts "Granted #{amount} CRED to #{hackr_alias}"
+    puts "  From: #{pool.address} (#{pool_key})"
+    puts "  To:   #{cache.address}"
+    puts "  TX:   #{tx.short_hash}"
+    puts "  New balance: #{cache.reload.balance}"
+  end
+end

--- a/lib/tasks/grant_cred.rake
+++ b/lib/tasks/grant_cred.rake
@@ -14,7 +14,7 @@ namespace :grid do
 
     hackr = GridHackr.find_by!(hackr_alias: hackr_alias)
     cache = GridCache.where(grid_hackr: hackr, is_default: true).first ||
-            GridCache.where(grid_hackr: hackr).active.first
+      GridCache.where(grid_hackr: hackr).active.first
     abort "ERROR: No active cache found for #{hackr_alias}." unless cache
 
     pool = (pool_key == "play") ? GridCache.gameplay_pool : GridCache.mining_pool

--- a/spec/factories/grid_schematics.rb
+++ b/spec/factories/grid_schematics.rb
@@ -47,5 +47,9 @@ FactoryBot.define do
     trait :clearance_gated do
       required_clearance { 5 }
     end
+
+    trait :den_required do
+      required_room_type { "den" }
+    end
   end
 end

--- a/spec/models/grid_schematic_spec.rb
+++ b/spec/models/grid_schematic_spec.rb
@@ -182,6 +182,69 @@ RSpec.describe GridSchematic do
       end
     end
 
+    context "room_type gate" do
+      let(:den_room) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+      let(:other_hackr) { create(:grid_hackr, current_room: room) }
+      let(:other_den) { create(:grid_room, :den, grid_zone: zone, owner: other_hackr) }
+
+      it "returns true when hackr is in own den" do
+        schematic = described_class.create!(
+          slug: "den-only", name: "Den Only",
+          output_definition: output_def, required_room_type: "den"
+        )
+        expect(schematic.craftable_by?(hackr, current_room: den_room)).to be true
+      end
+
+      it "returns false when hackr is in another hackr's den" do
+        schematic = described_class.create!(
+          slug: "den-only", name: "Den Only",
+          output_definition: output_def, required_room_type: "den"
+        )
+        expect(schematic.craftable_by?(hackr, current_room: other_den)).to be false
+      end
+
+      it "returns false when hackr is in a non-den room" do
+        schematic = described_class.create!(
+          slug: "den-only", name: "Den Only",
+          output_definition: output_def, required_room_type: "den"
+        )
+        expect(schematic.craftable_by?(hackr, current_room: room)).to be false
+      end
+
+      it "returns false when current_room is nil" do
+        schematic = described_class.create!(
+          slug: "den-only", name: "Den Only",
+          output_definition: output_def, required_room_type: "den"
+        )
+        expect(schematic.craftable_by?(hackr, current_room: nil)).to be false
+      end
+
+      it "rejects unknown room_type values" do
+        schematic = described_class.new(
+          slug: "bad-type", name: "Bad Type",
+          output_definition: output_def, required_room_type: "typo"
+        )
+        expect(schematic).not_to be_valid
+        expect(schematic.errors[:required_room_type]).to be_present
+      end
+
+      it "passes when no room_type required (nil)" do
+        schematic = described_class.create!(
+          slug: "anywhere", name: "Anywhere",
+          output_definition: output_def, required_room_type: nil
+        )
+        expect(schematic.craftable_by?(hackr, current_room: room)).to be true
+      end
+
+      it "skips room check when current_room is not provided" do
+        schematic = described_class.create!(
+          slug: "den-only", name: "Den Only",
+          output_definition: output_def, required_room_type: "den"
+        )
+        expect(schematic.craftable_by?(hackr)).to be true
+      end
+    end
+
     context "no gates" do
       it "returns true with all nil gates" do
         schematic = described_class.create!(

--- a/spec/services/grid/command_parser_spec.rb
+++ b/spec/services/grid/command_parser_spec.rb
@@ -444,6 +444,38 @@ RSpec.describe Grid::CommandParser do
         end
       end
 
+      context "with den-locked schematic outside own den" do
+        let(:input) { "schematics" }
+
+        before do
+          create(:grid_schematic, :den_required, slug: "den-sch", name: "Den Only",
+            output_definition: cpu_def)
+        end
+
+        it "shows schematic in locked section" do
+          result = parser.execute
+          expect(result[:output]).to include("[LOCKED]")
+          expect(result[:output]).to include("Den Only")
+        end
+      end
+
+      context "with den-locked schematic inside own den" do
+        let(:input) { "schematics" }
+        let(:den_room) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+
+        before do
+          hackr.update!(current_room: den_room)
+          create(:grid_schematic, :den_required, slug: "den-sch", name: "Den Only",
+            output_definition: cpu_def)
+        end
+
+        it "shows schematic in available section" do
+          result = described_class.new(hackr, "schematics").execute
+          expect(result[:output]).to include("[AVAILABLE]")
+          expect(result[:output]).to include("den-sch")
+        end
+      end
+
       context "aliases" do
         let(:input) { "schem" }
 
@@ -542,6 +574,25 @@ RSpec.describe Grid::CommandParser do
         it "shows usage hint" do
           result = parser.execute
           expect(result[:output]).to include("Usage:")
+        end
+      end
+
+      context "den-required schematic" do
+        let(:input) { "schematic fab-cpu" }
+        let(:den_room) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+
+        before { schematic.update!(required_room_type: "den") }
+
+        it "shows room error when not in own den" do
+          result = parser.execute
+          expect(result[:output]).to include("Workbench in your Den")
+        end
+
+        it "shows detail when in own den" do
+          hackr.update!(current_room: den_room)
+          result = described_class.new(hackr, "schematic fab-cpu").execute
+          expect(result[:output]).to include("Fabricate CPU")
+          expect(result[:output]).to include("INGREDIENTS")
         end
       end
     end
@@ -650,6 +701,96 @@ RSpec.describe Grid::CommandParser do
         it "works with full command name" do
           result = parser.execute
           expect(result[:output]).to include("Fabricated:")
+        end
+      end
+
+      context "den-required schematic" do
+        let(:input) { "fab fab-cpu" }
+        let(:den_room) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+
+        before do
+          schematic.update!(required_room_type: "den")
+          GridItem.create!(wafer_def.item_attributes.merge(grid_hackr: hackr, quantity: 5))
+        end
+
+        it "blocks fabrication when not in own den" do
+          result = parser.execute
+          expect(result[:output]).to include("Workbench in your Den")
+        end
+
+        it "allows fabrication when in own den" do
+          hackr.update!(current_room: den_room)
+          result = described_class.new(hackr, "fab fab-cpu").execute
+          expect(result[:output]).to include("Fabricated:")
+        end
+
+        it "blocks fabrication when in another hackr's den" do
+          other_hackr = create(:grid_hackr, current_room: room)
+          other_den = create(:grid_room, :den, grid_zone: zone, owner: other_hackr)
+          hackr.update!(current_room: other_den)
+          result = described_class.new(hackr, "fab fab-cpu").execute
+          expect(result[:output]).to include("Workbench in your Den")
+        end
+      end
+    end
+
+    describe "rig install/uninstall den restriction" do
+      let(:den_room) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+      let!(:rig) { create(:grid_mining_rig, grid_hackr: hackr, active: false) }
+
+      let(:motherboard_def) do
+        create(:grid_item_definition, :component,
+          slug: "test-mb", name: "Test Motherboard",
+          properties: {"slot" => "motherboard", "rate_multiplier" => 1.0,
+                       "cpu_slots" => 1, "gpu_slots" => 2, "ram_slots" => 2})
+      end
+
+      let(:component_def) do
+        create(:grid_item_definition, :component,
+          slug: "test-gpu", name: "Test GPU",
+          properties: {"slot" => "gpu", "rate_multiplier" => 1.5})
+      end
+
+      before do
+        # Install a motherboard so the rig has GPU slots
+        GridItem.create!(motherboard_def.item_attributes.merge(grid_mining_rig: rig))
+      end
+
+      context "rig install" do
+        let(:input) { "rig install Test GPU" }
+
+        before do
+          GridItem.create!(component_def.item_attributes.merge(grid_hackr: hackr))
+        end
+
+        it "blocks install when not in own den" do
+          result = parser.execute
+          expect(result[:output]).to include("Your rig isn't here")
+          expect(result[:output]).to include("in your Den")
+        end
+
+        it "allows install when in own den" do
+          hackr.update!(current_room: den_room)
+          result = described_class.new(hackr, "rig install Test GPU").execute
+          expect(result[:output]).to include("Installed")
+        end
+      end
+
+      context "rig uninstall" do
+        before do
+          # Install the GPU into the rig
+          GridItem.create!(component_def.item_attributes.merge(grid_mining_rig: rig))
+        end
+
+        it "blocks uninstall when not in own den" do
+          result = described_class.new(hackr, "rig uninstall Test GPU").execute
+          expect(result[:output]).to include("Your rig isn't here")
+        end
+
+        it "allows uninstall when in own den" do
+          hackr.update!(current_room: den_room)
+          result = described_class.new(hackr, "rig uninstall Test GPU").execute
+          expect(result[:output]).to include("Uninstalled")
         end
       end
     end


### PR DESCRIPTION
  Wire up the existing `required_room_type` column on grid_schematics as a
  per-schematic location gate. "den" requires the player's own den (other
  hackrs' dens don't count); future room types (Clean Room, Faraday Cage)
  slot in via ROOM_TYPE_LABELS.

  Rig install/uninstall now require being in own den ("Your rig isn't here.
  It's in your Den."). Rig on/off/inspect/status remain unrestricted.

  Changes:
  - GridSchematic: ROOM_TYPE_LABELS, validation, room gate in craftable_by?, NOT_PROVIDED sentinel to allow skipping room check when not passed
  - GridRoom#owned_den_of? — single source of truth for den ownership
  - CommandParser: in_own_den?, craftability_error_for (room-specific vs generic error), den guard on rig install/uninstall, current_room passed to all craftable_by? calls
  - API: required_room_type + required_room_type_label in JSON response
  - Admin: required_room_type select field + strong param
  - Frontend: "Requires the Workbench in your Den" badge on schematic cards
  - Seed: 5 rig-component schematics set to required_room_type: den
  - Rake: seeder reads required_room_type