### PR TITLE
[TPG] BREACH Phase 2A - Protocol Depth

### DIFF
--- a/app/models/grid_breach_protocol.rb
+++ b/app/models/grid_breach_protocol.rb
@@ -30,7 +30,7 @@
 #  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => cascade
 #
 class GridBreachProtocol < ApplicationRecord
-  PROTOCOL_TYPES = %w[trace feedback lock adapt].freeze
+  PROTOCOL_TYPES = %w[trace feedback lock adapt spike purge].freeze
   PROTOCOL_STATES = %w[idle charging active destroyed].freeze
 
   belongs_to :grid_hackr_breach

--- a/app/models/grid_region.rb
+++ b/app/models/grid_region.rb
@@ -3,19 +3,27 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id          :integer          not null, primary key
-#  description :text
-#  name        :string           not null
-#  slug        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :integer          not null, primary key
+#  description      :text
+#  name             :string           not null
+#  slug             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  hospital_room_id :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_slug  (slug) UNIQUE
+#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
+#  index_grid_regions_on_slug              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 class GridRegion < ApplicationRecord
   has_paper_trail
+
+  belongs_to :hospital_room, class_name: "GridRoom", optional: true
 
   has_many :grid_zones, dependent: :restrict_with_error
   has_many :grid_rooms, through: :grid_zones

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -48,7 +48,7 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den],
+    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital],
     allow_nil: true
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -5,6 +5,7 @@ module Grid
     ExecResult = Data.define(:hit, :damage_dealt, :program_name, :target_position,
       :protocol_destroyed, :battery_consumed, :all_destroyed)
     AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action)
+    RerouteResult = Data.define(:target_position, :protocol_type_label)
 
     class NotInBreach < StandardError; end
     class NoActionsRemaining < StandardError; end
@@ -12,6 +13,7 @@ module Grid
     class InsufficientBattery < StandardError; end
     class InvalidTarget < StandardError; end
     class ProtocolAlreadyDestroyed < StandardError; end
+    class AlreadyRerouted < StandardError; end
 
     def self.exec!(hackr:, program_name:, target_position:)
       new(hackr).exec!(program_name, target_position)
@@ -19,6 +21,10 @@ module Grid
 
     def self.analyze!(hackr:, target_position:)
       new(hackr).analyze!(target_position)
+    end
+
+    def self.reroute!(hackr:, target_position:)
+      new(hackr).reroute!(target_position)
     end
 
     def initialize(hackr)
@@ -135,18 +141,30 @@ module Grid
         protocol.analyze_level = level_reached
         protocol.save!
 
-        # Progressive reveal
+        # Progressive reveal (with psyche degradation + ADAPT+TRACE penalty)
+        wrong_info = psyche_wrong_info?(protocol)
+
         info_revealed = case level_reached
         when 1
-          "Protocol type identified: #{protocol.type_label}."
+          if wrong_info
+            fake_type = (GridBreachProtocol::PROTOCOL_TYPES - [protocol.protocol_type]).sample
+            "Protocol type identified: #{fake_type.upcase}."
+          else
+            "Protocol type identified: #{protocol.type_label}."
+          end
         when 2
           weakness = protocol.weakness || Grid::BreachProtocol::Engine.weakness_for(protocol.protocol_type)
           # Assign weakness if not yet set
           if protocol.weakness.nil? && weakness
             protocol.update!(weakness: weakness)
           end
-          weakness_label = protocol.weakness || "none"
-          "Weakness revealed: #{weakness_label}."
+          if wrong_info
+            fake_weakness = (%w[offensive defensive utility] - [protocol.weakness]).sample
+            "Weakness revealed: #{fake_weakness}."
+          else
+            weakness_label = protocol.weakness || "none"
+            "Weakness revealed: #{weakness_label}."
+          end
         when 3
           "Full protocol analysis complete. Thresholds exposed."
         end
@@ -170,6 +188,44 @@ module Grid
         level_reached: level_reached,
         info_revealed: info_revealed,
         bonus_action: bonus_action
+      )
+    end
+
+    def reroute!(target_position)
+      breach = @hackr.active_breach
+      raise NotInBreach, "You are not in a BREACH encounter." unless breach
+      raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+
+      protocol = find_protocol(breach, target_position)
+      raise AlreadyRerouted, "Protocol [#{target_position + 1}] is already rerouted." if protocol.rerouted?
+
+      ActiveRecord::Base.transaction do
+        breach.lock!
+        protocol.lock!
+
+        raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+        raise AlreadyRerouted, "Protocol [#{target_position + 1}] is already rerouted." if protocol.rerouted?
+
+        # Can't reroute a protocol that's still charging or idle
+        if protocol.state == "charging"
+          raise InvalidTarget, "Protocol [#{target_position + 1}] is still charging — nothing to reroute."
+        end
+        if protocol.state == "idle"
+          raise InvalidTarget, "Protocol [#{target_position + 1}] is idle — nothing to reroute."
+        end
+
+        protocol.update_columns(rerouted: true)
+
+        # Consume action
+        breach.update!(actions_remaining: breach.actions_remaining - 1)
+
+        # Inspiration bump on reroute
+        bump_inspiration!(breach)
+      end
+
+      RerouteResult.new(
+        target_position: target_position,
+        protocol_type_label: protocol.type_label
       )
     end
 
@@ -211,7 +267,57 @@ module Grid
         end
       end
 
-      [base, 1].max # Always deal at least 1 damage
+      # Energy degradation: low energy reduces damage output
+      energy_mult = energy_damage_multiplier
+      return 0 if energy_mult <= 0.0 # 0 energy = no damage
+      base = (base * energy_mult).floor
+
+      [base, 1].max # Always deal at least 1 damage (when energy > 0)
+    end
+
+    # Energy scaling: damage reduction when energy is low.
+    # 0 energy = no damage at all.
+    def energy_damage_multiplier
+      energy = @hackr.stat("energy")
+      max_energy = @hackr.effective_max("energy")
+      return 0.0 if energy <= 0
+      ratio = energy.to_f / max_energy
+      if ratio >= 0.50
+        1.0
+      elsif ratio >= 0.25
+        0.90
+      elsif ratio >= 0.10
+        0.75
+      else
+        0.50
+      end
+    end
+
+    # Psyche degradation: chance of wrong info during analyze.
+    # ADAPT+TRACE synergy adds +15% wrong-info chance on adapted protocols.
+    def psyche_wrong_info?(protocol)
+      psyche = @hackr.stat("psyche")
+      max_psyche = @hackr.effective_max("psyche")
+
+      base_chance = if psyche <= 0
+        1.0
+      else
+        ratio = psyche.to_f / max_psyche
+        if ratio >= 0.50
+          0.0
+        elsif ratio >= 0.25
+          0.10
+        elsif ratio >= 0.10
+          0.20
+        else
+          0.40
+        end
+      end
+
+      # ADAPT+TRACE synergy: adapted protocols are harder to analyze
+      base_chance += 0.15 if protocol.meta["adapted"]
+
+      rand < base_chance
     end
   end
 end

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -24,6 +24,8 @@ module Grid
         exec_command(args)
       when "analyze", "an"
         analyze_command(args.first)
+      when "reroute", "rr"
+        reroute_command(args.first)
       when "jackout", "jo"
         jackout_command
       when "status", "st"
@@ -96,15 +98,11 @@ module Grid
 
       append_notifications(output, notifications)
       output.join("\n")
-    rescue Grid::BreachActionService::NoActionsRemaining => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::ProgramNotLoaded => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::InsufficientBattery => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::InvalidTarget => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::ProtocolAlreadyDestroyed => e
+    rescue Grid::BreachActionService::NoActionsRemaining,
+      Grid::BreachActionService::ProgramNotLoaded,
+      Grid::BreachActionService::InsufficientBattery,
+      Grid::BreachActionService::InvalidTarget,
+      Grid::BreachActionService::ProtocolAlreadyDestroyed => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
@@ -131,11 +129,38 @@ module Grid
       output << round_output if round_output
 
       output.join("\n")
-    rescue Grid::BreachActionService::NoActionsRemaining => e
+    rescue Grid::BreachActionService::NoActionsRemaining,
+      Grid::BreachActionService::InvalidTarget,
+      Grid::BreachActionService::ProtocolAlreadyDestroyed => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::InvalidTarget => e
-      "<span style='color: #f87171;'>#{h(e.message)}</span>"
-    rescue Grid::BreachActionService::ProtocolAlreadyDestroyed => e
+    end
+
+    def reroute_command(target_str)
+      if target_str.nil?
+        return "<span style='color: #fbbf24;'>Usage: reroute &lt;target#&gt;</span>"
+      end
+
+      target_position = parse_target(target_str)
+      return "<span style='color: #f87171;'>Invalid target. Use protocol number (1, 2, 3...).</span>" unless target_position
+
+      result = Grid::BreachActionService.reroute!(
+        hackr: hackr,
+        target_position: target_position
+      )
+
+      output = []
+      output << "<span style='color: #22d3ee;'>REROUTE → Protocol [#{result.target_position + 1}] (#{result.protocol_type_label}) delayed.</span>"
+
+      # Check if round should end
+      breach.reload
+      round_output = maybe_end_round
+      output << round_output if round_output
+
+      output.join("\n")
+    rescue Grid::BreachActionService::NoActionsRemaining,
+      Grid::BreachActionService::InvalidTarget,
+      Grid::BreachActionService::ProtocolAlreadyDestroyed,
+      Grid::BreachActionService::AlreadyRerouted => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
@@ -193,6 +218,7 @@ module Grid
       output << ""
       output << "<span style='color: #fbbf24;'>exec &lt;program&gt; &lt;target#&gt;</span>  <span style='color: #9ca3af;'>Run software against a protocol (1 action + battery)</span>"
       output << "<span style='color: #fbbf24;'>analyze &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Scan a protocol for intel (1 action)</span>"
+      output << "<span style='color: #fbbf24;'>reroute &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Delay a protocol 1 round (1 action, 30% chance protocol fizzles on retry)</span>"
       output << "<span style='color: #fbbf24;'>jackout</span>                      <span style='color: #9ca3af;'>Abort the encounter</span>"
       output << ""
       output << "<span style='color: #6b7280;'>Free commands (no action cost):</span>"
