### PR TITLE
 [TPG] Command Quantity Syntax

### DIFF
--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -386,6 +386,8 @@ module Grid
     end
 
     def take_command(item_name)
+      parsed = Grid::QuantityParser.parse(item_name)
+      item_name = parsed.remainder
       return "<span style='color: #fbbf24;'>Take what?</span>" if item_name.empty?
 
       room = hackr.current_room
@@ -404,21 +406,29 @@ module Grid
         return "<span style='color: #f87171;'>#{h(item.name)} has items stored inside. Retrieve them first.</span>"
       end
 
-      # Inventory capacity check
-      used = hackr.grid_items.in_inventory(hackr).count
-      if used >= hackr.inventory_capacity
-        return "<span style='color: #f87171;'>Inventory full (#{used}/#{hackr.inventory_capacity} slots). Drop, sell, or store items to make room.</span>"
+      saved_name = item.name
+      saved_unicorn = item.unicorn?
+      saved_rarity = item.rarity
+      qty = nil
+
+      ActiveRecord::Base.transaction do
+        qty = Grid::ItemTransfer.move!(
+          source_item: item,
+          quantity: parsed.quantity,
+          destination_type: :inventory,
+          destination: hackr
+        )
       end
 
-      item.update!(grid_hackr: hackr, room: nil)
+      increment_stat!("items_taken", qty)
 
-      increment_stat!("items_taken")
-
-      output = "<span style='color: #34d399;'>You take the </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #34d399;'>#{h(item.name)}</span>"}<span style='color: #34d399;'>.</span>"
-      notifications = achievement_checker.check(:take_item, item_name: item.name)
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      name_display = saved_unicorn ? "<span class='rarity-unicorn'>#{h(saved_name)}</span>" : "<span style='color: #34d399;'>#{h(saved_name)}</span>"
+      output = "<span style='color: #34d399;'>You take </span>#{name_display}<span style='color: #34d399;'>#{h(qty_label)}.</span>"
+      notifications = achievement_checker.check(:take_item, item_name: saved_name)
       notifications += achievement_checker.check(:items_collected)
-      notifications += achievement_checker.check(:rarity_owned, rarity: item.rarity) if item.rarity.present?
-      notifications += mission_progressor.record(:collect_item, item_name: item.name)
+      notifications += achievement_checker.check(:rarity_owned, rarity: saved_rarity) if saved_rarity.present?
+      notifications += mission_progressor.record(:collect_item, item_name: saved_name, amount: qty)
       output = append_notifications(output, notifications)
 
       {
@@ -426,16 +436,22 @@ module Grid
         event: {
           type: "take",
           hackr_alias: hackr.hackr_alias,
-          item_name: item.name,
+          item_name: saved_name,
           room_id: room.id
         }
       }
+    rescue Grid::InventoryErrors::InventoryFull => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ItemTransfer::InsufficientQuantity => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def drop_command(item_name)
+      parsed = Grid::QuantityParser.parse(item_name)
+      item_name = parsed.remainder
       return "<span style='color: #fbbf24;'>Drop what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       # Fixtures must be placed via the place command
@@ -451,21 +467,27 @@ module Grid
         return "<span style='color: #f87171;'>You can't drop items in someone else's den.</span>"
       end
 
-      # Den storage cap
-      if room.den? && room.owner_id == hackr.id
-        if room.den_floor_count >= Grid::DenService::DEN_STORAGE_CAP
-          return "<span style='color: #f87171;'>Den storage full (#{Grid::DenService::DEN_STORAGE_CAP}/#{Grid::DenService::DEN_STORAGE_CAP}). Take something first.</span>"
-        end
-      end
+      saved_name = item.name
+      saved_unicorn = item.unicorn?
+      qty = nil
 
-      item.update!(room: room, grid_hackr: nil)
+      ActiveRecord::Base.transaction do
+        qty = Grid::ItemTransfer.move!(
+          source_item: item,
+          quantity: parsed.quantity,
+          destination_type: :room,
+          destination: room
+        )
+      end
 
       notifications = []
       if room.den? && room.owner_id == hackr.id
         notifications += achievement_checker.check(:items_stored)
       end
 
-      output = "<span style='color: #34d399;'>You drop the </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #34d399;'>#{h(item.name)}</span>"}<span style='color: #34d399;'>.</span>"
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      name_display = saved_unicorn ? "<span class='rarity-unicorn'>#{h(saved_name)}</span>" : "<span style='color: #34d399;'>#{h(saved_name)}</span>"
+      output = "<span style='color: #34d399;'>You drop </span>#{name_display}<span style='color: #34d399;'>#{h(qty_label)}.</span>"
       output = append_notifications(output, notifications) if notifications.any?
 
       {
@@ -473,10 +495,14 @@ module Grid
         event: {
           type: "drop",
           hackr_alias: hackr.hackr_alias,
-          item_name: item.name,
+          item_name: saved_name,
           room_id: room.id
         }
       }
+    rescue Grid::ItemTransfer::DestinationFull => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ItemTransfer::InsufficientQuantity => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def examine_command(target)
@@ -735,17 +761,17 @@ module Grid
 
         <span style='color: #fbbf24;'>Items:</span>
           <span style='color: #34d399;'>inventory, inv, i</span>          - View your inventory
-          <span style='color: #34d399;'>take &lt;item&gt;</span>                - Pick up an item
-          <span style='color: #34d399;'>drop &lt;item&gt;</span>                - Drop an item
+          <span style='color: #34d399;'>take [qty|all] &lt;item&gt;</span>     - Pick up item(s) from the room
+          <span style='color: #34d399;'>drop [qty|all] &lt;item&gt;</span>     - Drop item(s) from inventory
           <span style='color: #34d399;'>use &lt;item&gt;</span>                 - Use an item
-          <span style='color: #34d399;'>salvage &lt;item&gt;, sal</span>        - Break down an item for XP
+          <span style='color: #34d399;'>salvage [qty|all] &lt;item&gt;</span>  - Break down item(s) for XP
           <span style='color: #34d399;'>analyze &lt;item&gt;, an</span>         - Preview salvage yields before breaking down
           <span style='color: #34d399;'>examine &lt;target&gt;, x</span>        - Examine item, NPC, or hackr
 
         <span style='color: #fbbf24;'>NPCs:</span>
           <span style='color: #34d399;'>talk &lt;npc&gt;</span>                 - Talk to an NPC
           <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>    - Ask an NPC about a topic
-          <span style='color: #34d399;'>give &lt;item&gt; to &lt;npc&gt;</span>       - Hand an item to an NPC (for delivery missions)
+          <span style='color: #34d399;'>give [qty|all] &lt;item&gt; to &lt;npc&gt;</span> - Hand item(s) to an NPC (for delivery missions)
 
         <span style='color: #fbbf24;'>Missions:</span>
           <span style='color: #34d399;'>missions</span>                   - List your active missions
@@ -762,8 +788,8 @@ module Grid
 
         <span style='color: #fbbf24;'>Commerce:</span>
           <span style='color: #34d399;'>shop, browse</span>               - View vendor inventory &amp; prices
-          <span style='color: #34d399;'>buy &lt;item&gt;</span>                 - Purchase an item from vendor
-          <span style='color: #34d399;'>sell &lt;item&gt;</span>                - Sell an item to vendor
+          <span style='color: #34d399;'>buy [qty] &lt;item&gt;</span>            - Purchase item(s) from vendor
+          <span style='color: #34d399;'>sell [qty|all] &lt;item&gt;</span>      - Sell item(s) to vendor
 
         <span style='color: #fbbf24;'>Economy:</span>
           <span style='color: #34d399;'>cache</span>                      - List your caches
@@ -801,9 +827,9 @@ module Grid
         <span style='color: #fbbf24;'>Fixtures:</span>
           <span style='color: #34d399;'>place &lt;f&gt;, install &lt;f&gt;</span>     - Install a fixture in your den
           <span style='color: #34d399;'>unplace &lt;f&gt;, uninstall &lt;f&gt;</span> - Uninstall a fixture (must be empty)
-          <span style='color: #34d399;'>store &lt;item&gt; in &lt;f&gt;</span>        - Store an item in a fixture
-          <span style='color: #34d399;'>put &lt;item&gt; in &lt;f&gt;</span>          - Same as store
-          <span style='color: #34d399;'>retrieve &lt;item&gt; from &lt;f&gt;</span>   - Retrieve an item from a fixture
+          <span style='color: #34d399;'>store [qty|all] &lt;item&gt; in &lt;f&gt;</span>     - Store item(s) in a fixture
+          <span style='color: #34d399;'>put [qty|all] &lt;item&gt; in &lt;f&gt;</span>       - Same as store
+          <span style='color: #34d399;'>retrieve [qty|all] &lt;item&gt; from &lt;f&gt;</span> - Retrieve item(s) from a fixture
           <span style='color: #34d399;'>peek &lt;f&gt;, search &lt;f&gt;</span>       - Inspect fixture contents
 
         <span style='color: #fbbf24;'>Social:</span>
@@ -959,32 +985,32 @@ module Grid
     end
 
     def salvage_command(item_name)
