### PR TITLE
[TPG] Regions: hierarchy tier above GridZone, Region > Zone > Room

### DIFF
--- a/app/controllers/admin/grid_regions_controller.rb
+++ b/app/controllers/admin/grid_regions_controller.rb
@@ -1,0 +1,60 @@
+class Admin::GridRegionsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridRegion
+
+  before_action :set_region, only: %i[edit update destroy]
+
+  def index
+    @regions = GridRegion.includes(:grid_zones).order(:name)
+  end
+
+  def new
+    @region = GridRegion.new
+  end
+
+  def create
+    @region = GridRegion.new(region_params)
+    if @region.save
+      set_flash_success("Region '#{@region.name}' created.")
+      redirect_to admin_grid_regions_path
+    else
+      flash.now[:error] = @region.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @region.update(region_params)
+      set_flash_success("Region '#{@region.name}' updated.")
+      redirect_to admin_grid_regions_path
+    else
+      flash.now[:error] = @region.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @region.name
+    if @region.grid_zones.any?
+      set_flash_error("Can't delete '#{name}' — zones still reference it.")
+    else
+      @region.destroy
+      set_flash_success("Region '#{name}' deleted.")
+    end
+    redirect_to admin_grid_regions_path
+  end
+
+  private
+
+  def set_region
+    @region = GridRegion.find(params[:id])
+  end
+
+  def region_params
+    params.require(:grid_region).permit(:name, :slug, :description)
+  end
+end

--- a/app/controllers/admin/grid_zones_controller.rb
+++ b/app/controllers/admin/grid_zones_controller.rb
@@ -6,7 +6,7 @@ class Admin::GridZonesController < Admin::ApplicationController
   before_action :set_zone, only: %i[edit update destroy]
 
   def index
-    @zones = GridZone.includes(:ambient_playlist, :grid_faction, :grid_rooms).order(:name)
+    @zones = GridZone.includes(:grid_region, :ambient_playlist, :grid_faction, :grid_rooms).order(:name)
   end
 
   def new
@@ -59,13 +59,14 @@ class Admin::GridZonesController < Admin::ApplicationController
   end
 
   def load_selects
+    @regions = GridRegion.order(:name)
     @factions = GridFaction.ordered
     @playlists = ZonePlaylist.order(:name)
   end
 
   def zone_params
     params.require(:grid_zone).permit(
-      :name, :slug, :description, :zone_type, :color_scheme, :grid_faction_id, :ambient_playlist_id
+      :name, :slug, :description, :zone_type, :color_scheme, :grid_region_id, :grid_faction_id, :ambient_playlist_id
     )
   end
 end

--- a/app/models/grid_region.rb
+++ b/app/models/grid_region.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: grid_regions
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_regions_on_slug  (slug) UNIQUE
+#
+class GridRegion < ApplicationRecord
+  has_paper_trail
+
+  has_many :grid_zones, dependent: :restrict_with_error
+  has_many :grid_rooms, through: :grid_zones
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true
+end

--- a/app/models/grid_zone.rb
+++ b/app/models/grid_zone.rb
@@ -13,18 +13,22 @@
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer
 #  grid_faction_id     :integer
+#  grid_region_id      :integer
 #
 # Indexes
 #
 #  index_grid_zones_on_ambient_playlist_id  (ambient_playlist_id)
+#  index_grid_zones_on_grid_region_id       (grid_region_id)
 #
 # Foreign Keys
 #
 #  ambient_playlist_id  (ambient_playlist_id => zone_playlists.id)
+#  grid_region_id       (grid_region_id => grid_regions.id)
 #
 class GridZone < ApplicationRecord
   has_paper_trail
 
+  belongs_to :grid_region
   belongs_to :grid_faction, optional: true
   belongs_to :ambient_playlist, class_name: "ZonePlaylist", optional: true
 

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -124,7 +124,7 @@ module Grid
 
       output = []
       output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