@@ -200,7 +226,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>deck</span>                         <span style='color: #9ca3af;'>Show loaded software + battery</span>"
       output << "<span style='color: #fbbf24;'>help</span>                         <span style='color: #9ca3af;'>This reference</span>"
       output << ""
-      output << "<span style='color: #6b7280;'>Aliases: sh=exec, an=analyze, jo=jackout, st=status, dk=deck, ?=help</span>"
+      output << "<span style='color: #6b7280;'>Aliases: sh=exec, an=analyze, rr=reroute, jo=jackout, st=status, dk=deck, ?=help</span>"
       output.join("\n")
     end
 

--- a/app/services/grid/breach_protocol/engine.rb
+++ b/app/services/grid/breach_protocol/engine.rb
@@ -4,8 +4,9 @@ module Grid
   module BreachProtocol
     # Handles per-protocol-type behavior during the system turn.
     # Each protocol type has a tick! method that fires its effect.
-    # Phase 2 adds SPIKE and PURGE as new `when` branches.
     module Engine
+      REROUTE_FIZZLE_CHANCE = 0.30
+
       # Called once per protocol during the system turn.
       # Returns an array of HTML message strings for display.
       def self.tick!(protocol, breach)
@@ -19,18 +20,17 @@ module Grid
         # Fire active protocols
         return [] unless protocol.state == "active"
 
-        case protocol.protocol_type
-        when "trace"
-          tick_trace!(protocol, breach)
-        when "feedback"
-          tick_feedback!(protocol, breach)
-        when "lock"
-          tick_lock!(protocol, breach)
-        when "adapt"
-          tick_adapt!(protocol, breach)
-        else
-          []
+        # Reroute: skip this tick, queue fizzle check for next tick
+        if protocol.rerouted?
+          return handle_reroute!(protocol)
         end
+
+        # Fizzle check: protocol was rerouted last round, now retrying
+        if protocol.meta["fizzle_check"]
+          return handle_fizzle!(protocol, breach)
+        end
+
+        fire_protocol!(protocol, breach)
       end
 
       # Default weakness category for each protocol type.
@@ -40,11 +40,51 @@ module Grid
           "trace" => "offensive",
           "feedback" => "offensive",
           "lock" => "defensive",
-          "adapt" => "utility"
+          "adapt" => "utility",
+          "spike" => "defensive",
+          "purge" => "utility"
         }[protocol_type.to_s]
       end
 
       # --- Private class methods ---
+
+      def self.fire_protocol!(protocol, breach)
+        case protocol.protocol_type
+        when "trace"
+          tick_trace!(protocol, breach)
+        when "feedback"
+          tick_feedback!(protocol, breach)
+        when "lock"
+          tick_lock!(protocol, breach)
+        when "adapt"
+          tick_adapt!(protocol, breach)
+        when "spike"
+          tick_spike!(protocol, breach)
+        when "purge"
+          tick_purge!(protocol, breach)
+        else
+          []
+        end
+      end
+      private_class_method :fire_protocol!
+
+      def self.handle_reroute!(protocol)
+        protocol.update_columns(rerouted: false, meta: protocol.meta.merge("fizzle_check" => true))
+        [reroute_msg("Protocol [#{protocol.position + 1}] REROUTED — delayed.")]
+      end
+      private_class_method :handle_reroute!
+
+      def self.handle_fizzle!(protocol, breach)
+        new_meta = protocol.meta.except("fizzle_check")
+        protocol.update_columns(meta: new_meta)
+
+        if rand < REROUTE_FIZZLE_CHANCE
+          [reroute_msg("Protocol [#{protocol.position + 1}] fizzled on retry!")]
+        else
+          fire_protocol!(protocol, breach)
+        end
+      end
+      private_class_method :handle_fizzle!
 
       def self.advance_charge!(protocol)
         new_rounds = protocol.rounds_charging + 1
@@ -89,11 +129,19 @@ module Grid
       private_class_method :tick_lock!
 
       # ADAPT: after 3 rounds active, mutates a random living protocol's weakness.
+      # On low-tier encounters (ambient/standard), requires 3+ active TRACE protocols.
       def self.tick_adapt!(protocol, breach)
         rounds_active = protocol.meta["rounds_active"].to_i + 1
         protocol.update!(meta: protocol.meta.merge("rounds_active" => rounds_active))
 
         return [] unless rounds_active >= 3 && (rounds_active % 3).zero?
+
+        # Low-tier gate: ambient/standard encounters need TRACE chain to enable ADAPT
+        tier = breach.grid_breach_template.tier
+        if %w[ambient standard].include?(tier)
+          trace_count = breach.grid_breach_protocols.alive.where(protocol_type: "trace", state: "active").count
+          return [] unless trace_count >= 3
+        end
 
         target = breach.grid_breach_protocols
           .where.not(state: "destroyed")
@@ -107,6 +155,24 @@ module Grid
         [adapt_msg("ADAPT [#{protocol.position + 1}] MUTATED → Protocol [#{target.position + 1}] weakness shifted.")]
       end
       private_class_method :tick_adapt!
+
+      # SPIKE: direct HEALTH drain — rare, dangerous. HEALTH 0 = worst failure.
+      def self.tick_spike!(protocol, breach)
+        hackr = breach.grid_hackr
+        damage = 6
+        hackr.adjust_vital!("health", -damage)
+        [spike_msg("SPIKE [#{protocol.position + 1}] FIRING → HEALTH -#{damage}")]
+      end
+      private_class_method :tick_spike!
+
+      # PURGE: stair-step reward degradation. Each active PURGE compounds.
+      def self.tick_purge!(protocol, breach)
+        new_multiplier = (breach.reward_multiplier * 0.90).round(4)
+        breach.update!(reward_multiplier: new_multiplier)
+        pct = (new_multiplier * 100).round
+        [purge_msg("PURGE [#{protocol.position + 1}] FIRING → Rewards degraded to #{pct}%")]
+      end
+      private_class_method :tick_purge!
 
       def self.alert_msg(text)
         "<span style='color: #f87171; font-weight: bold;'>⚠ #{text}</span>"
@@ -127,6 +193,21 @@ module Grid
         "<span style='color: #a78bfa;'>#{text}</span>"
       end
       private_class_method :adapt_msg
+
+      def self.spike_msg(text)
+        "<span style='color: #dc2626; font-weight: bold;'>#{text}</span>"
+      end
+      private_class_method :spike_msg
+
+      def self.purge_msg(text)
+        "<span style='color: #8b5cf6;'>#{text}</span>"
+      end
+      private_class_method :purge_msg
+
+      def self.reroute_msg(text)
+        "<span style='color: #22d3ee;'>#{text}</span>"
+      end
+      private_class_method :reroute_msg
     end
   end
 end

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -13,15 +13,19 @@ module Grid
       "trace" => "#f59e0b",
       "feedback" => "#f87171",
       "lock" => "#ef4444",
-      "adapt" => "#a78bfa"
+      "adapt" => "#a78bfa",
+      "spike" => "#dc2626",
+      "purge" => "#8b5cf6"
     }.freeze
 
     STATE_LABELS = {
       "idle" => "idle",
       "charging" => "charging",
       "active" => "ACTIVE",
-      "destroyed" => "✓ CLEARED"
+      "destroyed" => "\u2713 CLEARED"
     }.freeze
+
+    SEPARATOR = "\u2550" * 62 # ═ repeated
 
     def initialize(breach, protocols = nil)
       @breach = breach
@@ -43,7 +47,7 @@ module Grid
     end
 
     def render_round_end(protocol_messages)
-      lines = ["<span style='color: #9ca3af;'>── SYSTEM TURN ──</span>"]
+      lines = ["<span style='color: #9ca3af;'>\u2500\u2500 SYSTEM TURN \u2500\u2500</span>"]
       if protocol_messages.any?
         lines.concat(protocol_messages)
       else
@@ -57,30 +61,30 @@ module Grid
     def render_success(xp_awarded, cred_awarded, template_name)
       lines = []
       lines << ""
-      lines << "<span style='color: #34d399; font-weight: bold;'>╔══════════════════════════════════════════════════════════════╗</span>"
-      lines << "<span style='color: #34d399; font-weight: bold;'>║  B R E A C H   C O M P L E T E                              ║</span>"
-      lines << "<span style='color: #34d399; font-weight: bold;'>╠══════════════════════════════════════════════════════════════╣</span>"
-      lines << "<span style='color: #34d399;'>║</span>  <span style='color: #d0d0d0;'>#{h(template_name)}</span>"
-      lines << "<span style='color: #34d399;'>║</span>  <span style='color: #fbbf24;'>XP:</span> <span style='color: #34d399;'>+#{xp_awarded}</span>" if xp_awarded > 0
-      lines << "<span style='color: #34d399;'>║</span>  <span style='color: #fbbf24;'>CRED:</span> <span style='color: #34d399;'>+#{cred_awarded}</span>" if cred_awarded > 0
-      lines << "<span style='color: #34d399; font-weight: bold;'>╚══════════════════════════════════════════════════════════════╝</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2551  B R E A C H   C O M P L E T E                              \u2551</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
+      lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #d0d0d0;'>#{h(template_name)}</span>"
+      lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #fbbf24;'>XP:</span> <span style='color: #34d399;'>+#{xp_awarded}</span>" if xp_awarded > 0
+      lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #fbbf24;'>CRED:</span> <span style='color: #34d399;'>+#{cred_awarded}</span>" if cred_awarded > 0
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u255a#{SEPARATOR}\u255d</span>"
       lines.join("\n")
     end
 
     def render_failure(vitals_hit, zone_lockout_minutes = nil)
       lines = []
       lines << ""