+      parsed = Grid::QuantityParser.parse(item_name)
+      item_name = parsed.remainder
       return "<span style='color: #fbbf24;'>Salvage what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       if item.unicorn?
         return "<span style='color: #f87171;'>UNICORN items are irreducible. They cannot be salvaged.</span>"
       end
 
-      if item.fixture? && item.placed?
-        return "<span style='color: #f87171;'>#{h(item.name)} is placed in your den. Unplace it first.</span>"
-      end
-
       item_styled = h(item.name)
       begin
-        result = Grid::SalvageService.salvage!(hackr: hackr, item: item)
+        result = Grid::SalvageService.salvage!(hackr: hackr, item: item, quantity: parsed.quantity)
       rescue ArgumentError => e
         return "<span style='color: #f87171;'>#{h(e.message)}</span>"
       end
 
-      increment_stat!("salvage_count")
+      qty = result.quantity_salvaged
+      increment_stat!("salvage_count", qty)
 
       level_msg = result.xp_result[:leveled_up] ?
         "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{result.xp_result[:new_clearance]}!</span>" : ""
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
       output = "<span style='color: #34d399;'>You salvage </span>#{item_styled}" \
-        "<span style='color: #34d399;'>. +#{result.xp_awarded} XP.</span>#{level_msg}"
+        "<span style='color: #34d399;'>#{h(qty_label)}. +#{result.xp_awarded} XP.</span>#{level_msg}"
 
       result.yielded_items.each do |yi|
         output += "\n<span style='color: #a78bfa;'>  ▸ Decomposed: </span>" \
@@ -994,7 +1020,7 @@ module Grid
 
       notifications = achievement_checker.check(:salvage_item)
       notifications += achievement_checker.check(:salvage_count)
-      notifications += mission_progressor.record(:salvage_item, item_name: result.item_name)
+      notifications += mission_progressor.record(:salvage_item, item_name: result.item_name, amount: qty)
 
       if result.yielded_items.any?
         total_yield_qty = result.yielded_items.sum { |yi| yi[:quantity] }
@@ -1002,7 +1028,7 @@ module Grid
 
         result.yielded_items.each do |yi|
           notifications += achievement_checker.check(:salvage_yield_received)
-          notifications += mission_progressor.record(:salvage_yield_received, item_name: yi[:name])
+          notifications += mission_progressor.record(:salvage_yield_received, item_name: yi[:name], amount: yi[:quantity])
         end
 
         notifications += achievement_checker.check(:salvage_yield_count)
@@ -1366,7 +1392,12 @@ module Grid
     end
 
     def buy_command(item_name)
-      return "<span style='color: #fbbf24;'>Buy what? Usage: buy &lt;item&gt;</span>" if item_name.empty?
+      parsed = Grid::QuantityParser.parse(item_name)
+      item_name = parsed.remainder
+      return "<span style='color: #fbbf24;'>Buy what? Usage: buy [qty] &lt;item&gt;</span>" if item_name.empty?
+
+      return "<span style='color: #f87171;'>Specify a number to buy, not 'all'.</span>" if parsed.quantity == :all
+      qty = parsed.quantity
 
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
@@ -1374,18 +1405,19 @@ module Grid
       vendor = room.grid_mobs.find_by(mob_type: "vendor")
       return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
 
-      result = Grid::ShopService.buy!(hackr: hackr, mob: vendor, item_name: item_name)
+      result = Grid::ShopService.buy!(hackr: hackr, mob: vendor, item_name: item_name, quantity: qty)
 
       item = result[:item]
       color = item.rarity_color
       name_display = item.unicorn? ? item.rainbow_name_html : "<span style='color: #{color};'>#{h(item.name)}</span>"
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
 
-      output = "<span style='color: #34d399;'>Purchased </span>#{name_display}<span style='color: #34d399;'> for <span style='color: #fbbf24;'>#{format_cred(result[:price_paid])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
+      output = "<span style='color: #34d399;'>Purchased </span>#{name_display}<span style='color: #34d399;'>#{h(qty_label)} for <span style='color: #fbbf24;'>#{format_cred(result[:price_paid])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
 
       rep_notif = grant_faction_rep(vendor.grid_faction, 2, reason: "buy:#{slugify(item.name)}", source: vendor)
       notifications = achievement_checker.check(:purchase_item, item_name: item.name)
       notifications.unshift(rep_notif) if rep_notif
-      notifications += mission_progressor.record(:buy_item, item_name: item.name)
+      notifications += mission_progressor.record(:buy_item, item_name: item.name, amount: qty)
       notifications += mission_progressor.record(:spend_cred, amount: result[:price_paid].to_i)
       if vendor.grid_faction
         notifications += mission_progressor.record(
@@ -1409,7 +1441,9 @@ module Grid
     end
 
     def sell_command(item_name)
-      return "<span style='color: #fbbf24;'>Sell what? Usage: sell &lt;item&gt;</span>" if item_name.empty?
+      parsed = Grid::QuantityParser.parse(item_name)
+      item_name = parsed.remainder
+      return "<span style='color: #fbbf24;'>Sell what? Usage: sell [qty|all] &lt;item&gt;</span>" if item_name.empty?
 
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
@@ -1417,13 +1451,17 @@ module Grid
       vendor = room.grid_mobs.find_by(mob_type: "vendor")
       return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
 
-      result = Grid::ShopService.sell!(hackr: hackr, mob: vendor, item_name: item_name)
+      result = Grid::ShopService.sell!(hackr: hackr, mob: vendor, item_name: item_name, quantity: parsed.quantity)
 
-      "<span style='color: #34d399;'>Sold </span><span style='color: #d0d0d0;'>#{h(result[:item_name])}</span><span style='color: #34d399;'> for <span style='color: #fbbf24;'>#{format_cred(result[:sell_price])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
+      qty = result[:quantity]
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      "<span style='color: #34d399;'>Sold </span><span style='color: #d0d0d0;'>#{h(result[:item_name])}</span><span style='color: #34d399;'>#{h(qty_label)} for <span style='color: #fbbf24;'>#{format_cred(result[:sell_price])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
     rescue Grid::ShopService::AccessDenied => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     rescue Grid::ShopService::ItemNotFound => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::InsufficientStock => e
+      "<span style='color: #fbbf24;'>#{h(e.message)}</span>"
     rescue Grid::TransactionService::InsufficientBalance
       "<span style='color: #f87171;'>The vendor can't afford to buy that right now.</span>"
     end
@@ -2192,24 +2230,33 @@ module Grid
     # objective matches, the item is NOT consumed (flavor-only delivery)
     # and the NPC offers a non-committal line.
     def give_command(args)
-      return "<span style='color: #fbbf24;'>Usage: give &lt;item&gt; to &lt;npc&gt;</span>" if args.length < 3
+      return "<span style='color: #fbbf24;'>Usage: give [qty] &lt;item&gt; to &lt;npc&gt;</span>" if args.length < 3
 
       # Split on the last occurrence of "to" so multi-word item + NPC names
-      # round-trip correctly (e.g. "give Signal Fragment to Codec Prime").
+      # round-trip correctly (e.g. "give 5 Signal Fragment to Codec Prime").
       to_index = args.rindex { |w| w.downcase == "to" }
-      return "<span style='color: #fbbf24;'>Usage: give &lt;item&gt; to &lt;npc&gt;</span>" unless to_index && to_index > 0 && to_index < args.length - 1
+      return "<span style='color: #fbbf24;'>Usage: give [qty] &lt;item&gt; to &lt;npc&gt;</span>" unless to_index && to_index > 0 && to_index < args.length - 1
 
-      item_name = args[0...to_index].join(" ")
+      raw_item_part = args[0...to_index].join(" ")
       npc_name = args[(to_index + 1)..].join(" ")
+
+      parsed = Grid::QuantityParser.parse(raw_item_part)
+      item_name = parsed.remainder
+      return "<span style='color: #fbbf24;'>Usage: give [qty] &lt;item&gt; to &lt;npc&gt;</span>" if item_name.empty?
 
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+
+      qty = (parsed.quantity == :all) ? item.quantity : parsed.quantity
+      return "<span style='color: #f87171;'>You only have #{item.quantity} #{h(item.name)} (requested #{qty}).</span>" if qty > item.quantity
 
       mob = room.grid_mobs.find_by("LOWER(name) = ?", npc_name.downcase)
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
+
+      saved_name = item.name
 
       # Wrap progressor + consumption in one transaction so a mid-flow
       # exception can't leave the objective advanced without the item
@@ -2217,10 +2264,18 @@ module Grid
       # progress (lost reward). All-or-nothing.
       notifications = []
       tx_committed = false
+      qty_insufficient = false
       begin
         ActiveRecord::Base.transaction do
+          item.lock!
+          # Re-check after lock — concurrent request may have consumed units
+          if qty > item.quantity
+            qty_insufficient = true
+            raise ActiveRecord::Rollback
+          end
+
           notifications = mission_progressor.record(
-            :deliver_item, item_name: item.name, npc_name: mob.name
+            :deliver_item, item_name: saved_name, npc_name: mob.name, amount: qty
           )
 
           if notifications.empty?
@@ -2230,9 +2285,10 @@ module Grid
             raise ActiveRecord::Rollback
           end
 
-          # Consume the item only when a delivery objective matched.
-          if item.quantity.to_i > 1
-            item.update!(quantity: item.quantity - 1)
+          # Consume the items only when a delivery objective matched.
+          remaining = item.quantity - qty
+          if remaining > 0
+            item.update!(quantity: remaining)
           else
             item.destroy!
           end
@@ -2248,6 +2304,10 @@ module Grid
         @mission_progressor = nil unless tx_committed
       end
 
+      if qty_insufficient
+        return "<span style='color: #f87171;'>You only have #{item.quantity} #{h(saved_name)} (requested #{qty}).</span>"
+      end
+
       if notifications.empty?
         return dialogue_box(
           "<span style='color: #c084fc;'>#{h(mob.name)}</span>: " \
@@ -2255,9 +2315,10 @@ module Grid
         )
       end
 
-      output = "<span style='color: #34d399;'>You hand the </span>" \
-        "<span style='color: #d0d0d0;'>#{h(item.name)}</span>" \
-        "<span style='color: #34d399;'> to </span>" \
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      output = "<span style='color: #34d399;'>You hand </span>" \
+        "<span style='color: #d0d0d0;'>#{h(saved_name)}</span>" \
+        "<span style='color: #34d399;'>#{h(qty_label)} to </span>" \
         "<span style='color: #c084fc;'>#{h(mob.name)}</span><span style='color: #34d399;'>.</span>"
       append_notifications(output, notifications)
     end
@@ -2578,11 +2639,15 @@ module Grid
     def store_in_fixture_command(args)
       in_idx = args.rindex { |w| w.downcase == "in" }
       unless in_idx && in_idx > 0 && in_idx < args.length - 1
-        return "<span style='color: #fbbf24;'>Usage: store &lt;item&gt; in &lt;fixture&gt;</span>"
+        return "<span style='color: #fbbf24;'>Usage: store [qty] &lt;item&gt; in &lt;fixture&gt;</span>"
       end
 
-      item_name = args[0...in_idx].join(" ")
+      raw_item_part = args[0...in_idx].join(" ")
       fixture_name = args[(in_idx + 1)..].join(" ")
+
+      parsed = Grid::QuantityParser.parse(raw_item_part)
+      item_name = parsed.remainder
+      return "<span style='color: #fbbf24;'>Usage: store [qty] &lt;item&gt; in &lt;fixture&gt;</span>" if item_name.empty?
 
       return "<span style='color: #f87171;'>You can only store items in fixtures in your own den.</span>" unless in_own_den?
 
@@ -2597,31 +2662,46 @@ module Grid
         return "<span style='color: #f87171;'>You can't store a fixture inside another fixture.</span>"
       end
 
+      saved_name = item.name
+      saved_unicorn = item.unicorn?
+      fixture_display = fixture.name
+      cap = fixture.storage_capacity
+      qty = nil
+
       ActiveRecord::Base.transaction do
-        fixture.lock!
-        cap = fixture.storage_capacity
-        stored_count = fixture.stored_items.count
-        if stored_count >= cap
-          return "<span style='color: #f87171;'>#{h(fixture.name)} is full (#{stored_count}/#{cap}).</span>"
-        end
-
-        item.update!(container: fixture, grid_hackr: nil, room: nil)
-
-        notifications = achievement_checker.check(:items_stored)
-        output = "<span style='color: #34d399;'>Stored </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #d0d0d0;'>#{h(item.name)}</span>"}<span style='color: #34d399;'> in </span><span style='color: #a78bfa;'>#{h(fixture.name)}</span><span style='color: #34d399;'>. (#{stored_count + 1}/#{cap} slots)</span>"
-        output = append_notifications(output, notifications)
-        {output: output, event: nil}
+        qty = Grid::ItemTransfer.move!(
+          source_item: item,
+          quantity: parsed.quantity,
+          destination_type: :fixture,
+          destination: fixture
+        )
       end