-      output << "<span style='color: #22d3ee; font-weight: bold;'>#{room.name.upcase}</span> <span style='color: #666;'>::</span> <span style='color: #fbbf24;'>#{room.grid_zone.name}</span>"
+      output << "<span style='color: #22d3ee; font-weight: bold;'>#{room.name.upcase}</span> <span style='color: #666;'>::</span> <span style='color: #fbbf24;'>#{room.grid_zone.name}</span> <span style='color: #666;'>::</span> <span style='color: #a78bfa;'>#{room.grid_zone.grid_region&.name || "Unknown Region"}</span>"
       output << "<span style='color: #9ca3af;'>[#{room.color_scheme}]</span>" if room.color_scheme
       output << ""
       output << "<span style='color: #d0d0d0;'>#{codex_linkify(room.description)}</span>" if room.description

--- a/app/views/admin/grid_regions/_form.html.erb
+++ b/app/views/admin/grid_regions/_form.html.erb
@@ -1,0 +1,34 @@
+<% if @region.errors.any? %>
+  <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+    <p class="red-255-text">ERRORS:</p>
+    <ul style="margin: 5px 0 0 20px;">
+      <% @region.errors.full_messages.each do |msg| %>
+        <li class="white-text"><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="margin-top: 15px;">
+  <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+  <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+</div>
+
+<div style="margin-top: 30px; display: flex; gap: 10px;">
+  <%= f.submit @region.new_record? ? "Create Region" : "Update Region", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+  <%= link_to "Cancel", admin_grid_regions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% if @region.persisted? %>
+    <%= link_to "History", history_admin_grid_region_path(@region), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+  <% end %>
+</div>

--- a/app/views/admin/grid_regions/edit.html.erb
+++ b/app/views/admin/grid_regions/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/regions/<%= @region.slug %> :: EDIT REGION</legend>
+
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @region], local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_regions/index.html.erb
+++ b/app/views/admin/grid_regions/index.html.erb
@@ -1,0 +1,63 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/regions :: MANAGE GRID REGIONS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
+        <%= link_to "+ New Region", new_admin_grid_region_path, class: "tui-button green-168" %>
+      </div>
+
+      <% if @regions.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: left;">Name</th>
+                <th style="text-align: left;">Slug</th>
+                <th style="text-align: left;">Description</th>
+                <th style="text-align: center;">Zones</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @regions.each_with_index do |region, i| %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td class="cyan-255-text"><strong><%= region.name %></strong></td>
+                  <td style="font-family: monospace; color: #666;">/<%= region.slug %></td>
+                  <td style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"><%= truncate(region.description, length: 60) %></td>
+                  <td style="text-align: center;"><%= region.grid_zones.size %></td>
+                  <td style="text-align: right; white-space: nowrap;">
+                    <%= link_to "Edit", edit_admin_grid_region_path(region), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "History", history_admin_grid_region_path(region), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= button_to "Delete", admin_grid_region_path(region), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{region.name}'?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <p style="color: #666; margin-top: 10px; font-size: 0.85em;">
+          <%= @regions.count %> regions
+        </p>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666; font-size: 1.2em;">No regions yet.</p>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_regions/new.html.erb
+++ b/app/views/admin/grid_regions/new.html.erb
@@ -1,0 +1,11 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/regions/new :: CREATE REGION</legend>
+
+    <div style="padding: 20px;">
+      <%= form_with model: [:admin, @region], local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_zones/_form.html.erb
+++ b/app/views/admin/grid_zones/_form.html.erb
@@ -40,6 +40,10 @@
 
 <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
   <div style="flex: 1; min-width: 200px;">
+    <%= f.label :grid_region_id, "REGION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :grid_region_id, @regions, :id, :name, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
     <%= f.label :grid_faction_id, "FACTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.collection_select :grid_faction_id, @factions, :id, :name, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>

