### PR TITLE
[TPG] Storage Fixtures

### DIFF
--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -68,6 +68,8 @@ class GridAchievement < ApplicationRecord
     fabricate_count
     den_created
     items_stored
+    place_fixture
+    fixtures_placed
   ].freeze
 
   CATEGORIES = %w[grid music social meta progression].freeze
@@ -87,6 +89,7 @@ class GridAchievement < ApplicationRecord
     missions_completed_count
     fabricate_count
     items_stored
+    fixtures_placed
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -13,6 +13,7 @@
 #  value                   :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  container_id            :integer
 #  grid_hackr_id           :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
@@ -20,18 +21,20 @@
 #
 # Indexes
 #
+#  index_grid_items_on_container_id             (container_id)
 #  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
 #  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
 #
 # Foreign Keys
 #
+#  container_id             (container_id => grid_items.id)
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 class GridItem < ApplicationRecord
   has_paper_trail
 
-  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material].freeze
+  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material fixture].freeze
   RARITIES = %w[scrap ubiquitous common uncommon rare ultra_rare unicorn].freeze
   RARITY_LABELS = {
     "scrap" => "SCRAP",
@@ -60,6 +63,8 @@ class GridItem < ApplicationRecord
   belongs_to :room, class_name: "GridRoom", optional: true
   belongs_to :grid_hackr, optional: true
   belongs_to :grid_mining_rig, optional: true
+  belongs_to :container, class_name: "GridItem", optional: true
+  has_many :stored_items, class_name: "GridItem", foreign_key: :container_id, dependent: :restrict_with_error
 
   validates :name, presence: true
   validates :item_type, inclusion: {in: ITEM_TYPES, allow_nil: true}
@@ -67,9 +72,12 @@ class GridItem < ApplicationRecord
   validates :quantity, numericality: {greater_than: 0}, allow_nil: true
   validate :single_location
 
-  scope :in_room, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil) }
-  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil) }
+  scope :in_room, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
+  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil) }
   scope :installed_in, ->(rig) { where(grid_mining_rig: rig, grid_hackr: nil, room: nil) }