+
+      stored_count = fixture.stored_items.count
+      notifications = achievement_checker.check(:items_stored)
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      name_display = saved_unicorn ? "<span class='rarity-unicorn'>#{h(saved_name)}</span>" : "<span style='color: #d0d0d0;'>#{h(saved_name)}</span>"
+      output = "<span style='color: #34d399;'>Stored </span>#{name_display}<span style='color: #34d399;'>#{h(qty_label)} in </span><span style='color: #a78bfa;'>#{h(fixture_display)}</span><span style='color: #34d399;'>. (#{stored_count}/#{cap} slots)</span>"
+      output = append_notifications(output, notifications)
+      {output: output, event: nil}
+    rescue Grid::ItemTransfer::DestinationFull => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ItemTransfer::InsufficientQuantity => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def retrieve_from_fixture_command(args)
       from_idx = args.rindex { |w| w.downcase == "from" }
       unless from_idx && from_idx > 0 && from_idx < args.length - 1
-        return "<span style='color: #fbbf24;'>Usage: retrieve &lt;item&gt; from &lt;fixture&gt;</span>"
+        return "<span style='color: #fbbf24;'>Usage: retrieve [qty] &lt;item&gt; from &lt;fixture&gt;</span>"
       end
 
-      item_name = args[0...from_idx].join(" ")
+      raw_item_part = args[0...from_idx].join(" ")
       fixture_name = args[(from_idx + 1)..].join(" ")
+
+      parsed = Grid::QuantityParser.parse(raw_item_part)
+      item_name = parsed.remainder
+      return "<span style='color: #fbbf24;'>Usage: retrieve [qty] &lt;item&gt; from &lt;fixture&gt;</span>" if item_name.empty?
 
       return "<span style='color: #f87171;'>You can only retrieve items from fixtures in your own den.</span>" unless in_own_den?
 
@@ -2632,16 +2712,27 @@ module Grid
       item = fixture.stored_items.find_by("LOWER(name) = ?", item_name.downcase)
       return "<span style='color: #f87171;'>#{h(fixture.name)} doesn't contain '#{h(item_name)}'.</span>" unless item
 
-      ActiveRecord::Base.transaction do
-        hackr.lock!
-        used = hackr.grid_items.in_inventory(hackr).count
-        if used >= hackr.inventory_capacity
-          return "<span style='color: #f87171;'>Inventory full (#{used}/#{hackr.inventory_capacity} slots). Make room first.</span>"
-        end
+      saved_name = item.name
+      saved_unicorn = item.unicorn?
+      fixture_display = fixture.name
+      qty = nil
 
-        item.update!(grid_hackr: hackr, container: nil)
+      ActiveRecord::Base.transaction do
+        qty = Grid::ItemTransfer.move!(
+          source_item: item,
+          quantity: parsed.quantity,
+          destination_type: :inventory,
+          destination: hackr
+        )
       end
-      "<span style='color: #34d399;'>Retrieved </span>#{item.unicorn? ? item.rainbow_name_html : "<span style='color: #d0d0d0;'>#{h(item.name)}</span>"}<span style='color: #34d399;'> from </span><span style='color: #a78bfa;'>#{h(fixture.name)}</span><span style='color: #34d399;'>.</span>"
+
+      qty_label = (qty > 1) ? " ×#{qty}" : ""
+      name_display = saved_unicorn ? "<span class='rarity-unicorn'>#{h(saved_name)}</span>" : "<span style='color: #d0d0d0;'>#{h(saved_name)}</span>"
+      "<span style='color: #34d399;'>Retrieved </span>#{name_display}<span style='color: #34d399;'>#{h(qty_label)} from </span><span style='color: #a78bfa;'>#{h(fixture_display)}</span><span style='color: #34d399;'>.</span>"
+    rescue Grid::InventoryErrors::InventoryFull => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ItemTransfer::InsufficientQuantity => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def peek_fixture_command(fixture_name)