--- a/app/views/admin/grid_zones/index.html.erb
+++ b/app/views/admin/grid_zones/index.html.erb
@@ -27,6 +27,7 @@
               <tr>
                 <th style="text-align: left;">Name</th>
                 <th style="text-align: left;">Slug</th>
+                <th style="text-align: left;">Region</th>
                 <th style="text-align: left;">Type</th>
                 <th style="text-align: left;">Faction</th>
                 <th style="text-align: left;">Ambient Playlist</th>
@@ -39,6 +40,7 @@
                 <tr style="<%= " background: #112;" if i.odd? %>">
                   <td class="cyan-255-text"><strong><%= zone.name %></strong></td>
                   <td style="font-family: monospace; color: #666;">/<%= zone.slug %></td>
+                  <td><%= zone.grid_region&.name || "—" %></td>
                   <td><%= zone.zone_type || "—" %></td>
                   <td><%= zone.grid_faction&.name || "—" %></td>
                   <td>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -91,6 +91,7 @@
           <%= link_to "Schematics", admin_grid_schematics_path, class: "green-168-text" %>
           <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
+          <%= link_to "Regions", admin_grid_regions_path, class: "green-168-text" %>
           <%= link_to "Zones", admin_grid_zones_path, class: "green-168-text" %>
           <%= link_to "Rooms", admin_grid_rooms_path, class: "green-168-text" %>
           <%= link_to "Mobs", admin_grid_mobs_path, class: "green-168-text" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -300,6 +300,11 @@ Rails.application.routes.draw do
     resources :zone_playlists, only: %i[index show]
 
     # World resources (full CRUD)
+    resources :grid_regions do
+      member do
+        get :history
+      end
+    end
     resources :grid_zones do
       member do
         get :history

--- a/data/world/regions.yml
+++ b/data/world/regions.yml
@@ -1,0 +1,57 @@
+# Grid Regions
+regions:
+  - name: The Lakeshore
+    slug: the-lakeshore
+    description: "A dense urban region on the western shore of a vast freshwater inland sea — home to Sector X and the Fracture Network's primary operations hub."
+
+  - name: The Riverlands
+    slug: the-riverlands
+    description: "River country along a great continental river — bluffs overlooking the water, dense with musical heritage. Home to The Hackr Hangar and a region where music seeped into the substrate long before GovCorp existed."
+
+  - name: The Arch
+    slug: the-arch
+    description: "A massive steel monument at the confluence of two great rivers — and the Fracture Network's only known persistent RIDE deadzone, created by amplifying the structure's natural interference with RIDE signal propagation."
+
+  - name: The Narrows
+    slug: the-narrows
+    description: "A dense vertical region built across a series of islands and peninsulas compressed around a deep natural harbor — the most heavily populated and most thoroughly RIDE-saturated zone on the continent."
+
+  - name: The Basin
+    slug: the-basin
+    description: "A broad coastal basin bounded by mountains and desert — GovCorp's entertainment production center, where the line between RIDE-manufactured experience and curated culture disappeared long before the RIDE existed."
+
+  - name: The Gate
+    slug: the-gate
+    description: "A region built around a strait connecting an inland bay to the open ocean — historically a center of technical innovation, now a GovCorp research hub where RIDE infrastructure is developed and refined."
+
+  - name: The Front
+    slug: the-front
+    description: "A high-altitude region where vast plains abruptly meet a massive mountain range — thin air, wide sky, and RIDE coverage that struggles with the terrain's extreme vertical variation."
+
+  - name: The Straits
+    slug: the-straits
+    description: "A region built around a river strait connecting two great freshwater lakes — once a center of manufacturing, now a landscape of industrial ruins that GovCorp's Cultural Zone programming frames as heritage."
+
+  - name: The Bend
+    slug: the-bend
+    description: "A low-lying region where a great river curves sharply before meeting the sea — built below sea level, perpetually at war with water, and home to a Cultural Zone identity built on music and celebration that GovCorp exploits ruthlessly."
+
+  - name: The Canopy
+    slug: the-canopy
+    description: "A densely forested region of volcanic peaks, ancient evergreens, and persistent rain — where the tree cover and terrain create natural RIDE attenuation that GovCorp has struggled to fully resolve."
+
+  - name: The Flats
+    slug: the-flats
+    description: "Vast coastal prairie stretching flat to the horizon along a warm gulf — the most geographically exposed region, where there is nowhere to hide and RIDE coverage is total."
+
+  - name: The Marshes
+    slug: the-marshes
+    description: "A peninsula of wetlands, swamp, and subtropical heat jutting into warm ocean — where the boundary between land and water is so uncertain that even the RIDE has trouble deciding what to render."
+
+  - name: The Works
+    slug: the-works
+    description: "River valleys dense with the skeletal remains of a vanished industrial age — a region whose identity is built on labor and craft that the actual economy hasn't supported in two centuries."
+
+  - name: The Badlands
+    slug: the-badlands
+    description: "High plains and eroded rock formations under an enormous sky — the most sparsely populated region, where RIDE coverage is thin by design because there is almost no one to render for."

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -5,6 +5,7 @@ zones:
     description: "The central hub of Fracture Network broadcasting operations."
     zone_type: faction_base
     color_scheme: purple