+  scope :on_floor, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil).where.not(item_type: "fixture") }
+  scope :placed_fixtures, ->(room) { where(room: room, item_type: "fixture", grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
+  scope :in_fixture, ->(fixture) { where(container: fixture) }
 
   RAINBOW_COLORS = %w[#ff6b6b #fbbf24 #34d399 #22d3ee #60a5fa #a78bfa].freeze
 
@@ -107,6 +115,18 @@ class GridItem < ApplicationRecord
     item_type == "rig_component"
   end
 
+  def fixture?
+    item_type == "fixture"
+  end
+
+  def storage_capacity
+    properties&.dig("storage_capacity").to_i
+  end
+
+  def placed?
+    fixture? && room_id.present?
+  end
+
   def slot
     properties&.dig("slot")
   end
@@ -117,11 +137,11 @@ class GridItem < ApplicationRecord
 
   private
 
-  # An item can only be in one place: room, inventory, or mining rig
+  # An item can only be in one place: room, inventory, mining rig, or container
   def single_location
-    locations = [room_id, grid_hackr_id, grid_mining_rig_id].compact.count
+    locations = [room_id, grid_hackr_id, grid_mining_rig_id, container_id].compact.count
     if locations > 1
-      errors.add(:base, "Item can only be in one location (room, inventory, or mining rig)")
+      errors.add(:base, "Item can only be in one location (room, inventory, mining rig, or container)")
     end
   end
 end

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -71,10 +71,22 @@ class GridRoom < ApplicationRecord
   end
 
   def den_floor_items
-    grid_items.where(grid_hackr_id: nil, grid_mining_rig_id: nil)
+    grid_items.on_floor(self)
   end
 
   def den_floor_count
     den_floor_items.count
+  end
+
+  def placed_fixtures
+    grid_items.placed_fixtures(self)
+  end
+
+  def den_fixture_capacity
+    placed_fixtures.sum { |f| f.storage_capacity }
+  end
+
+  def den_stored_in_fixtures_count
+    GridItem.where(container_id: placed_fixtures.select(:id)).count
   end
 end

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -108,7 +108,11 @@ module Grid
         derive(@hackr.stat("fabricate_count").to_i, data[:count].to_i)
       when "items_stored"
         den = @hackr.den
-        current = den ? den.den_floor_count : 0
+        current = den ? (den.den_floor_count + den.den_stored_in_fixtures_count) : 0
+        derive(current, data[:count].to_i)
+      when "fixtures_placed"
+        den = @hackr.den
+        current = den ? den.placed_fixtures.distinct.count(:grid_item_definition_id) : 0
         derive(current, data[:count].to_i)
       end
     end
@@ -300,6 +304,8 @@ module Grid
         # useful — `missions_completed_count` covers the generic case).
         return data[:mission_slug].blank? || data[:mission_slug].to_s == context[:mission_slug].to_s
       when "den_created"
+        return true
+      when "place_fixture"
         return true
       when "manual"
         return false

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -96,6 +96,16 @@ module Grid
         args.any? ? schematic_detail_command(args.first) : schematics_command
       when "schematic"
         schematic_detail_command(args.first)
+      when "place", "install"
+        place_fixture_command(args.join(" "))
+      when "unplace", "uninstall"
+        unplace_fixture_command(args.join(" "))
+      when "store", "put"
+        store_in_fixture_command(args)
+      when "retrieve"
+        retrieve_from_fixture_command(args)
+      when "peek", "search"
+        peek_fixture_command(args.join(" "))
       when "den"
         den_command(args)
       when "out"
@@ -138,7 +148,7 @@ module Grid
           owner_alias = room.owner&.hackr_alias || "Unknown"
           output << "<span style='color: #a78bfa;'>[ This is #{h(owner_alias)}'s Den ]</span>"
         end
-        output << "<span style='color: #6b7280;'>Storage: #{room.den_floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} items</span>"
+        output << "<span style='color: #6b7280;'>Floor: #{room.den_floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} items</span>"
         output << "<span style='color: #6b7280;'>Owner: <span style='color: #a78bfa;'>#{h(room.owner&.hackr_alias)}</span></span>"
         output << "<span style='color: #f87171;'>[ DEN IS LOCKED ]</span>" if room.locked?
       end
@@ -178,11 +188,25 @@ module Grid
         output << "<span style='color: #fbbf24;'>Exits:</span> <span style='color: #6b7280;'>none</span>"
       end
 
-      # Show items
-      items = room.grid_items.in_room(room)
-      if items.any?
+      # Show fixtures (den only)
+      if room.den?
+        fixtures = room.placed_fixtures.includes(:stored_items)
+        if fixtures.any?
+          output << ""
+          output << "<span style='color: #fbbf24;'>Fixtures:</span>"
+          fixtures.each do |f|
+            used = f.stored_items.size
+            cap = f.storage_capacity
+            output << "  <span style='color: #a78bfa;'>#{h(f.name)}</span> <span style='color: #6b7280;'>[#{used}/#{cap} slots]</span>"
+          end
+        end
+      end
+
+      # Show items (floor items, excluding placed fixtures)
+      floor_items = room.den? ? room.den_floor_items : room.grid_items.in_room(room)
+      if floor_items.any?
         output << ""
-        item_names = items.map { |item| item.unicorn? ? item.rainbow_name_html : "<span style='color: #34d399;'>#{h(item.name)}</span>" }
+        item_names = floor_items.map { |item| item.unicorn? ? item.rainbow_name_html : "<span style='color: #34d399;'>#{h(item.name)}</span>" }
         output << "<span style='color: #fbbf24;'>Items:</span> #{item_names.join(", ")}"
       end
 
@@ -375,6 +399,11 @@ module Grid
         return "<span style='color: #f87171;'>You can't take items from someone else's den.</span>"
       end
 
+      # Placed fixture with contents cannot be picked up
+      if item.fixture? && item.placed? && item.stored_items.exists?
+        return "<span style='color: #f87171;'>#{h(item.name)} has items stored inside. Retrieve them first.</span>"
+      end
+
       # Inventory capacity check
       used = hackr.grid_items.in_inventory(hackr).count
       if used >= hackr.inventory_capacity
@@ -408,6 +437,11 @@ module Grid
 
       item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+
+      # Fixtures must be placed via the place command
+      if item.fixture?
+        return "<span style='color: #f87171;'>Use 'place #{h(item.name.downcase)}' to install fixtures in your den.</span>"
+      end
 
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
@@ -693,86 +727,94 @@ module Grid
         <span style='color: #22d3ee; font-weight: bold;'>Available Commands:</span>
 
         <span style='color: #fbbf24;'>Navigation:</span>
-          <span style='color: #34d399;'>look, l</span>                   - Look around the room
-          <span style='color: #34d399;'>go &lt;direction&gt;</span>            - Move in a direction
-          <span style='color: #34d399;'>north, n / south, s</span>       - Move north/south
-          <span style='color: #34d399;'>east, e / west, w</span>         - Move east/west
-          <span style='color: #34d399;'>up, u / down, d</span>           - Move up/down
+          <span style='color: #34d399;'>look, l</span>                    - Look around the room
+          <span style='color: #34d399;'>go &lt;direction&gt;</span>             - Move in a direction
+          <span style='color: #34d399;'>north, n / south, s</span>        - Move north/south
+          <span style='color: #34d399;'>east, e / west, w</span>          - Move east/west
+          <span style='color: #34d399;'>up, u / down, d</span>            - Move up/down
 
         <span style='color: #fbbf24;'>Items:</span>
-          <span style='color: #34d399;'>inventory, inv, i</span>         - View your inventory
-          <span style='color: #34d399;'>take &lt;item&gt;</span>               - Pick up an item
-          <span style='color: #34d399;'>drop &lt;item&gt;</span>               - Drop an item
-          <span style='color: #34d399;'>use &lt;item&gt;</span>                - Use an item
-          <span style='color: #34d399;'>salvage &lt;item&gt;, sal</span>       - Break down an item for XP
-          <span style='color: #34d399;'>analyze &lt;item&gt;, an</span>        - Preview salvage yields before breaking down
-          <span style='color: #34d399;'>examine &lt;target&gt;, x</span>       - Examine item, NPC, or hackr
+          <span style='color: #34d399;'>inventory, inv, i</span>          - View your inventory
+          <span style='color: #34d399;'>take &lt;item&gt;</span>                - Pick up an item
+          <span style='color: #34d399;'>drop &lt;item&gt;</span>                - Drop an item
+          <span style='color: #34d399;'>use &lt;item&gt;</span>                 - Use an item
+          <span style='color: #34d399;'>salvage &lt;item&gt;, sal</span>        - Break down an item for XP
+          <span style='color: #34d399;'>analyze &lt;item&gt;, an</span>         - Preview salvage yields before breaking down
+          <span style='color: #34d399;'>examine &lt;target&gt;, x</span>        - Examine item, NPC, or hackr
 
         <span style='color: #fbbf24;'>NPCs:</span>
-          <span style='color: #34d399;'>talk &lt;npc&gt;</span>                - Talk to an NPC
-          <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>   - Ask an NPC about a topic
-          <span style='color: #34d399;'>give &lt;item&gt; to &lt;npc&gt;</span>      - Hand an item to an NPC (for delivery missions)
+          <span style='color: #34d399;'>talk &lt;npc&gt;</span>                 - Talk to an NPC
+          <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>    - Ask an NPC about a topic
+          <span style='color: #34d399;'>give &lt;item&gt; to &lt;npc&gt;</span>       - Hand an item to an NPC (for delivery missions)
 
         <span style='color: #fbbf24;'>Missions:</span>
-          <span style='color: #34d399;'>missions</span>                  - List your active missions
-          <span style='color: #34d399;'>mission &lt;slug&gt;</span>            - View details for a specific mission
-          <span style='color: #34d399;'>ask &lt;npc&gt; about missions</span>  - See what work an NPC is offering
-          <span style='color: #34d399;'>accept &lt;slug&gt;, acc, ac</span>    - Accept a mission (must be with giver)
-          <span style='color: #34d399;'>abandon &lt;slug&gt;</span>            - Drop an active mission
-          <span style='color: #34d399;'>turn_in &lt;slug&gt;, ti</span>        - Turn in a completed mission (must be with giver)
+          <span style='color: #34d399;'>missions</span>                   - List your active missions
+          <span style='color: #34d399;'>mission &lt;slug&gt;</span>             - View details for a specific mission
+          <span style='color: #34d399;'>ask &lt;npc&gt; about missions</span>   - See what work an NPC is offering
+          <span style='color: #34d399;'>accept &lt;slug&gt;, acc, ac</span>     - Accept a mission (must be with giver)
+          <span style='color: #34d399;'>abandon &lt;slug&gt;</span>             - Drop an active mission
+          <span style='color: #34d399;'>turn_in &lt;slug&gt;, ti</span>         - Turn in a completed mission (must be with giver)
 
         <span style='color: #fbbf24;'>Fabrication:</span>
           <span style='color: #34d399;'>schematics, schem, sch</span>     - Browse available schematics
-          <span style='color: #34d399;'>schematic &lt;slug&gt;</span>          - View schematic details &amp; ingredients
-          <span style='color: #34d399;'>fabricate &lt;slug&gt;, fab</span>     - Fabricate an item from a schematic
+          <span style='color: #34d399;'>schematic &lt;slug&gt;</span>           - View schematic details &amp; ingredients
+          <span style='color: #34d399;'>fabricate &lt;slug&gt;, fab</span>      - Fabricate an item from a schematic
 
         <span style='color: #fbbf24;'>Commerce:</span>
-          <span style='color: #34d399;'>shop, browse</span>              - View vendor inventory &amp; prices
-          <span style='color: #34d399;'>buy &lt;item&gt;</span>                - Purchase an item from vendor
-          <span style='color: #34d399;'>sell &lt;item&gt;</span>               - Sell an item to vendor
+          <span style='color: #34d399;'>shop, browse</span>               - View vendor inventory &amp; prices
+          <span style='color: #34d399;'>buy &lt;item&gt;</span>                 - Purchase an item from vendor
+          <span style='color: #34d399;'>sell &lt;item&gt;</span>                - Sell an item to vendor
 
         <span style='color: #fbbf24;'>Economy:</span>
-          <span style='color: #34d399;'>cache</span>                     - List your caches
-          <span style='color: #34d399;'>cache create</span>              - Create a new cache
-          <span style='color: #34d399;'>cache balance [addr]</span>      - Check balance
-          <span style='color: #34d399;'>cache history [addr]</span>      - Transaction history
-          <span style='color: #34d399;'>cache send &lt;amt&gt; &lt;to&gt;</span>     - Send CRED (opts: from &lt;src&gt;, memo &lt;text&gt;)
-          <span style='color: #34d399;'>cache default &lt;addr&gt;</span>      - Set default cache
-          <span style='color: #34d399;'>cache name &lt;addr&gt; &lt;nick&gt;</span>  - Nickname a cache
-          <span style='color: #34d399;'>cache abandon &lt;addr&gt;</span>      - Abandon a cache (WARNING: This is irreversible)
+          <span style='color: #34d399;'>cache</span>                      - List your caches
+          <span style='color: #34d399;'>cache create</span>               - Create a new cache
+          <span style='color: #34d399;'>cache balance [addr]</span>       - Check balance
+          <span style='color: #34d399;'>cache history [addr]</span>       - Transaction history
+          <span style='color: #34d399;'>cache send &lt;amt&gt; &lt;to&gt;</span>      - Send CRED (opts: from &lt;src&gt;, memo &lt;text&gt;)
+          <span style='color: #34d399;'>cache default &lt;addr&gt;</span>       - Set default cache
+          <span style='color: #34d399;'>cache name &lt;addr&gt; &lt;nick&gt;</span>   - Nickname a cache
+          <span style='color: #34d399;'>cache abandon &lt;addr&gt;</span>       - Abandon a cache (WARNING: This is irreversible)
 
         <span style='color: #fbbf24;'>Ledger:</span>
-          <span style='color: #34d399;'>chain latest</span>              - Recent global transactions
-          <span style='color: #34d399;'>chain tx &lt;hash&gt;</span>           - Look up a transaction
-          <span style='color: #34d399;'>chain cache &lt;addr&gt;</span>        - Public history for a cache
-          <span style='color: #34d399;'>chain supply</span>              - CRED supply overview
+          <span style='color: #34d399;'>chain latest</span>               - Recent global transactions
+          <span style='color: #34d399;'>chain tx &lt;hash&gt;</span>            - Look up a transaction
+          <span style='color: #34d399;'>chain cache &lt;addr&gt;</span>         - Public history for a cache
+          <span style='color: #34d399;'>chain supply</span>               - CRED supply overview
 
         <span style='color: #fbbf24;'>Mining:</span>
-          <span style='color: #34d399;'>rig</span>                       - Mining rig status
-          <span style='color: #34d399;'>rig on / rig off</span>          - Toggle mining
-          <span style='color: #34d399;'>rig install &lt;item&gt;</span>        - Install component (rig must be off)
-          <span style='color: #34d399;'>rig uninstall &lt;item&gt;</span>      - Remove component (rig must be off)
-          <span style='color: #34d399;'>rig inspect</span>               - Detailed rig view
+          <span style='color: #34d399;'>rig</span>                        - Mining rig status
+          <span style='color: #34d399;'>rig on / rig off</span>           - Toggle mining
+          <span style='color: #34d399;'>rig install &lt;item&gt;</span>         - Install component (rig must be off)
+          <span style='color: #34d399;'>rig uninstall &lt;item&gt;</span>       - Remove component (rig must be off)
+          <span style='color: #34d399;'>rig inspect</span>                - Detailed rig view
 
         <span style='color: #fbbf24;'>Den:</span>
-          <span style='color: #34d399;'>den</span>                       - View den status
-          <span style='color: #34d399;'>den rename &lt;name&gt;</span>         - Rename your den (80 char max)
-          <span style='color: #34d399;'>den describe &lt;text&gt;</span>       - Set den description
-          <span style='color: #34d399;'>den invite &lt;hackr&gt;</span>        - Invite a hackr (1 hour)
-          <span style='color: #34d399;'>den uninvite &lt;hackr&gt;</span>      - Revoke invite
-          <span style='color: #34d399;'>den lock</span>                  - Lock den (blocks entry &amp; exit)
-          <span style='color: #34d399;'>den unlock</span>                - Unlock den
-          <span style='color: #34d399;'>out</span>                       - Leave a den (shortcut for 'go out')
+          <span style='color: #34d399;'>den</span>                        - View den status
+          <span style='color: #34d399;'>den rename &lt;name&gt;</span>          - Rename your den (80 char max)
+          <span style='color: #34d399;'>den describe &lt;text&gt;</span>        - Set den description
+          <span style='color: #34d399;'>den invite &lt;hackr&gt;</span>         - Invite a hackr (1 hour)
+          <span style='color: #34d399;'>den uninvite &lt;hackr&gt;</span>       - Revoke invite
+          <span style='color: #34d399;'>den lock</span>                   - Lock den (blocks entry &amp; exit)
+          <span style='color: #34d399;'>den unlock</span>                 - Unlock den
+          <span style='color: #34d399;'>out</span>                        - Leave a den (shortcut for 'go out')
+
+        <span style='color: #fbbf24;'>Fixtures:</span>
+          <span style='color: #34d399;'>place &lt;f&gt;, install &lt;f&gt;</span>     - Install a fixture in your den
+          <span style='color: #34d399;'>unplace &lt;f&gt;, uninstall &lt;f&gt;</span> - Uninstall a fixture (must be empty)
+          <span style='color: #34d399;'>store &lt;item&gt; in &lt;f&gt;</span>        - Store an item in a fixture
+          <span style='color: #34d399;'>put &lt;item&gt; in &lt;f&gt;</span>          - Same as store
+          <span style='color: #34d399;'>retrieve &lt;item&gt; from &lt;f&gt;</span>   - Retrieve an item from a fixture
+          <span style='color: #34d399;'>peek &lt;f&gt;, search &lt;f&gt;</span>       - Inspect fixture contents
 
         <span style='color: #fbbf24;'>Social:</span>
-          <span style='color: #34d399;'>say &lt;message&gt;</span>             - Say something in the room
-          <span style='color: #34d399;'>who</span>                       - See who's online
+          <span style='color: #34d399;'>say &lt;message&gt;</span>              - Say something in the room
+          <span style='color: #34d399;'>who</span>                        - See who's online
 
         <span style='color: #fbbf24;'>Operative:</span>
-          <span style='color: #34d399;'>stat, stats, st</span>           - View your operative profile
-          <span style='color: #34d399;'>rep, reputation</span>           - View faction standings in detail
-          <span style='color: #34d399;'>clear, cls, cl</span>            - Clear the screen
-          <span style='color: #34d399;'>help, ?</span>                   - Show this help message
+          <span style='color: #34d399;'>stat, stats, st</span>            - View your operative profile
+          <span style='color: #34d399;'>rep, reputation</span>            - View faction standings in detail
+          <span style='color: #34d399;'>clear, cls, cl</span>             - Clear the screen
+          <span style='color: #34d399;'>help, ?</span>                    - Show this help message
       HELP
     end
 
@@ -924,6 +966,10 @@ module Grid
 
       if item.unicorn?
         return "<span style='color: #f87171;'>UNICORN items are irreducible. They cannot be salvaged.</span>"
+      end
+
+      if item.fixture? && item.placed?
+        return "<span style='color: #f87171;'>#{h(item.name)} is placed in your den. Unplace it first.</span>"
       end
 
       item_styled = h(item.name)
@@ -1208,6 +1254,17 @@ module Grid
       if props["effect_type"] == "redeem_den"
         output += "\n<span style='color: #a78bfa;'>▸ USE this item to claim a private den in the Residential District.</span>"
         output += "\n<span style='color: #9ca3af;'>  Type: <span style='color: #22d3ee;'>use #{h(item.name.downcase)}</span></span>"
+      end
+      if item.fixture?
+        cap = item.storage_capacity
+        if item.placed?
+          used = item.stored_items.count
+          output += "\n<span style='color: #a78bfa;'>Storage Fixture</span> <span style='color: #34d399;'>[PLACED]</span> <span style='color: #9ca3af;'>#{used}/#{cap} slots used</span>"
+          output += "\n<span style='color: #9ca3af;'>  Inspect: <span style='color: #22d3ee;'>peek #{h(item.name.downcase)}</span></span>"
+        else
+          output += "\n<span style='color: #a78bfa;'>Storage Fixture</span> <span style='color: #6b7280;'>[in inventory]</span> <span style='color: #9ca3af;'>#{cap} slots</span>"
+          output += "\n<span style='color: #9ca3af;'>  Place in your den: <span style='color: #22d3ee;'>place #{h(item.name.downcase)}</span></span>"
+        end
       end
       output
     end
@@ -2431,7 +2488,20 @@ module Grid
       lines = []
       lines << "<span style='color: #22d3ee; font-weight: bold;'>DEN STATUS :: #{h(den.name)}</span>"
       lines << "<span style='color: #fbbf24;'>Location:</span> <span style='color: #d0d0d0;'>#{h(den.grid_zone.name)}</span>"
-      lines << "<span style='color: #fbbf24;'>Storage:</span> <span style='color: #d0d0d0;'>#{den.den_floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} items</span>"
+      lines << "<span style='color: #fbbf24;'>Floor:</span> <span style='color: #d0d0d0;'>#{den.den_floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} items</span>"
+
+      fixtures = den.placed_fixtures.includes(:stored_items)
+      if fixtures.any?
+        lines << "<span style='color: #fbbf24;'>Fixtures (#{fixtures.size}/#{Grid::DenService::MAX_DEN_FIXTURES}):</span>"
+        fixtures.each do |f|
+          used = f.stored_items.size
+          cap = f.storage_capacity
+          lines << "  <span style='color: #a78bfa;'>#{h(f.name)}</span> <span style='color: #6b7280;'>(#{used}/#{cap} slots)</span>"
+        end
+      else
+        lines << "<span style='color: #6b7280;'>No fixtures installed.</span>"
+      end
+
       lines << "<span style='color: #fbbf24;'>Locked:</span> <span style='color: #{den.locked? ? "#f87171" : "#34d399"};'>#{den.locked? ? "YES" : "NO"}</span>"
 
       active_invites = GridDenInvite.active.where(hackr: hackr).includes(:guest)
@@ -2449,6 +2519,157 @@ module Grid
 
     def den_service
       @den_service ||= Grid::DenService.new(hackr)
+    end
+
+    # --- Fixture commands ---
+
+    def place_fixture_command(item_name)
+      return "<span style='color: #fbbf24;'>Place what? Usage: place &lt;fixture&gt;</span>" if item_name.empty?
+      return "<span style='color: #f87171;'>You can only place fixtures in your own den.</span>" unless in_own_den?
+
+      room = hackr.current_room
+
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+      unless item.fixture?
+        return "<span style='color: #f87171;'>#{h(item.name)} is not a fixture.</span>"
+      end
+
+      fixture_count = room.placed_fixtures.count
+      if fixture_count >= Grid::DenService::MAX_DEN_FIXTURES
+        return "<span style='color: #f87171;'>Fixture limit reached (#{fixture_count}/#{Grid::DenService::MAX_DEN_FIXTURES}). Unplace one first.</span>"
+      end
+
+      item.update!(room: room, grid_hackr: nil)
+
+      notifications = achievement_checker.check(:place_fixture, item_name: item.name)
+      notifications += achievement_checker.check(:fixtures_placed)
+      notifications += mission_progressor.record(:place_fixture, item_name: item.name)
+
+      output = "<span style='color: #34d399;'>Installed </span><span style='color: #a78bfa;'>#{h(item.name)}</span><span style='color: #34d399;'>. +#{item.storage_capacity} storage slots.</span>"
+      output = append_notifications(output, notifications)
+      {output: output, event: nil}
+    end
+
+    def unplace_fixture_command(item_name)
+      return "<span style='color: #fbbf24;'>Unplace what? Usage: unplace &lt;fixture&gt;</span>" if item_name.empty?
+      return "<span style='color: #f87171;'>You can only unplace fixtures from your own den.</span>" unless in_own_den?
+
+      room = hackr.current_room
+      item = room.placed_fixtures.find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>No placed fixture called '#{h(item_name)}' here.</span>" unless item
+
+      if item.stored_items.exists?
+        return "<span style='color: #f87171;'>#{h(item.name)} has items stored inside. Retrieve them first.</span>"
+      end
+
+      ActiveRecord::Base.transaction do
+        hackr.lock!
+        used = hackr.grid_items.in_inventory(hackr).count
+        if used >= hackr.inventory_capacity
+          return "<span style='color: #f87171;'>Inventory full (#{used}/#{hackr.inventory_capacity} slots). Make room first.</span>"
+        end
+
+        item.update!(grid_hackr: hackr, room: nil)
+      end
+      "<span style='color: #34d399;'>#{h(item.name)} uninstalled and returned to inventory.</span>"
+    end
+
+    def store_in_fixture_command(args)
+      in_idx = args.rindex { |w| w.downcase == "in" }
+      unless in_idx && in_idx > 0 && in_idx < args.length - 1
+        return "<span style='color: #fbbf24;'>Usage: store &lt;item&gt; in &lt;fixture&gt;</span>"
+      end
+
+      item_name = args[0...in_idx].join(" ")
+      fixture_name = args[(in_idx + 1)..].join(" ")
+
+      return "<span style='color: #f87171;'>You can only store items in fixtures in your own den.</span>" unless in_own_den?
+
+      room = hackr.current_room
+      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
+
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+
+      if item.fixture?
+        return "<span style='color: #f87171;'>You can't store a fixture inside another fixture.</span>"
+      end
+
+      ActiveRecord::Base.transaction do
+        fixture.lock!
+        cap = fixture.storage_capacity
+        stored_count = fixture.stored_items.count
+        if stored_count >= cap
+          return "<span style='color: #f87171;'>#{h(fixture.name)} is full (#{stored_count}/#{cap}).</span>"
+        end
+
+        item.update!(container: fixture, grid_hackr: nil, room: nil)
+
+        notifications = achievement_checker.check(:items_stored)
+        output = "<span style='color: #34d399;'>Stored </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #d0d0d0;'>#{h(item.name)}</span>"}<span style='color: #34d399;'> in </span><span style='color: #a78bfa;'>#{h(fixture.name)}</span><span style='color: #34d399;'>. (#{stored_count + 1}/#{cap} slots)</span>"
+        output = append_notifications(output, notifications)
+        {output: output, event: nil}
+      end
+    end
+
+    def retrieve_from_fixture_command(args)
+      from_idx = args.rindex { |w| w.downcase == "from" }
+      unless from_idx && from_idx > 0 && from_idx < args.length - 1
+        return "<span style='color: #fbbf24;'>Usage: retrieve &lt;item&gt; from &lt;fixture&gt;</span>"
+      end
+
+      item_name = args[0...from_idx].join(" ")
+      fixture_name = args[(from_idx + 1)..].join(" ")
+
+      return "<span style='color: #f87171;'>You can only retrieve items from fixtures in your own den.</span>" unless in_own_den?
+
+      room = hackr.current_room
+      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
+
+      item = fixture.stored_items.find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>#{h(fixture.name)} doesn't contain '#{h(item_name)}'.</span>" unless item
+
+      ActiveRecord::Base.transaction do
+        hackr.lock!
+        used = hackr.grid_items.in_inventory(hackr).count
+        if used >= hackr.inventory_capacity
+          return "<span style='color: #f87171;'>Inventory full (#{used}/#{hackr.inventory_capacity} slots). Make room first.</span>"
+        end
+
+        item.update!(grid_hackr: hackr, container: nil)
+      end
+      "<span style='color: #34d399;'>Retrieved </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #d0d0d0;'>#{h(item.name)}</span>"}<span style='color: #34d399;'> from </span><span style='color: #a78bfa;'>#{h(fixture.name)}</span><span style='color: #34d399;'>.</span>"
+    end
+
+    def peek_fixture_command(fixture_name)
+      return "<span style='color: #fbbf24;'>Peek inside what? Usage: peek &lt;fixture&gt;</span>" if fixture_name.empty?
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
+
+      cap = fixture.storage_capacity
+      stored = fixture.stored_items.to_a
+      slot_color = (stored.count >= cap) ? "#f87171" : "#9ca3af"
+
+      output = []
+      output << "<span style='color: #a78bfa; font-weight: bold;'>#{h(fixture.name)}</span> <span style='color: #{slot_color};'>[#{stored.count}/#{cap} slots]</span>"
+      if stored.any?
+        stored.each do |item|
+          name_display = item.unicorn? ? item.rainbow_name_html : "<span style='color: #{item.rarity_color};'>#{h(item.name)}</span>"
+          rarity_tag = item.rarity ? " <span style='color: #{item.rarity_color};'>[#{item.rarity_label}]</span>" : ""
+          qty_tag = (item.quantity.to_i > 1) ? " <span style='color: #6b7280;'>×#{item.quantity}</span>" : ""
+          output << "  ▸ #{name_display}#{rarity_tag}#{qty_tag}"
+        end
+      else
+        output << "  <span style='color: #6b7280;'>Empty.</span>"
+      end
+      output.join("\n")
     end
 
     # All den room IDs this hackr can enter: their own + actively invited.

--- a/app/services/grid/den_service.rb
+++ b/app/services/grid/den_service.rb
@@ -7,6 +7,7 @@ module Grid
     class NotInDenOrCorridor < StandardError; end
 
     DEN_STORAGE_CAP = 16
+    MAX_DEN_FIXTURES = 3
     RESIDENTIAL_CORRIDOR_SLUG = "residential-corridor"
     MAX_SLUG_RETRIES = 3
 

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -115,7 +115,7 @@ module Grid
       case trigger_type.to_s
       when "visit_room"
         target.blank? || target.casecmp?(context[:room_slug].to_s)
-      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item"
+      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item", "place_fixture"
         target.blank? || target.casecmp?(name_context(context).to_s)
       when "deliver_item"
         # Convention: `target_slug` holds the item name. The delivery
@@ -149,7 +149,7 @@ module Grid
     # target_count so the `progress >= target_count` completion check fires.
     def next_progress_value(current, trigger_type, context, target_count)
       case trigger_type.to_s
-      when "visit_room", "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "deliver_item", "fabricate_item"
+      when "visit_room", "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "deliver_item", "fabricate_item", "place_fixture"
         [current + 1, target_count].min
       when "spend_cred"
         [current + context[:amount].to_i, target_count].min

--- a/data/world/achievements.yml
+++ b/data/world/achievements.yml
@@ -729,8 +729,8 @@ achievements:
     xp_reward: 100
     cred_reward: 0
 
-  - slug: pack_rat
-    name: "Pack Rat"
+  - slug: den_stash
+    name: "Den Stash"
     description: "Stored 5 items in your den."
     badge_icon: "STR"
     category: grid
@@ -742,7 +742,7 @@ achievements:
 
   - slug: den_hoarder
     name: "Den Hoarder"
-    description: "Filled your den storage to capacity."
+    description: "Stored 16 items in your den."
     badge_icon: "FUL"
     category: grid
     trigger_type: items_stored
@@ -750,3 +750,25 @@ achievements:
       count: 16
     xp_reward: 100
     cred_reward: 0
+
+  # --- Fixtures ---
+  - slug: den_architect
+    name: "Den Architect"
+    description: "Placed your first storage fixture."
+    badge_icon: "FIX"
+    category: grid
+    trigger_type: place_fixture
+    trigger_data: {}
+    xp_reward: 25
+    cred_reward: 0
+
+  - slug: den_outfitter
+    name: "Den Outfitter"
+    description: "Placed 3 unique fixtures in your den."
+    badge_icon: "FIX"
+    category: grid
+    trigger_type: fixtures_placed
+    trigger_data:
+      count: 3
+    xp_reward: 75
+    cred_reward: 5

--- a/data/world/item_definitions.yml
+++ b/data/world/item_definitions.yml
@@ -343,6 +343,86 @@ item_definitions:
     properties:
       effect_type: redeem_den
 
+  # ── Fixture Materials ────────────────────────────────────────────
+  - slug: alloy-plate
+    name: Alloy Plate
+    description: "Reinforced composite sheeting salvaged from GovCorp structural waste. Dense and workable."
+    item_type: material
+    rarity: common
+    value: 15
+    max_stack: 32
+    properties: {}
+
+  - slug: logic-core
+    name: Logic Core
+    description: "A compact processor substrate. Runs basic control firmware. Essential for anything smarter than a doorstop."
+    item_type: material
+    rarity: uncommon
+    value: 40
+    max_stack: 16
+    properties: {}
+
+  - slug: quantum-shard
+    name: Quantum Shard
+    description: "A fragment of crystallized quantum matter. Unstable but extremely dense. Handle with gloves."
+    item_type: material
+    rarity: rare
+    value: 150
+    max_stack: 8
+    properties: {}
+
+  - slug: synth-fiber
+    name: Synth Fiber
+    description: "Woven synthetic cabling stripped from decommissioned network conduits. Ideal for internal fixture wiring."
+    item_type: material
+    rarity: common
+    value: 10
+    max_stack: 32
+    properties: {}
+
+  - slug: cipher-chip
+    name: Cipher Chip
+    description: "An encryption module recovered from a GovCorp security terminal. Powers compartmentalized storage systems."
+    item_type: material
+    rarity: uncommon
+    value: 60
+    max_stack: 16
+    properties: {}
+
+  # ── Storage Fixtures ────────────────────────────────────────────
+  - slug: basic-data-rack
+    name: Basic Data Rack
+    description: "A compact open-frame rack for holding data media and small components. Nothing fancy, but it keeps things organized."
+    item_type: fixture
+    rarity: common
+    value: 50
+    max_stack: 1
+    properties:
+      storage_capacity: 8
+      fixture_type: data_rack
+
+  - slug: reinforced-locker
+    name: Reinforced Locker
+    description: "A heavy-duty locker with a mag-seal closure. Holds a significant volume and keeps curious hands out."
+    item_type: fixture
+    rarity: uncommon
+    value: 120
+    max_stack: 1
+    properties:
+      storage_capacity: 16
+      fixture_type: locker
+
+  - slug: cryo-vault
+    name: Cryo Vault
+    description: "A cryogenic storage unit that preserves volatile materials indefinitely. Quantum-shielded. Expensive to build. Worth every shard."
+    item_type: fixture
+    rarity: rare
+    value: 300
+    max_stack: 1
+    properties:
+      storage_capacity: 32
+      fixture_type: cryo_vault
+
   # ── Faction Items ──────────────────────────────────────────────
   - slug: fracture-beacon
     name: Fracture Beacon

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -126,3 +126,67 @@ schematics:
       - input_slug: data-shard
         quantity: 2
         position: 1
+
+  # ── Storage Fixtures ─────────────────────────────────────────────
+  - slug: fab-basic-data-rack
+    name: Fabricate Basic Data Rack
+    description: "Assemble a compact 8-slot storage rack from alloy and wiring."
+    output_slug: basic-data-rack
+    output_quantity: 1
+    xp_reward: 25
+    required_clearance: 0
+    required_room_type: den
+    published: true
+    position: 100
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 4
+        position: 0
+      - input_slug: synth-fiber
+        quantity: 2
+        position: 1
+
+  - slug: fab-reinforced-locker
+    name: Fabricate Reinforced Locker
+    description: "Weld together a heavy-duty 16-slot storage locker from alloy, logic substrates, and cipher modules."
+    output_slug: reinforced-locker
+    output_quantity: 1
+    xp_reward: 60
+    required_clearance: 5
+    required_room_type: den
+    published: true
+    position: 110
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 6
+        position: 0
+      - input_slug: logic-core
+        quantity: 2
+        position: 1
+      - input_slug: cipher-chip
+        quantity: 1
+        position: 2
+
+  - slug: fab-cryo-vault
+    name: Fabricate Cryo Vault
+    description: "Construct a quantum-shielded 32-slot cryogenic vault from high-grade alloy, logic cores, and quantum shards."
+    output_slug: cryo-vault
+    output_quantity: 1
+    xp_reward: 120
+    required_clearance: 15
+    required_room_type: den
+    published: true
+    position: 120
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 8
+        position: 0
+      - input_slug: logic-core
+        quantity: 4
+        position: 1
+      - input_slug: quantum-shard
+        quantity: 2
+        position: 2
+      - input_slug: cipher-chip
+        quantity: 2
+        position: 3

--- a/db/migrate/20260421120001_add_container_id_to_grid_items.rb
+++ b/db/migrate/20260421120001_add_container_id_to_grid_items.rb
@@ -1,0 +1,7 @@
+class AddContainerIdToGridItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_items, :container_id, :integer, null: true
+    add_index :grid_items, :container_id
+    add_foreign_key :grid_items, :grid_items, column: :container_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_120003) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_120001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -343,6 +343,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120003) do
   end
 
   create_table "grid_items", force: :cascade do |t|