--- a/app/services/grid/item_transfer.rb
+++ b/app/services/grid/item_transfer.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+module Grid
+  # Atomically moves N units of a GridItem from its current location to a
+  # destination. Handles source-row split (decrement or destroy), destination
+  # stack merge, overflow into new rows, and capacity pre-checks.
+  #
+  # Must be called inside an open ActiveRecord transaction.
+  #
+  # Destination types:
+  #   :inventory — hackr's inventory (slot-capped by inventory_capacity)
+  #   :room      — a room's floor (capped by DEN_STORAGE_CAP for dens, uncapped otherwise)
+  #   :fixture   — a placed fixture (capped by storage_capacity)
+  module ItemTransfer
+    class InsufficientQuantity < StandardError; end
+    class DestinationFull < StandardError; end
+
+    module_function
+
+    # Move `quantity` units of `source_item` to the described destination.
+    #
+    # source_item:      GridItem row to take units from
+    # quantity:         Integer or :all
+    # destination_type: :inventory | :room | :fixture
+    # destination:      GridHackr (for :inventory), GridRoom (for :room), GridItem (for :fixture)
+    #
+    # Returns Integer — actual quantity moved.
+    def move!(source_item:, quantity:, destination_type:, destination:)
+      unless ActiveRecord::Base.connection.transaction_open?
+        raise "Grid::ItemTransfer.move! must be called inside a transaction"
+      end
+
+      source_item.lock!
+      qty = (quantity == :all) ? source_item.quantity : quantity.to_i
+
+      if qty > source_item.quantity
+        raise InsufficientQuantity,
+          "You only have #{source_item.quantity} (requested #{qty})."
+      end
+
+      definition = source_item.grid_item_definition
+      max_stack = definition.max_stack
+
+      # --- Pre-flight capacity check (refuse entirely if can't hold full amount) ---
+      moving_whole_stack = (qty == source_item.quantity)
+      # When moving a whole stack, check if there's an existing destination stack
+      # to merge into. If so, go through the full deposit path instead of relocating.
+      existing_dest = moving_whole_stack ? find_existing_at_destination(definition, destination_type, destination) : nil
+      can_relocate = moving_whole_stack && existing_dest.nil?
+
+      check_destination_capacity!(qty, definition, max_stack, destination_type, destination,
+        skip_existing_merge: can_relocate)
+
+      if can_relocate
+        # Optimization: relocate the source row directly to avoid destroy+create.
+        # This preserves the row ID, which is important for callers that hold a
+        # reference and expect to reload the item after the transfer.
+        relocate_source!(source_item, destination_type, destination)
+      else
+        # Partial stack or merge needed: decrement/destroy source, deposit at destination
+        remaining_on_source = source_item.quantity - qty
+        if remaining_on_source > 0
+          source_item.update!(quantity: remaining_on_source)
+        else
+          source_item.destroy!
+        end
+        deposit!(qty, definition, max_stack, destination_type, destination)
+      end
+
+      qty
+    end
+
+    # --- Private helpers ---
+
+    def relocate_source!(source_item, destination_type, destination)
+      attrs = case destination_type
+      when :inventory
+        {grid_hackr: destination, room: nil, container: nil}
+      when :room
+        {room: destination, grid_hackr: nil, container: nil}
+      when :fixture
+        {container: destination, grid_hackr: nil, room: nil}
+      end
+      source_item.update!(attrs)
+    end
+
+    def check_destination_capacity!(qty, definition, max_stack, destination_type, destination, skip_existing_merge: false)
+      case destination_type
+      when :inventory
+        hackr = destination
+        hackr.lock! # Serialize concurrent inventory modifications
+        if skip_existing_merge
+          # Whole-stack relocate: 1 row incoming, no merge needed
+          current_used = hackr.grid_items.in_inventory(hackr).count
+          free_slots = hackr.inventory_capacity - current_used
+          if free_slots < 1
+            raise Grid::InventoryErrors::InventoryFull,
+              "Inventory full (#{current_used}/#{hackr.inventory_capacity} slots). Drop, sell, or store items to make room."
+          end
+        else
+          inv_items = hackr.grid_items.in_inventory(hackr)
+          existing = inv_items.where(grid_item_definition_id: definition.id).lock.first
+          space_in_existing = existing ? stack_space(max_stack, existing.quantity) : 0
+          overflow = [qty - space_in_existing, 0].max
+          new_slots_needed = slots_for(overflow, max_stack)
+          current_used = inv_items.count
+          free_slots = hackr.inventory_capacity - current_used
+          if new_slots_needed > free_slots
+            raise Grid::InventoryErrors::InventoryFull,
+              "Inventory full. Need #{new_slots_needed} slot(s) but only #{free_slots} free."
+          end
+        end
+
+      when :room
+        room = destination
+        if room.den?
+          room.lock! # Serialize concurrent drops into this den
+          if skip_existing_merge
+            floor_count = room.den_floor_count
+            free = Grid::DenService::DEN_STORAGE_CAP - floor_count
+            if free < 1
+              raise DestinationFull,
+                "Den floor full (#{floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} slots)."
+            end
+          else
+            existing = room.grid_items.on_floor(room)
+              .where(grid_item_definition_id: definition.id).lock.first
+            space_in_existing = existing ? stack_space(max_stack, existing.quantity) : 0
+            overflow = [qty - space_in_existing, 0].max
+            new_rows = slots_for(overflow, max_stack)
+            floor_count = room.den_floor_count
+            free = Grid::DenService::DEN_STORAGE_CAP - floor_count
+            if new_rows > free
+              raise DestinationFull,
+                "Den floor full (#{floor_count}/#{Grid::DenService::DEN_STORAGE_CAP} slots)."
+            end
+          end
+        end
+        # Non-den rooms: no cap
+
+      when :fixture
+        fixture = destination
+        fixture.lock!
+        cap = fixture.storage_capacity
+        used = fixture.stored_items.count
+        if skip_existing_merge
+          if used >= cap
+            raise DestinationFull,
+              "#{fixture.name} is full (#{used}/#{cap} slots)."
+          end
+        else
+          existing = fixture.stored_items
+            .where(grid_item_definition_id: definition.id).lock.first
+          space_in_existing = existing ? stack_space(max_stack, existing.quantity) : 0
+          overflow = [qty - space_in_existing, 0].max
+          new_rows = slots_for(overflow, max_stack)
+          free = cap - used
+          if new_rows > free
+            raise DestinationFull,
+              "#{fixture.name} is full (#{used}/#{cap} slots)."
+          end
+        end
+      end
+    end
+
+    def deposit!(qty, definition, max_stack, destination_type, destination)
+      remaining = qty
+
+      # Try to merge into existing stack at destination
+      existing = find_existing_at_destination(definition, destination_type, destination)
+      if existing
+        space = stack_space(max_stack, existing.quantity)
+        fill = [space, remaining].min
+        if fill > 0
+          existing.update!(quantity: existing.quantity + fill)
+          remaining -= fill
+        end
+      end
+
+      # Spill overflow into new rows
+      while remaining > 0
+        batch = max_stack ? [remaining, max_stack].min : remaining
+        create_at_destination!(definition, batch, destination_type, destination)
+        remaining -= batch
+      end
+    end
+
+    def find_existing_at_destination(definition, destination_type, destination)
+      scope = case destination_type
+      when :inventory
+        destination.grid_items.in_inventory(destination)
+      when :room
+        destination.grid_items.on_floor(destination)
+      when :fixture
+        destination.stored_items
+      end
+      scope.where(grid_item_definition_id: definition.id).lock.first
+    end
+
+    def create_at_destination!(definition, quantity, destination_type, destination)
+      attrs = definition.item_attributes.merge(quantity: quantity)
+      case destination_type
+      when :inventory
+        attrs[:grid_hackr] = destination
+      when :room
+        attrs[:room] = destination
+      when :fixture
+        attrs[:container] = destination
+      end
+      GridItem.create!(attrs)
+    end
+
+    # How many units can still fit in the existing stack.
+    def stack_space(max_stack, current_quantity)
+      return Float::INFINITY unless max_stack
+      [max_stack - current_quantity, 0].max
+    end
+
+    # How many new rows are needed to hold `overflow` units.
+    def slots_for(overflow, max_stack)
+      return 0 if overflow <= 0
+      max_stack ? (overflow.to_f / max_stack).ceil : 1
+    end
+
+    private_class_method :check_destination_capacity!, :relocate_source!,
+      :deposit!, :find_existing_at_destination, :create_at_destination!,
+      :stack_space, :slots_for
+  end
+end

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -24,15 +24,15 @@ module Grid
     # `context` keys expected per trigger_type:
     #   :visit_room       → room_slug:
     #   :talk_npc         → npc_name:  (case-insensitive match on target_slug)
-    #   :collect_item     → item_name: (case-insensitive)
-    #   :deliver_item     → item_name:, npc_name:
+    #   :collect_item     → item_name:, amount: (default 1)
+    #   :deliver_item     → item_name:, npc_name:, amount: (default 1)
     #   :spend_cred       → amount:   (accumulator, capped at target_count)
-    #   :buy_item         → item_name:
+    #   :buy_item         → item_name:, amount: (default 1)
     #   :reach_rep        → faction_slug:, rep_value:  (threshold; rep_value is NEW value)
     #   :reach_clearance  → clearance: (threshold; NEW value)
     #   :use_item         → item_name:
-    #   :salvage_item     → item_name:
-    #   :salvage_yield_received → item_name: (name of yielded item)
+    #   :salvage_item     → item_name:, amount: (default 1)
+    #   :salvage_yield_received → item_name:, amount: (default 1)
     #   :fabricate_item   → item_name: (name of crafted output item)
     def record(trigger_type, context = {})
       return [] unless @hackr
@@ -143,14 +143,16 @@ module Grid
     end
 
     # Compute the new `progress` column value given the event semantics.
-    # Event-style triggers (visit, talk, take, use, salvage, buy, deliver)
-    # increment by 1 per event. Threshold triggers (spend_cred accumulates,
-    # reach_rep / reach_clearance take the NEW value directly) clamp to
-    # target_count so the `progress >= target_count` completion check fires.
+    # Event-style triggers increment by 1 (or by context[:amount] when
+    # present). Threshold triggers (spend_cred accumulates, reach_rep /
+    # reach_clearance take the NEW value directly) clamp to target_count
+    # so the `progress >= target_count` completion check fires.
     def next_progress_value(current, trigger_type, context, target_count)
       case trigger_type.to_s