-      lines << "<span style='color: #f87171; font-weight: bold;'>╔══════════════════════════════════════════════════════════════╗</span>"
-      lines << "<span style='color: #f87171; font-weight: bold;'>║  B R E A C H   F A I L E D                                   ║</span>"
-      lines << "<span style='color: #f87171; font-weight: bold;'>╠══════════════════════════════════════════════════════════════╣</span>"
-      lines << "<span style='color: #f87171;'>║</span>  <span style='color: #d0d0d0;'>Detection reached 100% — system countermeasures engaged.</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2551  B R E A C H   F A I L E D                                   \u2551</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
+      lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #d0d0d0;'>Detection reached 100% \u2014 system countermeasures engaged.</span>"
       vitals_hit.each do |hit|
-        lines << "<span style='color: #f87171;'>║</span>  <span style='color: #f87171;'>#{hit[:vital].upcase} -#{hit[:amount]}</span>"
+        lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #f87171;'>#{hit[:vital].upcase} -#{hit[:amount]}</span>"
       end
       if zone_lockout_minutes
-        lines << "<span style='color: #f87171;'>║</span>  <span style='color: #ef4444;'>Zone lockout: #{zone_lockout_minutes} minute(s)</span>"
+        lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #ef4444;'>Zone lockout: #{zone_lockout_minutes} minute(s)</span>"
       end
-      lines << "<span style='color: #f87171; font-weight: bold;'>╚══════════════════════════════════════════════════════════════╝</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u255a#{SEPARATOR}\u255d</span>"
       lines.join("\n")
     end
 
@@ -97,7 +101,7 @@ module Grid
     end
 
     def render_pnr_warning
-      "<span style='color: #f87171; font-weight: bold;'>⚠ SYSTEM ALERT: Intrusion signature locked. Jack-out route compromised.</span>"
+      "<span style='color: #f87171; font-weight: bold;'>\u26a0 SYSTEM ALERT: Intrusion signature locked. Jack-out route compromised.</span>"
     end
 
     private