+    t.integer "container_id"
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "grid_hackr_id"
@@ -356,6 +357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120003) do
     t.integer "room_id"
     t.datetime "updated_at", null: false
     t.integer "value", default: 0, null: false
+    t.index ["container_id"], name: "index_grid_items_on_container_id"
     t.index ["grid_hackr_id"], name: "index_grid_items_on_grid_hackr_id"
     t.index ["grid_item_definition_id"], name: "index_grid_items_on_grid_item_definition_id"
     t.index ["grid_mining_rig_id"], name: "index_grid_items_on_grid_mining_rig_id"
@@ -1121,6 +1123,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_120003) do
   add_foreign_key "grid_hackr_track_plays", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "tracks"
   add_foreign_key "grid_items", "grid_item_definitions"
+  add_foreign_key "grid_items", "grid_items", column: "container_id"
   add_foreign_key "grid_mission_objectives", "grid_missions", on_delete: :cascade
   add_foreign_key "grid_mission_rewards", "grid_missions", on_delete: :cascade
   add_foreign_key "grid_missions", "grid_factions", column: "min_rep_faction_id", on_delete: :nullify

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -714,6 +714,7 @@ namespace :data do
         item_type: attrs["item_type"],
         rarity: attrs["rarity"],
         value: attrs["value"] || 0,