-      when "visit_room", "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "deliver_item", "fabricate_item", "place_fixture"
+      when "visit_room", "talk_npc", "use_item", "fabricate_item", "place_fixture"
         [current + 1, target_count].min
+      when "collect_item", "deliver_item", "buy_item", "salvage_item", "salvage_yield_received"
+        [current + context.fetch(:amount, 1).to_i, target_count].min
       when "spend_cred"
         [current + context[:amount].to_i, target_count].min
       when "reach_rep"

--- a/app/services/grid/quantity_parser.rb
+++ b/app/services/grid/quantity_parser.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Grid
+  # Parses an optional leading quantity token from a command argument string.
+  #
+  # Examples:
+  #   Grid::QuantityParser.parse("5 scrap metal")    → ParseResult(quantity: 5, remainder: "scrap metal")
+  #   Grid::QuantityParser.parse("all scrap metal")  → ParseResult(quantity: :all, remainder: "scrap metal")
+  #   Grid::QuantityParser.parse("scrap metal")      → ParseResult(quantity: 1, remainder: "scrap metal")
+  #   Grid::QuantityParser.parse("")                  → ParseResult(quantity: 1, remainder: "")
+  module QuantityParser
+    ParseResult = Data.define(:quantity, :remainder)
+
+    module_function
+
+    def parse(raw)
+      raw = raw.to_s.strip
+      case raw
+      when /\A(\d+)\s+(.+)\z/
+        qty = $1.to_i
+        qty = 1 if qty < 1
+        ParseResult.new(quantity: qty, remainder: $2)
+      when /\Aall\s+(.+)\z/i
+        ParseResult.new(quantity: :all, remainder: $1)
+      else
+        ParseResult.new(quantity: 1, remainder: raw)
+      end
+    end
+  end
+end

--- a/app/services/grid/salvage_service.rb
+++ b/app/services/grid/salvage_service.rb
@@ -2,15 +2,16 @@
 
 module Grid
   class SalvageService
-    Result = Data.define(:xp_awarded, :xp_result, :yielded_items, :item_name)
+    Result = Data.define(:xp_awarded, :xp_result, :yielded_items, :item_name, :quantity_salvaged)
 
-    def self.salvage!(hackr:, item:)
-      new(hackr, item).salvage!
+    def self.salvage!(hackr:, item:, quantity: 1)
+      new(hackr, item, quantity).salvage!
     end
 
-    def initialize(hackr, item)
+    def initialize(hackr, item, quantity)
       @hackr = hackr
       @item = item
+      @quantity = quantity
     end
 
     def salvage!
@@ -18,39 +19,50 @@ module Grid
 
       item_name = @item.name
       definition = @item.grid_item_definition
-      xp_amount = [@item.value, 1].max
-      yielded_items = []
+      xp_per_unit = [@item.value, 1].max
+      yielded_items = {}
+      qty = nil
+      total_xp = nil
 
       ActiveRecord::Base.transaction do
-        if @item.quantity > 1
-          @item.update!(quantity: @item.quantity - 1)
+        @item.lock!
+        qty = (@quantity == :all) ? @item.quantity : @quantity.to_i
+        if qty > @item.quantity
+          raise ArgumentError, "You only have #{@item.quantity} (requested #{qty})."
+        end
+        total_xp = xp_per_unit * qty
+        remaining = @item.quantity - qty
+        if remaining > 0
+          @item.update!(quantity: remaining)
         else
           @item.destroy!
         end
 
-        xp_result = @hackr.grant_xp!(xp_amount)
+        xp_result = @hackr.grant_xp!(total_xp)
 
         definition.salvage_yields.ordered.includes(:output_definition).each do |yield_row|
-          granted = grant_yield!(yield_row)
-          yielded_items << {name: granted.name, quantity: yield_row.quantity}
+          total_yield_qty = yield_row.quantity * qty
+          granted = grant_yield!(yield_row, total_yield_qty)
+          yielded_items[granted.name] = (yielded_items[granted.name] || 0) + total_yield_qty
         end
 
         Result.new(
-          xp_awarded: xp_amount,
+          xp_awarded: total_xp,
           xp_result: xp_result,
-          yielded_items: yielded_items,
-          item_name: item_name
+          yielded_items: yielded_items.map { |name, q| {name: name, quantity: q} },
+          item_name: item_name,
+          quantity_salvaged: qty
         )
       end
     end
 
     private
 
-    def grant_yield!(yield_row)
+    def grant_yield!(yield_row, total_quantity)
       Grid::Inventory.grant_item!(
         hackr: @hackr,
         definition: yield_row.output_definition,
-        quantity: yield_row.quantity
+        quantity: total_quantity
       )
     end
   end

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -31,8 +31,8 @@ module Grid
       end.compact
     end
 
-    # Buy an item from a vendor
-    def self.buy!(hackr:, mob:, item_name:)
+    # Buy item(s) from a vendor. Quantity defaults to 1.
+    def self.buy!(hackr:, mob:, item_name:, quantity: 1)
       raise AccessDenied, "This vendor doesn't sell anything" unless mob.vendor?
 
       clearance = hackr.stat("clearance")
@@ -43,31 +43,37 @@ module Grid
 
       raise ItemNotFound, "This vendor doesn't sell '#{item_name}'" unless listing
       raise AccessDenied, "CLEARANCE #{listing.min_clearance}+ required" if clearance < listing.min_clearance
-      raise InsufficientStock, "'#{listing.name}' is out of stock" if listing.out_of_stock?
 
-      price = effective_price(listing: listing, mob: mob, clearance: clearance)
+      unit_price = effective_price(listing: listing, mob: mob, clearance: clearance)
+      total_price = unit_price * quantity
       cache = hackr.default_cache
-      raise InsufficientBalance, "Insufficient CRED (need #{price}, have #{cache&.balance || 0})" unless cache && cache.balance >= price
+      raise InsufficientBalance, "Insufficient CRED (need #{total_price}, have #{cache&.balance || 0})" unless cache && cache.balance >= total_price
+
+      # Check stock availability for full quantity
+      unless listing.unlimited_stock?
+        raise InsufficientStock, "'#{listing.name}' is out of stock" if listing.out_of_stock?
+        raise InsufficientStock, "Only #{listing.stock} '#{listing.name}' in stock (requested #{quantity})" if listing.stock < quantity
+      end
 
       item = nil
 
       ActiveRecord::Base.transaction do
         # Optimistic stock decrement — prevents race condition
         unless listing.unlimited_stock?
-          updated = GridShopListing.where(id: listing.id).where("stock > 0")
-            .update_all("stock = stock - 1")
+          updated = GridShopListing.where(id: listing.id).where("stock >= ?", quantity)
+            .update_all(["stock = stock - ?", quantity])
           raise InsufficientStock, "'#{listing.name}' is out of stock" if updated == 0
         end
 
-        # Grant item first — fail fast on inventory full before touching CRED
+        # Grant items — fail fast on inventory full before touching CRED
         item = Grid::Inventory.grant_item!(
           hackr: hackr,
           definition: listing.grid_item_definition,
-          quantity: 1
+          quantity: quantity
         )
 
         # Split CRED: burn 70%, recycle 30% to gameplay pool
-        split_purchase!(hackr_cache: cache, amount: price, item_name: listing.name)
+        split_purchase!(hackr_cache: cache, amount: total_price, item_name: listing.name)
 
         # Record the shop transaction
         GridShopTransaction.create!(
@@ -75,51 +81,59 @@ module Grid
           grid_shop_listing: listing,
           grid_mob: mob,
           transaction_type: "buy",
-          quantity: 1,
-          price_paid: price,
-          burn_amount: burn_amount(price),
-          recycle_amount: price - burn_amount(price),
+          quantity: quantity,
+          price_paid: total_price,
+          burn_amount: burn_amount(total_price),
+          recycle_amount: total_price - burn_amount(total_price),
           created_at: Time.current
         )
       end
 
-      {listing: listing, item: item, price_paid: price, new_balance: cache.reload.balance}
+      {listing: listing, item: item, price_paid: total_price, quantity: quantity, new_balance: cache.reload.balance}
     end
 
-    # Sell an item to a vendor
-    def self.sell!(hackr:, mob:, item_name:)
+    # Sell item(s) to a vendor. Quantity defaults to 1; :all sells entire stack.
+    def self.sell!(hackr:, mob:, item_name:, quantity: 1)
       raise AccessDenied, "This vendor doesn't buy anything" unless mob.vendor?
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
       raise ItemNotFound, "You don't have '#{item_name}'" unless item
 
       # Find matching listing for sell price, or use item.value * SELL_PRICE_RATIO
       listing = mob.grid_shop_listings.joins(:grid_item_definition)
         .where("LOWER(grid_item_definitions.name) = ?", item_name.downcase)
         .first
-      sell_price = if listing
+      unit_sell_price = if listing
         listing.sell_price
       else
         (item.value * EconomyConfig::SELL_PRICE_RATIO).ceil
       end