@@ -107,10 +111,10 @@ module Grid
       tier_label = template.tier_label
       alive_count = @protocols.count(&:alive?)
       [
-        "<span style='color: #{BORDER_COLOR};'>╔══════════════════════════════════════════════════════════════╗</span>",
-        "<span style='color: #{BORDER_COLOR};'>║</span>  <span style='color: #22d3ee; font-weight: bold;'>B R E A C H</span>  <span style='color: #6b7280;'>::</span>  <span style='color: #d0d0d0;'>#{h(template.name)}</span>",
-        "<span style='color: #{BORDER_COLOR};'>║</span>  <span style='color: #fbbf24;'>Tier:</span> <span style='color: #d0d0d0;'>#{tier_label}</span>    <span style='color: #fbbf24;'>Protocols:</span> <span style='color: #f87171;'>#{alive_count} active</span>",
-        "<span style='color: #{BORDER_COLOR};'>╠══════════════════════════════════════════════════════════════╣</span>"
+        "<span style='color: #{BORDER_COLOR};'>\u2554#{SEPARATOR}\u2557</span>",
+        "<span style='color: #{BORDER_COLOR};'>\u2551</span>  <span style='color: #22d3ee; font-weight: bold;'>B R E A C H</span>  <span style='color: #6b7280;'>::</span>  <span style='color: #d0d0d0;'>#{h(template.name)}</span>",
+        "<span style='color: #{BORDER_COLOR};'>\u2551</span>  <span style='color: #fbbf24;'>Tier:</span> <span style='color: #d0d0d0;'>#{tier_label}</span>    <span style='color: #fbbf24;'>Protocols:</span> <span style='color: #f87171;'>#{alive_count} active</span>",
+        "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       ].join("\n")
     end
 
@@ -121,18 +125,28 @@ module Grid
       battery_max = @deck&.deck_battery_max || 0
       actions = @breach.actions_remaining
       actions_total = @breach.actions_this_round
+      reward_mult = @breach.reward_multiplier
       pnr_crossed = detect >= pnr
 
       pnr_label = pnr_crossed ?
         " <span style='color: #f87171; font-weight: bold;'>[PNR CROSSED]</span>" : ""
 
-      [
+      lines = [
         "#{border}  <span style='color: #fbbf24;'>DETECTION</span>  #{bar(detect, 100, DETECT_COLOR)}  #{detect}%#{pnr_label}",
-        "#{border}              <span style='color: #6b7280;'>PNR ──────────▶</span>  #{pnr}%",
+        "#{border}              <span style='color: #6b7280;'>PNR \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6</span>  #{pnr}%",
         "#{border}  <span style='color: #fbbf24;'>BATTERY  </span>  #{bar(battery, battery_max, BATTERY_COLOR)}  #{battery}/#{battery_max}",
-        "#{border}  <span style='color: #fbbf24;'>ACTIONS  </span>  #{bar(actions, actions_total, INSPIRE_COLOR)}  #{actions}/#{actions_total}",
-        "<span style='color: #{BORDER_COLOR};'>╠══════════════════════════════════════════════════════════════╣</span>"
-      ].join("\n")
+        "#{border}  <span style='color: #fbbf24;'>ACTIONS  </span>  #{bar(actions, actions_total, INSPIRE_COLOR)}  #{actions}/#{actions_total}"
+      ]
+
+      # Show reward multiplier when degraded by PURGE
+      if reward_mult < 1.0
+        pct = (reward_mult * 100).round
+        reward_color = (pct >= 70) ? "#34d399" : "#8b5cf6"
+        lines << "#{border}  <span style='color: #fbbf24;'>REWARDS  </span>  #{bar(pct, 100, reward_color)}  #{pct}%"
+      end
+
+      lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
+      lines.join("\n")
     end
 
     def protocols_block
@@ -143,7 +157,7 @@ module Grid
         analyze = p.analyze_level
 
         if p.destroyed?
-          lines << "  <span style='color: #6b7280;'>[#{p.position + 1}] ──────── ✓ CLEARED</span>"
+          lines << "  <span style='color: #6b7280;'>[#{p.position + 1}] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \u2713 CLEARED</span>"
           next
         end
 
@@ -162,16 +176,21 @@ module Grid
         end
 
         health_bar = bar(p.health, p.max_health, color, width: 8)
-        charge_info = if p.state == "charging"
+
+        state_info = if p.state == "charging"
           remaining = p.charge_rounds - p.rounds_charging
           " <span style='color: #6b7280;'>(#{remaining} rounds)</span>"
+        elsif p.rerouted?
+          " <span style='color: #22d3ee;'>[REROUTED]</span>"
+        elsif p.meta["fizzle_check"]
+          " <span style='color: #22d3ee;'>[RETRYING]</span>"
         else
           ""
         end
 
-        lines << "  <span style='color: #9ca3af;'>[#{p.position + 1}]</span> #{health_bar}  #{type_hint}  <span style='color: #9ca3af;'>#{state_label}#{charge_info}</span>  <span style='color: #6b7280;'>weak:</span> #{weakness_hint}"
+        lines << "  <span style='color: #9ca3af;'>[#{p.position + 1}]</span> #{health_bar}  #{type_hint}  <span style='color: #9ca3af;'>#{state_label}#{state_info}</span>  <span style='color: #6b7280;'>weak:</span> #{weakness_hint}"
       end
-      lines << "<span style='color: #{BORDER_COLOR};'>╠══════════════════════════════════════════════════════════════╣</span>"
+      lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       lines.join("\n")
     end
 
@@ -179,9 +198,9 @@ module Grid
       rank_data = Grid::BreachService.breach_rank(@hackr.stat("clearance"))
       rank_label = rank_data ? rank_data[:rank] : "Unknown"
       [
-        "#{border}  <span style='color: #9ca3af;'>Round #{@breach.round_number}</span>  <span style='color: #6b7280;'>—</span>  <span style='color: #9ca3af;'>#{@breach.actions_remaining} actions remaining</span>",
+        "#{border}  <span style='color: #9ca3af;'>Round #{@breach.round_number}</span>  <span style='color: #6b7280;'>\u2014</span>  <span style='color: #9ca3af;'>#{@breach.actions_remaining} actions remaining</span>",
         "#{border}  <span style='color: #fbbf24;'>BREACH RANK:</span> <span style='color: #22d3ee;'>#{h(rank_label)}</span>",
-        "<span style='color: #{BORDER_COLOR};'>╚══════════════════════════════════════════════════════════════╝</span>"
+        "<span style='color: #{BORDER_COLOR};'>\u255a#{SEPARATOR}\u255d</span>"
       ].join("\n")
     end
 
@@ -193,7 +212,7 @@ module Grid
     end
 
     def border
-      "<span style='color: #{BORDER_COLOR};'>║</span>"
+      "<span style='color: #{BORDER_COLOR};'>\u2551</span>"
     end
 
     def h(text)

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -139,6 +139,7 @@ module Grid
     def end_round!(hackr_breach)
       protocol_messages = []
       failure_display = nil
+      restore_point_display = nil
       state = :ongoing
 
       ActiveRecord::Base.transaction do
@@ -148,55 +149,83 @@ module Grid
         protocols = hackr_breach.grid_breach_protocols.alive.ordered.to_a
 
         # 1. Protocol ticks (system turn)
+        # Break on death: if a tick kills the hackr, stop ticking remaining protocols.
         protocols.each do |protocol|
           messages = Grid::BreachProtocol::Engine.tick!(protocol, hackr_breach)
           protocol_messages.concat(messages)
+
+          # Check for death between ticks
+          @hackr.reload
+          break if @hackr.stat("health") <= 0
         end
 
-        # 2. Detection increment
-        hackr_breach.reload # re-read after protocol engine updates
-        trace_count = hackr_breach.grid_breach_protocols.alive.where(protocol_type: "trace", state: "active").count
-        base_rate = hackr_breach.grid_breach_template.base_detection_rate
-        detection_delta = base_rate + (trace_count * TRACE_DETECTION_BONUS)
-        new_detection = [hackr_breach.detection_level + detection_delta, 100].min
-
-        # 3. Inspiration ramp + action calculation for new round
-        new_inspiration = compute_new_inspiration(hackr_breach)
-        new_actions = actions_for_inspiration(new_inspiration)
-
-        hackr_breach.update!(
-          detection_level: new_detection,
-          round_number: hackr_breach.round_number + 1,
-          inspiration: new_inspiration,
-          actions_this_round: new_actions,
-          actions_remaining: new_actions
-        )
-
-        # 4. Check loss condition
-        if new_detection >= 100
+        # 1b. Health-at-zero check
+        @hackr.reload
+        if @hackr.stat("health") <= 0
           failure_result = resolve_failure!(hackr_breach)
-          state = :failure
+          state = :health_zero
           failure_display = failure_result.display
         end
 
-        # 5. Check win condition (all protocols destroyed)
-        if state == :ongoing && hackr_breach.all_protocols_destroyed?
-          # This shouldn't normally happen here (checked in exec!), but safety net
-          state = :success
+        unless state == :health_zero
+          # 1c. Protocol synergies (evaluated after all ticks)
+          synergy_result = evaluate_synergies!(hackr_breach, protocols)
+          protocol_messages.concat(synergy_result[:messages])
+
+          # 2. Detection increment
+          hackr_breach.reload # re-read after protocol engine updates
+          trace_count = hackr_breach.grid_breach_protocols.alive.where(protocol_type: "trace", state: "active").count
+          base_rate = hackr_breach.grid_breach_template.base_detection_rate
+          trace_bonus = trace_count * TRACE_DETECTION_BONUS
+
+          # TRACE+TRACE synergy: double trace bonus when 2+ active
+          trace_bonus *= 2 if synergy_result[:trace_synergy]
+
+          detection_delta = base_rate + trace_bonus
+          new_detection = [hackr_breach.detection_level + detection_delta, 100].min
+
+          # 3. Inspiration ramp + action calculation for new round
+          new_inspiration = compute_new_inspiration(hackr_breach)
+          new_actions = actions_for_inspiration(new_inspiration)
+
+          hackr_breach.update!(
+            detection_level: new_detection,
+            round_number: hackr_breach.round_number + 1,
+            inspiration: new_inspiration,
+            actions_this_round: new_actions,
+            actions_remaining: new_actions
+          )
+
+          # 4. Check loss condition
+          if new_detection >= 100
+            failure_result = resolve_failure!(hackr_breach)
+            state = :failure
+            failure_display = failure_result.display
+          end
+
+          # 5. Check win condition (all protocols destroyed)
+          if state == :ongoing && hackr_breach.all_protocols_destroyed?
+            state = :success
+          end
         end
+      end
+
+      # RestorePoint™ admission happens outside the breach transaction
+      if state == :health_zero
+        restore_result = Grid::RestorePointService.admit!(@hackr)
+        restore_point_display = restore_result.display
       end
 
       # Reload protocols for display
       hackr_breach.reload
-      display = if state == :failure
-        Grid::BreachRenderer.new(hackr_breach).render_round_end(protocol_messages) + "\n" + failure_display
-      else
-        Grid::BreachRenderer.new(hackr_breach).render_round_end(protocol_messages)
-      end
+      display_parts = [Grid::BreachRenderer.new(hackr_breach).render_round_end(protocol_messages)]
+      display_parts << failure_display if failure_display
+      display_parts << restore_point_display if restore_point_display
+      display = display_parts.join("\n")
 
       EndRoundResult.new(
         hackr_breach: hackr_breach,
-        state: state,
+        state: (state == :health_zero) ? :failure : state,
         protocol_messages: protocol_messages,
         display: display,
         failure_display: failure_display
@@ -395,6 +424,33 @@ module Grid
       new_val = @hackr.stat(key)
       return nil if old == new_val
       {vital: key, amount: old - new_val}
+    end
+
+    # Evaluate protocol synergies after all ticks.
+    # Returns { messages: [], trace_synergy: bool }
+    def evaluate_synergies!(hackr_breach, protocols)
+      messages = []
+      trace_synergy = false
+
+      # Reload protocols to get fresh state after ticks
+      active_types = protocols.select(&:alive?).select { |p| p.state == "active" }.map(&:protocol_type)
+      type_counts = active_types.tally
+
+      # TRACE+TRACE: detection rate doubled (consumed in detection calc)
+      if type_counts.fetch("trace", 0) >= 2
+        trace_synergy = true
+        # Message emitted only on first occurrence. evaluate_synergies! runs before
+        # round_number is incremented, so round_number == 1 on the first end_round! call.
+        if hackr_breach.round_number <= 1
+          messages << "<span style='color: #f59e0b; font-weight: bold;'>\u26a1 SYNERGY: TRACE\u00d7#{type_counts["trace"]} \u2014 detection rate doubled!</span>"
+        end
+      end
+
+      # ADAPT+TRACE: adapted protocols harder to analyze
+      # (mechanical effect applied in BreachActionService#analyze! via protocol.meta["adapted"])
+      # Silent synergy — players discover it through analyze accuracy, not announcements.
+
+      {messages: messages, trace_synergy: trace_synergy}
     end
   end
 end

--- a/app/services/grid/debt_service.rb
+++ b/app/services/grid/debt_service.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Grid
+  # Manages GovCorp debt incurred at RestorePoint™ facilities.
+  # Debt is stored as `govcorp_debt` in the hackr's stats JSON.
+  # When a hackr has outstanding debt, 50% of all incoming CRED
+  # (mining, gameplay rewards) is garnished until the debt is cleared.
+  class DebtService
+    GARNISHMENT_RATE = 0.50
+
+    class InsufficientFunds < StandardError; end
+
+    # Incur a debt (or add to existing). Attempts to pay from cache first;
+    # any shortfall becomes debt.
+    # Returns { paid:, debt_incurred:, total_debt: }
+    def self.assess!(hackr:, amount:, memo: "GovCorp fee")
+      raise ArgumentError, "Amount must be positive" unless amount.is_a?(Integer) && amount.positive?
+
+      cache = hackr.default_cache
+      paid = 0
+
+      # Pay what we can from cache
+      if cache&.active?
+        available = cache.reload.balance
+        payable = [available, amount].min
+        if payable > 0
+          Grid::TransactionService.burn!(from_cache: cache, amount: payable, memo: memo)
+          paid = payable
+        end
+      end
+
+      # Remainder becomes debt
+      shortfall = amount - paid
+      if shortfall > 0
+        current_debt = hackr.stat("govcorp_debt").to_i
+        hackr.set_stat!("govcorp_debt", current_debt + shortfall)
+      end
+
+      total_debt = hackr.stat("govcorp_debt").to_i
+      {paid: paid, debt_incurred: shortfall, total_debt: total_debt}
+    end
+
+    # Garnish incoming CRED. Called before minting to a hackr's cache.
+    # Returns { net_amount:, garnished:, remaining_debt: }
+    # If hackr has no debt, returns full amount with 0 garnished.
+    def self.garnish(hackr:, gross_amount:)
+      debt = hackr.stat("govcorp_debt").to_i
+      return {net_amount: gross_amount, garnished: 0, remaining_debt: 0} if debt <= 0
+
+      garnish_amount = (gross_amount * GARNISHMENT_RATE).ceil
+      # Don't garnish more than the remaining debt
+      garnish_amount = [garnish_amount, debt].min
+      # Don't garnish more than the gross amount
+      garnish_amount = [garnish_amount, gross_amount].min
+
+      new_debt = debt - garnish_amount
+      hackr.set_stat!("govcorp_debt", new_debt)
+
+      net = gross_amount - garnish_amount
+      {net_amount: net, garnished: garnish_amount, remaining_debt: new_debt}
+    end
+
+    # Voluntary debt payment from cache.
+    # Returns { paid:, remaining_debt: }
+    def self.pay!(hackr:, amount: nil)
+      debt = hackr.stat("govcorp_debt").to_i
+      return {paid: 0, remaining_debt: 0} if debt <= 0
+
+      cache = hackr.default_cache
+      raise InsufficientFunds, "No active cache." unless cache&.active?
+
+      available = cache.reload.balance
+      # Default: pay as much as possible
+      amount ||= [available, debt].min
+      amount = [amount, debt].min
+      amount = [amount, available].min
+
+      return {paid: 0, remaining_debt: debt} if amount <= 0
+
+      Grid::TransactionService.burn!(from_cache: cache, amount: amount, memo: "GovCorp debt payment")
+      new_debt = debt - amount
+      hackr.set_stat!("govcorp_debt", new_debt)
+
+      {paid: amount, remaining_debt: new_debt}
+    end
+
+    # Check current debt
+    def self.debt_for(hackr)
+      hackr.stat("govcorp_debt").to_i
+    end
+  end
+end

--- a/app/services/grid/restore_point_service.rb
+++ b/app/services/grid/restore_point_service.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Grid
+  # GovCorp RestorePoint™ — emergency medical service for hackrs
+  # who reach HEALTH 0. Respawns at the regional RestorePoint™ facility
+  # and assesses a CRED fee (deducted from cache or incurred as debt).
+  #
+  # Design: GTA-style. You wake up, money gone, free to leave.
+  # No lock mechanic. The fee IS the punishment.
+  class RestorePointService
+    BASE_FEE = 50
+    FEE_PER_CLEARANCE = 5
+    HEALTH_RESTORE_FRACTION = 0.25
+
+    AdmitResult = Data.define(:hackr, :fee_amount, :paid, :debt_incurred,
+      :total_debt, :destination_room, :health_restored, :display)
+
+    # Admit a hackr to the nearest RestorePoint™.
+    # Called when HEALTH reaches 0 during BREACH (or any future context).
+    def self.admit!(hackr)
+      new(hackr).admit!
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def admit!
+      fee = compute_fee
+      destination = find_restore_point
+
+      # Assess fee (pay from cache, remainder becomes debt)
+      # Done outside the state transaction — DebtService.assess! calls
+      # TransactionService.burn! which has its own LEDGER_MUTEX.
+      debt_result = Grid::DebtService.assess!(
+        hackr: @hackr,
+        amount: fee,
+        memo: "RestorePoint\u2122 recovery fee"
+      )
+
+      # Restore health + move in a single transaction
+      max_health = @hackr.effective_max("health")
+      restored_to = (max_health * HEALTH_RESTORE_FRACTION).ceil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        @hackr.set_stat!("health", restored_to)
+
+        if destination && destination.id != @hackr.current_room_id
+          @hackr.update!(current_room_id: destination.id)
+        end
+      end
+
+      display = render_admission(fee, debt_result, destination, restored_to)
+
+      AdmitResult.new(
+        hackr: @hackr,
+        fee_amount: fee,
+        paid: debt_result[:paid],
+        debt_incurred: debt_result[:debt_incurred],
+        total_debt: debt_result[:total_debt],
+        destination_room: destination,
+        health_restored: restored_to,
+        display: display
+      )
+    end
+
+    private
+
+    def compute_fee
+      clearance = @hackr.stat("clearance")
+      BASE_FEE + (clearance * FEE_PER_CLEARANCE)
+    end
+
+    def find_restore_point
+      # Find RestorePoint™ in current region
+      current_room = @hackr.current_room
+      return current_room unless current_room
+
+      region = current_room.grid_zone&.grid_region
+      return fallback_room if region.nil?
+
+      # Use region's designated hospital room
+      if region.hospital_room_id.present?
+        return region.hospital_room
+      end
+
+      # Fallback: zone entry room
+      fallback_room
+    end
+
+    def fallback_room
+      room_id = @hackr.zone_entry_room_id || @hackr.current_room_id
+      GridRoom.find_by(id: room_id) || @hackr.current_room
+    end
+
+    def render_admission(fee, debt_result, destination, restored_to)
+      separator = Grid::BreachRenderer::SEPARATOR
+
+      lines = []
+      lines << ""
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2551  \u26a0 RESTOREPOINT\u2122 :: GovCorp Emergency Services              \u2551</span>"
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #d0d0d0;'>Neural link severed. Emergency recovery engaged.</span>"
+      lines << "<span style='color: #f87171;'>\u2551</span>"
+      lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #fbbf24;'>Recovery fee assessed:</span> <span style='color: #f87171;'>#{fee} CRED</span>"
+
+      border = "<span style='color: #f87171;'>\u2551</span>"
+
+      if debt_result[:debt_incurred] <= 0
+        # Full payment from cache
+        lines << "#{border}  <span style='color: #9ca3af;'>Deducted from cache. Paid in full.</span>"
+      elsif debt_result[:paid] > 0
+        # Partial payment
+        lines << "#{border}  <span style='color: #9ca3af;'>Cache balance insufficient. #{debt_result[:paid]} CRED deducted.</span>"
+        lines << "#{border}  <span style='color: #ef4444;'>GovCorp debt incurred: #{debt_result[:debt_incurred]} CRED</span>"
+        lines << "#{border}  <span style='color: #ef4444;'>\u26a0 CRED income garnished at 50% until debt cleared.</span>"
+      else
+        # No funds at all
+        lines << "#{border}  <span style='color: #ef4444;'>No funds available. Full debt incurred: #{fee} CRED</span>"
+        lines << "#{border}  <span style='color: #ef4444;'>\u26a0 CRED income garnished at 50% until debt cleared.</span>"
+      end
+
+      if debt_result[:total_debt] > 0
+        lines << "#{border}  <span style='color: #ef4444;'>Total GovCorp debt: #{debt_result[:total_debt]} CRED</span>"
+      end
+
+      lines << border
+      lines << "#{border}  <span style='color: #34d399;'>HEALTH restored to #{restored_to}.</span>"
+
+      if destination
+        zone_name = destination.grid_zone&.name || "Unknown"
+        lines << "#{border}  <span style='color: #9ca3af;'>Location: RestorePoint\u2122 \u2014 #{ERB::Util.html_escape(zone_name)}</span>"
+      end
+
+      lines << "<span style='color: #f87171; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+  end
+end

--- a/app/services/grid/transaction_service.rb
+++ b/app/services/grid/transaction_service.rb
@@ -23,13 +23,15 @@ module Grid
     end
 
     # Mining reward (mining pool → hackr's cache)
+    # Auto-garnishes 50% if hackr has GovCorp debt.
     def self.mint_mining!(to_cache:, amount:)
-      execute!(from_cache: GridCache.mining_pool, to_cache: to_cache, amount: amount, tx_type: "mining_reward", memo: "Mining reward")
+      garnish_and_mint!(from_cache: GridCache.mining_pool, to_cache: to_cache, amount: amount, tx_type: "mining_reward", memo: "Mining reward")
     end
 
     # Gameplay reward (gameplay pool → hackr's cache)
+    # Auto-garnishes 50% if hackr has GovCorp debt.
     def self.mint_gameplay!(to_cache:, amount:, memo: "Gameplay reward")
-      execute!(from_cache: GridCache.gameplay_pool, to_cache: to_cache, amount: amount, tx_type: "gameplay_reward", memo: memo)
+      garnish_and_mint!(from_cache: GridCache.gameplay_pool, to_cache: to_cache, amount: amount, tx_type: "gameplay_reward", memo: memo)
     end
 
     # General burn (hackr cache → burn address)
@@ -52,33 +54,59 @@ module Grid
       execute!(from_cache: GridCache.genesis, to_cache: to_cache, amount: amount, tx_type: "genesis", memo: memo)
     end
 
+    # Garnish + mint atomically inside LEDGER_MUTEX to prevent double-garnishment races.
+    # Returns the GridTransaction (same contract as execute!).
+    def self.garnish_and_mint!(from_cache:, to_cache:, amount:, tx_type:, memo:)
+      raise InvalidTransfer, "Amount must be positive" unless amount.positive?
+
+      LEDGER_MUTEX.synchronize do
+        # Garnishment inside the mutex — atomic with the mint
+        hackr = to_cache.grid_hackr
+        if hackr
+          result = Grid::DebtService.garnish(hackr: hackr, gross_amount: amount)
+          amount = result[:net_amount]
+        end
+
+        return nil if amount <= 0
+
+        write_transaction!(from_cache: from_cache, to_cache: to_cache, amount: amount, tx_type: tx_type, memo: memo)
+      end
+    end
+    private_class_method :garnish_and_mint!
+
     private_class_method def self.execute!(from_cache:, to_cache:, amount:, tx_type:, memo: nil)
       raise InvalidTransfer, "Amount must be positive" unless amount.positive?
 
       LEDGER_MUTEX.synchronize do
-        ActiveRecord::Base.transaction do
-          # Balance check inside the lock — no stale reads
-          unless tx_type == "genesis"
-            balance = from_cache.reload.balance
-            raise InsufficientBalance, "Insufficient balance" if balance < amount
-          end
+        write_transaction!(from_cache: from_cache, to_cache: to_cache, amount: amount, tx_type: tx_type, memo: memo)
+      end
+    end
 
-          last_tx = GridTransaction.recent.first
-          now = Time.current
-
-          tx = GridTransaction.new(
-            from_cache: from_cache,
-            to_cache: to_cache,
-            amount: amount,
-            tx_type: tx_type,
-            memo: memo,
-            previous_tx_hash: last_tx&.tx_hash,
-            created_at: now
-          )
-          tx.tx_hash = tx.compute_hash
-          tx.save!
-          tx
+    # Shared inner mint logic. Must be called inside LEDGER_MUTEX.synchronize.
+    private_class_method def self.write_transaction!(from_cache:, to_cache:, amount:, tx_type:, memo:)
+      raise "write_transaction! must be called under LEDGER_MUTEX" unless LEDGER_MUTEX.owned?
+      ActiveRecord::Base.transaction do
+        # Balance check inside the lock — no stale reads
+        unless tx_type == "genesis"
+          balance = from_cache.reload.balance
+          raise InsufficientBalance, "Insufficient balance" if balance < amount
         end
+
+        last_tx = GridTransaction.recent.first
+        now = Time.current
+
+        tx = GridTransaction.new(
+          from_cache: from_cache,
+          to_cache: to_cache,
+          amount: amount,
+          tx_type: tx_type,
+          memo: memo,
+          previous_tx_hash: last_tx&.tx_hash,
+          created_at: now
+        )
+        tx.tx_hash = tx.compute_hash
+        tx.save!
+        tx
       end
     end
   end

--- a/data/world/breach_templates.yml
+++ b/data/world/breach_templates.yml
@@ -3,7 +3,7 @@
 # Idempotent: find_or_initialize_by slug, skip if exists.
 #
 # protocol_composition: array of protocol definitions
-#   type: trace | feedback | lock | adapt
+#   type: trace | feedback | lock | adapt | spike | purge
 #   count: number of instances to spawn
 #   health/max_health: protocol durability
 #   charge_rounds: rounds before activation (0 = active immediately)
@@ -71,4 +71,115 @@ breach_templates:
         count: 1
         health: 45
         max_health: 45
+        charge_rounds: 3
+
+  - slug: data-vault-theta
+    name: "Encrypted Data Vault \u0398"
+    description: "A hardened GovCorp data vault. PURGE protocols bleed your rewards while SPIKE countermeasures target your neural link directly. Speed matters."
+    tier: standard
+    min_clearance: 10
+    pnr_threshold: 65
+    base_detection_rate: 6
+    cooldown_min: 600
+    cooldown_max: 1200
+    xp_reward: 300
+    cred_reward: 120
+    published: true
+    position: 3
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 0
+      - type: spike
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 2
+        weakness: defensive
+      - type: purge
+        count: 1
+        health: 40
+        max_health: 40
+        charge_rounds: 1
+        weakness: utility
+      - type: feedback
+        count: 1
+        health: 60
+        max_health: 60
+        charge_rounds: 1
+        weakness: offensive
+
+  - slug: rainn-nexus-gateway
+    name: "RAINN Nexus Gateway"
+    description: "A RAINN tri-node relay cluster. Triple TRACE protocols enable ADAPT mutation even at standard tier. Speed is critical — the detection clock accelerates fast."
+    tier: standard
+    min_clearance: 15
+    pnr_threshold: 65
+    base_detection_rate: 7
+    cooldown_min: 900
+    cooldown_max: 1500
+    xp_reward: 400
+    cred_reward: 150
+    published: true
+    position: 4
+    protocol_composition:
+      - type: trace
+        count: 3
+        health: 40
+        max_health: 40
+        charge_rounds: 0
+      - type: adapt
+        count: 1
+        health: 35
+        max_health: 35
+        charge_rounds: 3
+      - type: feedback
+        count: 1
+        health: 55
+        max_health: 55
+        charge_rounds: 1
+        weakness: offensive
+
+  - slug: rainn-command-relay
+    name: "RAINN Command Relay"
+    description: "A RAINN command-and-control relay node. Heavy protocol synergies — dual TRACE accelerates detection, ADAPT mutates weaknesses, SPIKE punishes hesitation."
+    tier: advanced
+    min_clearance: 20
+    pnr_threshold: 60
+    base_detection_rate: 7
+    cooldown_min: 900
+    cooldown_max: 1800
+    xp_reward: 500
+    cred_reward: 200
+    published: true
+    position: 5
+    protocol_composition:
+      - type: trace
+        count: 2
+        health: 55
+        max_health: 55
+        charge_rounds: 0
+      - type: spike
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 1
+        weakness: defensive
+      - type: lock
+        count: 1
+        health: 65
+        max_health: 65
+        charge_rounds: 2
+      - type: purge
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 0
+        weakness: utility
+      - type: adapt
+        count: 1
+        health: 40
+        max_health: 40
         charge_rounds: 3

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -49,3 +49,9 @@ rooms:
     description: "Ryker's domain. A cavernous space converted into a combination recording studio, performance venue, and resistance headquarters. Drum kits and recording equipment share space with server racks. Vintage analog gear - tape machines, tube amplifiers, physical mixing boards - stands alongside digital systems. Purple and cyan neon cuts through the darkness. The air vibrates with potential energy even when no one's playing."
     zone_slug: hackr-hangar
     room_type: faction_base
+
+  - name: "RestorePoint\u2122 Recovery Bay"
+    slug: restorepoint-lakeshore-bay
+    description: "You wake on a padded recovery slab under painfully neutral lighting. A holographic GovCorp logo rotates slowly overhead. A soothing voice intones: 'Welcome back to consciousness. Your RestorePoint\u2122 recovery fee has been automatically assessed. GovCorp cares.' The exit is to the south."
+    zone_slug: restorepoint-lakeshore
+    room_type: hospital

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -62,3 +62,12 @@ zones:
     region_slug: the-riverlands
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
+
+  - name: "GovCorp RestorePoint\u2122 — Lakeshore"
+    slug: restorepoint-lakeshore
+    description: "A sterile GovCorp medical facility. Soft lighting, ambient wellness muzak, and the faint smell of antiseptic. A scrolling display reads: 'RestorePoint\u2122 — Because Your Wellbeing Is Our Priority.' The exit is clearly marked. Your CRED balance is clearly lower."
+    zone_type: govcorp
+    color_scheme: white/cyan
+    region_slug: the-lakeshore
+    faction_slug: null
+    ambient_playlist_slug: null

--- a/db/migrate/20260422300001_add_breach_phase2a_fields.rb
+++ b/db/migrate/20260422300001_add_breach_phase2a_fields.rb
@@ -1,0 +1,7 @@
+class AddBreachPhase2aFields < ActiveRecord::Migration[8.1]
+  def change
+    # RestorePoint™ — regional hospital room for health-at-zero respawn
+    add_reference :grid_regions, :hospital_room, null: true,
+      foreign_key: {to_table: :grid_rooms, on_delete: :nullify}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_200003) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -525,9 +525,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_200003) do
   create_table "grid_regions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