+        max_stack: attrs["max_stack"],
         properties: attrs["properties"] || {}
       )
       defn.save!

--- a/spec/factories/grid_item_definitions.rb
+++ b/spec/factories/grid_item_definitions.rb
@@ -40,6 +40,14 @@ FactoryBot.define do
       properties { {"effect_type" => "heal", "amount" => 25} }
     end
 
+    trait :fixture do
+      sequence(:slug) { |n| "fixture-def-#{n}" }
+      sequence(:name) { |n| "Storage Fixture #{n}" }
+      item_type { "fixture" }
+      max_stack { 1 }
+      properties { {"storage_capacity" => 8, "fixture_type" => "data_rack"} }
+    end
+
     trait :rare do
       rarity { "rare" }
     end

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -13,6 +13,7 @@
 #  value                   :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  container_id            :integer
 #  grid_hackr_id           :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
@@ -20,12 +21,14 @@
 #
 # Indexes
 #
+#  index_grid_items_on_container_id             (container_id)
 #  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
 #  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
 #
 # Foreign Keys
 #
+#  container_id             (container_id => grid_items.id)
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 FactoryBot.define do
@@ -56,6 +59,16 @@ FactoryBot.define do
 
     trait :consumable do
       association :grid_item_definition, factory: [:grid_item_definition, :consumable]