+    region_slug: the-lakeshore
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
 
@@ -13,6 +14,7 @@ zones:
     description: "XERAEN's homebase. A fortress of temporal technology and Fracture Network operations."
     zone_type: faction_base
     color_scheme: purple
+    region_slug: the-lakeshore
     faction_slug: xeraen
     ambient_playlist_slug: fracture-network-ambience
 
@@ -21,6 +23,7 @@ zones:
     description: "Neutral corridors connecting the major zones of THE PULSE GRID."
     zone_type: transit
     color_scheme: gray/neon green
+    region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: transit-network-ambience
 
@@ -29,6 +32,7 @@ zones:
     description: "Enemy territory under total GovCorp control."
     zone_type: govcorp
     color_scheme: red
+    region_slug: the-lakeshore
     faction_slug: govcorp
     ambient_playlist_slug: govcorp-surveillance-ambience
 
@@ -37,6 +41,7 @@ zones:
     description: "A network of unregistered passages beneath the Transit Network. Surveillance dead zone. If you know, you know."
     zone_type: danger_zone
     color_scheme: red/black
+    region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
 
@@ -45,6 +50,7 @@ zones:
     description: "A quieter section of THE PULSE GRID. Rows of private nodes line the data-corridors. Hackrs with enough standing have claimed their own spaces here."
     zone_type: residential
     color_scheme: blue/gray
+    region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
 
@@ -53,5 +59,6 @@ zones:
     description: "Ryker M. Pulse's headquarters and primary broadcast facility. Where the raw signal is created before transmission to Sector X."
     zone_type: faction_base
     color_scheme: purple/cyan
+    region_slug: the-riverlands
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience

--- a/db/migrate/20260420120002_create_grid_regions.rb
+++ b/db/migrate/20260420120002_create_grid_regions.rb
@@ -1,0 +1,15 @@
+class CreateGridRegions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_regions do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_index :grid_regions, :slug, unique: true
+
+    add_reference :grid_zones, :grid_region, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20260420120003_backfill_grid_zones_region.rb
+++ b/db/migrate/20260420120003_backfill_grid_zones_region.rb
@@ -1,0 +1,27 @@
+class BackfillGridZonesRegion < ActiveRecord::Migration[8.1]
+  def up
+    # Ensure regions exist before backfilling
+    execute <<~SQL
+      INSERT INTO grid_regions (name, slug, description, created_at, updated_at)
+      SELECT 'The Lakeshore', 'the-lakeshore', 'A dense urban region on the western shore of a vast freshwater inland sea — home to Sector X and the Fracture Network''s primary operations hub.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      WHERE NOT EXISTS (SELECT 1 FROM grid_regions WHERE slug = 'the-lakeshore')
+    SQL
+
+    execute <<~SQL
+      INSERT INTO grid_regions (name, slug, description, created_at, updated_at)
+      SELECT 'The Riverlands', 'the-riverlands', 'River country along a great continental river — bluffs overlooking the water, dense with musical heritage.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      WHERE NOT EXISTS (SELECT 1 FROM grid_regions WHERE slug = 'the-riverlands')
+    SQL
+
+    # Assign The Hackr Hangar to The Riverlands, everything else to The Lakeshore
+    lakeshore_id = Integer(execute("SELECT id FROM grid_regions WHERE slug = 'the-lakeshore' LIMIT 1").first.fetch("id"))
+    riverlands_id = Integer(execute("SELECT id FROM grid_regions WHERE slug = 'the-riverlands' LIMIT 1").first.fetch("id"))
+
+    execute("UPDATE grid_zones SET grid_region_id = #{lakeshore_id} WHERE grid_region_id IS NULL AND slug != 'hackr-hangar'")
+    execute("UPDATE grid_zones SET grid_region_id = #{riverlands_id} WHERE grid_region_id IS NULL AND slug = 'hackr-hangar'")
+  end
+
+  def down
+    # No-op — region assignments are not destructively reversible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_120003) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -450,6 +450,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120001) do
     t.json "vendor_config"
   end
 
+  create_table "grid_regions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_grid_regions_on_slug", unique: true
+  end
+
   create_table "grid_registration_tokens", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -622,11 +631,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120001) do
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "grid_faction_id"
+    t.integer "grid_region_id"
     t.string "name"
     t.string "slug"
     t.datetime "updated_at", null: false
     t.string "zone_type"
     t.index ["ambient_playlist_id"], name: "index_grid_zones_on_ambient_playlist_id"
+    t.index ["grid_region_id"], name: "index_grid_zones_on_grid_region_id"
   end
 
   create_table "hackr_log_reads", force: :cascade do |t|
@@ -1127,6 +1138,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120001) do
   add_foreign_key "grid_shop_listings", "grid_item_definitions"
   add_foreign_key "grid_shop_listings", "grid_mobs"
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
+  add_foreign_key "grid_zones", "grid_regions"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "hackr_log_reads", "grid_hackrs"
   add_foreign_key "hackr_log_reads", "hackr_logs"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -4,20 +4,21 @@
 #
 # Import Order (respecting dependencies):
 # 1. catalog           (artists, releases, tracks from per-artist YAML files)
-# 4. hackrs            (no deps)
-# 5. channels          (no deps)
-# 6. radio_stations    (no deps)
-# 7. zone_playlists    (depends on tracks)
-# 8. factions          (depends on artists)
-# 9. zones             (depends on factions, zone_playlists)
-# 10. rooms            (depends on zones)
-# 11. exits            (depends on rooms)
-# 12. mobs             (depends on rooms, factions)
-# 13. items            (depends on rooms)
-# 14. key_playlists    (depends on hackrs, tracks, radio_stations)
-# 15. codex            (no deps)
-# 16. hackr_logs       (depends on hackrs)
-# 17. wire             (depends on hackrs) - sets is_seed: true
+# 2. hackrs            (no deps)
+# 3. channels          (no deps)
+# 4. radio_stations    (no deps)
+# 5. zone_playlists    (depends on tracks)
+# 6. factions          (depends on artists)
+# 7. regions           (no deps)
+# 8. zones             (depends on factions, zone_playlists, regions)
+# 9. rooms             (depends on zones)
+# 10. exits            (depends on rooms)
+# 11. mobs             (depends on rooms, factions)
+# 12. items            (depends on rooms)
+# 13. key_playlists    (depends on hackrs, tracks, radio_stations)
+# 14. codex            (no deps)
+# 15. hackr_logs       (depends on hackrs)
+# 16. wire             (depends on hackrs) - sets is_seed: true
 # 18. vidz             (depends on artists) - HackrStream VODs
 # 19. overlay_elements (no deps)
 # 20. overlay_tickers  (no deps)