+    t.integer "hospital_room_id"
     t.string "name", null: false
     t.string "slug", null: false
     t.datetime "updated_at", null: false
+    t.index ["hospital_room_id"], name: "index_grid_regions_on_hospital_room_id"
     t.index ["slug"], name: "index_grid_regions_on_slug", unique: true
   end
 
@@ -1207,6 +1209,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_200003) do
   add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "hospital_room_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "grid_hackrs", column: "owner_id"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -617,6 +617,18 @@ namespace :data do
       puts "  ↻ Updated breach target: #{room.name} → #{attrs["breach_template_slug"]}"
     end
 
+    # Assign RestorePoint™ hospital rooms to regions
+    {
+      "the-lakeshore" => "restorepoint-lakeshore-bay"
+    }.each do |region_slug, room_slug|
+      region = GridRegion.find_by(slug: region_slug)
+      room = GridRoom.find_by(slug: room_slug)
+      next unless region && room
+      next if region.hospital_room_id == room.id
+      region.update!(hospital_room: room)
+      puts "  ↻ Assigned RestorePoint™: #{region.name} → #{room.name}"
+    end
+
     puts "Rooms: #{created} created, #{GridRoom.count} total"
   end
 

--- a/spec/factories/grid_regions.rb
+++ b/spec/factories/grid_regions.rb
@@ -3,16 +3,22 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id          :integer          not null, primary key
-#  description :text
-#  name        :string           not null
-#  slug        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :integer          not null, primary key
+#  description      :text
+#  name             :string           not null
+#  slug             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  hospital_room_id :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_slug  (slug) UNIQUE
+#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
+#  index_grid_regions_on_slug              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 FactoryBot.define do
   factory :grid_region do