+    end
+
+    trait :fixture do
+      association :grid_item_definition, factory: [:grid_item_definition, :fixture]
+    end
+
+    trait :placed_fixture do
+      fixture
+      grid_hackr { nil }
+      # room must be set by caller (the den room)
     end
   end
 end

--- a/spec/models/grid_item_spec.rb
+++ b/spec/models/grid_item_spec.rb
@@ -13,6 +13,7 @@
 #  value                   :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  container_id            :integer
 #  grid_hackr_id           :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
@@ -20,16 +21,172 @@
 #
 # Indexes
 #
+#  index_grid_items_on_container_id             (container_id)
 #  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
 #  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
 #
 # Foreign Keys
 #
+#  container_id             (container_id => grid_items.id)
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 require "rails_helper"
 
 RSpec.describe GridItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr) }
+  let(:fixture_def) { create(:grid_item_definition, :fixture) }
+  let(:tool_def) { create(:grid_item_definition, item_type: "tool") }
+
+  describe "#fixture?" do
+    it "returns true for fixture items" do
+      item = build(:grid_item, :fixture)
+      expect(item.fixture?).to be true
+    end
+
+    it "returns false for non-fixture items" do
+      item = build(:grid_item)
+      expect(item.fixture?).to be false
+    end
+  end
+
+  describe "#placed?" do
+    it "returns true for a fixture with room_id set" do
+      item = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      expect(item.placed?).to be true
+    end
+
+    it "returns false for a fixture in inventory" do
+      item = create(:grid_item, :fixture, :in_inventory, grid_hackr: hackr, grid_item_definition: fixture_def)
+      expect(item.placed?).to be false
+    end
+
+    it "returns false for non-fixture items in a room" do
+      item = create(:grid_item, room: room)
+      expect(item.placed?).to be false
+    end
+  end
+
+  describe "#storage_capacity" do
+    it "reads from properties" do
+      item = build(:grid_item, :fixture, properties: {"storage_capacity" => 16})
+      expect(item.storage_capacity).to eq(16)
+    end
+
+    it "returns 0 when not set" do
+      item = build(:grid_item, properties: {})
+      expect(item.storage_capacity).to eq(0)
+    end
+  end
+
+  describe "single_location validation" do
+    it "allows exactly one location FK set" do
+      item = build(:grid_item, room: room, grid_hackr: nil, grid_mining_rig: nil, container: nil)
+      expect(item).to be_valid
+    end
+
+    it "allows container_id as sole location" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      item = build(:grid_item, container: fixture, room: nil, grid_hackr: nil, grid_mining_rig: nil)
+      expect(item).to be_valid
+    end
+
+    it "rejects container_id + room_id" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      item = build(:grid_item, container: fixture, room: room, grid_hackr: nil)
+      expect(item).not_to be_valid
+      expect(item.errors[:base].first).to include("one location")
+    end
+
+    it "rejects container_id + grid_hackr_id" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      item = build(:grid_item, container: fixture, grid_hackr: hackr, room: nil)
+      expect(item).not_to be_valid
+    end
+
+    it "allows zero locations (transitional state)" do
+      item = build(:grid_item, room: nil, grid_hackr: nil, grid_mining_rig: nil, container: nil)
+      expect(item).to be_valid
+    end
+  end
+
+  describe "scopes" do
+    let(:fixture) { create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def) }
+    let(:floor_item) { create(:grid_item, room: room, grid_hackr: nil, grid_item_definition: tool_def) }
+    let(:stored_item) { create(:grid_item, container: fixture, room: nil, grid_hackr: nil, grid_item_definition: tool_def) }
+    let(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: tool_def) }
+
+    before do
+      fixture
+      floor_item
+      stored_item
+      inv_item
+    end
+
+    describe ".in_room" do
+      it "includes floor items and placed fixtures" do
+        results = described_class.in_room(room)
+        expect(results).to include(floor_item, fixture)
+      end
+
+      it "excludes container-stored items" do
+        results = described_class.in_room(room)
+        expect(results).not_to include(stored_item)
+      end
+
+      it "excludes inventory items" do
+        results = described_class.in_room(room)
+        expect(results).not_to include(inv_item)
+      end
+    end
+
+    describe ".on_floor" do
+      it "includes non-fixture floor items" do
+        results = described_class.on_floor(room)
+        expect(results).to include(floor_item)
+      end
+
+      it "excludes placed fixtures" do
+        results = described_class.on_floor(room)
+        expect(results).not_to include(fixture)
+      end
+
+      it "excludes container-stored items" do
+        results = described_class.on_floor(room)
+        expect(results).not_to include(stored_item)
+      end
+    end
+
+    describe ".placed_fixtures" do
+      it "includes placed fixtures" do
+        results = described_class.placed_fixtures(room)
+        expect(results).to include(fixture)
+      end
+
+      it "excludes non-fixture items" do
+        results = described_class.placed_fixtures(room)
+        expect(results).not_to include(floor_item)
+      end
+    end
+
+    describe ".in_inventory" do
+      it "excludes container-stored items" do
+        results = described_class.in_inventory(hackr)
+        expect(results).to include(inv_item)
+        expect(results).not_to include(stored_item)
+      end
+    end
+  end
+
+  describe "stored_items association" do
+    it "prevents deleting a fixture with stored items" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      create(:grid_item, container: fixture, room: nil, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(fixture.destroy).to be false
+      expect(fixture.errors[:base].first).to include("Cannot delete")
+    end
+  end
 end

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -31,5 +31,80 @@
 require "rails_helper"
 
 RSpec.describe GridRoom, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone, room_type: "den") }