@@ -185,8 +186,8 @@ namespace :data do
   desc "Load system data (hackrs, channels, radio stations, etc.)"
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
-  desc "Load world data (factions, zones, rooms, etc.)"
-  task world: [:factions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics]
+  desc "Load world data (factions, regions, zones, rooms, etc.)"
+  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -243,6 +244,7 @@ namespace :data do
     GridHackr.destroy_all
     GridRoom.destroy_all
     GridZone.destroy_all
+    GridRegion.destroy_all
     GridFaction.destroy_all
     ZonePlaylistTrack.destroy_all
     ZonePlaylist.destroy_all
@@ -495,8 +497,38 @@ namespace :data do
     puts "Rep links: #{links_created} created, #{GridFactionRepLink.count} total"
   end
 
+  desc "Load regions from YAML"
+  task regions: :environment do
+    puts "\n--- Loading Regions ---"
+    yaml_file = Rails.root.join("data", "world", "regions.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    regions_data = data["regions"]
+    created = 0
+
+    regions_data.each do |attrs|
+      region = GridRegion.find_or_initialize_by(slug: attrs["slug"])
+      next unless region.new_record?
+
+      region.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"]
+      )
+      region.save!
+      created += 1
+      puts "  ✓ Created: #{region.name}"
+    end
+
+    puts "Regions: #{created} created, #{GridRegion.count} total"
+  end
+
   desc "Load zones from YAML"
-  task zones: :environment do
+  task zones: [:environment, :regions] do
     puts "\n--- Loading Zones ---"
     yaml_file = Rails.root.join("data", "world", "zones.yml")
 
@@ -508,11 +540,17 @@ namespace :data do
     data = YAML.load_file(yaml_file)
     zones_data = data["zones"]
     created = 0
+    region_map = GridRegion.all.index_by(&:slug)
 
     zones_data.each do |attrs|
       zone = GridZone.find_or_initialize_by(slug: attrs["slug"])
       next unless zone.new_record?
 
+      region = region_map[attrs["region_slug"]]
+      unless region
+        puts "  ✗ Region not found: #{attrs["region_slug"]} (zone: #{attrs["slug"]})"
+        next
+      end
       faction = attrs["faction_slug"].present? ? GridFaction.find_by(slug: attrs["faction_slug"]) : nil
       playlist = attrs["ambient_playlist_slug"].present? ? ZonePlaylist.find_by(slug: attrs["ambient_playlist_slug"]) : nil
 
@@ -521,6 +559,7 @@ namespace :data do
         description: attrs["description"],
         zone_type: attrs["zone_type"],
         color_scheme: attrs["color_scheme"],
+        grid_region: region,
         grid_faction: faction,
         ambient_playlist: playlist
       )

--- a/spec/factories/grid_regions.rb
+++ b/spec/factories/grid_regions.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: grid_regions
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_regions_on_slug  (slug) UNIQUE
+#
+FactoryBot.define do
+  factory :grid_region do
+    sequence(:name) { |n| "Region #{n}" }
+    sequence(:slug) { |n| "region-#{n}" }
+    description { "A test region in THE PULSE GRID" }
+  end
+end

--- a/spec/factories/grid_zones.rb
+++ b/spec/factories/grid_zones.rb
@@ -13,14 +13,17 @@
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer
 #  grid_faction_id     :integer
+#  grid_region_id      :integer
 #
 # Indexes
 #
 #  index_grid_zones_on_ambient_playlist_id  (ambient_playlist_id)