-      sell_price = [sell_price, 1].max # minimum 1 CRED
+      unit_sell_price = [unit_sell_price, 1].max # minimum 1 CRED
 
       cache = hackr.default_cache
       raise AccessDenied, "You need a cache to receive CRED" unless cache
 
       item_name_saved = item.name
+      qty = nil
+      total_sell_price = nil
 
       ActiveRecord::Base.transaction do
+        item.lock!
+        qty = (quantity == :all) ? item.quantity : quantity.to_i
+        raise InsufficientStock, "You only have #{item.quantity} (requested #{qty})." if qty > item.quantity
+        total_sell_price = unit_sell_price * qty
+
         # Pay the hackr from gameplay pool
         Grid::TransactionService.mint_gameplay!(
           to_cache: cache,
-          amount: sell_price,
-          memo: "Sell: #{item.name}"
+          amount: total_sell_price,
+          memo: "Sell: #{item.name} ×#{qty}"
         )
 
-        # Remove the item
-        if item.quantity > 1
-          item.update!(quantity: item.quantity - 1)
+        # Remove the items
+        remaining = item.quantity - qty
+        if remaining > 0
+          item.update!(quantity: remaining)
         else
           item.destroy!
         end
@@ -130,15 +144,15 @@ module Grid
           grid_shop_listing: listing,
           grid_mob: mob,
           transaction_type: "sell",
-          quantity: 1,
-          price_paid: sell_price,
+          quantity: qty,
+          price_paid: total_sell_price,
           burn_amount: 0,
           recycle_amount: 0,
           created_at: Time.current
         )
       end
 
-      {item_name: item_name_saved, sell_price: sell_price, new_balance: cache.reload.balance}
+      {item_name: item_name_saved, sell_price: total_sell_price, quantity: qty, new_balance: cache.reload.balance}
     end
 
     # Compute effective price for a listing

--- a/spec/services/grid/item_transfer_spec.rb
+++ b/spec/services/grid/item_transfer_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::ItemTransfer do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:definition) { create(:grid_item_definition, item_type: "material", max_stack: 10) }
+
+  describe ".move! to :inventory" do
+    let(:floor_item) { create(:grid_item, grid_item_definition: definition, room: room, quantity: 5) }
+
+    before { floor_item }
+
+    it "moves whole stack to inventory (preserves row)" do
+      ActiveRecord::Base.transaction do
+        qty = described_class.move!(source_item: floor_item, quantity: :all, destination_type: :inventory, destination: hackr)
+        expect(qty).to eq(5)
+      end
+      floor_item.reload
+      expect(floor_item.grid_hackr).to eq(hackr)
+      expect(floor_item.room).to be_nil
+      expect(floor_item.quantity).to eq(5)
+    end
+
+    it "splits partial quantity" do
+      ActiveRecord::Base.transaction do
+        qty = described_class.move!(source_item: floor_item, quantity: 3, destination_type: :inventory, destination: hackr)
+        expect(qty).to eq(3)
+      end
+      floor_item.reload
+      expect(floor_item.room).to eq(room)
+      expect(floor_item.quantity).to eq(2)
+
+      inv_item = hackr.grid_items.in_inventory(hackr).find_by(grid_item_definition: definition)
+      expect(inv_item.quantity).to eq(3)
+    end
+
+    it "merges into existing inventory stack" do
+      existing = create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 4)
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: floor_item, quantity: 3, destination_type: :inventory, destination: hackr)
+      end
+      existing.reload
+      expect(existing.quantity).to eq(7)
+    end
+
+    it "spills overflow into new stack when existing is full" do
+      create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 8)
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: floor_item, quantity: 5, destination_type: :inventory, destination: hackr)
+      end
+      stacks = hackr.grid_items.in_inventory(hackr).where(grid_item_definition: definition).order(:id)
+      expect(stacks.map(&:quantity)).to contain_exactly(10, 3)
+    end
+
+    it "raises InsufficientQuantity when requesting more than available" do
+      expect {
+        ActiveRecord::Base.transaction do
+          described_class.move!(source_item: floor_item, quantity: 10, destination_type: :inventory, destination: hackr)
+        end
+      }.to raise_error(Grid::ItemTransfer::InsufficientQuantity, /only have 5/)
+    end
+
+    it "raises InventoryFull when no slots available" do
+      hackr.inventory_capacity.times do
+        create(:grid_item, :in_inventory, grid_hackr: hackr)
+      end
+      expect {
+        ActiveRecord::Base.transaction do
+          described_class.move!(source_item: floor_item, quantity: 1, destination_type: :inventory, destination: hackr)
+        end
+      }.to raise_error(Grid::InventoryErrors::InventoryFull)
+    end
+  end
+
+  describe ".move! to :room" do
+    let(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 8) }
+
+    before { inv_item }
+
+    it "moves whole stack to room (preserves row)" do
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: :all, destination_type: :room, destination: room)
+      end
+      inv_item.reload
+      expect(inv_item.room).to eq(room)
+      expect(inv_item.grid_hackr).to be_nil
+    end
+
+    it "splits partial quantity and creates floor row" do
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: 3, destination_type: :room, destination: room)
+      end
+      inv_item.reload
+      expect(inv_item.quantity).to eq(5)
+
+      floor_item = room.grid_items.on_floor(room).find_by(grid_item_definition: definition)
+      expect(floor_item.quantity).to eq(3)
+    end
+
+    it "merges into existing floor stack" do
+      existing_floor = create(:grid_item, grid_item_definition: definition, room: room, quantity: 6)
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: 3, destination_type: :room, destination: room)
+      end
+      existing_floor.reload
+      expect(existing_floor.quantity).to eq(9)
+    end
+
+    it "merges and spills into new row when floor stack overflows" do
+      create(:grid_item, grid_item_definition: definition, room: room, quantity: 7)
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: 8, destination_type: :room, destination: room)
+      end
+      floor_items = room.grid_items.on_floor(room).where(grid_item_definition: definition).order(:id)
+      expect(floor_items.map(&:quantity)).to contain_exactly(10, 5)
+    end
+
+    context "den floor cap" do
+      let(:den) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+
+      it "raises DestinationFull when den floor is at cap" do
+        Grid::DenService::DEN_STORAGE_CAP.times do
+          create(:grid_item, grid_item_definition: create(:grid_item_definition), room: den, quantity: 1)
+        end
+        expect {
+          ActiveRecord::Base.transaction do
+            described_class.move!(source_item: inv_item, quantity: 1, destination_type: :room, destination: den)
+          end
+        }.to raise_error(Grid::ItemTransfer::DestinationFull, /Den floor full/)
+      end
+    end
+  end
+
+  describe ".move! to :fixture" do
+    let(:fixture_def) { create(:grid_item_definition, :fixture) }
+    let(:fixture) { create(:grid_item, :placed_fixture, room: room, grid_item_definition: fixture_def) }
+    let(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 5) }
+
+    before do
+      fixture
+      inv_item
+    end
+
+    it "moves whole stack into fixture (preserves row)" do
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: :all, destination_type: :fixture, destination: fixture)
+      end
+      inv_item.reload
+      expect(inv_item.container).to eq(fixture)
+      expect(inv_item.grid_hackr).to be_nil
+    end
+
+    it "splits partial quantity into fixture" do
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: 2, destination_type: :fixture, destination: fixture)
+      end
+      inv_item.reload
+      expect(inv_item.quantity).to eq(3)
+
+      stored = fixture.stored_items.find_by(grid_item_definition: definition)
+      expect(stored.quantity).to eq(2)
+    end
+
+    it "raises DestinationFull when fixture is at capacity" do
+      fixture.storage_capacity.times do
+        create(:grid_item, container: fixture, grid_item_definition: create(:grid_item_definition),
+          room: nil, grid_hackr: nil)
+      end
+      expect {
+        ActiveRecord::Base.transaction do
+          described_class.move!(source_item: inv_item, quantity: 1, destination_type: :fixture, destination: fixture)
+        end
+      }.to raise_error(Grid::ItemTransfer::DestinationFull)
+    end
+
+    it "merges and spills into new slot when fixture stack overflows max_stack" do
+      # Existing stack in fixture with 8 of max 10
+      create(:grid_item, grid_item_definition: definition, container: fixture,
+        room: nil, grid_hackr: nil, quantity: 8)
+      # Move 5 from inventory — should fill existing to 10, spill 3 into new slot
+      ActiveRecord::Base.transaction do
+        described_class.move!(source_item: inv_item, quantity: 5, destination_type: :fixture, destination: fixture)
+      end
+      # Source destroyed (qty was exactly 5)
+      expect(GridItem.find_by(id: inv_item.id)).to be_nil
+      stored = fixture.stored_items.where(grid_item_definition: definition).order(:id)
+      expect(stored.map(&:quantity)).to contain_exactly(10, 3)
+    end
+  end
+end