+  let(:fixture_def) { create(:grid_item_definition, :fixture, properties: {"storage_capacity" => 8}) }
+  let(:fixture_def_16) { create(:grid_item_definition, :fixture, properties: {"storage_capacity" => 16}) }
+  let(:tool_def) { create(:grid_item_definition, item_type: "tool") }
+
+  describe "#den_floor_items / #den_floor_count" do
+    it "counts non-fixture items on the floor" do
+      create(:grid_item, room: room, grid_hackr: nil, grid_item_definition: tool_def)
+      create(:grid_item, room: room, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(room.den_floor_count).to eq(2)
+    end
+
+    it "excludes placed fixtures" do
+      create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      create(:grid_item, room: room, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(room.den_floor_count).to eq(1)
+    end
+
+    it "excludes items stored in fixtures" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      create(:grid_item, container: fixture, room: nil, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(room.den_floor_count).to eq(0)
+    end
+  end
+
+  describe "#placed_fixtures" do
+    it "returns only fixture items placed in the room" do
+      fixture = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      create(:grid_item, room: room, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(room.placed_fixtures).to eq([fixture])
+    end
+
+    it "returns empty when no fixtures placed" do
+      expect(room.placed_fixtures).to be_empty
+    end
+  end
+
+  describe "#den_fixture_capacity" do
+    it "sums storage_capacity of all placed fixtures" do
+      create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def_16)
+
+      expect(room.den_fixture_capacity).to eq(24)
+    end
+
+    it "returns 0 with no fixtures" do
+      expect(room.den_fixture_capacity).to eq(0)
+    end
+  end
+
+  describe "#den_stored_in_fixtures_count" do
+    it "counts items stored across all placed fixtures" do
+      f1 = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+      f2 = create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def_16)
+      create(:grid_item, container: f1, room: nil, grid_hackr: nil, grid_item_definition: tool_def)
+      create(:grid_item, container: f1, room: nil, grid_hackr: nil, grid_item_definition: tool_def)
+      create(:grid_item, container: f2, room: nil, grid_hackr: nil, grid_item_definition: tool_def)
+
+      expect(room.den_stored_in_fixtures_count).to eq(3)
+    end
+
+    it "returns 0 with no fixtures" do
+      expect(room.den_stored_in_fixtures_count).to eq(0)
+    end
+
+    it "returns 0 with empty fixtures" do
+      create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def)
+
+      expect(room.den_stored_in_fixtures_count).to eq(0)
+    end
+  end
 end

--- a/spec/services/grid/fixture_commands_spec.rb
+++ b/spec/services/grid/fixture_commands_spec.rb
@@ -1,0 +1,526 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Fixture Commands", type: :service do
+  let(:zone) { create(:grid_zone, :residential, slug: "residential-district") }
+  let(:corridor) { create(:grid_room, :hub, grid_zone: zone, slug: "residential-corridor", name: "Residential Corridor") }
+  let(:hackr) { create(:grid_hackr, current_room: den) }
+  let(:den) { Grid::DenService.new(hackr_for_den).create_den! }
+  let(:hackr_for_den) { create(:grid_hackr) }
+  let(:parser) { Grid::CommandParser.new(hackr, input) }
+
+  before do
+    corridor # ensure corridor exists
+    # hackr_for_den creates the den, then we set hackr to own it
+    den
+    hackr_for_den.update!(current_room: den)
+  end
+
+  # Use hackr_for_den as the actual hackr in all tests
+  let(:hackr) { hackr_for_den }
+
+  let(:fixture_def) { create(:grid_item_definition, :fixture) }
+  let(:fixture_item) do
+    create(:grid_item, :fixture, :in_inventory, grid_hackr: hackr, grid_item_definition: fixture_def)
+  end
+
+  describe "place command" do
+    before { fixture_item }
+
+    context "happy path" do
+      let(:input) { "place #{fixture_item.name}" }
+
+      it "moves fixture from inventory to den" do
+        result = parser.execute
+        expect(result[:output]).to include("Installed")
+        fixture_item.reload
+        expect(fixture_item.room).to eq(den)
+        expect(fixture_item.grid_hackr).to be_nil
+      end
+
+      it "counts as a placed fixture for achievements" do
+        parser.execute
+        expect(den.placed_fixtures.distinct.count(:grid_item_definition_id)).to eq(1)
+      end
+    end
+
+    context "not in own den" do
+      let(:other_room) { create(:grid_room, grid_zone: zone) }
+      let(:input) { "place #{fixture_item.name}" }
+
+      before { hackr.update!(current_room: other_room) }
+
+      it "rejects with error" do
+        result = parser.execute
+        expect(result[:output]).to include("only place fixtures in your own den")
+      end
+    end
+
+    context "item is not a fixture" do
+      let(:tool_item) { create(:grid_item, :in_inventory, grid_hackr: hackr) }
+      let(:input) { "place #{tool_item.name}" }
+
+      before { tool_item }
+
+      it "rejects non-fixture items" do
+        result = parser.execute
+        expect(result[:output]).to include("not a fixture")
+      end
+    end
+
+    context "fixture limit reached" do
+      let(:input) { "place #{fixture_item.name}" }
+
+      before do
+        Grid::DenService::MAX_DEN_FIXTURES.times do
+          d = create(:grid_item_definition, :fixture)
+          create(:grid_item, :placed_fixture, room: den, grid_item_definition: d)
+        end
+      end
+
+      it "rejects when at max fixtures" do
+        result = parser.execute
+        expect(result[:output]).to include("Fixture limit reached")
+      end
+    end
+
+    context "aliases" do
+      let(:input) { "install #{fixture_item.name}" }
+
+      it "works with install alias" do
+        result = parser.execute
+        expect(result[:output]).to include("Installed")
+      end
+    end
+  end
+
+  describe "unplace command" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+
+    before { placed_fixture }
+
+    context "happy path" do
+      let(:input) { "unplace #{placed_fixture.name}" }
+
+      it "moves fixture back to inventory" do
+        result = parser.execute
+        expect(result[:output]).to include("uninstalled")
+        placed_fixture.reload
+        expect(placed_fixture.grid_hackr).to eq(hackr)
+        expect(placed_fixture.room).to be_nil
+      end
+    end
+
+    context "fixture has stored items" do
+      let(:input) { "unplace #{placed_fixture.name}" }
+      let(:stored_item) do
+        create(:grid_item, container: placed_fixture, grid_item_definition: create(:grid_item_definition),
+          room: nil, grid_hackr: nil)
+      end
+
+      before { stored_item }
+
+      it "rejects when fixture contains items" do
+        result = parser.execute
+        expect(result[:output]).to include("Retrieve them first")
+      end
+    end
+
+    context "inventory full" do
+      let(:input) { "unplace #{placed_fixture.name}" }
+
+      before do
+        hackr.stat("clearance") # ensure stats initialized
+        16.times do
+          create(:grid_item, :in_inventory, grid_hackr: hackr)
+        end
+      end
+
+      it "rejects when inventory is full" do
+        result = parser.execute
+        expect(result[:output]).to include("Inventory full")
+      end
+    end
+
+    context "not in own den" do
+      let(:other_room) { create(:grid_room, grid_zone: zone) }
+      let(:input) { "unplace #{placed_fixture.name}" }
+
+      before { hackr.update!(current_room: other_room) }
+
+      it "rejects with error" do
+        result = parser.execute
+        expect(result[:output]).to include("only unplace fixtures from your own den")
+      end
+    end
+
+    context "fixture not found" do
+      let(:input) { "unplace nonexistent" }
+
+      it "returns not found error" do
+        result = parser.execute
+        expect(result[:output]).to include("No placed fixture called")
+      end
+    end
+
+    context "uninstall alias" do
+      let(:input) { "uninstall #{placed_fixture.name}" }
+
+      it "works with uninstall alias" do
+        result = parser.execute
+        expect(result[:output]).to include("uninstalled")
+      end
+    end
+  end
+
+  describe "store command" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+    let(:item_to_store) { create(:grid_item, :in_inventory, grid_hackr: hackr) }
+
+    before do
+      placed_fixture
+      item_to_store
+    end
+
+    context "happy path" do
+      let(:input) { "store #{item_to_store.name} in #{placed_fixture.name}" }
+
+      it "moves item from inventory to fixture" do
+        result = parser.execute
+        expect(result[:output]).to include("Stored")
+        item_to_store.reload
+        expect(item_to_store.container).to eq(placed_fixture)
+        expect(item_to_store.grid_hackr).to be_nil
+        expect(item_to_store.room).to be_nil
+      end
+    end
+
+    context "fixture is full" do
+      let(:input) { "store #{item_to_store.name} in #{placed_fixture.name}" }
+
+      before do
+        placed_fixture.storage_capacity.times do
+          create(:grid_item, container: placed_fixture, grid_item_definition: create(:grid_item_definition),
+            room: nil, grid_hackr: nil)
+        end
+      end
+
+      it "rejects when fixture is full" do
+        result = parser.execute
+        expect(result[:output]).to include("full")
+      end
+    end
+
+    context "storing a fixture inside another fixture" do
+      let(:second_fixture) { create(:grid_item, :fixture, :in_inventory, grid_hackr: hackr) }
+      let(:input) { "store #{second_fixture.name} in #{placed_fixture.name}" }
+
+      before { second_fixture }
+
+      it "rejects nesting" do
+        result = parser.execute
+        expect(result[:output]).to include("can't store a fixture inside another fixture")
+      end
+    end
+
+    context "visitor cannot store" do
+      let(:visitor) { create(:grid_hackr, current_room: den) }
+      let(:visitor_item) { create(:grid_item, :in_inventory, grid_hackr: visitor) }
+      let(:parser) { Grid::CommandParser.new(visitor, input) }
+      let(:input) { "store #{visitor_item.name} in #{placed_fixture.name}" }
+
+      before { visitor_item }
+
+      it "rejects visitors from storing" do
+        result = parser.execute
+        expect(result[:output]).to include("only store items in fixtures in your own den")
+      end
+    end
+
+    context "put alias" do
+      let(:input) { "put #{item_to_store.name} in #{placed_fixture.name}" }
+
+      it "works with put alias" do
+        result = parser.execute
+        expect(result[:output]).to include("Stored")
+      end
+    end
+  end
+
+  describe "retrieve command" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+    let(:stored_item) do
+      create(:grid_item, container: placed_fixture, grid_item_definition: create(:grid_item_definition),
+        room: nil, grid_hackr: nil)
+    end
+
+    before do
+      placed_fixture
+      stored_item
+    end
+
+    context "happy path" do
+      let(:input) { "retrieve #{stored_item.name} from #{placed_fixture.name}" }
+
+      it "moves item from fixture to inventory" do
+        result = parser.execute
+        expect(result[:output]).to include("Retrieved")
+        stored_item.reload
+        expect(stored_item.grid_hackr).to eq(hackr)
+        expect(stored_item.container).to be_nil
+      end
+    end
+
+    context "item not in fixture" do
+      let(:input) { "retrieve nonexistent from #{placed_fixture.name}" }
+
+      it "returns error when item not found" do
+        result = parser.execute
+        expect(result[:output]).to include("doesn't contain")
+      end
+    end
+
+    context "inventory full" do
+      let(:input) { "retrieve #{stored_item.name} from #{placed_fixture.name}" }
+
+      before do
+        16.times do
+          create(:grid_item, :in_inventory, grid_hackr: hackr)
+        end
+      end
+
+      it "rejects when inventory is full" do
+        result = parser.execute
+        expect(result[:output]).to include("Inventory full")
+      end
+    end
+
+    context "visitor cannot retrieve" do
+      let(:visitor) { create(:grid_hackr, current_room: den) }
+      let(:parser) { Grid::CommandParser.new(visitor, input) }
+      let(:input) { "retrieve #{stored_item.name} from #{placed_fixture.name}" }
+
+      it "rejects visitors" do
+        result = parser.execute
+        expect(result[:output]).to include("only retrieve items from fixtures in your own den")
+      end
+    end
+  end
+
+  describe "peek command" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+
+    before { placed_fixture }
+
+    context "empty fixture" do
+      let(:input) { "peek #{placed_fixture.name}" }
+
+      it "shows empty fixture" do
+        result = parser.execute
+        expect(result[:output]).to include(placed_fixture.name)
+        expect(result[:output]).to include("0/#{placed_fixture.storage_capacity}")
+        expect(result[:output]).to include("Empty")
+      end
+    end
+
+    context "fixture with items" do
+      let(:stored_item) do
+        create(:grid_item, container: placed_fixture, grid_item_definition: create(:grid_item_definition, name: "Data Shard"),
+          room: nil, grid_hackr: nil, name: "Data Shard")
+      end
+      let(:input) { "peek #{placed_fixture.name}" }
+
+      before { stored_item }
+
+      it "lists stored items" do
+        result = parser.execute
+        expect(result[:output]).to include("Data Shard")
+        expect(result[:output]).to include("1/#{placed_fixture.storage_capacity}")
+      end
+    end
+
+    context "visitor can peek" do
+      let(:visitor) { create(:grid_hackr, current_room: den) }
+      let(:parser) { Grid::CommandParser.new(visitor, input) }
+      let(:input) { "peek #{placed_fixture.name}" }
+
+      it "allows visitors to peek" do
+        result = parser.execute
+        expect(result[:output]).to include(placed_fixture.name)
+        expect(result[:output]).not_to include("can't")
+      end
+    end
+
+    context "search alias" do
+      let(:input) { "search #{placed_fixture.name}" }
+
+      it "works with search alias" do
+        result = parser.execute
+        expect(result[:output]).to include(placed_fixture.name)
+      end
+    end
+  end
+
+  describe "take command with placed fixture" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+
+    before { placed_fixture }
+
+    context "empty fixture can be taken" do
+      let(:input) { "take #{placed_fixture.name}" }
+
+      it "allows taking empty placed fixture" do
+        result = parser.execute
+        expect(result[:output]).to include("You take")
+        placed_fixture.reload
+        expect(placed_fixture.grid_hackr).to eq(hackr)
+        expect(placed_fixture.room).to be_nil
+      end
+    end
+
+    context "non-empty fixture cannot be taken" do
+      let(:stored_item) do
+        create(:grid_item, container: placed_fixture, grid_item_definition: create(:grid_item_definition),
+          room: nil, grid_hackr: nil)
+      end
+      let(:input) { "take #{placed_fixture.name}" }
+
+      before { stored_item }
+
+      it "blocks take on non-empty fixture" do
+        result = parser.execute
+        expect(result[:output]).to include("Retrieve them first")
+      end
+    end
+  end
+
+  describe "salvage command with placed fixture" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+
+    before { placed_fixture }
+
+    # salvage searches hackr.grid_items — placed fixtures have grid_hackr: nil,
+    # so they won't be found. But an in-inventory fixture should be salvageable.
+    context "fixture in inventory" do
+      let(:inv_fixture) { create(:grid_item, :fixture, :in_inventory, grid_hackr: hackr, grid_item_definition: fixture_def) }
+      let(:input) { "salvage #{inv_fixture.name}" }
+
+      before { inv_fixture }
+
+      it "allows salvaging unplaced fixture" do
+        result = parser.execute
+        # Won't error about being placed — will proceed to salvage logic
+        expect(result[:output]).not_to include("Unplace")
+      end
+    end
+  end
+
+  describe "drop command with fixture" do
+    let(:input) { "drop #{fixture_item.name}" }
+
+    before { fixture_item }
+
+    it "blocks dropping fixtures with a hint to use place" do
+      result = parser.execute
+      expect(result[:output]).to include("place")
+    end
+  end
+
+  describe "examine command on fixture" do
+    context "placed fixture" do
+      let(:placed_fixture) do
+        create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+      end
+      let(:input) { "examine #{placed_fixture.name}" }
+
+      before { placed_fixture }
+
+      it "shows storage capacity and placed status" do
+        result = parser.execute
+        expect(result[:output]).to include("Storage Fixture")
+        expect(result[:output]).to include("PLACED")
+        expect(result[:output]).to include("#{placed_fixture.storage_capacity} slots")
+      end
+
+      it "shows peek hint" do
+        result = parser.execute
+        expect(result[:output]).to include("peek")
+      end
+    end
+
+    context "fixture in inventory" do
+      let(:input) { "examine #{fixture_item.name}" }
+
+      before { fixture_item }
+
+      it "shows capacity and place hint" do
+        result = parser.execute
+        expect(result[:output]).to include("Storage Fixture")
+        expect(result[:output]).to include("in inventory")
+        expect(result[:output]).to include("place")
+      end
+    end
+  end
+
+  describe "look command with fixtures" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+    let(:floor_item) do
+      create(:grid_item, room: den, grid_hackr: nil, grid_item_definition: create(:grid_item_definition, name: "Scrap Metal"), name: "Scrap Metal")
+    end
+
+    before do
+      placed_fixture
+      floor_item
+    end
+
+    let(:input) { "look" }
+
+    it "shows fixtures in a separate section" do
+      result = parser.execute
+      expect(result[:output]).to include("Fixtures:")
+      expect(result[:output]).to include(placed_fixture.name)
+    end
+
+    it "shows floor items separately from fixtures" do
+      result = parser.execute
+      expect(result[:output]).to include("Items:")
+      expect(result[:output]).to include("Scrap Metal")
+    end
+
+    it "shows floor count in den banner" do
+      result = parser.execute
+      expect(result[:output]).to include("Floor:")
+    end
+  end
+
+  describe "den status with fixtures" do
+    let(:placed_fixture) do
+      create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def)
+    end
+
+    before { placed_fixture }
+
+    let(:input) { "den" }
+
+    it "shows fixture info in den status" do
+      result = parser.execute
+      expect(result[:output]).to include("Fixtures")
+      expect(result[:output]).to include(placed_fixture.name)
+    end
+  end
+end