+#  index_grid_zones_on_grid_region_id       (grid_region_id)
 #
 # Foreign Keys
 #
 #  ambient_playlist_id  (ambient_playlist_id => zone_playlists.id)
+#  grid_region_id       (grid_region_id => grid_regions.id)
 #
 FactoryBot.define do
   factory :grid_zone do
@@ -29,6 +32,7 @@ FactoryBot.define do
     description { "A test zone in THE PULSE GRID" }
     zone_type { "transit" }
     color_scheme { "gray/neon green" }
+    association :grid_region
     grid_faction { nil }
 
     trait :faction_base do

--- a/spec/models/grid_region_spec.rb
+++ b/spec/models/grid_region_spec.rb
@@ -1,0 +1,63 @@
+# == Schema Information
+#
+# Table name: grid_regions
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  description :text
+#  name        :string           not null
+#  slug        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_grid_regions_on_slug  (slug) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe GridRegion, type: :model do
+  subject(:region) { build(:grid_region) }
+
+  describe "validations" do
+    it { is_expected.to be_valid }
+
+    it "requires name" do
+      region.name = nil
+      expect(region).not_to be_valid
+    end
+
+    it "requires slug" do
+      region.slug = nil
+      expect(region).not_to be_valid
+    end
+
+    it "requires unique slug" do
+      create(:grid_region, slug: "taken")
+      region.slug = "taken"
+      expect(region).not_to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "has many grid_zones" do
+      region.save!
+      zone = create(:grid_zone, grid_region: region)
+      expect(region.grid_zones).to include(zone)
+    end
+
+    it "has many grid_rooms through grid_zones" do
+      region.save!
+      zone = create(:grid_zone, grid_region: region)
+      room = create(:grid_room, grid_zone: zone)
+      expect(region.grid_rooms).to include(room)
+    end
+
+    it "restricts deletion when zones exist" do
+      region.save!
+      create(:grid_zone, grid_region: region)
+      expect { region.destroy }.not_to change(GridRegion, :count)
+      expect(region.errors[:base]).to be_present
+    end
+  end
+end

--- a/spec/models/grid_zone_spec.rb
+++ b/spec/models/grid_zone_spec.rb
@@ -13,14 +13,17 @@
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer
 #  grid_faction_id     :integer
+#  grid_region_id      :integer
 #
 # Indexes
 #
 #  index_grid_zones_on_ambient_playlist_id  (ambient_playlist_id)
+#  index_grid_zones_on_grid_region_id       (grid_region_id)
 #
 # Foreign Keys
 #
 #  ambient_playlist_id  (ambient_playlist_id => zone_playlists.id)
+#  grid_region_id       (grid_region_id => grid_regions.id)
 #
 require "rails_helper"
 


### PR DESCRIPTION
Schema:
- grid_regions table: name, slug (unique), description, timestamps
- grid_zones gets grid_region_id FK (nullable at DB, required at model)
- Data migration backfills all 7 existing zones (6 → The Lakeshore, 1 → The Riverlands)

Model:
- GridRegion — PaperTrail, has_many :grid_zones (restrict_with_error), has_many :grid_rooms through :grid_zones
- GridZone — added belongs_to :grid_region

Admin:
- Full CRUD for GridRegions at /root/grid_regions with Versionable/history
- Zone form gains region dropdown, zone index shows region column
- Nav link added between Factions and Zones
- Destroy guarded (zones must be empty)

Look command:
- Display changed from ROOM NAME :: Zone Name to ROOM NAME :: Zone Name :: Region Name

Seed data:
- data/world/regions.yml — all 14 Codex geographic regions
- zones.yml — added region_slug to all zones
- data.rake — new data:regions task, zones task depends on regions, region preload map, data:clear includes GridRegion, import order renumbered

Tests:
- 7 new specs (validations + associations + restrict_with_error)
- Factory for GridRegion, GridZone factory updated
- CI: 2042 RSpec (0 failures)