--- a/spec/services/grid/quantity_commands_spec.rb
+++ b/spec/services/grid/quantity_commands_spec.rb
@@ -1,0 +1,442 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Command Quantity Syntax", type: :service do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:parser) { Grid::CommandParser.new(hackr, input) }
+  let(:definition) { create(:grid_item_definition, item_type: "material", max_stack: 10, name: "Scrap Metal") }
+
+  describe "take with quantity" do
+    let!(:floor_item) { create(:grid_item, grid_item_definition: definition, room: room, quantity: 5) }
+
+    context "take 3 scrap metal" do
+      let(:input) { "take 3 scrap metal" }
+
+      it "takes 3 from the floor stack" do
+        result = parser.execute
+        expect(result[:output]).to include("Scrap Metal")
+        expect(result[:output]).to include("×3")
+        floor_item.reload
+        expect(floor_item.quantity).to eq(2)
+        expect(hackr.grid_items.in_inventory(hackr).find_by(grid_item_definition: definition).quantity).to eq(3)
+      end
+    end
+
+    context "take all scrap metal" do
+      let(:input) { "take all scrap metal" }
+
+      it "takes entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("Scrap Metal")
+        expect(result[:output]).to include("×5")
+        floor_item.reload
+        expect(floor_item.grid_hackr).to eq(hackr)
+        expect(floor_item.room).to be_nil
+      end
+    end
+
+    context "take scrap metal (no quantity = 1)" do
+      let(:input) { "take scrap metal" }
+
+      it "takes exactly 1" do
+        result = parser.execute
+        expect(result[:output]).to include("Scrap Metal")
+        expect(result[:output]).not_to include("×")
+        floor_item.reload
+        expect(floor_item.quantity).to eq(4)
+      end
+    end
+
+    context "quantity exceeds available" do
+      let(:input) { "take 10 scrap metal" }
+
+      it "refuses with error" do
+        result = parser.execute
+        expect(result[:output]).to include("only have 5")
+      end
+    end
+  end
+
+  describe "drop with quantity" do
+    let!(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 8) }
+
+    context "drop 3 scrap metal" do
+      let(:input) { "drop 3 scrap metal" }
+
+      it "drops 3 from inventory to floor" do
+        result = parser.execute
+        expect(result[:output]).to include("Scrap Metal")
+        expect(result[:output]).to include("×3")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(5)
+        floor_item = room.grid_items.on_floor(room).find_by(grid_item_definition: definition)
+        expect(floor_item.quantity).to eq(3)
+      end
+    end
+
+    context "drop all scrap metal" do
+      let(:input) { "drop all scrap metal" }
+
+      it "drops entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("×8")
+        inv_item.reload
+        expect(inv_item.room).to eq(room)
+        expect(inv_item.grid_hackr).to be_nil
+      end
+    end
+
+    context "drop scrap metal (no quantity = 1)" do
+      let(:input) { "drop scrap metal" }
+
+      it "drops exactly 1" do
+        result = parser.execute
+        expect(result[:output]).to include("Scrap Metal")
+        expect(result[:output]).not_to include("×")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(7)
+      end
+    end
+  end
+
+  describe "give with quantity" do
+    let!(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 5, name: "Basic CPU") }
+    let!(:mob) { create(:grid_mob, grid_room: room, name: "Nighthawk", mob_type: "quest_giver") }
+
+    let(:mission) { create(:grid_mission, giver_mob: mob, published: true) }
+    let!(:hackr_mission) { create(:grid_hackr_mission, grid_hackr: hackr, grid_mission: mission, status: "active") }
+    let(:objective) do
+      create(:grid_mission_objective,
+        grid_mission: mission,
+        objective_type: "deliver_item",
+        target_slug: "basic cpu",
+        target_count: 5)
+    end
+    let!(:hackr_objective) do
+      create(:grid_hackr_mission_objective,
+        grid_hackr_mission: hackr_mission,
+        grid_mission_objective: objective,
+        progress: 0)
+    end
+
+    context "give 5 basic cpu to nighthawk" do
+      let(:input) { "give 5 basic cpu to nighthawk" }
+
+      it "gives 5 at once and advances mission by 5" do
+        result = parser.execute
+        expect(result[:output]).to include("×5")
+        expect(result[:output]).to include("Nighthawk")
+        expect(GridItem.find_by(id: inv_item.id)).to be_nil
+        hackr_objective.reload
+        expect(hackr_objective.progress).to eq(5)
+        expect(hackr_objective.completed_at).to be_present
+      end
+    end
+
+    context "give basic cpu to nighthawk (no quantity = 1)" do
+      # Override objective to target_count: 1 so a single delivery completes it.
+      # The give command only consumes items when the progressor returns a
+      # completion notification (by design — prevents consuming items when
+      # no objective matches).
+      let(:objective) do
+        create(:grid_mission_objective,
+          grid_mission: mission,
+          objective_type: "deliver_item",
+          target_slug: "basic cpu",
+          target_count: 1)
+      end
+      let(:input) { "give basic cpu to nighthawk" }
+
+      it "gives 1 and completes the objective" do
+        result = parser.execute
+        expect(result[:output]).not_to include("×")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(4)
+        hackr_objective.reload
+        expect(hackr_objective.progress).to eq(1)
+        expect(hackr_objective.completed_at).to be_present
+      end
+    end
+
+    context "no matching mission objective" do
+      let(:input) { "give 3 scrap metal to nighthawk" }
+      let!(:scrap_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, name: "Scrap Metal", quantity: 5) }
+
+      it "rolls back and NPC declines" do
+        result = parser.execute
+        expect(result[:output]).to include("no use for that")
+        scrap_item.reload
+        expect(scrap_item.quantity).to eq(5)
+      end
+    end
+  end
+
+  describe "store with quantity" do
+    let(:den_zone) { create(:grid_zone, slug: "residential-district-#{SecureRandom.hex(4)}") }
+    let(:den) { create(:grid_room, :den, grid_zone: den_zone, owner: hackr) }
+    let(:fixture_def) { create(:grid_item_definition, :fixture) }
+    let!(:fixture) { create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def) }
+    let!(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 6) }
+
+    before { hackr.update!(current_room: den) }
+
+    context "store 3 scrap metal in fixture" do
+      let(:input) { "store 3 #{definition.name} in #{fixture.name}" }
+
+      it "stores 3 in fixture, keeps 3 in inventory" do
+        result = parser.execute
+        expect(result[:output]).to include("Stored")
+        expect(result[:output]).to include("×3")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(3)
+        stored = fixture.stored_items.find_by(grid_item_definition: definition)
+        expect(stored.quantity).to eq(3)
+      end
+    end
+
+    context "store all scrap metal in fixture" do
+      let(:input) { "store all #{definition.name} in #{fixture.name}" }
+
+      it "stores entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("×6")
+        inv_item.reload
+        expect(inv_item.container).to eq(fixture)
+      end
+    end
+  end
+
+  describe "retrieve with quantity" do
+    let(:den_zone) { create(:grid_zone, slug: "residential-district-#{SecureRandom.hex(4)}") }
+    let(:den) { create(:grid_room, :den, grid_zone: den_zone, owner: hackr) }
+    let(:fixture_def) { create(:grid_item_definition, :fixture) }
+    let!(:fixture) { create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def) }
+    let!(:stored_item) do
+      create(:grid_item, grid_item_definition: definition, container: fixture,
+        room: nil, grid_hackr: nil, quantity: 7)
+    end
+
+    before { hackr.update!(current_room: den) }
+
+    context "retrieve 4 scrap metal from fixture" do
+      let(:input) { "retrieve 4 #{definition.name} from #{fixture.name}" }
+
+      it "retrieves 4, leaves 3 in fixture" do
+        result = parser.execute
+        expect(result[:output]).to include("Retrieved")
+        expect(result[:output]).to include("×4")
+        stored_item.reload
+        expect(stored_item.quantity).to eq(3)
+        inv = hackr.grid_items.in_inventory(hackr).find_by(grid_item_definition: definition)
+        expect(inv.quantity).to eq(4)
+      end
+    end
+
+    context "retrieve all from fixture" do
+      let(:input) { "retrieve all #{definition.name} from #{fixture.name}" }
+
+      it "retrieves entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("×7")
+        stored_item.reload
+        expect(stored_item.grid_hackr).to eq(hackr)
+        expect(stored_item.container).to be_nil
+      end
+    end
+  end
+
+  describe "salvage with quantity" do
+    let!(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 5) }
+
+    context "salvage 3 scrap metal" do
+      let(:input) { "salvage 3 scrap metal" }
+
+      it "salvages 3 at once" do
+        result = parser.execute
+        expect(result[:output]).to include("×3")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(2)
+      end
+    end
+
+    context "salvage all scrap metal" do
+      let(:input) { "salvage all scrap metal" }
+
+      it "salvages entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("×5")
+        expect(GridItem.find_by(id: inv_item.id)).to be_nil
+      end
+    end
+
+    context "salvage scrap metal (no quantity = 1)" do
+      let(:input) { "salvage scrap metal" }
+
+      it "salvages exactly 1" do
+        result = parser.execute
+        expect(result[:output]).not_to include("×")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(4)
+      end
+    end
+
+    context "salvage 3 with yields (2 per unit)" do
+      let(:yield_def) { create(:grid_item_definition, item_type: "material", name: "Raw Scrap", max_stack: 32) }
+      let!(:salvage_yield) do
+        create(:grid_salvage_yield,
+          source_definition: definition,
+          output_definition: yield_def,
+          quantity: 2)
+      end
+      let(:input) { "salvage 3 scrap metal" }
+
+      it "produces 6 yield items (2 per unit × 3)" do
+        result = parser.execute
+        expect(result[:output]).to include("×3")
+        expect(result[:output]).to include("Raw Scrap")
+        expect(result[:output]).to include("×6")
+        yielded = hackr.grid_items.in_inventory(hackr).find_by(grid_item_definition: yield_def)
+        expect(yielded.quantity).to eq(6)
+      end
+    end
+
+    context "salvage item stored in fixture" do
+      let(:fixture_def) { create(:grid_item_definition, :fixture) }
+      let(:stored_def) { create(:grid_item_definition, item_type: "material", name: "Vault Chip") }
+      let(:den) { create(:grid_room, :den, grid_zone: zone, owner: hackr) }
+      let!(:fixture) { create(:grid_item, :placed_fixture, room: den, grid_item_definition: fixture_def) }
+      let!(:stored_item) do
+        create(:grid_item, grid_item_definition: stored_def, container: fixture,
+          room: nil, grid_hackr: nil, quantity: 3)
+      end
+      let(:input) { "salvage vault chip" }
+
+      before { hackr.update!(current_room: den) }
+
+      it "cannot salvage items inside fixtures" do
+        result = parser.execute
+        expect(result[:output]).to include("don't have")
+        expect(stored_item.reload.quantity).to eq(3)
+      end
+    end
+  end
+
+  describe "buy with quantity" do
+    let!(:vendor) { create(:grid_mob, grid_room: room, mob_type: "vendor") }
+    let(:buy_def) { create(:grid_item_definition, name: "Cipher Chip", item_type: "data", max_stack: 8) }
+    let!(:listing) do
+      create(:grid_shop_listing,
+        grid_mob: vendor,
+        grid_item_definition: buy_def,
+        base_price: 10,
+        active: true,
+        stock: nil, max_stock: nil)
+    end
+    let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+    let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+    let(:burn_cache) { create(:grid_cache, :burn) }
+
+    def fund_cache(target_cache, amount)
+      source = create(:grid_cache)
+      GridTransaction.create!(
+        from_cache: source, to_cache: target_cache, amount: amount,
+        tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+      )
+    end
+
+    before do
+      cache
+      gameplay_pool
+      burn_cache
+      fund_cache(cache, 500)
+    end
+
+    context "buy 3 cipher chip" do
+      let(:input) { "buy 3 cipher chip" }
+
+      it "buys 3 at once for 30 CRED" do
+        result = parser.execute
+        expect(result[:output]).to include("Purchased")
+        expect(result[:output]).to include("×3")
+        expect(result[:output]).to include("30")
+        inv = hackr.grid_items.in_inventory(hackr).find_by(grid_item_definition: buy_def)
+        expect(inv.quantity).to eq(3)
+      end
+    end
+
+    context "buy all cipher chip" do
+      let(:input) { "buy all cipher chip" }
+
+      it "rejects 'all' for buy" do
+        result = parser.execute
+        expect(result[:output]).to include("Specify a number")
+      end
+    end
+
+    context "buy 3 with limited stock of 2" do
+      let!(:limited_listing) do
+        create(:grid_shop_listing,
+          grid_mob: vendor,
+          grid_item_definition: buy_def,
+          base_price: 10,
+          active: true,
+          stock: 2, max_stock: 5)
+      end
+      let(:input) { "buy 3 cipher chip" }
+
+      before { listing.update!(active: false) } # disable unlimited listing
+
+      it "refuses when stock insufficient" do
+        result = parser.execute
+        expect(result[:output]).to include("in stock")
+        expect(hackr.grid_items.in_inventory(hackr).count).to eq(0)
+      end
+    end
+  end
+
+  describe "sell with quantity" do
+    let!(:vendor) { create(:grid_mob, grid_room: room, mob_type: "vendor") }
+    let!(:inv_item) { create(:grid_item, :in_inventory, grid_hackr: hackr, grid_item_definition: definition, quantity: 5) }
+    let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+    let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+
+    def fund_cache(target_cache, amount)
+      source = create(:grid_cache)
+      GridTransaction.create!(
+        from_cache: source, to_cache: target_cache, amount: amount,
+        tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+      )
+    end
+
+    before do
+      cache
+      gameplay_pool
+      fund_cache(gameplay_pool, 100_000)
+    end
+
+    context "sell 3 scrap metal" do
+      let(:input) { "sell 3 scrap metal" }
+
+      it "sells 3 at once" do
+        result = parser.execute
+        expect(result[:output]).to include("Sold")
+        expect(result[:output]).to include("×3")
+        inv_item.reload
+        expect(inv_item.quantity).to eq(2)
+      end
+    end
+
+    context "sell all scrap metal" do
+      let(:input) { "sell all scrap metal" }
+
+      it "sells entire stack" do
+        result = parser.execute
+        expect(result[:output]).to include("×5")
+        expect(GridItem.find_by(id: inv_item.id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/grid/quantity_parser_spec.rb
+++ b/spec/services/grid/quantity_parser_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::QuantityParser do
+  describe ".parse" do
+    it "parses a leading integer" do
+      result = described_class.parse("5 scrap metal")
+      expect(result.quantity).to eq(5)
+      expect(result.remainder).to eq("scrap metal")
+    end
+
+    it "parses 'all' keyword (case-insensitive)" do
+      result = described_class.parse("All Cipher Chip")
+      expect(result.quantity).to eq(:all)
+      expect(result.remainder).to eq("Cipher Chip")
+    end
+
+    it "defaults to 1 when no quantity prefix" do
+      result = described_class.parse("scrap metal")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("scrap metal")
+    end
+
+    it "handles single-word item name" do
+      result = described_class.parse("3 scrap")
+      expect(result.quantity).to eq(3)
+      expect(result.remainder).to eq("scrap")
+    end
+
+    it "treats zero as 1" do
+      result = described_class.parse("0 scrap")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("scrap")
+    end
+
+    it "treats negative as part of item name" do
+      result = described_class.parse("-1 scrap")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("-1 scrap")
+    end
+
+    it "treats a bare number without item name as remainder" do
+      result = described_class.parse("5")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("5")
+    end
+
+    it "treats bare 'all' without item name as remainder" do
+      result = described_class.parse("all")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("all")
+    end
+
+    it "handles empty string" do
+      result = described_class.parse("")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("")
+    end
+
+    it "handles nil" do
+      result = described_class.parse(nil)
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("")
+    end
+
+    it "preserves case of remainder" do
+      result = described_class.parse("3 Signal Fragment")
+      expect(result.remainder).to eq("Signal Fragment")
+    end
+
+    it "does not parse 'all' mid-string as quantity" do
+      result = described_class.parse("recall chip")
+      expect(result.quantity).to eq(1)
+      expect(result.remainder).to eq("recall chip")
+    end
+  end
+end


### PR DESCRIPTION
  Add [N|all] quantity prefix to take, drop, store, retrieve, give,
  buy, sell, and salvage. No quantity defaults to 1 (backward compatible).

  New modules:
  - Grid::QuantityParser — strips leading integer or "all" from command args, returns ParseResult(quantity, remainder)
  - Grid::ItemTransfer — atomic split+merge item transfer engine with three destination types (:inventory, :room, :fixture). Pre-flight capacity checks refuse entirely if destination can't hold full amount. Whole-stack moves relocate the row in-place; partial moves split the source and merge into existing destination stacks respecting max_stack.

  Modified services:
  - MissionProgressor#next_progress_value — collect_item, deliver_item, buy_item, salvage_item, salvage_yield_received now advance by context[:amount] (default 1) instead of always +1
  - SalvageService#salvage! — accepts quantity: param, multiplies XP and yields in a single transaction
  - ShopService.buy! — accepts quantity: param, validates stock and CRED for full amount atomically
  - ShopService.sell! — accepts quantity:/:all, computes total price

  Concurrency hardening:
  - ItemTransfer locks source_item, hackr (inventory), room (den), and fixture rows before capacity checks and mutations
  - find_existing_at_destination uses SELECT FOR UPDATE to serialize concurrent merges into the same stack
  - SalvageService and ShopService.sell! lock item row before decrement
  - give_command locks item row with post-lock qty re-check
  - ShopService.sell! resolves qty inside transaction after lock

  Additional fixes surfaced during review:
  - salvage_command and give_command scoped to .in_inventory(hackr) (previously could reach fixture-stored/rig items)
  - ShopService.sell! scoped to .in_inventory(hackr)
  - ShopService.sell! raises InsufficientStock (not ItemNotFound) for quantity errors
  - drop_command scoped to .in_inventory(hackr)
  - Unicorn name display uses saved_name instead of calling rainbow_name_html on potentially destroyed records
  - store_in_fixture_command output building moved outside transaction
  - Removed dead DestinationFull rescue from retrieve_from_fixture_command
  - sell_command InsufficientStock rendered in amber (matches buy_command)

  Help text updated with [qty|all] syntax for all affected commands.