### PR TITLE
[TPG] Loadout (Equipment) System

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,7 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action :require_admin_api, only: [:debit]
 
@@ -129,6 +129,36 @@ class Api::GridController < ApplicationController
           craftable: craftable,
           has_ingredients: has_ingredients
         }
+      }
+    }
+  end
+
+  # GET /api/grid/loadout - Loadout data for the SPA page
+  def loadout_index
+    loadout = current_hackr.loadout_by_slot
+    effects = current_hackr.loadout_effects
+
+    inventory_gear = current_hackr.grid_items
+      .in_inventory(current_hackr)
+      .where(item_type: "gear")
+      .includes(:grid_item_definition)
+
+    render json: {
+      slots: GridItem::GEAR_SLOTS.map { |slot|
+        item = loadout[slot]
+        {
+          slot: slot,
+          label: GridHackr::Loadout::GEAR_SLOT_LABELS[slot],
+          item: item ? loadout_item_json(item) : nil
+        }
+      },
+      inventory_gear: inventory_gear.map { |item| loadout_item_json(item) },
+      active_effects: effects.reject { |_, v| v == 0 || v == false },
+      vitals: {
+        health: {current: current_hackr.stat("health"), max: current_hackr.effective_max("health")},
+        energy: {current: current_hackr.stat("energy"), max: current_hackr.effective_max("energy")},
+        psyche: {current: current_hackr.stat("psyche"), max: current_hackr.effective_max("psyche")},
+        inspiration: {current: current_hackr.stat("inspiration"), max: current_hackr.effective_max("inspiration")}
       }
     }
   end
@@ -603,6 +633,22 @@ class Api::GridController < ApplicationController
     Rails.logger.info "=== BROADCASTING to room #{room.id} (#{room.name}): #{event.inspect} ==="
     GridChannel.broadcast_to(room, event)
     Rails.logger.info "=== BROADCAST COMPLETE ==="
+  end
+
+  def loadout_item_json(item)
+    {
+      id: item.id,
+      name: item.name,
+      rarity: item.rarity,
+      rarity_color: item.rarity_color,
+      rarity_label: item.rarity_label,
+      description: item.description,
+      gear_slot: item.gear_slot,
+      gear_slot_label: GridHackr::Loadout::GEAR_SLOT_LABELS[item.gear_slot] || item.gear_slot&.upcase,
+      equipped_slot: item.equipped_slot,
+      effects: item.gear_effects,
+      required_clearance: item.required_clearance
+    }
   end
 
   def room_json(room)

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -28,6 +28,7 @@ const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').t
 const AchievementsPage = lazy(() => import('~/components/pages/grid/AchievementsPage'))
 const MissionsPage = lazy(() => import('~/components/pages/grid/MissionsPage'))
 const SchematicsPage = lazy(() => import('~/components/pages/grid/SchematicsPage'))
+const LoadoutPage = lazy(() => import('~/components/pages/grid/LoadoutPage'))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
@@ -107,6 +108,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/achievements" element={<ProtectedRoute><AchievementsPage /></ProtectedRoute>} />
           <Route path="/missions" element={<ProtectedRoute><MissionsPage /></ProtectedRoute>} />
           <Route path="/schematics" element={<ProtectedRoute><SchematicsPage /></ProtectedRoute>} />