### PR DESCRIPTION
  Storage fixtures are craftable furniture items that hackrs place in their
  dens to gain additional storage slots, independent of the 16-slot floor.

  Schema: Self-referential container_id FK on grid_items. Items stored
  inside a fixture have only container_id set; all other location FKs nil.
  single_location validation extended to 4 FKs. Scope guards added to
  in_room/in_inventory (container_id: nil). New scopes: on_floor,
  placed_fixtures, in_fixture.

  Commands: place/install, unplace/uninstall, store/put...in,
  retrieve...from, peek/search. All owner-gated via in_own_den?.
  Store locks fixture row; retrieve/unplace lock hackr row (race prevention).
  drop blocks fixtures (must use place). take blocks non-empty placed
  fixtures. salvage blocks placed fixtures. look shows Fixtures section.
  examine shows capacity + state. den status shows per-fixture usage.

  Fixtures: Basic Data Rack (8), Reinforced Locker (16), Cryo Vault (32).
  Max 3 per den. max_stack: 1. All schematics require room_type: den.

  Materials: Alloy Plate, Logic Core, Quantum Shard, Synth Fiber, Cipher Chip.

  Achievements: place_fixture (event), fixtures_placed (cumulative,
  counts distinct definition IDs from placed fixtures). items_stored
  progress updated to include fixture-stored items. Renamed duplicate
  pack_rat slug to den_stash. Updated den_hoarder description.

  Mission objective: place_fixture added to progressor dispatch.

  Seed: max_stack added to data.rake item_definitions seeder.