--- a/spec/models/grid_region_spec.rb
+++ b/spec/models/grid_region_spec.rb
@@ -3,16 +3,22 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id          :integer          not null, primary key
-#  description :text
-#  name        :string           not null
-#  slug        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id               :integer          not null, primary key
+#  description      :text
+#  name             :string           not null
+#  slug             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  hospital_room_id :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_slug  (slug) UNIQUE
+#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
+#  index_grid_regions_on_slug              (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 require "rails_helper"
 

--- a/spec/services/grid/breach_phase2a_spec.rb
+++ b/spec/services/grid/breach_phase2a_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe "BREACH Phase 2A" do
 
       # SPIKE×2 at positions 0,1 — FEEDBACK at position 2
       spike_protocols = breach.grid_breach_protocols.where(protocol_type: "spike").order(:position)
-      feedback_protocol = breach.grid_breach_protocols.find_by(protocol_type: "feedback")
+      breach.grid_breach_protocols.find_by(protocol_type: "feedback")
 
       breach.update!(actions_remaining: 0)
       Grid::BreachService.end_round!(hackr_breach: breach)

--- a/spec/services/grid/breach_phase2a_spec.rb
+++ b/spec/services/grid/breach_phase2a_spec.rb
@@ -1,0 +1,672 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BREACH Phase 2A" do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "test-deck-2a",
+      name: "Test Deck",
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "firmware_slot_count" => 1, "effects" => {}})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let(:software_def) do
+    create(:grid_item_definition,
+      slug: "test-sw-2a",
+      name: "Test Program",
+      item_type: "software",
+      properties: {"software_category" => "offensive", "slot_cost" => 1, "battery_cost" => 10, "effect_type" => "damage", "effect_magnitude" => 20, "level" => 1})
+  end
+
+  let!(:software) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: software_def, grid_hackr: hackr)
+    item.update!(deck_id: deck.id)
+    item
+  end
+
+  # Helper: start a breach and return the breach record
+  def start_breach!(template: nil)
+    template ||= create(:grid_breach_template)
+    result = Grid::BreachService.start!(hackr: hackr, template: template)
+    result.hackr_breach
+  end
+
+  describe "SPIKE Protocol" do
+    let(:template) do
+      create(:grid_breach_template, protocol_composition: [
+        {"type" => "spike", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+    end
+
+    it "drains HEALTH each round" do
+      breach = start_breach!(template: template)
+      old_health = hackr.stat("health")
+
+      # Spend the action so round ends
+      breach.update!(actions_remaining: 0)
+      Grid::BreachService.end_round!(hackr_breach: breach)
+
+      hackr.reload
+      expect(hackr.stat("health")).to eq(old_health - 6)
+    end
+
+    it "has 'defensive' as default weakness" do
+      expect(Grid::BreachProtocol::Engine.weakness_for("spike")).to eq("defensive")
+    end
+  end
+
+  describe "PURGE Protocol" do
+    let(:template) do
+      create(:grid_breach_template, protocol_composition: [
+        {"type" => "purge", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+    end
+
+    it "degrades reward_multiplier each round" do
+      breach = start_breach!(template: template)
+      expect(breach.reward_multiplier).to eq(1.0)
+
+      breach.update!(actions_remaining: 0)
+      Grid::BreachService.end_round!(hackr_breach: breach)
+
+      breach.reload
+      expect(breach.reward_multiplier).to be_within(0.001).of(0.9)
+    end
+
+    it "compounds with multiple PURGE protocols" do
+      double_purge = create(:grid_breach_template, protocol_composition: [
+        {"type" => "purge", "count" => 2, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(template: double_purge)
+
+      breach.update!(actions_remaining: 0)
+      Grid::BreachService.end_round!(hackr_breach: breach)
+
+      breach.reload
+      # Two PURGEs: 1.0 * 0.9 * 0.9 = 0.81
+      expect(breach.reward_multiplier).to be_within(0.001).of(0.81)
+    end
+
+    it "has 'utility' as default weakness" do
+      expect(Grid::BreachProtocol::Engine.weakness_for("purge")).to eq("utility")
+    end
+  end
+
+  describe "Protocol Synergies" do
+    describe "TRACE+TRACE detection doubling" do
+      let(:template) do
+        create(:grid_breach_template, base_detection_rate: 5, protocol_composition: [
+          {"type" => "trace", "count" => 2, "health" => 50, "max_health" => 50, "charge_rounds" => 0}
+        ])
+      end
+
+      it "doubles trace detection bonus with 2+ active TRACE" do
+        breach = start_breach!(template: template)
+        breach.update!(actions_remaining: 0)
+
+        Grid::BreachService.end_round!(hackr_breach: breach)
+        breach.reload
+
+        # base_rate(5) + trace_count(2) * TRACE_BONUS(4) * 2(synergy) = 5 + 16 = 21
+        expect(breach.detection_level).to eq(21)
+      end
+
+      it "stops doubling when one TRACE is destroyed mid-encounter" do
+        breach = start_breach!(template: template)
+
+        # Destroy one TRACE protocol
+        trace = breach.grid_breach_protocols.where(protocol_type: "trace").first
+        trace.update_columns(state: "destroyed", health: 0)
+
+        breach.update!(actions_remaining: 0)
+        old_detection = breach.detection_level
+
+        Grid::BreachService.end_round!(hackr_breach: breach)
+        breach.reload
+
+        # Only 1 TRACE active: base_rate(5) + trace_count(1) * TRACE_BONUS(4) * 1(no synergy) = 5 + 4 = 9
+        expect(breach.detection_level).to eq(old_detection + 9)
+      end
+    end
+
+    describe "ADAPT gated by TRACE on low-tier encounters" do
+      let(:template) do
+        create(:grid_breach_template, :ambient, protocol_composition: [
+          {"type" => "adapt", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0},
+          {"type" => "trace", "count" => 1, "health" => 50, "max_health" => 50, "charge_rounds" => 0}
+        ])
+      end
+
+      it "prevents ADAPT from mutating on ambient tier without 3+ TRACE" do
+        breach = start_breach!(template: template)
+        adapt_protocol = breach.grid_breach_protocols.find_by(protocol_type: "adapt")
+
+        # Simulate 3 rounds of ADAPT ticking
+        3.times do
+          Grid::BreachProtocol::Engine.tick!(adapt_protocol, breach)
+          adapt_protocol.reload
+        end
+
+        # Should NOT have mutated any protocol (only 1 TRACE, need 3)
+        other = breach.grid_breach_protocols.find_by(protocol_type: "trace")
+        expect(other.meta["adapted"]).to be_nil
+      end
+    end
+  end
+
+  describe "Reroute Command" do
+    it "delays a protocol for one round" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.first
+
+      result = Grid::BreachActionService.reroute!(hackr: hackr, target_position: protocol.position)
+
+      protocol.reload
+      expect(protocol.rerouted?).to be true
+      expect(result).to be_a(Grid::BreachActionService::RerouteResult)
+    end
+
+    it "costs one action" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.first
+      old_actions = breach.actions_remaining
+
+      Grid::BreachActionService.reroute!(hackr: hackr, target_position: protocol.position)
+      breach.reload
+
+      expect(breach.actions_remaining).to eq(old_actions - 1)
+    end
+
+    it "raises AlreadyRerouted if protocol is already rerouted" do
+      breach = start_breach!
+      # Bump actions to allow multiple reroutes
+      breach.update!(actions_this_round: 3, actions_remaining: 3)
+      protocol = breach.grid_breach_protocols.alive.first
+
+      Grid::BreachActionService.reroute!(hackr: hackr, target_position: protocol.position)
+
+      expect {
+        Grid::BreachActionService.reroute!(hackr: hackr, target_position: protocol.position)
+      }.to raise_error(Grid::BreachActionService::AlreadyRerouted)
+    end
+
+    it "fizzle check: protocol fizzles when rand < 0.30" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.where(protocol_type: "trace").first
+      protocol.update_columns(meta: {"fizzle_check" => true})
+
+      allow(Grid::BreachProtocol::Engine).to receive(:rand).and_return(0.1) # < 0.30 = fizzle
+      messages = Grid::BreachProtocol::Engine.tick!(protocol, breach)
+      protocol.reload
+
+      expect(messages.first).to include("fizzled")
+      expect(protocol.meta["fizzle_check"]).to be_nil
+    end
+
+    it "fizzle check: protocol fires normally when rand >= 0.30" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.where(protocol_type: "trace").first
+      protocol.update_columns(meta: {"fizzle_check" => true})
+
+      allow(Grid::BreachProtocol::Engine).to receive(:rand).and_return(0.5) # >= 0.30 = fire
+      messages = Grid::BreachProtocol::Engine.tick!(protocol, breach)
+      protocol.reload
+
+      expect(messages.first).to include("TRACE")
+      expect(messages.first).to include("cycling")
+      expect(protocol.meta["fizzle_check"]).to be_nil
+    end
+
+    it "protocol skips tick when rerouted, then has fizzle check" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.where(protocol_type: "trace").first
+      protocol.update_columns(rerouted: true)
+
+      # Tick should skip and set fizzle_check
+      messages = Grid::BreachProtocol::Engine.tick!(protocol, breach)
+      protocol.reload
+
+      expect(protocol.rerouted?).to be false
+      expect(protocol.meta["fizzle_check"]).to be true
+      expect(messages.first).to include("REROUTED")
+    end
+  end
+
+  describe "Vitals-at-Zero: HEALTH 0" do
+    let(:hospital_room) { create(:grid_room, grid_zone: zone, room_type: "hospital", slug: "test-restorepoint") }
+    let(:template) do
+      create(:grid_breach_template, protocol_composition: [
+        {"type" => "spike", "count" => 1, "health" => 100, "max_health" => 100, "charge_rounds" => 0}
+      ])
+    end
+
+    before do
+      region.update!(hospital_room: hospital_room)
+    end
+
+    it "forces failure and admits to RestorePoint when HEALTH drops to 0" do
+      hackr.set_stat!("health", 5) # Will drop to 0 on first SPIKE tick (6 damage)
+      breach = start_breach!(template: template)
+
+      breach.update!(actions_remaining: 0)
+      result = Grid::BreachService.end_round!(hackr_breach: breach)
+
+      breach.reload
+      hackr.reload
+
+      expect(breach.state).to eq("failure")
+      expect(hackr.stat("health")).to be > 0 # Restored by RestorePoint
+      expect(hackr.current_room_id).to eq(hospital_room.id)
+      expect(result.display).to include("RESTOREPOINT")
+    end
+  end
+
+  describe "Break on Death" do
+    let(:double_spike_template) do
+      create(:grid_breach_template, protocol_composition: [
+        {"type" => "spike", "count" => 2, "health" => 100, "max_health" => 100, "charge_rounds" => 0},
+        {"type" => "feedback", "count" => 1, "health" => 100, "max_health" => 100, "charge_rounds" => 0}
+      ])
+    end
+
+    it "stops ticking protocols after HEALTH reaches 0" do
+      hackr.set_stat!("health", 5) # First SPIKE kills (6 damage), second should NOT fire
+      breach = start_breach!(template: double_spike_template)
+      old_energy = hackr.stat("energy")
+      old_psyche = hackr.stat("psyche")
+
+      # SPIKE×2 at positions 0,1 — FEEDBACK at position 2
+      spike_protocols = breach.grid_breach_protocols.where(protocol_type: "spike").order(:position)
+      feedback_protocol = breach.grid_breach_protocols.find_by(protocol_type: "feedback")
+
+      breach.update!(actions_remaining: 0)
+      Grid::BreachService.end_round!(hackr_breach: breach)
+
+      hackr.reload
+      # FEEDBACK should not have fired — energy and psyche should only be drained by failure (20 each), not FEEDBACK (4/4)
+      expect(hackr.stat("health")).to be > 0 # Restored by failure path
+      expect(hackr.stat("energy")).to eq(old_energy - 20)
+      expect(hackr.stat("psyche")).to eq(old_psyche - 20)
+
+      # Second SPIKE should still be alive (never got to fire, wasn't destroyed)
+      spike_protocols.last.reload
+      expect(spike_protocols.last.state).not_to eq("destroyed")
+      expect(spike_protocols.last.health).to eq(spike_protocols.last.max_health)
+    end
+  end
+
+  describe "Energy Degradation" do
+    it "reduces damage at 0 energy to 0" do
+      breach = start_breach!
+      hackr.set_stat!("energy", 0)
+
+      protocol = breach.grid_breach_protocols.alive.first
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: protocol.position
+      )
+
+      expect(result.damage_dealt).to eq(0)
+    end
+
+    it "reduces damage below 50% energy (25-49%: 0.90x)" do
+      breach = start_breach!
+      hackr.set_stat!("energy", 40) # 40% of 100 max
+
+      protocol = breach.grid_breach_protocols.alive.first
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: protocol.position
+      )
+
+      # Base 20, at 40% energy: 0.90 multiplier = 18
+      expect(result.damage_dealt).to eq(18)
+    end
+
+    it "reduces damage at 10-24% energy (0.75x)" do
+      breach = start_breach!
+      hackr.set_stat!("energy", 15) # 15% of 100 max
+
+      protocol = breach.grid_breach_protocols.alive.first
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: protocol.position
+      )
+
+      # Base 20, at 15% energy: 0.75 multiplier = 15
+      expect(result.damage_dealt).to eq(15)
+    end
+
+    it "reduces damage below 10% energy (0.50x)" do
+      breach = start_breach!
+      hackr.set_stat!("energy", 5) # 5% of 100 max
+
+      protocol = breach.grid_breach_protocols.alive.first
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: protocol.position
+      )
+
+      # Base 20, at 5% energy: 0.50 multiplier = 10
+      expect(result.damage_dealt).to eq(10)
+    end
+
+    it "deals full damage at 50%+ energy" do
+      breach = start_breach!
+      hackr.set_stat!("energy", 50) # exactly 50%
+
+      protocol = breach.grid_breach_protocols.alive.first
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: protocol.position
+      )
+
+      # Base 20, at 50% energy: 1.0 multiplier = 20
+      expect(result.damage_dealt).to eq(20)
+    end
+  end
+
+  describe "Psyche Degradation" do
+    it "returns wrong info at 0 psyche" do
+      breach = start_breach!
+      hackr.set_stat!("psyche", 0)
+
+      protocol = breach.grid_breach_protocols.alive.first
+
+      # Run analyze multiple times — at 0 psyche, should always get wrong info
+      wrong_count = 0
+      10.times do
+        # Reset analyze level for each test
+        protocol.update!(meta: protocol.meta.merge("analyze_level" => 0))
+        result = Grid::BreachActionService.analyze!(hackr: hackr, target_position: protocol.position)
+        # Wrong info means reported type won't match actual type
+        actual_type = protocol.type_label
+        wrong_count += 1 unless result.info_revealed.include?(actual_type)
+        # Restore action
+        breach.reload
+        breach.update!(actions_remaining: 1) unless breach.actions_remaining > 0
+      end
+
+      # At 0 psyche, should be wrong 100% of the time
+      expect(wrong_count).to eq(10)
+    end
+  end
+
+  describe "BreachCommandParser reroute" do
+    it "routes reroute/rr command" do
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "reroute 1", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("REROUTE")
+    end
+
+    it "routes rr alias" do
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "rr 1", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("REROUTE")
+    end
+
+    it "shows reroute in help" do
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "help", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("reroute")
+      expect(result[:output]).to include("rr=reroute")
+    end
+  end
+
+  describe "BreachRenderer" do
+    it "renders SPIKE protocol with correct color" do
+      template = create(:grid_breach_template, protocol_composition: [
+        {"type" => "spike", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(template: template)
+
+      renderer = Grid::BreachRenderer.new(breach)
+      output = renderer.render_full
+
+      expect(output).to include("#dc2626") # SPIKE color
+    end
+
+    it "renders PURGE protocol with correct color" do
+      template = create(:grid_breach_template, protocol_composition: [
+        {"type" => "purge", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(template: template)
+
+      renderer = Grid::BreachRenderer.new(breach)
+      output = renderer.render_full
+
+      expect(output).to include("#8b5cf6") # PURGE color
+    end
+
+    it "shows reward meter when PURGE degrades multiplier" do
+      template = create(:grid_breach_template, protocol_composition: [
+        {"type" => "purge", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(template: template)
+      breach.update!(reward_multiplier: 0.81)
+
+      renderer = Grid::BreachRenderer.new(breach)
+      output = renderer.render_full
+
+      expect(output).to include("REWARDS")
+      expect(output).to include("81%")
+    end
+
+    it "shows [REROUTED] tag on rerouted protocol" do
+      breach = start_breach!
+      protocol = breach.grid_breach_protocols.alive.first
+      protocol.update_columns(rerouted: true)
+
+      renderer = Grid::BreachRenderer.new(breach)
+      output = renderer.render_full
+
+      expect(output).to include("REROUTED")
+    end
+  end
+end
+
+RSpec.describe Grid::DebtService do
+  let(:hackr) { create(:grid_hackr) }
+  let!(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+
+  describe ".assess!" do
+    it "pays from cache when funds available" do
+      # Stub reload chain so balance works
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(200)
+      allow(Grid::TransactionService).to receive(:burn!)
+
+      result = Grid::DebtService.assess!(hackr: hackr, amount: 100, memo: "test")
+
+      expect(result[:paid]).to eq(100)
+      expect(result[:debt_incurred]).to eq(0)
+    end
+
+    it "incurs debt when cache has insufficient funds" do
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(30)
+      allow(Grid::TransactionService).to receive(:burn!)
+
+      result = Grid::DebtService.assess!(hackr: hackr, amount: 100, memo: "test")
+
+      expect(result[:paid]).to eq(30)
+      expect(result[:debt_incurred]).to eq(70)
+      expect(hackr.stat("govcorp_debt")).to eq(70)
+    end
+
+    it "incurs full debt when no funds" do
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(0)
+
+      result = Grid::DebtService.assess!(hackr: hackr, amount: 100, memo: "test")
+
+      expect(result[:paid]).to eq(0)
+      expect(result[:debt_incurred]).to eq(100)
+      expect(hackr.stat("govcorp_debt")).to eq(100)
+    end
+  end
+
+  describe ".garnish" do
+    it "returns full amount when no debt" do
+      result = Grid::DebtService.garnish(hackr: hackr, gross_amount: 100)
+
+      expect(result[:net_amount]).to eq(100)
+      expect(result[:garnished]).to eq(0)
+    end
+
+    it "garnishes 50% when hackr has debt" do
+      hackr.set_stat!("govcorp_debt", 200)
+
+      result = Grid::DebtService.garnish(hackr: hackr, gross_amount: 100)
+
+      expect(result[:net_amount]).to eq(50)
+      expect(result[:garnished]).to eq(50)
+      expect(result[:remaining_debt]).to eq(150)
+    end
+
+    it "garnishes exact debt amount when 50% exceeds debt" do
+      hackr.set_stat!("govcorp_debt", 10)
+
+      result = Grid::DebtService.garnish(hackr: hackr, gross_amount: 100)
+
+      expect(result[:net_amount]).to eq(90)
+      expect(result[:garnished]).to eq(10)
+      expect(result[:remaining_debt]).to eq(0)
+    end
+  end
+
+  describe ".pay!" do
+    it "pays debt from cache" do
+      hackr.set_stat!("govcorp_debt", 100)
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(80)
+      allow(Grid::TransactionService).to receive(:burn!)
+
+      result = Grid::DebtService.pay!(hackr: hackr, amount: 80)
+
+      expect(result[:paid]).to eq(80)
+      expect(result[:remaining_debt]).to eq(20)
+      expect(hackr.stat("govcorp_debt")).to eq(20)
+    end
+
+    it "pays full debt when cache has enough" do
+      hackr.set_stat!("govcorp_debt", 50)
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(200)
+      allow(Grid::TransactionService).to receive(:burn!)
+
+      result = Grid::DebtService.pay!(hackr: hackr)
+
+      expect(result[:paid]).to eq(50)
+      expect(result[:remaining_debt]).to eq(0)
+    end
+
+    it "pays nothing when no debt exists" do
+      result = Grid::DebtService.pay!(hackr: hackr)
+
+      expect(result[:paid]).to eq(0)
+      expect(result[:remaining_debt]).to eq(0)
+    end
+
+    it "caps payment at available balance" do
+      hackr.set_stat!("govcorp_debt", 200)
+      allow_any_instance_of(GridCache).to receive(:balance).and_return(30)
+      allow(Grid::TransactionService).to receive(:burn!)
+
+      result = Grid::DebtService.pay!(hackr: hackr)
+
+      expect(result[:paid]).to eq(30)
+      expect(result[:remaining_debt]).to eq(170)
+    end
+
+    it "raises InsufficientFunds when no active cache" do
+      hackr.set_stat!("govcorp_debt", 100)
+      allow(hackr).to receive(:default_cache).and_return(nil)
+
+      expect {
+        Grid::DebtService.pay!(hackr: hackr)
+      }.to raise_error(Grid::DebtService::InsufficientFunds)
+    end
+  end
+end
+
+RSpec.describe Grid::RestorePointService do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hospital_zone) { create(:grid_zone, grid_region: region) }
+  let(:hospital_room) { create(:grid_room, grid_zone: hospital_zone, room_type: "hospital", slug: "test-rp") }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  before do
+    region.update!(hospital_room: hospital_room)
+    hackr.set_stat!("health", 0)
+  end
+
+  describe ".admit!" do
+    it "moves hackr to hospital room" do
+      allow(Grid::DebtService).to receive(:assess!).and_return({paid: 50, debt_incurred: 0, total_debt: 0})
+
+      Grid::RestorePointService.admit!(hackr)
+
+      hackr.reload
+      expect(hackr.current_room_id).to eq(hospital_room.id)
+    end
+
+    it "restores health to 25% of max" do
+      allow(Grid::DebtService).to receive(:assess!).and_return({paid: 50, debt_incurred: 0, total_debt: 0})
+
+      Grid::RestorePointService.admit!(hackr)
+
+      hackr.reload
+      expect(hackr.stat("health")).to eq(25) # 25% of 100 max
+    end
+
+    it "assesses CRED fee based on clearance" do
+      hackr.set_stat!("clearance", 10)
+      # Fee = 50 + (10 * 5) = 100
+      expect(Grid::DebtService).to receive(:assess!).with(
+        hackr: hackr,
+        amount: 100,
+        memo: "RestorePoint\u2122 recovery fee"
+      ).and_return({paid: 100, debt_incurred: 0, total_debt: 0})
+
+      Grid::RestorePointService.admit!(hackr)
+    end
+
+    it "renders RestorePoint display" do
+      allow(Grid::DebtService).to receive(:assess!).and_return({paid: 50, debt_incurred: 0, total_debt: 0})
+
+      result = Grid::RestorePointService.admit!(hackr)
+
+      expect(result.display).to include("RESTOREPOINT")
+      expect(result.display).to include("Recovery fee assessed")
+    end
+
+    it "renders debt warning when funds insufficient" do
+      allow(Grid::DebtService).to receive(:assess!).and_return({paid: 20, debt_incurred: 30, total_debt: 30})
+
+      result = Grid::RestorePointService.admit!(hackr)
+
+      expect(result.display).to include("GovCorp debt")
+      expect(result.display).to include("garnished")
+    end
+  end
+end


### PR DESCRIPTION
  Add SPIKE/PURGE protocols, reroute action, vitals-at-zero respawn,
  GovCorp debt/garnishment economy, energy/psyche degradation, and
  protocol synergies. Includes all code review fixes.

  Phase 2A scope:
  - SPIKE protocol (6 HEALTH/tick) + PURGE protocol (0.90x reward/tick)
  - Protocol synergies: TRACE+TRACE detection doubling, TRACE chain gates ADAPT on low-tier, ADAPT+TRACE harder analyze
  - Reroute command (1-round delay, 30% fizzle on retry)
  - Energy degradation tiers (0/50/75/90/100% damage output)
  - Psyche degradation tiers (wrong analyze info at low psyche)
  - Health-at-zero: RestorePoint™ admission + CRED fee + debt
  - GovCorp Debt System: assess/garnish/pay, 50% CRED garnishment
  - CRED garnishment hooks in TransactionService mint paths
  - 3 new breach templates (Data Vault Θ CL10, RAINN Nexus Gateway CL15, RAINN Command Relay CL20)
  - RestorePoint™ zone + room seeded for Lakeshore

  Code review fixes:
  - Extract write_transaction! to deduplicate execute!/garnish_and_mint! with LEDGER_MUTEX.owned? runtime assertion
  - Break on death: stop ticking protocols when HEALTH hits 0
  - Synergy message emits only on first occurrence (round 1)
  - Block reroute on idle protocols
  - Reroute help text clarified ("30% chance protocol fizzles on retry")
  - RestorePoint renderer uses BreachRenderer::SEPARATOR + unicode escapes
  - Rescue block consolidation in BreachCommandParser
  - RAINN Nexus Gateway template (3×TRACE) enables ADAPT on standard tier