+          <Route path="/loadout" element={<ProtectedRoute><LoadoutPage /></ProtectedRoute>} />
           <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
           <Route path="/grid/login" element={<GridLoginPage />} />
           <Route path="/grid/register" element={<GridRegisterPage />} />

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -294,6 +294,9 @@ export const HeaderMenu: React.FC = () => {
                     <Link to="/schematics" className={`mobile-menu-item${isActive('/schematics') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>schematics
                     </Link>
+                    <Link to="/loadout" className={`mobile-menu-item${isActive('/loadout') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                      <span className="purple-168-text">/</span>loadout
+                    </Link>
                     <Link to="/fm/playlists" className={`mobile-menu-item${isActive('/fm') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                       <span className="purple-168-text">/</span>playlists
                     </Link>
@@ -559,7 +562,7 @@ export const HeaderMenu: React.FC = () => {
           </li>
 
           {/* THE PULSE GRID */}
-          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') || isActive('/missions') || isActive('/schematics') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
+          <li className={`header-dropdown${isActive('/grid') || isActive('/code') || isActive('/achievements') || isActive('/missions') || isActive('/schematics') || isActive('/loadout') ? ' active' : ''}`} onClick={() => toggleDropdown('grid')}>
             <span className="purple-168-text">{isLoggedIn ? '11' : '9'}</span>&nbsp;THE PULSE GRID&nbsp;
             <div className={`header-dropdown-content ${openDropdown === 'grid' ? 'open' : ''}`}>
               <ul>
@@ -602,6 +605,11 @@ export const HeaderMenu: React.FC = () => {
                     <li>
                       <Link to="/schematics" onClick={closeDropdown}>
                         <span className="purple-168-text">/</span>schematics
+                      </Link>
+                    </li>
+                    <li>
+                      <Link to="/loadout" onClick={closeDropdown}>
+                        <span className="purple-168-text">/</span>loadout
                       </Link>
                     </li>
                     <li>

--- a/app/javascript/components/pages/grid/LoadoutPage.tsx
+++ b/app/javascript/components/pages/grid/LoadoutPage.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useState } from 'react'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+
+interface GearItem {
+  id: number
+  name: string
+  rarity: string
+  rarity_color: string
+  rarity_label: string
+  description: string | null
+  gear_slot: string | null
+  gear_slot_label: string | null
+  equipped_slot: string | null
+  effects: Record<string, number | boolean>
+  required_clearance: number
+}
+
+interface LoadoutSlot {
+  slot: string
+  label: string
+  item: GearItem | null
+}
+
+interface VitalInfo {
+  current: number
+  max: number
+}
+
+interface LoadoutResponse {
+  slots: LoadoutSlot[]
+  inventory_gear: GearItem[]
+  active_effects: Record<string, number | boolean>
+  vitals: {
+    health: VitalInfo
+    energy: VitalInfo
+    psyche: VitalInfo
+    inspiration: VitalInfo
+  }
+}
+
+const LoadoutPage: React.FC = () => {
+  const [data, setData] = useState<LoadoutResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    apiJson<LoadoutResponse>('/api/grid/loadout')
+      .then(json => { setData(json); setLoading(false) })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Failed to load loadout')
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+          <LoadingSpinner message="Loading loadout..." color="cyan-255-text" size="large" />
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto', padding: 40, textAlign: 'center', color: '#f87171' }}>
+          {error || 'Failed to load loadout'}
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  const equippedCount = data.slots.filter(s => s.item).length
+  const effectEntries = Object.entries(data.active_effects)
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+        <div
+          className="tui-window white-text"
+          style={{
+            display: 'block',
+            background: '#0a0a0a',
+            border: '2px solid #22d3ee',
+            boxShadow: '0 0 30px rgba(34, 211, 238, 0.3)'
+          }}
+        >
+          <fieldset style={{ borderColor: '#22d3ee' }}>
+            <legend
+              className="center"
+              style={{ color: '#22d3ee', textShadow: '0 0 15px rgba(34, 211, 238, 0.6)', letterSpacing: 3 }}
+            >
+              LOADOUT
+            </legend>
+            <div style={{ padding: 20 }}>
+              {/* Equipped count */}
+              <div style={{ marginBottom: 16, color: '#9ca3af', fontSize: '0.85em' }}>
+                {equippedCount}/{data.slots.length} slots equipped
+              </div>
+
+              {/* Slot grid */}
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 10 }}>
+                {data.slots.map(s => <SlotCard key={s.slot} slot={s} />)}
+              </div>
+
+              {/* Active effects */}
+              {effectEntries.length > 0 && (
+                <div style={{ marginTop: 24, padding: 14, background: '#0f0f0f', border: '1px solid #2a2a2a' }}>
+                  <div style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: 8, fontFamily: 'monospace' }}>ACTIVE EFFECTS</div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+                    {effectEntries.map(([key, val]) => (
+                      <span key={key} style={{ color: '#34d399', fontFamily: 'monospace', fontSize: '0.85em' }}>
+                        {formatEffectLabel(key)}: +{String(val)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Vitals with gear caps */}
+              <div style={{ marginTop: 24, padding: 14, background: '#0f0f0f', border: '1px solid #2a2a2a' }}>
+                <div style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: 8, fontFamily: 'monospace' }}>VITALS</div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, fontFamily: 'monospace', fontSize: '0.85em' }}>
+                  <VitalBar label="HEALTH" vital={data.vitals.health} color="#34d399" />
+                  <VitalBar label="ENERGY" vital={data.vitals.energy} color="#60a5fa" />
+                  <VitalBar label="PSYCHE" vital={data.vitals.psyche} color="#c084fc" />
+                  <VitalBar label="INSPIRATION" vital={data.vitals.inspiration} color="#f59e0b" />
+                </div>
+              </div>
+
+              {/* Unequipped gear in inventory */}
+              {data.inventory_gear.length > 0 && (
+                <div style={{ marginTop: 24 }}>
+                  <div style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: 8, fontFamily: 'monospace' }}>
+                    GEAR IN INVENTORY ({data.inventory_gear.length})
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))', gap: 10 }}>
+                    {data.inventory_gear.map(item => <InventoryGearCard key={item.id} item={item} />)}
+                  </div>
+                </div>
+              )}
+
+              <div style={{ marginTop: 20, color: '#6b7280', fontSize: '0.8em', textAlign: 'center' }}>
+                Use <code style={{ color: '#22d3ee' }}>loadout</code> in the Terminal to view.
+                Use <code style={{ color: '#34d399' }}>equip &lt;item&gt;</code> / <code style={{ color: '#34d399' }}>unequip &lt;item&gt;</code> to manage gear.
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const SlotCard: React.FC<{ slot: LoadoutSlot }> = ({ slot: s }) => {
+  const hasItem = !!s.item
+  const borderColor = hasItem ? (s.item!.rarity_color || '#34d399') : '#2a2a2a'
+
+  return (
+    <div style={{ background: '#0f0f0f', border: `1px solid ${borderColor}`, padding: 12, fontFamily: 'monospace' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span style={{ color: '#22d3ee', fontWeight: 'bold', fontSize: '0.8em' }}>{s.label}</span>
+        {hasItem && (
+          <span style={{
+            color: s.item!.rarity_color,
+            fontSize: '0.65em',
+            background: '#1a1a1a',
+            padding: '1px 6px',
+            border: `1px solid ${s.item!.rarity_color}`
+          }}>
+            {s.item!.rarity_label}
+          </span>
+        )}
+      </div>
+      {hasItem ? (
+        <>
+          <div style={{ color: s.item!.rarity_color, fontWeight: 'bold' }}>{s.item!.name}</div>
+          {s.item!.description && (
+            <div style={{ color: '#6b7280', fontSize: '0.8em', marginTop: 4, lineHeight: 1.3 }}>{s.item!.description}</div>
+          )}
+          {Object.keys(s.item!.effects).length > 0 && (
+            <div style={{ marginTop: 6, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+              {Object.entries(s.item!.effects).filter(([, v]) => v !== 0 && v !== false).map(([key, val]) => (
+                <span key={key} style={{ color: '#34d399', fontSize: '0.75em', background: '#001a10', padding: '1px 4px', border: '1px solid #1a3a2a' }}>
+                  +{String(val)} {formatEffectLabel(key)}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      ) : (
+        <div style={{ color: '#4b5563', fontStyle: 'italic' }}>-- empty --</div>
+      )}
+    </div>
+  )
+}
+
+const InventoryGearCard: React.FC<{ item: GearItem }> = ({ item }) => (
+  <div style={{ background: '#0f0f0f', border: '1px solid #2a2a2a', padding: 12, fontFamily: 'monospace' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+      <span style={{ color: item.rarity_color, fontWeight: 'bold' }}>{item.name}</span>
+      <span style={{ color: '#6b7280', fontSize: '0.7em' }}>{item.gear_slot_label || item.gear_slot?.toUpperCase().replace(/_/g, ' ')}</span>
+    </div>
+    {item.description && <div style={{ color: '#6b7280', fontSize: '0.8em', lineHeight: 1.3 }}>{item.description}</div>}
+    {Object.keys(item.effects).length > 0 && (
+      <div style={{ marginTop: 6, display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {Object.entries(item.effects).filter(([, v]) => v !== 0 && v !== false).map(([key, val]) => (
+          <span key={key} style={{ color: '#34d399', fontSize: '0.75em' }}>
+            +{String(val)} {formatEffectLabel(key)}
+          </span>
+        ))}
+      </div>
+    )}
+    {item.required_clearance > 0 && (
+      <div style={{ marginTop: 4, color: '#fbbf24', fontSize: '0.75em' }}>CL{item.required_clearance}+</div>
+    )}
+    <div style={{ marginTop: 6, color: '#6b7280', fontSize: '0.7em' }}>
+      equip {item.name.toLowerCase()}
+    </div>
+  </div>
+)
+
+const VitalBar: React.FC<{ label: string; vital: VitalInfo; color: string }> = ({ label, vital, color }) => {
+  const boosted = vital.max > 100
+  return (
+    <div style={{ minWidth: 120 }}>
+      <span style={{ color }}>{label}</span>{' '}
+      <span style={{ color: '#d0d0d0' }}>{vital.current}/{vital.max}</span>
+      {boosted && <span style={{ color: '#34d399', fontSize: '0.8em' }}> (+{vital.max - 100})</span>}
+    </div>
+  )
+}
+
+function formatEffectLabel(key: string): string {
+  return key.replace(/_/g, ' ')
+}
+
+export default LoadoutPage

--- a/app/javascript/components/pages/grid/LoadoutPage.tsx
+++ b/app/javascript/components/pages/grid/LoadoutPage.tsx
@@ -235,7 +235,7 @@ const VitalBar: React.FC<{ label: string; vital: VitalInfo; color: string }> = (
   )
 }
 
-function formatEffectLabel(key: string): string {
+function formatEffectLabel (key: string): string {
   return key.replace(/_/g, ' ')
 }
 

--- a/app/models/concerns/grid_hackr/loadout.rb
+++ b/app/models/concerns/grid_hackr/loadout.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module GridHackr::Loadout
+  extend ActiveSupport::Concern
+
+  GEAR_SLOT_LABELS = {
+    "deck" => "DECK",
+    "back" => "BACK",
+    "chest" => "CHEST",
+    "head" => "HEAD",
+    "ears" => "EARS",
+    "eyes" => "EYES",
+    "left_wrist" => "L.WRIST",
+    "right_wrist" => "R.WRIST",
+    "hands" => "HANDS",
+    "neck" => "NECK",
+    "waist" => "WAIST",
+    "legs" => "LEGS",
+    "feet" => "FEET"
+  }.freeze
+
+  # Returns Hash { slot => GridItem } for all 13 slots.
+  def loadout_by_slot
+    equipped = grid_items.equipped_by(self).includes(:grid_item_definition).index_by(&:equipped_slot)
+    GridItem::GEAR_SLOTS.each_with_object({}) { |slot, h| h[slot] = equipped[slot] }
+  end
+
+  # Aggregate all effects from currently equipped gear.
+  # Additive stacking for numeric values; boolean effects use logical OR.
+  # Memoized per-instance to avoid repeated queries within a single request.
+  def loadout_effects
+    return @loadout_effects if defined?(@loadout_effects)
+    @loadout_effects = grid_items.equipped_by(self).each_with_object(Hash.new(0)) do |item, acc|
+      item.gear_effects.each do |key, value|
+        if value == true || value == false
+          acc[key] = false if acc[key] == 0
+          acc[key] = acc[key] || value
+        else
+          acc[key] += value.to_f
+        end
+      end
+    end
+  end
+
+  # Effective max for a vital, incorporating gear bonuses.
+  # Base cap is 100. Gear effects key: "bonus_max_<vital>"
+  def effective_max(vital)
+    100 + loadout_effects["bonus_max_#{vital}"].to_i
+  end
+
+  # Clear memoized loadout effects (call after equip/unequip).
+  def reset_loadout_cache!
+    remove_instance_variable(:@loadout_effects) if defined?(@loadout_effects)
+  end
+
+  # Override inventory_capacity from Stats to include gear bonuses.
+  def inventory_capacity
+    GridHackr::Stats::INVENTORY_BASE_SLOTS + stat("bonus_inventory_slots").to_i + loadout_effects["bonus_inventory_slots"].to_i
+  end
+end

--- a/app/models/concerns/grid_hackr/stats.rb
+++ b/app/models/concerns/grid_hackr/stats.rb
@@ -51,10 +51,12 @@ module GridHackr::Stats
     INVENTORY_BASE_SLOTS + stat("bonus_inventory_slots").to_i
   end
 
-  # Adjust a vital (health/energy/psyche/inspiration) clamped to 0..100
+  # Adjust a vital (health/energy/psyche/inspiration) clamped to 0..max.
+  # Max defaults to 100 but may be raised by equipped gear via effective_max.
   def adjust_vital!(key, delta)
     current = stat(key)
-    clamped = (current + delta).clamp(0, 100)
+    max = effective_max(key.to_s)
+    clamped = (current + delta).clamp(0, max)
     set_stat!(key, clamped)
     clamped
   end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -32,6 +32,7 @@
 class GridHackr < ApplicationRecord
   include ProfanityFilterable
   include GridHackr::Stats
+  include GridHackr::Loadout
 
   has_paper_trail ignore: %i[
     password_digest api_token_digest last_activity_at stats

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  description             :text
+#  equipped_slot           :string
 #  item_type               :string
 #  name                    :string
 #  properties              :json
@@ -21,10 +22,11 @@
 #
 # Indexes
 #
-#  index_grid_items_on_container_id             (container_id)
-#  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
-#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#  index_grid_items_on_container_id                (container_id)
+#  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
+#  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
 #
 # Foreign Keys
 #
@@ -34,7 +36,9 @@
 class GridItem < ApplicationRecord
   has_paper_trail
 
-  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material fixture].freeze
+  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material fixture gear].freeze
+  GEAR_SLOTS = %w[deck back chest head ears eyes left_wrist right_wrist hands neck waist legs feet].freeze
+  VISIBLE_SLOTS = %w[head eyes chest legs feet].freeze
   RARITIES = %w[scrap ubiquitous common uncommon rare ultra_rare unicorn].freeze
   RARITY_LABELS = {
     "scrap" => "SCRAP",
@@ -70,10 +74,13 @@ class GridItem < ApplicationRecord
   validates :item_type, inclusion: {in: ITEM_TYPES, allow_nil: true}
   validates :rarity, inclusion: {in: RARITIES, allow_nil: true}
   validates :quantity, numericality: {greater_than: 0}, allow_nil: true
+  validates :equipped_slot, inclusion: {in: GEAR_SLOTS, allow_nil: true}
   validate :single_location
+  validate :equipped_slot_requirements
 
   scope :in_room, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
-  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil) }
+  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil, equipped_slot: nil) }
+  scope :equipped_by, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil).where.not(equipped_slot: nil) }
   scope :installed_in, ->(rig) { where(grid_mining_rig: rig, grid_hackr: nil, room: nil) }
   scope :on_floor, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil).where.not(item_type: "fixture") }
   scope :placed_fixtures, ->(room) { where(room: room, item_type: "fixture", grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
@@ -135,6 +142,24 @@ class GridItem < ApplicationRecord
     properties&.dig("rate_multiplier")&.to_f || 1.0
   end
 
+  def gear?
+    item_type == "gear"
+  end
+
+  def equipped?
+    equipped_slot.present?
+  end
+
+  alias_method :gear_slot, :slot
+
+  def gear_effects
+    properties&.dig("effects") || {}
+  end
+
+  def required_clearance
+    properties&.dig("required_clearance").to_i
+  end
+
   private
 
   # An item can only be in one place: room, inventory, mining rig, or container
@@ -143,5 +168,11 @@ class GridItem < ApplicationRecord
     if locations > 1
       errors.add(:base, "Item can only be in one location (room, inventory, mining rig, or container)")
     end
+  end
+
+  def equipped_slot_requirements
+    return if equipped_slot.nil?
+    errors.add(:equipped_slot, "can only be set on gear items") unless gear?
+    errors.add(:equipped_slot, "requires a hackr owner") if grid_hackr_id.nil?
   end
 end

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -307,6 +307,8 @@ module Grid
         return true
       when "place_fixture"
         return true
+      when "equip_item"
+        return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
       when "manual"
         return false
       end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -106,6 +106,12 @@ module Grid
         retrieve_from_fixture_command(args)
       when "peek", "search"
         peek_fixture_command(args.join(" "))
+      when "equip", "wear"
+        equip_command(args.join(" "))
+      when "unequip", "remove"
+        unequip_command(args.join(" "))
+      when "loadout", "lo"
+        loadout_command
       when "den"
         den_command(args)
       when "out"
@@ -221,7 +227,17 @@ module Grid
       other_hackrs = room.grid_hackrs.recently_active.where.not(id: hackr.id)
       if other_hackrs.any?
         output << ""
-        output << "<span style='color: #fbbf24;'>Hackrs:</span> <span style='color: #a78bfa;'>#{other_hackrs.map(&:hackr_alias).join(", ")}</span>"
+        hackr_entries = other_hackrs.map do |other|
+          visible = other.grid_items.equipped_by(other).where(equipped_slot: GridItem::VISIBLE_SLOTS)
+          gear_tag = if visible.any?
+            items = visible.map { |gi| "<span style='color: #{gi.rarity_color};'>#{h(gi.name)}</span>" }
+            " <span style='color: #6b7280;'>[#{items.join(", ")}]</span>"
+          else
+            ""
+          end
+          "<span style='color: #a78bfa;'>#{h(other.hackr_alias)}</span>#{gear_tag}"
+        end
+        output << "<span style='color: #fbbf24;'>Hackrs:</span> #{hackr_entries.join(", ")}"
       end
 
       output.join("\n")
@@ -452,7 +468,7 @@ module Grid
       return "<span style='color: #fbbf24;'>Drop what?</span>" if item_name.empty?
 
       item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
-      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+      return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       # Fixtures must be placed via the place command
       if item.fixture?
@@ -768,6 +784,11 @@ module Grid
           <span style='color: #34d399;'>analyze &lt;item&gt;, an</span>         - Preview salvage yields before breaking down
           <span style='color: #34d399;'>examine &lt;target&gt;, x</span>        - Examine item, NPC, or hackr
 
+        <span style='color: #fbbf24;'>Loadout:</span>
+          <span style='color: #34d399;'>equip &lt;item&gt;, wear</span>         - Equip a gear item
+          <span style='color: #34d399;'>unequip &lt;item|slot&gt;, remove</span> - Remove equipped gear
+          <span style='color: #34d399;'>loadout, lo</span>                - View your current loadout
+
         <span style='color: #fbbf24;'>NPCs:</span>
           <span style='color: #34d399;'>talk &lt;npc&gt;</span>                 - Talk to an NPC
           <span style='color: #34d399;'>ask &lt;npc&gt; about &lt;topic&gt;</span>    - Ask an NPC about a topic
@@ -887,10 +908,16 @@ module Grid
       output << "<span style='color: #fbbf24;'>CRED:</span> <span style='color: #34d399;'>#{format_cred(total_balance)}</span> <span style='color: #6b7280;'>(total across all caches)</span>"
       output << ""
       output << "<span style='color: #fbbf24;'>VITALS:</span>"
-      output << "  <span style='color: #34d399;'>HEALTH      #{s["health"]}/100</span>"
-      output << "  <span style='color: #60a5fa;'>ENERGY      #{s["energy"]}/100</span>"
-      output << "  <span style='color: #c084fc;'>PSYCHE      #{s["psyche"]}/100</span>"
-      output << "  <span style='color: #f59e0b;'>INSPIRATION #{s["inspiration"]}/100</span>"
+      output << "  <span style='color: #34d399;'>HEALTH      #{s["health"]}/#{hackr.effective_max("health")}</span>"
+      output << "  <span style='color: #60a5fa;'>ENERGY      #{s["energy"]}/#{hackr.effective_max("energy")}</span>"
+      output << "  <span style='color: #c084fc;'>PSYCHE      #{s["psyche"]}/#{hackr.effective_max("psyche")}</span>"
+      output << "  <span style='color: #f59e0b;'>INSPIRATION #{s["inspiration"]}/#{hackr.effective_max("inspiration")}</span>"
+
+      equipped_count = hackr.grid_items.equipped_by(hackr).count
+      if equipped_count > 0
+        output << ""
+        output << "<span style='color: #fbbf24;'>LOADOUT:</span> <span style='color: #9ca3af;'>#{equipped_count}/#{GridItem::GEAR_SLOTS.size} slots</span> <span style='color: #6b7280;'>(use 'loadout' for details)</span>"
+      end
 
       if achievements.any?
         output << ""
@@ -959,6 +986,142 @@ module Grid
       output.join("\n")
     end
 
+    # --- Loadout commands ---
+
+    def equip_command(item_name)
+      return "<span style='color: #fbbf24;'>Equip what? Usage: equip &lt;item&gt;</span>" if item_name.empty?
+
+      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      unless item
+        candidate = hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+        if candidate
+          return "<span style='color: #f87171;'>#{h(candidate.name)} is already equipped.</span>"
+        end
+        return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>"
+      end
+
+      result = Grid::LoadoutService.equip!(hackr: hackr, item: item)
+
+      slot_label = GridHackr::Loadout::GEAR_SLOT_LABELS[result.slot] || result.slot.upcase
+      color = result.item.rarity_color
+      name_display = result.item.unicorn? ? result.item.rainbow_name_html : "<span style='color: #{color};'>#{h(result.item.name)}</span>"
+
+      lines = ["<span style='color: #34d399;'>Equipped </span>#{name_display}<span style='color: #9ca3af;'> → [#{slot_label}]</span>"]
+
+      if result.swapped_item
+        lines << "<span style='color: #9ca3af;'>  ↳ Swapped out: #{h(result.swapped_item.name)}</span>"
+      end
+
+      effects = result.item.gear_effects
+      if effects.any?
+        effect_parts = effects.reject { |_, v| v == 0 || v == false }.map do |key, val|
+          label = h(key.to_s.tr("_", " "))
+          (val == true) ? label : "#{label} +#{h(val.to_s)}"
+        end
+        lines << "<span style='color: #a78bfa;'>  Effects: #{effect_parts.join(", ")}</span>" if effect_parts.any?
+      end
+
+      output = lines.join("\n")
+
+      notifications = []
+      notifications += achievement_checker.check(:equip_item, item_name: result.item.name, slot: result.slot)
+      notifications += mission_progressor.record(:equip_item, item_name: result.item.name)
+      output = append_notifications(output, notifications) if notifications.any?
+
+      output
+    rescue Grid::LoadoutService::NotGear, Grid::LoadoutService::NoGearSlot => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::LoadoutService::ClearanceBlocked => e
+      "<span style='color: #f87171;'>ACCESS DENIED — #{h(e.message)}</span>"
+    rescue Grid::LoadoutService::ZoneRestricted, ArgumentError => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def unequip_command(item_name)
+      return "<span style='color: #fbbf24;'>Unequip what? Usage: unequip &lt;item|slot&gt;</span>" if item_name.empty?
+
+      # Allow "unequip <slot>" as alternative
+      if GridItem::GEAR_SLOTS.include?(item_name.downcase)
+        result = Grid::LoadoutService.unequip_by_slot!(hackr: hackr, slot: item_name.downcase)
+        return format_unequip_output(result)
+      end
+
+      item = hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}' equipped.</span>" unless item
+
+      result = Grid::LoadoutService.unequip!(hackr: hackr, item: item)
+      format_unequip_output(result)
+    rescue Grid::LoadoutService::NotEquipped => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::LoadoutService::ZoneRestricted => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def loadout_command
+      loadout = hackr.loadout_by_slot
+
+      lines = []
+      lines << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines << "<span style='color: #22d3ee; font-weight: bold;'>LOADOUT :: #{h(hackr.hackr_alias)}</span>"
+      lines << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines << ""
+
+      GridItem::GEAR_SLOTS.each do |slot|
+        label = GridHackr::Loadout::GEAR_SLOT_LABELS[slot] || slot.upcase
+        item = loadout[slot]
+        if item
+          color = item.rarity_color
+          name_display = item.unicorn? ? item.rainbow_name_html : "<span style='color: #{color};'>#{h(item.name)}</span>"
+          rarity_tag = " <span style='color: #{color};'>[#{item.rarity_label}]</span>"
+          effect_str = format_gear_effects(item.gear_effects)
+          effect_tag = effect_str.present? ? " <span style='color: #6b7280;'>#{effect_str}</span>" : ""
+          lines << "  <span style='color: #22d3ee;'>#{label.ljust(8)}</span> #{name_display}#{rarity_tag}#{effect_tag}"
+        else
+          lines << "  <span style='color: #22d3ee;'>#{label.ljust(8)}</span> <span style='color: #4b5563;'>-- empty --</span>"
+        end
+      end
+
+      total_effects = hackr.loadout_effects
+      if total_effects.any? { |_, v| v != 0 && v != false }
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>Active Effects:</span>"
+        total_effects.reject { |_, v| v == 0 || v == false }.each do |key, val|
+          label = key.to_s.tr("_", " ")
+          display = (val == true) ? label : "#{label}: +#{val}"
+          lines << "  <span style='color: #34d399;'>#{h(display)}</span>"
+        end
+      end
+
+      lines << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines.join("\n")
+    end
+
+    def equipped_item_hint(item_name)
+      return nil unless hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      "<span style='color: #f87171;'>That item is equipped. Use 'unequip #{h(item_name)}' first.</span>"
+    end
+
+    def format_unequip_output(result)
+      slot_label = GridHackr::Loadout::GEAR_SLOT_LABELS[result.slot] || result.slot.upcase
+      color = result.item.rarity_color
+      name_display = result.item.unicorn? ? result.item.rainbow_name_html : "<span style='color: #{color};'>#{h(result.item.name)}</span>"
+
+      lines = ["<span style='color: #34d399;'>Unequipped </span>#{name_display}<span style='color: #9ca3af;'> from [#{slot_label}]</span>"]
+      result.vitals_clamped.each do |clamp|
+        lines << "<span style='color: #f87171;'>  ↳ #{clamp[:vital].capitalize} reduced to #{clamp[:new_value]} (cap lowered)</span>"
+      end
+      lines.join("\n")
+    end
+
+    def format_gear_effects(effects)
+      return "" if effects.blank?
+      parts = effects.reject { |_, v| v == 0 || v == false }.map do |key, val|
+        label = h(key.to_s.tr("_", " "))
+        (val == true) ? label : "+#{h(val.to_s)} #{label}"
+      end
+      parts.any? ? "[#{parts.join(", ")}]" : ""
+    end
+
     def use_command(item_name)
       return "<span style='color: #fbbf24;'>Use what?</span>" if item_name.empty?
 
@@ -990,7 +1153,7 @@ module Grid
       return "<span style='color: #fbbf24;'>Salvage what?</span>" if item_name.empty?
 
       item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
-      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+      return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       if item.unicorn?
         return "<span style='color: #f87171;'>UNICORN items are irreducible. They cannot be salvaged.</span>"
@@ -1248,11 +1411,24 @@ module Grid
     def examine_hackr(target_hackr)
       cl = target_hackr.stat("clearance")
       achievements = target_hackr.grid_achievements.order(:name)
+      loadout = target_hackr.loadout_by_slot
 
       output = []
       output << "<span style='color: #a78bfa; font-weight: bold;'>#{h(target_hackr.hackr_alias)}</span> <span style='color: #9ca3af;'>:: CLEARANCE #{cl}</span>"
 
+      equipped_slots = loadout.select { |_, item| item }
+      if equipped_slots.any?
+        output << ""
+        output << "<span style='color: #fbbf24;'>LOADOUT:</span>"
+        equipped_slots.each do |slot, item|
+          label = GridHackr::Loadout::GEAR_SLOT_LABELS[slot] || slot.upcase
+          name_display = item.unicorn? ? item.rainbow_name_html : "<span style='color: #{item.rarity_color};'>#{h(item.name)}</span>"
+          output << "  <span style='color: #22d3ee;'>#{label.ljust(8)}</span> #{name_display}"
+        end
+      end
+
       if achievements.any?
+        output << ""
         badges = achievements.map { |a|
           icon = a.badge_icon.present? ? "#{a.badge_icon} " : ""
           "<span style='color: #fbbf24;'>#{icon}#{h(a.name)}</span>"
@@ -1290,6 +1466,23 @@ module Grid
         else
           output += "\n<span style='color: #a78bfa;'>Storage Fixture</span> <span style='color: #6b7280;'>[in inventory]</span> <span style='color: #9ca3af;'>#{cap} slots</span>"
           output += "\n<span style='color: #9ca3af;'>  Place in your den: <span style='color: #22d3ee;'>place #{h(item.name.downcase)}</span></span>"
+        end
+      end
+      if item.gear?
+        slot_label = item.gear_slot&.upcase&.tr("_", " ") || "UNKNOWN"
+        status = item.equipped? ? "<span style='color: #34d399;'>[EQUIPPED]</span>" : "<span style='color: #6b7280;'>[in inventory]</span>"
+        output += "\n<span style='color: #22d3ee;'>Gear Slot: #{slot_label}</span> #{status}"
+        output += " <span style='color: #fbbf24;'>Requires CLEARANCE #{item.required_clearance}</span>" if item.required_clearance > 0
+        effects = item.gear_effects
+        if effects.any?
+          output += "\n<span style='color: #a78bfa;'>Effects:</span>"
+          effects.each do |key, val|
+            label = key.to_s.tr("_", " ")
+            output += "\n  <span style='color: #34d399;'>#{h(label)}: #{h(val.to_s)}</span>"
+          end
+        end
+        unless item.equipped?
+          output += "\n<span style='color: #9ca3af;'>  Equip: <span style='color: #22d3ee;'>equip #{h(item.name.downcase)}</span></span>"
         end
       end
       output
@@ -1458,8 +1651,8 @@ module Grid
       "<span style='color: #34d399;'>Sold </span><span style='color: #d0d0d0;'>#{h(result[:item_name])}</span><span style='color: #34d399;'>#{h(qty_label)} for <span style='color: #fbbf24;'>#{format_cred(result[:sell_price])} CRED</span>. Balance: #{format_cred(result[:new_balance])} CRED.</span>"
     rescue Grid::ShopService::AccessDenied => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::ShopService::ItemNotFound => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::ShopService::ItemNotFound
+      equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>"
     rescue Grid::ShopService::InsufficientStock => e
       "<span style='color: #fbbf24;'>#{h(e.message)}</span>"
     rescue Grid::TransactionService::InsufficientBalance
@@ -2248,7 +2441,7 @@ module Grid
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
       item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
-      return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+      return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       qty = (parsed.quantity == :all) ? item.quantity : parsed.quantity
       return "<span style='color: #f87171;'>You only have #{item.quantity} #{h(item.name)} (requested #{qty}).</span>" if qty > item.quantity

--- a/app/services/grid/inventory.rb
+++ b/app/services/grid/inventory.rb
@@ -19,7 +19,7 @@ module Grid
     # Acquires an exclusive lock on the hackr row to serialize concurrent grants.
     def check_capacity!(hackr)
       hackr.lock!
-      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil).count
+      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil).count
       if used >= hackr.inventory_capacity
         raise Grid::InventoryErrors::InventoryFull,
           "Inventory full (#{used}/#{hackr.inventory_capacity} slots). Drop, sell, or store items to make room."

--- a/app/services/grid/loadout_service.rb
+++ b/app/services/grid/loadout_service.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Grid
+  class LoadoutService
+    EquipResult = Data.define(:item, :slot, :swapped_item)
+    UnequipResult = Data.define(:item, :slot, :vitals_clamped)
+
+    class NotGear < StandardError; end
+    class NoGearSlot < StandardError; end
+    class ClearanceBlocked < StandardError; end
+    class ZoneRestricted < StandardError; end
+    class NotEquipped < StandardError; end
+
+    VITAL_KEYS = %w[health energy psyche inspiration].freeze
+
+    def self.equip!(hackr:, item:)
+      new(hackr).equip!(item)
+    end
+
+    def self.unequip!(hackr:, item:)
+      new(hackr).unequip!(item)
+    end
+
+    def self.unequip_by_slot!(hackr:, slot:)
+      new(hackr).unequip_by_slot!(slot)
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def equip!(item)
+      raise ArgumentError, "Item does not belong to this hackr." unless item.grid_hackr_id == @hackr.id
+      raise NotGear, "#{item.name} is not gear." unless item.gear?
+
+      slot = item.gear_slot
+      raise NoGearSlot, "#{item.name} has no gear slot defined." if slot.blank?
+
+      cl = @hackr.stat("clearance")
+      if item.required_clearance > cl
+        raise ClearanceBlocked, "Requires CLEARANCE #{item.required_clearance}. You are CLEARANCE #{cl}."
+      end
+
+      swapped_item = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        validate_zone!
+
+        existing = @hackr.grid_items.equipped_by(@hackr).find_by(equipped_slot: slot)
+        if existing
+          existing.update!(equipped_slot: nil)
+          swapped_item = existing
+        end
+
+        item.update!(equipped_slot: slot)
+        @hackr.reset_loadout_cache!
+      end
+
+      EquipResult.new(item: item, slot: slot, swapped_item: swapped_item)
+    rescue ActiveRecord::RecordNotUnique
+      raise ArgumentError, "That slot is already occupied. Try again."
+    end
+
+    def unequip!(item)
+      raise NotEquipped, "#{item.name} is not equipped." unless item.equipped?
+
+      slot = item.equipped_slot
+      vitals_clamped = []
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        validate_zone!
+        item.update!(equipped_slot: nil)
+        @hackr.reset_loadout_cache!
+        vitals_clamped = clamp_vitals!
+      end
+
+      UnequipResult.new(item: item, slot: slot, vitals_clamped: vitals_clamped)
+    end
+
+    def unequip_by_slot!(slot)
+      item = @hackr.grid_items.equipped_by(@hackr).find_by(equipped_slot: slot)
+      raise NotEquipped, "Nothing equipped in #{slot} slot." unless item
+      unequip!(item)
+    end
+
+    private
+
+    def validate_zone!
+      room = @hackr.current_room
+      return unless room
+      if room.respond_to?(:room_type) && room.room_type == "danger_zone"
+        raise ZoneRestricted, "You can't manage equipment in a danger zone."
+      end
+    end
+
+    def clamp_vitals!
+      clamped = []
+      VITAL_KEYS.each do |key|
+        cap = @hackr.effective_max(key)
+        current = @hackr.stat(key)
+        if current > cap
+          @hackr.set_stat!(key, cap)
+          clamped << {vital: key, old_value: current, new_value: cap}
+        end
+      end
+      clamped
+    end
+  end
+end

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -115,7 +115,7 @@ module Grid
       case trigger_type.to_s
       when "visit_room"
         target.blank? || target.casecmp?(context[:room_slug].to_s)
-      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item", "place_fixture"
+      when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item", "place_fixture", "equip_item"
         target.blank? || target.casecmp?(name_context(context).to_s)
       when "deliver_item"
         # Convention: `target_slug` holds the item name. The delivery
@@ -149,7 +149,7 @@ module Grid
     # so the `progress >= target_count` completion check fires.
     def next_progress_value(current, trigger_type, context, target_count)
       case trigger_type.to_s
-      when "visit_room", "talk_npc", "use_item", "fabricate_item", "place_fixture"
+      when "visit_room", "talk_npc", "use_item", "fabricate_item", "place_fixture", "equip_item"
         [current + 1, target_count].min
       when "collect_item", "deliver_item", "buy_item", "salvage_item", "salvage_yield_received"
         [current + context.fetch(:amount, 1).to_i, target_count].min

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,8 @@ Rails.application.routes.draw do
   # we don't expose `/missions/:slug` as a Rails SPA path either.
   get "missions", to: "pages#spa_root", as: :missions
   get "schematics", to: "pages#spa_root", as: :schematics
+  get "loadout", to: "pages#spa_root", as: :loadout
+  get "gear", to: redirect("/loadout")
 
   # Codex (wiki) routes - SPA
   scope "codex" do
@@ -165,6 +167,7 @@ Rails.application.routes.draw do
     get "grid/achievements", to: "grid#achievements_index"
     get "grid/missions", to: "grid#missions_index"
     get "grid/schematics", to: "grid#schematics_index"
+    get "grid/loadout", to: "grid#loadout_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
     get "grid/verify/:token", to: "grid#verify_token"

--- a/db/migrate/20260422120001_add_equipped_slot_to_grid_items.rb
+++ b/db/migrate/20260422120001_add_equipped_slot_to_grid_items.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddEquippedSlotToGridItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_items, :equipped_slot, :string
+
+    add_index :grid_items, [:grid_hackr_id, :equipped_slot],
+      unique: true,
+      where: "equipped_slot IS NOT NULL",
+      name: "index_grid_items_on_hackr_equipped_slot_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_120001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -346,6 +346,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120001) do
     t.integer "container_id"
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "equipped_slot"
     t.integer "grid_hackr_id"
     t.integer "grid_item_definition_id", null: false
     t.integer "grid_mining_rig_id"
@@ -358,6 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_120001) do
     t.datetime "updated_at", null: false
     t.integer "value", default: 0, null: false
     t.index ["container_id"], name: "index_grid_items_on_container_id"
+    t.index ["grid_hackr_id", "equipped_slot"], name: "index_grid_items_on_hackr_equipped_slot_unique", unique: true, where: "equipped_slot IS NOT NULL"
     t.index ["grid_hackr_id"], name: "index_grid_items_on_grid_hackr_id"
     t.index ["grid_item_definition_id"], name: "index_grid_items_on_grid_item_definition_id"
     t.index ["grid_mining_rig_id"], name: "index_grid_items_on_grid_mining_rig_id"

--- a/spec/controllers/api/grid_loadout_index_spec.rb
+++ b/spec/controllers/api/grid_loadout_index_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::GridController, type: :controller do
+  describe "GET #loadout_index" do
+    context "with no logged-in hackr" do
+      it "returns 401 unauthorized" do
+        get :loadout_index, format: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a logged-in hackr" do
+      let(:hackr) { create(:grid_hackr) }
+      before { session[:grid_hackr_id] = hackr.id }
+
+      it "returns the expected JSON shape with empty loadout" do
+        get :loadout_index, format: :json
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+
+        expect(json).to have_key("slots")
+        expect(json).to have_key("inventory_gear")
+        expect(json).to have_key("active_effects")
+        expect(json).to have_key("vitals")
+
+        expect(json["slots"].length).to eq(13)
+        expect(json["slots"].map { |s| s["slot"] }).to eq(GridItem::GEAR_SLOTS)
+        json["slots"].each do |slot|
+          expect(slot).to have_key("slot")
+          expect(slot).to have_key("label")
+          expect(slot).to have_key("item")
+          expect(slot["item"]).to be_nil
+        end
+
+        expect(json["inventory_gear"]).to eq([])
+        expect(json["active_effects"]).to eq({})
+
+        %w[health energy psyche inspiration].each do |vital|
+          expect(json["vitals"][vital]).to eq({"current" => 100, "max" => 100})
+        end
+      end
+
+      it "returns equipped items in their slots" do
+        gear_def = create(:grid_item_definition, :gear, name: "Test Helm",
+          properties: {"slot" => "head", "effects" => {"bonus_max_health" => 15}})
+        gear = create(:grid_item, :in_inventory, grid_item_definition: gear_def, grid_hackr: hackr)
+        gear.update!(equipped_slot: "head")
+
+        get :loadout_index, format: :json
+        json = JSON.parse(response.body)
+
+        head_slot = json["slots"].find { |s| s["slot"] == "head" }
+        expect(head_slot["item"]).not_to be_nil
+        expect(head_slot["item"]["name"]).to eq("Test Helm")
+        expect(head_slot["item"]["effects"]).to eq({"bonus_max_health" => 15})
+        expect(head_slot["item"]["equipped_slot"]).to eq("head")
+
+        expect(json["active_effects"]).to eq({"bonus_max_health" => 15.0})
+        expect(json["vitals"]["health"]["max"]).to eq(115)
+      end
+
+      it "returns unequipped gear in inventory_gear" do
+        gear_def = create(:grid_item_definition, :gear, name: "Spare Visor",
+          properties: {"slot" => "eyes", "effects" => {}})
+        create(:grid_item, :in_inventory, grid_item_definition: gear_def, grid_hackr: hackr)
+
+        get :loadout_index, format: :json
+        json = JSON.parse(response.body)
+
+        expect(json["inventory_gear"].length).to eq(1)
+        expect(json["inventory_gear"].first["name"]).to eq("Spare Visor")
+        expect(json["inventory_gear"].first["gear_slot"]).to eq("eyes")
+      end
+    end
+  end
+end

--- a/spec/factories/grid_item_definitions.rb
+++ b/spec/factories/grid_item_definitions.rb
@@ -48,6 +48,14 @@ FactoryBot.define do
       properties { {"storage_capacity" => 8, "fixture_type" => "data_rack"} }
     end
 
+    trait :gear do
+      sequence(:slug) { |n| "gear-def-#{n}" }
+      sequence(:name) { |n| "Gear Item #{n}" }
+      item_type { "gear" }
+      max_stack { 1 }
+      properties { {"slot" => "head", "effects" => {}} }
+    end
+
     trait :rare do
       rarity { "rare" }
     end

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  description             :text
+#  equipped_slot           :string
 #  item_type               :string
 #  name                    :string
 #  properties              :json
@@ -21,10 +22,11 @@
 #
 # Indexes
 #
-#  index_grid_items_on_container_id             (container_id)
-#  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
-#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#  index_grid_items_on_container_id                (container_id)
+#  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
+#  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
 #
 # Foreign Keys
 #

--- a/spec/models/grid_item_spec.rb
+++ b/spec/models/grid_item_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  description             :text
+#  equipped_slot           :string
 #  item_type               :string
 #  name                    :string
 #  properties              :json
@@ -21,10 +22,11 @@
 #
 # Indexes
 #
-#  index_grid_items_on_container_id             (container_id)
-#  index_grid_items_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_items_on_grid_item_definition_id  (grid_item_definition_id)
-#  index_grid_items_on_grid_mining_rig_id       (grid_mining_rig_id)
+#  index_grid_items_on_container_id                (container_id)
+#  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
+#  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
+#  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
 #
 # Foreign Keys
 #

--- a/spec/services/grid/loadout_commands_spec.rb
+++ b/spec/services/grid/loadout_commands_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Grid::CommandParser loadout commands" do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:gear_def) { create(:grid_item_definition, :gear, name: "Neural Visor", properties: {"slot" => "eyes", "effects" => {"bonus_max_psyche" => 10}}) }
+  let(:gear_item) { create(:grid_item, :in_inventory, grid_item_definition: gear_def, grid_hackr: hackr) }
+
+  def execute(input)
+    Grid::CommandParser.new(hackr, input).execute
+  end
+
+  describe "equip command" do
+    before { gear_item }
+
+    it "equips a gear item" do
+      result = execute("equip Neural Visor")
+      expect(result[:output]).to include("Equipped")
+      expect(result[:output]).to include("Neural Visor")
+      expect(result[:output]).to include("EYES")
+      expect(gear_item.reload.equipped_slot).to eq("eyes")
+    end
+
+    it "shows effects on equip" do
+      result = execute("equip Neural Visor")
+      expect(result[:output]).to include("bonus max psyche")
+    end
+
+    it "auto-swaps when slot is occupied" do
+      gear_item.update!(equipped_slot: "eyes")
+      second_def = create(:grid_item_definition, :gear, name: "Stealth Goggles", properties: {"slot" => "eyes", "effects" => {}})
+      create(:grid_item, :in_inventory, grid_item_definition: second_def, grid_hackr: hackr)
+
+      result = execute("equip Stealth Goggles")
+      expect(result[:output]).to include("Swapped out: Neural Visor")
+      expect(gear_item.reload.equipped_slot).to be_nil
+    end
+
+    it "rejects non-gear items" do
+      tool_def = create(:grid_item_definition, name: "Wrench")
+      create(:grid_item, :in_inventory, grid_item_definition: tool_def, grid_hackr: hackr)
+
+      result = execute("equip Wrench")
+      expect(result[:output]).to include("not gear")
+    end
+
+    it "shows already equipped message" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("equip Neural Visor")
+      expect(result[:output]).to include("already equipped")
+    end
+
+    it "shows not found for missing items" do
+      result = execute("equip Nonexistent")
+      expect(result[:output]).to include("don't have")
+    end
+
+    it "blocks equip in danger zones" do
+      danger_room = create(:grid_room, grid_zone: zone, room_type: "danger_zone")
+      hackr.update!(current_room: danger_room)
+
+      result = execute("equip Neural Visor")
+      expect(result[:output]).to include("danger zone")
+    end
+
+    it "blocks equip with insufficient clearance" do
+      cl_def = create(:grid_item_definition, :gear, name: "Elite Helm", properties: {"slot" => "head", "required_clearance" => 50, "effects" => {}})
+      create(:grid_item, :in_inventory, grid_item_definition: cl_def, grid_hackr: hackr)
+
+      result = execute("equip Elite Helm")
+      expect(result[:output]).to include("ACCESS DENIED")
+      expect(result[:output]).to include("CLEARANCE 50")
+    end
+
+    it "works with wear alias" do
+      result = execute("wear Neural Visor")
+      expect(result[:output]).to include("Equipped")
+      expect(gear_item.reload.equipped_slot).to eq("eyes")
+    end
+  end
+
+  describe "unequip command" do
+    before { gear_item.update!(equipped_slot: "eyes") }
+
+    it "unequips by item name" do
+      result = execute("unequip Neural Visor")
+      expect(result[:output]).to include("Unequipped")
+      expect(result[:output]).to include("Neural Visor")
+      expect(gear_item.reload.equipped_slot).to be_nil
+    end
+
+    it "unequips by slot name" do
+      result = execute("unequip eyes")
+      expect(result[:output]).to include("Unequipped")
+      expect(gear_item.reload.equipped_slot).to be_nil
+    end
+
+    it "clamps vitals on unequip" do
+      hackr.set_stat!("psyche", 110)
+      result = execute("unequip Neural Visor")
+      expect(result[:output]).to include("Psyche reduced to 100")
+      expect(hackr.stat("psyche")).to eq(100)
+    end
+
+    it "shows error for non-equipped items" do
+      gear_item.update!(equipped_slot: nil)
+      result = execute("unequip Neural Visor")
+      expect(result[:output]).to include("don't have")
+    end
+
+    it "works with remove alias" do
+      result = execute("remove Neural Visor")
+      expect(result[:output]).to include("Unequipped")
+    end
+  end
+
+  describe "loadout command" do
+    it "shows all slots" do
+      result = execute("loadout")
+      expect(result[:output]).to include("LOADOUT")
+      expect(result[:output]).to include("DECK")
+      expect(result[:output]).to include("HEAD")
+      expect(result[:output]).to include("EYES")
+      expect(result[:output]).to include("-- empty --")
+    end
+
+    it "shows equipped items" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("loadout")
+      expect(result[:output]).to include("Neural Visor")
+    end
+
+    it "shows active effects" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("lo")
+      expect(result[:output]).to include("Active Effects")
+      expect(result[:output]).to include("bonus max psyche")
+    end
+  end
+
+  describe "equipped item guards" do
+    before { gear_item.update!(equipped_slot: "eyes") }
+
+    it "blocks drop with equipped message" do
+      result = execute("drop Neural Visor")
+      expect(result[:output]).to include("equipped")
+      expect(result[:output]).to include("unequip")
+    end
+
+    it "blocks salvage with equipped message" do
+      result = execute("salvage Neural Visor")
+      expect(result[:output]).to include("equipped")
+      expect(result[:output]).to include("unequip")
+    end
+
+    it "blocks give with equipped message" do
+      create(:grid_mob, grid_room: room, name: "Test NPC")
+      result = execute("give Neural Visor to Test NPC")
+      expect(result[:output]).to include("equipped")
+      expect(result[:output]).to include("unequip")
+    end
+  end
+
+  describe "stat command with gear" do
+    it "shows effective max vitals" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("stat")
+      expect(result[:output]).to include("PSYCHE")
+      expect(result[:output]).to include("/110")
+    end
+
+    it "shows loadout summary" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("stat")
+      expect(result[:output]).to include("LOADOUT:")
+      expect(result[:output]).to include("1/13 slots")
+    end
+  end
+
+  describe "examine with gear" do
+    before { gear_item }
+
+    it "shows gear properties on examine" do
+      result = execute("examine Neural Visor")
+      expect(result[:output]).to include("Gear Slot: EYES")
+      expect(result[:output]).to include("bonus max psyche")
+      expect(result[:output]).to include("equip neural visor")
+    end
+
+    it "shows equipped status on examine" do
+      gear_item.update!(equipped_slot: "eyes")
+      result = execute("examine Neural Visor")
+      expect(result[:output]).to include("EQUIPPED")
+    end
+  end
+end

--- a/spec/services/grid/loadout_service_spec.rb
+++ b/spec/services/grid/loadout_service_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::LoadoutService do
+  let(:hackr) { create(:grid_hackr) }
+  let(:room) { create(:grid_room) }
+  let(:gear_def) { create(:grid_item_definition, :gear, properties: {"slot" => "head", "effects" => {"bonus_max_health" => 10}}) }
+  let(:gear_item) { create(:grid_item, :in_inventory, grid_item_definition: gear_def, grid_hackr: hackr) }
+
+  before do
+    hackr.update!(current_room: room)
+  end
+
+  describe ".equip!" do
+    it "equips a gear item to its slot" do
+      result = described_class.equip!(hackr: hackr, item: gear_item)
+      expect(result.slot).to eq("head")
+      expect(result.item).to eq(gear_item)
+      expect(result.swapped_item).to be_nil
+      expect(gear_item.reload.equipped_slot).to eq("head")
+    end
+
+    it "auto-swaps when slot is occupied" do
+      gear_item.update!(equipped_slot: "head")
+
+      second_def = create(:grid_item_definition, :gear, properties: {"slot" => "head", "effects" => {}})
+      second_item = create(:grid_item, :in_inventory, grid_item_definition: second_def, grid_hackr: hackr)
+
+      result = described_class.equip!(hackr: hackr, item: second_item)
+      expect(result.swapped_item).to eq(gear_item)
+      expect(result.item).to eq(second_item)
+      expect(gear_item.reload.equipped_slot).to be_nil
+      expect(second_item.reload.equipped_slot).to eq("head")
+    end
+
+    it "raises NotGear for non-gear items" do
+      tool = create(:grid_item, :in_inventory, grid_hackr: hackr)
+
+      expect { described_class.equip!(hackr: hackr, item: tool) }
+        .to raise_error(Grid::LoadoutService::NotGear)
+    end
+
+    it "raises ClearanceBlocked when clearance too low" do
+      cl_def = create(:grid_item_definition, :gear, properties: {"slot" => "eyes", "required_clearance" => 50, "effects" => {}})
+      cl_item = create(:grid_item, :in_inventory, grid_item_definition: cl_def, grid_hackr: hackr)
+
+      expect { described_class.equip!(hackr: hackr, item: cl_item) }
+        .to raise_error(Grid::LoadoutService::ClearanceBlocked)
+    end
+
+    it "raises ZoneRestricted in danger zones" do
+      danger_room = create(:grid_room, room_type: "danger_zone")
+      hackr.update!(current_room: danger_room)
+
+      expect { described_class.equip!(hackr: hackr, item: gear_item) }
+        .to raise_error(Grid::LoadoutService::ZoneRestricted)
+    end
+  end
+
+  describe ".unequip!" do
+    before { gear_item.update!(equipped_slot: "head") }
+
+    it "unequips an item" do
+      result = described_class.unequip!(hackr: hackr, item: gear_item)
+      expect(result.slot).to eq("head")
+      expect(gear_item.reload.equipped_slot).to be_nil
+    end
+
+    it "clamps vitals when cap is lowered" do
+      hackr.set_stat!("health", 110)
+      result = described_class.unequip!(hackr: hackr, item: gear_item)
+      expect(result.vitals_clamped).to include(hash_including(vital: "health", new_value: 100))
+      expect(hackr.stat("health")).to eq(100)
+    end
+
+    it "raises NotEquipped for non-equipped items" do
+      gear_item.update!(equipped_slot: nil)
+      expect { described_class.unequip!(hackr: hackr, item: gear_item) }
+        .to raise_error(Grid::LoadoutService::NotEquipped)
+    end
+  end
+
+  describe "inventory exclusion" do
+    it "equipped items are excluded from in_inventory scope" do
+      gear_item.update!(equipped_slot: "head")
+      expect(hackr.grid_items.in_inventory(hackr)).not_to include(gear_item)
+    end
+
+    it "equipped items appear in equipped_by scope" do
+      gear_item.update!(equipped_slot: "head")
+      expect(hackr.grid_items.equipped_by(hackr)).to include(gear_item)
+    end
+
+    it "equipped items do not count against inventory capacity" do
+      gear_item.update!(equipped_slot: "head")
+      expect(hackr.grid_items.in_inventory(hackr).count).to eq(0)
+    end
+  end
+
+  describe "loadout_effects" do
+    it "sums effects from equipped gear" do
+      gear_item.update!(equipped_slot: "head")
+
+      eyes_def = create(:grid_item_definition, :gear, properties: {"slot" => "eyes", "effects" => {"bonus_max_health" => 5, "bonus_max_energy" => 10}})
+      eyes_item = create(:grid_item, :in_inventory, grid_item_definition: eyes_def, grid_hackr: hackr)
+      eyes_item.update!(equipped_slot: "eyes")
+
+      effects = hackr.loadout_effects
+      expect(effects["bonus_max_health"]).to eq(15.0)
+      expect(effects["bonus_max_energy"]).to eq(10.0)
+    end
+  end
+
+  describe "effective_max" do
+    it "returns 100 with no gear" do
+      expect(hackr.effective_max("health")).to eq(100)
+    end
+
+    it "returns boosted cap with gear equipped" do
+      gear_item.update!(equipped_slot: "head")
+      expect(hackr.effective_max("health")).to eq(110)
+    end
+  end
+
+  describe "loadout_by_slot" do
+    it "returns all 13 slots" do
+      loadout = hackr.loadout_by_slot
+      expect(loadout.keys).to eq(GridItem::GEAR_SLOTS)
+    end
+
+    it "shows equipped items in correct slots" do
+      gear_item.update!(equipped_slot: "head")
+      loadout = hackr.loadout_by_slot
+      expect(loadout["head"]).to eq(gear_item)
+      expect(loadout["eyes"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
  13-slot gear equipment system. Hackrs equip gear items into body slots
  (deck, back, chest, head, ears, eyes, wrists, hands, neck, waist, legs,
  feet) for stat bonuses — vitals cap raises, inventory expansion, and
  future BREACH-relevant effects.

  `equipped_slot` column on grid_items with partial unique index. New
  `gear` item_type. Effects stored in properties["effects"] hash, stacked
  additively across equipped items. LoadoutService handles equip/unequip
  with row-level locking, auto-swap, clearance gates, danger zone
  restrictions, and vital clamping on unequip.

  Commands: equip/wear, unequip/remove (by name or slot), loadout/lo.
  Equipped items excluded from inventory slots and blocked from
  drop/salvage/sell/give with targeted error messages. look shows visible
  gear on other hackrs, examine shows full loadout, stat shows boosted
  vitals. Achievement trigger: equip_item. Mission objective: equip_item.

  API endpoint at /api/grid/loadout. SPA page at /loadout with slot grid,
  effects panel, and vitals display. /gear redirects. Nav links in Grid
  dropdown.