### PR TITLE
[TPG] BREACH Phase 2B: Encounter Infrastructure

### DIFF
--- a/app/controllers/admin/grid_breach_encounters_controller.rb
+++ b/app/controllers/admin/grid_breach_encounters_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class Admin::GridBreachEncountersController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridBreachEncounter
+
+  before_action :set_encounter, only: %i[edit update destroy]
+
+  def index
+    @encounters = GridBreachEncounter
+      .joins(:grid_breach_template, grid_room: :grid_zone)
+      .includes(:grid_breach_template, grid_room: :grid_zone)
+      .order("grid_rooms.name ASC, grid_breach_templates.position ASC")
+    @active_counts = GridHackrBreach.where(state: "active")
+      .group(:grid_breach_encounter_id).count
+  end
+
+  def new
+    @encounter = GridBreachEncounter.new(state: "available")
+    load_selects
+  end
+
+  def create
+    @encounter = GridBreachEncounter.new(encounter_params)
+
+    if @encounter.save
+      set_flash_success("Encounter placed in #{@encounter.grid_room&.name}.")
+      redirect_to edit_admin_grid_breach_encounter_path(@encounter)
+    else
+      flash.now[:error] = @encounter.errors.full_messages.join(", ")
+      load_selects
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_selects
+  end
+
+  def update
+    if @encounter.update(encounter_params)
+      set_flash_success("Encounter updated.")
+      redirect_to edit_admin_grid_breach_encounter_path(@encounter)
+    else
+      flash.now[:error] = @encounter.errors.full_messages.join(", ")
+      load_selects
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    room_name = @encounter.grid_room&.name
+    if @encounter.grid_hackr_breaches.where(state: "active").exists?
+      flash[:error] = "Cannot delete — active breaches reference this encounter."
+    else
+      @encounter.destroy!
+      set_flash_success("Encounter in '#{room_name}' deleted.")
+    end
+    redirect_to admin_grid_breach_encounters_path
+  end
+
+  private
+
+  def set_encounter
+    @encounter = GridBreachEncounter.find(params[:id])
+  end
+
+  def load_selects
+    @templates = GridBreachTemplate.published.ordered
+    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name ASC, grid_rooms.name ASC")
+  end
+
+  def encounter_params
+    params.require(:grid_breach_encounter).permit(
+      :grid_breach_template_id, :grid_room_id, :state, :instance_seed
+    )
+  end
+end

--- a/app/models/grid_breach_encounter.rb
+++ b/app/models/grid_breach_encounter.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_breach_encounters
+# Database name: primary
+#
+#  id                      :integer          not null, primary key
+#  cooldown_until          :datetime
+#  instance_seed           :integer
+#  state                   :string           default("available"), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_breach_template_id :integer          not null
+#  grid_room_id            :integer          not null
+#
+# Indexes
+#
+#  index_breach_encounters_on_room_and_template             (grid_room_id,grid_breach_template_id)
+#  index_grid_breach_encounters_on_grid_breach_template_id  (grid_breach_template_id)
+#  index_grid_breach_encounters_on_grid_room_id             (grid_room_id)
+#  index_grid_breach_encounters_on_state                    (state)
+#
+# Foreign Keys
+#
+#  grid_breach_template_id  (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
+#  grid_room_id             (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
+class GridBreachEncounter < ApplicationRecord
+  has_paper_trail
+
+  STATES = %w[available active cooldown depleted].freeze
+
+  belongs_to :grid_breach_template
+  belongs_to :grid_room
+  has_many :grid_hackr_breaches, dependent: :nullify
+
+  validates :state, presence: true, inclusion: {in: STATES}
+  validates :grid_breach_template_id, uniqueness: {scope: :grid_room_id, message: "already placed in this room"}
+
+  scope :available, -> { where(state: "available") }
+  scope :not_depleted, -> { where.not(state: "depleted") }
+  scope :for_room, ->(room) { where(grid_room: room) }
+
+  delegate :name, :tier, :tier_label, :min_clearance, :published?, to: :grid_breach_template
+
+  def available?
+    state == "available"
+  end
+
+  def active?
+    state == "active"
+  end
+
+  def cooldown?
+    state == "cooldown"
+  end
+
+  def depleted?
+    state == "depleted"
+  end
+
+  # Check if cooldown has expired and transition back to available
+  def check_cooldown!
+    return unless cooldown? && cooldown_until.present? && Time.current >= cooldown_until
+    update!(state: "available", cooldown_until: nil)
+  end
+
+  # Start cooldown with randomized duration from template
+  def start_cooldown!
+    template = grid_breach_template
+    duration = if template.cooldown_min >= template.cooldown_max
+      template.cooldown_max
+    else
+      rand(template.cooldown_min..template.cooldown_max)
+    end
+
+    update!(
+      state: "cooldown",
+      cooldown_until: Time.current + duration.seconds
+    )
+  end
+
+  def cooldown_remaining
+    return nil unless cooldown? && cooldown_until.present?
+    remaining = cooldown_until - Time.current
+    (remaining > 0) ? remaining : 0
+  end
+end

--- a/app/models/grid_breach_template.rb
+++ b/app/models/grid_breach_template.rb
@@ -37,6 +37,7 @@ class GridBreachTemplate < ApplicationRecord
 
   TIERS = %w[ambient standard advanced elite world_event].freeze
 
+  has_many :grid_breach_encounters, dependent: :restrict_with_error
   has_many :grid_hackr_breaches, dependent: :restrict_with_error
 
   validates :slug, presence: true, uniqueness: true,

--- a/app/models/grid_hackr_breach.rb
+++ b/app/models/grid_hackr_breach.rb
@@ -5,43 +5,48 @@
 # Table name: grid_hackr_breaches
 # Database name: primary
 #
-#  id                      :integer          not null, primary key
-#  actions_remaining       :integer          default(1), not null
-#  actions_this_round      :integer          default(1), not null
-#  detection_level         :integer          default(0), not null
-#  ended_at                :datetime
-#  inspiration             :integer          default(0), not null
-#  pnr_threshold           :integer          default(75), not null
-#  reward_multiplier       :decimal(5, 4)    default(1.0), not null
-#  round_number            :integer          default(1), not null
-#  started_at              :datetime         not null
-#  state                   :string           default("active"), not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  grid_breach_template_id :integer          not null
-#  grid_hackr_id           :integer          not null
-#  origin_room_id          :integer
+#  id                       :integer          not null, primary key
+#  actions_remaining        :integer          default(1), not null
+#  actions_this_round       :integer          default(1), not null
+#  detection_level          :integer          default(0), not null
+#  ended_at                 :datetime
+#  inspiration              :integer          default(0), not null
+#  pnr_threshold            :integer          default(75), not null
+#  reward_multiplier        :decimal(5, 4)    default(1.0), not null
+#  round_number             :integer          default(1), not null
+#  started_at               :datetime         not null
+#  state                    :string           default("active"), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  grid_breach_encounter_id :integer
+#  grid_breach_template_id  :integer          not null
+#  grid_hackr_id            :integer          not null
+#  origin_room_id           :integer
 #
 # Indexes
 #
-#  index_grid_hackr_breaches_on_grid_breach_template_id  (grid_breach_template_id)
-#  index_grid_hackr_breaches_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_hackr_breaches_on_state                    (state)
-#  index_hackr_breaches_one_active_per_hackr             (grid_hackr_id) UNIQUE WHERE state = 'active'
+#  index_grid_hackr_breaches_on_grid_breach_encounter_id  (grid_breach_encounter_id)
+#  index_grid_hackr_breaches_on_grid_breach_template_id   (grid_breach_template_id)
+#  index_grid_hackr_breaches_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_hackr_breaches_on_state                     (state)
+#  index_hackr_breaches_one_active_per_hackr              (grid_hackr_id) UNIQUE WHERE state = 'active'
 #
 # Foreign Keys
 #
-#  grid_breach_template_id  (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
-#  grid_hackr_id            (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
-#  origin_room_id           (origin_room_id => grid_rooms.id) ON DELETE => nullify
+#  grid_breach_encounter_id  (grid_breach_encounter_id => grid_breach_encounters.id) ON DELETE => nullify
+#  grid_breach_template_id   (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
+#  grid_hackr_id             (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  origin_room_id            (origin_room_id => grid_rooms.id) ON DELETE => nullify
 #
 class GridHackrBreach < ApplicationRecord
   STATES = %w[active success failure jacked_out].freeze
 
   belongs_to :grid_hackr
   belongs_to :grid_breach_template
+  belongs_to :grid_breach_encounter, optional: true
   belongs_to :origin_room, class_name: "GridRoom", optional: true
   has_many :grid_breach_protocols, dependent: :destroy
+  has_many :grid_hackr_breach_logs, dependent: :destroy
 
   validates :state, presence: true, inclusion: {in: STATES}
   validates :detection_level, numericality: {only_integer: true, in: 0..100}

--- a/app/models/grid_hackr_breach_log.rb
+++ b/app/models/grid_hackr_breach_log.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_hackr_breach_logs
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  action_type          :string           not null
+#  program_slug         :string
+#  result               :json             not null
+#  round                :integer          not null
+#  target               :string
+#  created_at           :datetime         not null
+#  grid_hackr_breach_id :integer          not null
+#
+# Indexes
+#
+#  index_breach_logs_on_breach_and_round                 (grid_hackr_breach_id,round)
+#  index_grid_hackr_breach_logs_on_grid_hackr_breach_id  (grid_hackr_breach_id)
+#
+# Foreign Keys
+#
+#  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => cascade
+#
+class GridHackrBreachLog < ApplicationRecord
+  ACTION_TYPES = %w[exec analyze reroute jackout use system].freeze
+
+  belongs_to :grid_hackr_breach
+
+  validates :round, numericality: {only_integer: true, greater_than_or_equal_to: 1}
+  validates :action_type, presence: true, inclusion: {in: ACTION_TYPES}
+
+  scope :ordered, -> { order(:created_at) }
+  scope :for_round, ->(round) { where(round: round) }
+end

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -3,19 +3,18 @@
 # Table name: grid_rooms
 # Database name: primary
 #
-#  id                   :integer          not null, primary key
-#  breach_template_slug :string
-#  description          :text
-#  locked               :boolean          default(FALSE), not null
-#  min_clearance        :integer          default(0), not null
-#  name                 :string
-#  room_type            :string
-#  slug                 :string
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  ambient_playlist_id  :integer
-#  grid_zone_id         :integer          not null
-#  owner_id             :integer
+#  id                  :integer          not null, primary key
+#  description         :text
+#  locked              :boolean          default(FALSE), not null
+#  min_clearance       :integer          default(0), not null
+#  name                :string
+#  room_type           :string
+#  slug                :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  ambient_playlist_id :integer
+#  grid_zone_id        :integer          not null
+#  owner_id            :integer
 #
 # Indexes
 #
@@ -43,6 +42,7 @@ class GridRoom < ApplicationRecord
   has_many :grid_items, foreign_key: :room_id
   has_many :grid_mobs
   has_many :grid_hackrs, foreign_key: :current_room_id
+  has_many :grid_breach_encounters, dependent: :destroy
   has_many :den_invites, class_name: "GridDenInvite", foreign_key: :den_id, dependent: :destroy
 
   validates :name, presence: true
@@ -64,7 +64,7 @@ class GridRoom < ApplicationRecord
   end
 
   def breachable?
-    breach_template_slug.present?
+    grid_breach_encounters.any?
   end
 
   def den?

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -94,6 +94,13 @@ module Grid
 
         # Check all-destroyed win condition
         all_destroyed = breach.all_protocols_destroyed?
+
+        log_action!(breach, "exec", target_position, program.grid_item_definition&.slug, {
+          hit: damage > 0,
+          damage: damage,
+          destroyed: destroyed,
+          battery_consumed: battery_cost
+        })
       end
 
       ExecResult.new(
@@ -181,6 +188,12 @@ module Grid
 
         # Inspiration bump on analyze
         bump_inspiration!(breach)
+
+        log_action!(breach, "analyze", target_position, nil, {
+          level_reached: level_reached,
+          info: info_revealed,
+          bonus_action: bonus_action
+        })
       end
 
       AnalyzeResult.new(
@@ -221,6 +234,10 @@ module Grid
 
         # Inspiration bump on reroute
         bump_inspiration!(breach)
+
+        log_action!(breach, "reroute", target_position, nil, {
+          protocol_type: protocol.protocol_type
+        })
       end
 
       RerouteResult.new(
@@ -230,6 +247,17 @@ module Grid
     end
 
     private
+
+    def log_action!(breach, action_type, target_position, program_slug, result_data)
+      GridHackrBreachLog.create!(
+        grid_hackr_breach: breach,
+        round: breach.round_number,
+        action_type: action_type,
+        target: target_position&.to_s,
+        program_slug: program_slug,
+        result: result_data
+      )
+    end
 
     def find_loaded_program(deck, name)
       deck.loaded_software.find { |s| s.name.downcase == name.to_s.downcase }

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -36,8 +36,8 @@ module Grid
       BREACH_RANK_TABLE.find { |range, _| range.include?(clearance.to_i) }&.last
     end
 
-    def self.start!(hackr:, template:)
-      new(hackr).start!(template)
+    def self.start!(hackr:, encounter:)
+      new(hackr).start!(encounter)
     end
 
     def self.end_round!(hackr_breach:)
@@ -56,13 +56,41 @@ module Grid
       new(hackr).jackout!
     end
 
+    # List voluntary encounters in a room, respecting cooldowns and gates.
+    # Lazy expiration: expired cooldowns are flushed on read rather than via
+    # a background job. Each check_cooldown! is a single UPDATE when the timer
+    # has elapsed, no-op otherwise. Acceptable trade-off vs. cron infrastructure.
+    def self.available_encounters(room:, hackr: nil)
+      encounters = room.grid_breach_encounters
+        .not_depleted
+        .includes(:grid_breach_template)
+        .select { |enc| enc.grid_breach_template.published? }
+
+      # Flush expired cooldowns (lazy expiration — see class comment above)
+      encounters.each(&:check_cooldown!)
+
+      # Filter to available state after cooldown check
+      encounters = encounters.select(&:available?)
+
+      # Apply hackr-specific gates if provided
+      if hackr
+        cl = hackr.stat("clearance")
+        encounters = encounters.select { |enc| cl >= enc.min_clearance }
+      end
+
+      encounters.sort_by { |enc| enc.grid_breach_template.position }
+    end
+
     def initialize(hackr)
       @hackr = hackr
     end
 
-    def start!(template)
+    def start!(encounter)
       raise AlreadyInBreach, "You are already in a BREACH encounter." if @hackr.in_breach?
+
+      template = encounter.grid_breach_template
       raise TemplateGated, "This encounter is not available." unless template.published?
+      raise TemplateGated, "This encounter is not available." unless encounter.available?
 
       cl = @hackr.stat("clearance")
       if cl < template.min_clearance
@@ -77,6 +105,10 @@ module Grid
 
       ActiveRecord::Base.transaction do
         @hackr.lock!
+        encounter.lock!
+
+        # Re-check availability after lock
+        raise TemplateGated, "This encounter is not available." unless encounter.available?
 
         # Mission prerequisite gate
         if template.requires_mission_slug.present?
@@ -93,28 +125,15 @@ module Grid
           raise TemplateGated, "Requires item: #{template.requires_item_slug}." unless has_item
         end
 
-        # Cooldown gate
-        if template.cooldown_min > 0
-          last_breach = @hackr.grid_hackr_breaches
-            .where(grid_breach_template: template)
-            .where(state: %w[success failure jacked_out])
-            .order(ended_at: :desc)
-            .first
-          if last_breach&.ended_at
-            cooldown_seconds = [template.cooldown_min, template.cooldown_max].max
-            cooldown_until = last_breach.ended_at + cooldown_seconds.seconds
-            if Time.current < cooldown_until
-              remaining = ((cooldown_until - Time.current) / 60.0).ceil
-              raise TemplateGated, "Encounter on cooldown. Available in #{remaining} minute(s)."
-            end
-          end
-        end
+        # Mark encounter as active
+        encounter.update!(state: "active")
 
         initial_actions = 1 # Always start with 1 action — inspiration ramps during encounter
 
         breach = GridHackrBreach.create!(
           grid_hackr: @hackr,
           grid_breach_template: template,
+          grid_breach_encounter: encounter,
           origin_room_id: @hackr.current_room_id,
           state: "active",
           detection_level: 0,
@@ -245,6 +264,9 @@ module Grid
 
         hackr_breach.update!(state: "success", ended_at: Time.current)
 
+        # Transition encounter to cooldown
+        transition_encounter_cooldown!(hackr_breach)
+
         # Grant XP
         xp_result = @hackr.grant_xp!(xp_awarded) if xp_awarded > 0
 
@@ -294,6 +316,9 @@ module Grid
         @hackr.lock! if wrap
 
         hackr_breach.update!(state: "failure", ended_at: Time.current)
+
+        # Transition encounter to cooldown
+        transition_encounter_cooldown!(hackr_breach)
 
         # Tier 1: vitals drain (all tiers get this)
         vitals_hit << drain_vital!("energy", 20)
@@ -353,6 +378,17 @@ module Grid
         end
 
         hackr_breach.update!(state: "jacked_out", ended_at: Time.current)
+
+        # Transition encounter to cooldown
+        transition_encounter_cooldown!(hackr_breach)
+
+        # Log jackout action
+        GridHackrBreachLog.create!(
+          grid_hackr_breach: hackr_breach,
+          round: hackr_breach.round_number,
+          action_type: "jackout",
+          result: {clean: clean}
+        )
       end
 
       vitals_hit.compact!
@@ -416,6 +452,25 @@ module Grid
     def clearance_ceiling
       rank_data = self.class.breach_rank(@hackr.stat("clearance"))
       rank_data ? rank_data[:ceiling] : 1
+    end
+
+    # Transition the encounter back to cooldown (or available if no cooldown).
+    # Called inside the breach-ending transaction. Wrapped in rescue to prevent
+    # a cooldown transition failure from leaving the encounter stuck in "active".
+    def transition_encounter_cooldown!(hackr_breach)
+      encounter = hackr_breach.grid_breach_encounter
+      return unless encounter # Ambient encounters have no persistent record
+
+      encounter.lock!
+      encounter.start_cooldown!
+    rescue => e
+      Rails.logger.error("[BreachService] Failed to transition encounter #{encounter.id} to cooldown: #{e.message}")
+      # Force encounter back to available so it's not stuck in "active"
+      begin
+        encounter.update_columns(state: "available", cooldown_until: nil)
+      rescue
+        nil
+      end
     end
 
     def drain_vital!(key, amount)

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -168,13 +168,20 @@ module Grid
         output << "<span style='color: #f87171;'>[ DEN IS LOCKED ]</span>" if room.locked?
       end
 
-      # Breach target indicator
-      if room.breachable?
-        template = GridBreachTemplate.find_by(slug: room.breach_template_slug)
-        if template&.published?
-          output << ""
-          output << "<span style='color: #22d3ee; font-weight: bold;'>[ BREACH TARGET DETECTED ]</span> <span style='color: #9ca3af;'>#{h(template.name)} :: #{template.tier_label}</span>"
+      # Breach target indicator(s)
+      breach_encounters = Grid::BreachService.available_encounters(room: room, hackr: hackr)
+      if breach_encounters.any?
+        output << ""
+        if breach_encounters.size == 1
+          enc = breach_encounters.first
+          output << "<span style='color: #22d3ee; font-weight: bold;'>[ BREACH TARGET DETECTED ]</span> <span style='color: #9ca3af;'>#{h(enc.name)} :: #{enc.tier_label}</span>"
           output << "<span style='color: #6b7280;'>  Type 'breach' to initiate.</span>"
+        else
+          output << "<span style='color: #22d3ee; font-weight: bold;'>[ BREACH TARGETS DETECTED ]</span>"
+          breach_encounters.each_with_index do |enc, i|
+            output << "<span style='color: #9ca3af;'>  [#{i + 1}] #{h(enc.name)} :: #{enc.tier_label}</span>"
+          end
+          output << "<span style='color: #6b7280;'>  Type 'breach &lt;name or #&gt;' to initiate.</span>"
         end
       end
 
@@ -1272,16 +1279,17 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      unless room.breachable?
+      encounters = Grid::BreachService.available_encounters(room: room, hackr: hackr)
+      if encounters.empty?
         return "<span style='color: #f87171;'>Nothing to breach here.</span>"
       end
 
-      template = GridBreachTemplate.find_by(slug: room.breach_template_slug)
-      unless template&.published?
-        return "<span style='color: #f87171;'>Breach target is offline.</span>"
+      encounter = resolve_breach_target(encounters, target_name)
+      unless encounter
+        return "<span style='color: #f87171;'>No matching breach target. Type 'look' to see available targets.</span>"
       end
 
-      result = Grid::BreachService.start!(hackr: hackr, template: template)
+      result = Grid::BreachService.start!(hackr: hackr, encounter: encounter)
 
       output = []
       output << ""
@@ -1299,6 +1307,27 @@ module Grid
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     rescue Grid::BreachService::TemplateGated => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    # Resolve breach target from name or number
+    def resolve_breach_target(encounters, target_name)
+      # Single encounter + no target specified → auto-select
+      return encounters.first if encounters.size == 1 && target_name.blank?
+
+      # Must specify target when multiple encounters
+      return nil if target_name.blank? && encounters.size > 1
+
+      target = target_name.to_s.strip
+
+      # Try numeric index first (1-based)
+      if target.match?(/\A\d+\z/)
+        idx = target.to_i - 1
+        return encounters[idx] if idx >= 0 && idx < encounters.size
+        return nil # Out-of-range number — don't fall through to name search
+      end
+
+      # Try name match (case-insensitive, partial)
+      encounters.find { |enc| enc.name.downcase.include?(target.downcase) }
     end
 
     def equipped_item_hint(item_name)

--- a/app/views/admin/grid_breach_encounters/_form.html.erb
+++ b/app/views/admin/grid_breach_encounters/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with model: [:admin, encounter], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: ENCOUNTER PLACEMENT ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :grid_breach_template_id, "TEMPLATE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_breach_template_id, @templates.map { |t| ["#{t.name} (#{t.tier_label})", t.id] }, { include_blank: "-- Select Template --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if encounter.errors[:grid_breach_template_id].any? %>
+        <br><small class="red-255-text"><%= encounter.errors[:grid_breach_template_id].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :grid_room_id, "ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_room_id, @rooms.map { |r| ["#{r.grid_zone.name} :: #{r.name}", r.id] }, { include_blank: "-- Select Room --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if encounter.errors[:grid_room_id].any? %>
+        <br><small class="red-255-text"><%= encounter.errors[:grid_room_id].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :state, "STATE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :state, GridBreachEncounter::STATES.map { |s| [s.upcase, s] }, {}, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+    <div>
+      <%= f.label :instance_seed, "INSTANCE SEED", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :instance_seed, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">Optional — procedural variation seed</small>
+    </div>
+  </div>
+
+  <div style="margin-top: 25px;">
+    <%= f.submit encounter.new_record? ? "Place Encounter" : "Update Encounter", class: "tui-button green-168", style: "padding: 8px 20px;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_breach_encounters/edit.html.erb
+++ b/app/views/admin/grid_breach_encounters/edit.html.erb
@@ -1,0 +1,29 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/breach_encounters/<%= @encounter.id %> :: EDIT ENCOUNTER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", encounter: @encounter %>
+
+      <div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #333;">
+        <p style="color: #6b7280;">
+          Room: <span style="color: #d0d0d0;"><%= @encounter.grid_room&.name %></span> &middot;
+          Template: <span style="color: #d0d0d0;"><%= @encounter.grid_breach_template&.name %></span> &middot;
+          Created: <span style="color: #d0d0d0;"><%= @encounter.created_at&.strftime("%Y-%m-%d %H:%M") %></span>
+        </p>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_breach_encounters/index.html.erb
+++ b/app/views/admin/grid_breach_encounters/index.html.erb
@@ -1,0 +1,75 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/breach_encounters :: BREACH ENCOUNTERS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Encounter", new_admin_grid_breach_encounter_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 900px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Room</th>
+              <th style="text-align: left;">Zone</th>
+              <th style="text-align: left;">Template</th>
+              <th style="text-align: center;">Tier</th>
+              <th style="text-align: center;">State</th>
+              <th style="text-align: center;">Active</th>
+              <th style="text-align: center;">Cooldown Until</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @encounters.each do |enc| %>
+              <tr>
+                <td><%= enc.grid_room.name %></td>
+                <td style="color: #6b7280;"><%= enc.grid_room.grid_zone.name %></td>
+                <td><%= enc.grid_breach_template.name %></td>
+                <td style="text-align: center;"><%= enc.tier_label %></td>
+                <td style="text-align: center;">
+                  <% case enc.state %>
+                  <% when "available" %>
+                    <span class="green-255-text"><%= enc.state.upcase %></span>
+                  <% when "active" %>
+                    <span style="color: #22d3ee;"><%= enc.state.upcase %></span>
+                  <% when "cooldown" %>
+                    <span style="color: #fbbf24;"><%= enc.state.upcase %></span>
+                  <% when "depleted" %>
+                    <span style="color: #6b7280;"><%= enc.state.upcase %></span>
+                  <% end %>
+                </td>
+                <td style="text-align: center;"><%= @active_counts[enc.id] || 0 %></td>
+                <td style="text-align: center;">
+                  <% if enc.cooldown_until %>
+                    <span style="color: #fbbf24;"><%= enc.cooldown_until.strftime("%H:%M:%S") %></span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_breach_encounter_path(enc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_breach_encounter_path(enc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_breach_encounter_path(enc), data: { turbo_method: :delete, turbo_confirm: "Delete this encounter?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_breach_encounters/new.html.erb
+++ b/app/views/admin/grid_breach_encounters/new.html.erb
@@ -1,0 +1,15 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/breach_encounters/new :: PLACE ENCOUNTER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= render "form", encounter: @encounter %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -90,6 +90,7 @@
           <%= link_to "Missions", admin_grid_missions_path, class: "green-168-text" %>
           <%= link_to "Schematics", admin_grid_schematics_path, class: "green-168-text" %>
           <%= link_to "Breach Templates", admin_grid_breach_templates_path, class: "green-168-text" %>
+          <%= link_to "Breach Encounters", admin_grid_breach_encounters_path, class: "green-168-text" %>
           <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
           <%= link_to "Regions", admin_grid_regions_path, class: "green-168-text" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -408,6 +408,13 @@ Rails.application.routes.draw do
       end
     end
 
+    # BREACH encounters (placed in rooms)
+    resources :grid_breach_encounters, except: [:show] do
+      member do
+        get :history
+      end
+    end
+
     # Grid schematics (fabrication recipes)
     resources :grid_schematics, except: [:show] do
       member do

--- a/data/world/breach_encounters.yml
+++ b/data/world/breach_encounters.yml
@@ -1,0 +1,9 @@
+# BREACH Encounters — template placements in rooms.
+# Loaded by: rails data:breach_encounters (after breach_templates and rooms).
+# Idempotent: find_or_initialize_by template_slug + room_slug, skip if exists.
+
+breach_encounters:
+
+  - template_slug: patrol-node-alpha
+    room_slug: govcorp-surveillance-node
+    state: available

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -23,7 +23,6 @@ rooms:
     description: "Sterile white walls lined with surveillance feeds. Red warning lights pulse slowly. The oppressive atmosphere of total control permeates everything. You shouldn't be here. A RAINN patrol node blinks in the corner — its access port exposed."
     zone_slug: govcorp-surveillance
     room_type: govcorp
-    breach_template_slug: patrol-node-alpha
 
   - name: The Signal Bazaar
     slug: the-signal-bazaar

--- a/db/migrate/20260423120001_create_breach_encounter_infrastructure.rb
+++ b/db/migrate/20260423120001_create_breach_encounter_infrastructure.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class CreateBreachEncounterInfrastructure < ActiveRecord::Migration[8.0]
+  def up
+    # 1. grid_breach_encounters — persistent voluntary encounters placed in rooms
+    create_table :grid_breach_encounters do |t|
+      t.references :grid_breach_template, null: false, foreign_key: {on_delete: :restrict}
+      t.references :grid_room, null: false, foreign_key: {on_delete: :cascade}
+      t.string :state, null: false, default: "available"
+      t.datetime :cooldown_until
+      t.integer :instance_seed
+
+      t.timestamps
+    end
+
+    add_index :grid_breach_encounters, [:grid_room_id, :grid_breach_template_id],
+      name: "index_breach_encounters_on_room_and_template"
+    add_index :grid_breach_encounters, :state
+
+    # 2. grid_hackr_breach_logs — append-only action log
+    create_table :grid_hackr_breach_logs do |t|
+      t.references :grid_hackr_breach, null: false, foreign_key: {on_delete: :cascade}
+      t.integer :round, null: false
+      t.string :action_type, null: false
+      t.string :target
+      t.string :program_slug
+      t.json :result, null: false, default: {}
+      t.datetime :created_at, null: false
+    end
+
+    add_index :grid_hackr_breach_logs, [:grid_hackr_breach_id, :round],
+      name: "index_breach_logs_on_breach_and_round"
+
+    # 3. Add encounter FK to hackr_breaches (nullable — ambient encounters have no persistent record)
+    add_reference :grid_hackr_breaches, :grid_breach_encounter,
+      null: true,
+      foreign_key: {on_delete: :nullify}
+
+    # 4. Backfill existing breach_template_slug rooms into encounter rows
+    GridRoom.where.not(breach_template_slug: [nil, ""]).find_each do |room|
+      template = GridBreachTemplate.find_by(slug: room.breach_template_slug)
+      next unless template
+
+      unless GridBreachEncounter.exists?(grid_breach_template: template, grid_room: room)
+        GridBreachEncounter.create!(
+          grid_breach_template: template,
+          grid_room: room,
+          state: "available"
+        )
+      end
+    end
+
+    # 5. Drop breach_template_slug from grid_rooms
+    remove_column :grid_rooms, :breach_template_slug
+  end
+
+  def down
+    add_column :grid_rooms, :breach_template_slug, :string
+
+    # Restore breach_template_slug from encounter records
+    GridBreachEncounter.includes(:grid_breach_template, :grid_room).find_each do |enc|
+      enc.grid_room.update_columns(breach_template_slug: enc.grid_breach_template.slug)
+    end
+
+    remove_reference :grid_hackr_breaches, :grid_breach_encounter
+    drop_table :grid_hackr_breach_logs
+    drop_table :grid_breach_encounters
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -172,6 +172,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
     t.index ["trigger_type"], name: "index_grid_achievements_on_trigger_type"
   end
 
+  create_table "grid_breach_encounters", force: :cascade do |t|
+    t.datetime "cooldown_until"
+    t.datetime "created_at", null: false
+    t.integer "grid_breach_template_id", null: false
+    t.integer "grid_room_id", null: false
+    t.integer "instance_seed"
+    t.string "state", default: "available", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_breach_template_id"], name: "index_grid_breach_encounters_on_grid_breach_template_id"
+    t.index ["grid_room_id", "grid_breach_template_id"], name: "index_breach_encounters_on_room_and_template"
+    t.index ["grid_room_id"], name: "index_grid_breach_encounters_on_grid_room_id"
+    t.index ["state"], name: "index_grid_breach_encounters_on_state"
+  end
+
   create_table "grid_breach_protocols", force: :cascade do |t|
     t.integer "charge_rounds", default: 0, null: false
     t.datetime "created_at", null: false
@@ -295,12 +309,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
     t.index ["grid_hackr_id"], name: "index_grid_hackr_achievements_on_grid_hackr_id"
   end
 
+  create_table "grid_hackr_breach_logs", force: :cascade do |t|
+    t.string "action_type", null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_breach_id", null: false
+    t.string "program_slug"
+    t.json "result", default: {}, null: false
+    t.integer "round", null: false
+    t.string "target"
+    t.index ["grid_hackr_breach_id", "round"], name: "index_breach_logs_on_breach_and_round"
+    t.index ["grid_hackr_breach_id"], name: "index_grid_hackr_breach_logs_on_grid_hackr_breach_id"
+  end
+
   create_table "grid_hackr_breaches", force: :cascade do |t|
     t.integer "actions_remaining", default: 1, null: false
     t.integer "actions_this_round", default: 1, null: false
     t.datetime "created_at", null: false
     t.integer "detection_level", default: 0, null: false
     t.datetime "ended_at"
+    t.integer "grid_breach_encounter_id"
     t.integer "grid_breach_template_id", null: false
     t.integer "grid_hackr_id", null: false
     t.integer "inspiration", default: 0, null: false
@@ -311,6 +338,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
     t.datetime "started_at", null: false
     t.string "state", default: "active", null: false
     t.datetime "updated_at", null: false
+    t.index ["grid_breach_encounter_id"], name: "index_grid_hackr_breaches_on_grid_breach_encounter_id"
     t.index ["grid_breach_template_id"], name: "index_grid_hackr_breaches_on_grid_breach_template_id"
     t.index ["grid_hackr_id"], name: "index_grid_hackr_breaches_on_grid_hackr_id"
     t.index ["grid_hackr_id"], name: "index_hackr_breaches_one_active_per_hackr", unique: true, where: "state = 'active'"
@@ -564,7 +592,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
 
   create_table "grid_rooms", force: :cascade do |t|
     t.integer "ambient_playlist_id"
-    t.string "breach_template_slug"
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "grid_zone_id", null: false
@@ -1180,6 +1207,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
   add_foreign_key "echoes", "grid_hackrs"
   add_foreign_key "echoes", "pulses"
   add_foreign_key "feature_grants", "grid_hackrs"
+  add_foreign_key "grid_breach_encounters", "grid_breach_templates", on_delete: :restrict
+  add_foreign_key "grid_breach_encounters", "grid_rooms", on_delete: :cascade
   add_foreign_key "grid_breach_protocols", "grid_hackr_breaches", on_delete: :cascade
   add_foreign_key "grid_den_invites", "grid_hackrs", column: "guest_id"
   add_foreign_key "grid_den_invites", "grid_hackrs", column: "hackr_id"
@@ -1189,6 +1218,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_300001) do
   add_foreign_key "grid_factions", "grid_factions", column: "parent_id"
   add_foreign_key "grid_hackr_achievements", "grid_achievements"
   add_foreign_key "grid_hackr_achievements", "grid_hackrs"
+  add_foreign_key "grid_hackr_breach_logs", "grid_hackr_breaches", on_delete: :cascade
+  add_foreign_key "grid_hackr_breaches", "grid_breach_encounters", on_delete: :nullify
   add_foreign_key "grid_hackr_breaches", "grid_breach_templates", on_delete: :restrict
   add_foreign_key "grid_hackr_breaches", "grid_hackrs", on_delete: :cascade
   add_foreign_key "grid_hackr_breaches", "grid_rooms", column: "origin_room_id", on_delete: :nullify

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -28,6 +28,8 @@
 # 24. overlay_scene_groups (depends on scenes)
 # 25. redirects        (no deps)
 # 26. livestream_archive (depends on audio) - derived playlist
+# 27. breach_templates  (no deps)
+# 28. breach_encounters (depends on breach_templates, rooms)
 
 namespace :data do
   # === Master Tasks ===
@@ -187,7 +189,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, regions, zones, rooms, etc.)"
-  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics, :breach_templates]
+  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics, :breach_templates, :breach_encounters]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -237,6 +239,10 @@ namespace :data do
     OverlayElement.destroy_all
     PlaylistTrack.destroy_all
     Playlist.destroy_all
+    GridHackrBreachLog.destroy_all
+    GridHackrBreach.destroy_all
+    GridBreachEncounter.destroy_all
+    GridBreachTemplate.destroy_all
     GridItem.destroy_all
     GridMob.destroy_all
     GridExit.destroy_all
@@ -600,21 +606,11 @@ namespace :data do
         description: attrs["description"],
         grid_zone: zone,
         room_type: attrs["room_type"],
-        min_clearance: attrs["min_clearance"] || 0,
-        breach_template_slug: attrs["breach_template_slug"]
+        min_clearance: attrs["min_clearance"] || 0
       )
       room.save!
       created += 1
       puts "  ✓ Created: #{room.name}"
-    end
-
-    # Backfill breach_template_slug on existing rooms
-    rooms_data.select { |a| a["breach_template_slug"].present? }.each do |attrs|
-      room = GridRoom.find_by(slug: attrs["slug"])
-      next unless room
-      next if room.breach_template_slug == attrs["breach_template_slug"]
-      room.update!(breach_template_slug: attrs["breach_template_slug"])
-      puts "  ↻ Updated breach target: #{room.name} → #{attrs["breach_template_slug"]}"
     end
 
     # Assign RestorePoint™ hospital rooms to regions
@@ -879,6 +875,51 @@ namespace :data do
     end
 
     puts "BREACH Templates: #{created} created, #{GridBreachTemplate.count} total"
+  end
+
+  desc "Load BREACH encounters from YAML"
+  task breach_encounters: :environment do
+    puts "\n--- Loading BREACH Encounters ---"
+    yaml_file = Rails.root.join("data", "world", "breach_encounters.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    encounters_data = data["breach_encounters"]
+    created = 0
+
+    encounters_data.each do |attrs|
+      template = GridBreachTemplate.find_by(slug: attrs["template_slug"])
+      room = GridRoom.find_by(slug: attrs["room_slug"])
+
+      unless template
+        puts "  ✗ Template not found: #{attrs["template_slug"]}"
+        next
+      end
+      unless room
+        puts "  ✗ Room not found: #{attrs["room_slug"]}"
+        next
+      end
+
+      encounter = GridBreachEncounter.find_or_initialize_by(
+        grid_breach_template: template,
+        grid_room: room
+      )
+      next unless encounter.new_record?
+
+      encounter.assign_attributes(
+        state: attrs["state"] || "available",
+        instance_seed: attrs["instance_seed"]
+      )
+      encounter.save!
+      created += 1
+      puts "  ✓ Placed: #{template.name} → #{room.name}"
+    end
+
+    puts "BREACH Encounters: #{created} created, #{GridBreachEncounter.count} total"
   end
 
   desc "Sync existing grid_items with their current definitions"

--- a/spec/factories/grid_breach_encounters.rb
+++ b/spec/factories/grid_breach_encounters.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_breach_encounters
+# Database name: primary
+#
+#  id                      :integer          not null, primary key
+#  cooldown_until          :datetime
+#  instance_seed           :integer
+#  state                   :string           default("available"), not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  grid_breach_template_id :integer          not null
+#  grid_room_id            :integer          not null
+#
+# Indexes
+#
+#  index_breach_encounters_on_room_and_template             (grid_room_id,grid_breach_template_id)
+#  index_grid_breach_encounters_on_grid_breach_template_id  (grid_breach_template_id)
+#  index_grid_breach_encounters_on_grid_room_id             (grid_room_id)
+#  index_grid_breach_encounters_on_state                    (state)
+#
+# Foreign Keys
+#
+#  grid_breach_template_id  (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
+#  grid_room_id             (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :grid_breach_encounter do
+    association :grid_breach_template
+    association :grid_room
+    state { "available" }
+  end
+end

--- a/spec/factories/grid_hackr_breaches.rb
+++ b/spec/factories/grid_hackr_breaches.rb
@@ -5,35 +5,38 @@
 # Table name: grid_hackr_breaches
 # Database name: primary
 #
-#  id                      :integer          not null, primary key
-#  actions_remaining       :integer          default(1), not null
-#  actions_this_round      :integer          default(1), not null
-#  detection_level         :integer          default(0), not null
-#  ended_at                :datetime
-#  inspiration             :integer          default(0), not null
-#  pnr_threshold           :integer          default(75), not null
-#  reward_multiplier       :decimal(5, 4)    default(1.0), not null
-#  round_number            :integer          default(1), not null
-#  started_at              :datetime         not null
-#  state                   :string           default("active"), not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  grid_breach_template_id :integer          not null
-#  grid_hackr_id           :integer          not null
-#  origin_room_id          :integer
+#  id                       :integer          not null, primary key
+#  actions_remaining        :integer          default(1), not null
+#  actions_this_round       :integer          default(1), not null
+#  detection_level          :integer          default(0), not null
+#  ended_at                 :datetime
+#  inspiration              :integer          default(0), not null
+#  pnr_threshold            :integer          default(75), not null
+#  reward_multiplier        :decimal(5, 4)    default(1.0), not null
+#  round_number             :integer          default(1), not null
+#  started_at               :datetime         not null
+#  state                    :string           default("active"), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  grid_breach_encounter_id :integer
+#  grid_breach_template_id  :integer          not null
+#  grid_hackr_id            :integer          not null
+#  origin_room_id           :integer
 #
 # Indexes
 #
-#  index_grid_hackr_breaches_on_grid_breach_template_id  (grid_breach_template_id)
-#  index_grid_hackr_breaches_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_hackr_breaches_on_state                    (state)
-#  index_hackr_breaches_one_active_per_hackr             (grid_hackr_id) UNIQUE WHERE state = 'active'
+#  index_grid_hackr_breaches_on_grid_breach_encounter_id  (grid_breach_encounter_id)
+#  index_grid_hackr_breaches_on_grid_breach_template_id   (grid_breach_template_id)
+#  index_grid_hackr_breaches_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_hackr_breaches_on_state                     (state)
+#  index_hackr_breaches_one_active_per_hackr              (grid_hackr_id) UNIQUE WHERE state = 'active'
 #
 # Foreign Keys
 #
-#  grid_breach_template_id  (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
-#  grid_hackr_id            (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
-#  origin_room_id           (origin_room_id => grid_rooms.id) ON DELETE => nullify
+#  grid_breach_encounter_id  (grid_breach_encounter_id => grid_breach_encounters.id) ON DELETE => nullify
+#  grid_breach_template_id   (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
+#  grid_hackr_id             (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  origin_room_id            (origin_room_id => grid_rooms.id) ON DELETE => nullify
 #
 FactoryBot.define do
   factory :grid_hackr_breach do
@@ -49,6 +52,10 @@ FactoryBot.define do
     actions_remaining { 1 }
     reward_multiplier { 1.0 }
     started_at { Time.current }
+
+    trait :with_encounter do
+      association :grid_breach_encounter
+    end
 
     trait :completed do
       state { "success" }

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -3,19 +3,18 @@
 # Table name: grid_rooms
 # Database name: primary
 #
-#  id                   :integer          not null, primary key
-#  breach_template_slug :string
-#  description          :text
-#  locked               :boolean          default(FALSE), not null
-#  min_clearance        :integer          default(0), not null
-#  name                 :string
-#  room_type            :string
-#  slug                 :string
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  ambient_playlist_id  :integer
-#  grid_zone_id         :integer          not null
-#  owner_id             :integer
+#  id                  :integer          not null, primary key
+#  description         :text
+#  locked              :boolean          default(FALSE), not null
+#  min_clearance       :integer          default(0), not null
+#  name                :string
+#  room_type           :string
+#  slug                :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  ambient_playlist_id :integer
+#  grid_zone_id        :integer          not null
+#  owner_id            :integer
 #
 # Indexes
 #

--- a/spec/models/grid_hackr_breach_spec.rb
+++ b/spec/models/grid_hackr_breach_spec.rb
@@ -5,35 +5,38 @@
 # Table name: grid_hackr_breaches
 # Database name: primary
 #
-#  id                      :integer          not null, primary key
-#  actions_remaining       :integer          default(1), not null
-#  actions_this_round      :integer          default(1), not null
-#  detection_level         :integer          default(0), not null
-#  ended_at                :datetime
-#  inspiration             :integer          default(0), not null
-#  pnr_threshold           :integer          default(75), not null
-#  reward_multiplier       :decimal(5, 4)    default(1.0), not null
-#  round_number            :integer          default(1), not null
-#  started_at              :datetime         not null
-#  state                   :string           default("active"), not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  grid_breach_template_id :integer          not null
-#  grid_hackr_id           :integer          not null
-#  origin_room_id          :integer
+#  id                       :integer          not null, primary key
+#  actions_remaining        :integer          default(1), not null
+#  actions_this_round       :integer          default(1), not null
+#  detection_level          :integer          default(0), not null
+#  ended_at                 :datetime
+#  inspiration              :integer          default(0), not null
+#  pnr_threshold            :integer          default(75), not null
+#  reward_multiplier        :decimal(5, 4)    default(1.0), not null
+#  round_number             :integer          default(1), not null
+#  started_at               :datetime         not null
+#  state                    :string           default("active"), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  grid_breach_encounter_id :integer
+#  grid_breach_template_id  :integer          not null
+#  grid_hackr_id            :integer          not null
+#  origin_room_id           :integer
 #
 # Indexes
 #
-#  index_grid_hackr_breaches_on_grid_breach_template_id  (grid_breach_template_id)
-#  index_grid_hackr_breaches_on_grid_hackr_id            (grid_hackr_id)
-#  index_grid_hackr_breaches_on_state                    (state)
-#  index_hackr_breaches_one_active_per_hackr             (grid_hackr_id) UNIQUE WHERE state = 'active'
+#  index_grid_hackr_breaches_on_grid_breach_encounter_id  (grid_breach_encounter_id)
+#  index_grid_hackr_breaches_on_grid_breach_template_id   (grid_breach_template_id)
+#  index_grid_hackr_breaches_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_hackr_breaches_on_state                     (state)
+#  index_hackr_breaches_one_active_per_hackr              (grid_hackr_id) UNIQUE WHERE state = 'active'
 #
 # Foreign Keys
 #
-#  grid_breach_template_id  (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
-#  grid_hackr_id            (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
-#  origin_room_id           (origin_room_id => grid_rooms.id) ON DELETE => nullify
+#  grid_breach_encounter_id  (grid_breach_encounter_id => grid_breach_encounters.id) ON DELETE => nullify
+#  grid_breach_template_id   (grid_breach_template_id => grid_breach_templates.id) ON DELETE => restrict
+#  grid_hackr_id             (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  origin_room_id            (origin_room_id => grid_rooms.id) ON DELETE => nullify
 #
 require "rails_helper"
 

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -3,19 +3,18 @@
 # Table name: grid_rooms
 # Database name: primary
 #
-#  id                   :integer          not null, primary key
-#  breach_template_slug :string
-#  description          :text
-#  locked               :boolean          default(FALSE), not null
-#  min_clearance        :integer          default(0), not null
-#  name                 :string
-#  room_type            :string
-#  slug                 :string
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  ambient_playlist_id  :integer
-#  grid_zone_id         :integer          not null
-#  owner_id             :integer
+#  id                  :integer          not null, primary key
+#  description         :text
+#  locked              :boolean          default(FALSE), not null
+#  min_clearance       :integer          default(0), not null
+#  name                :string
+#  room_type           :string
+#  slug                :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  ambient_playlist_id :integer
+#  grid_zone_id        :integer          not null
+#  owner_id            :integer
 #
 # Indexes
 #

--- a/spec/services/grid/breach_action_service_spec.rb
+++ b/spec/services/grid/breach_action_service_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe Grid::BreachActionService do
     create(:grid_item, grid_item_definition: software_def, grid_hackr: hackr, room: nil, deck_id: deck.id)
   end
 
+  let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
   let!(:breach) do
-    result = Grid::BreachService.start!(hackr: hackr, template: template)
+    result = Grid::BreachService.start!(hackr: hackr, encounter: encounter)
     result.hackr_breach
   end
 

--- a/spec/services/grid/breach_phase2a_spec.rb
+++ b/spec/services/grid/breach_phase2a_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "BREACH Phase 2A" do
   # Helper: start a breach and return the breach record
   def start_breach!(template: nil)
     template ||= create(:grid_breach_template)
-    result = Grid::BreachService.start!(hackr: hackr, template: template)
+    enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room)
+    result = Grid::BreachService.start!(hackr: hackr, encounter: enc)
     result.hackr_breach
   end
 

--- a/spec/services/grid/breach_phase2b_spec.rb
+++ b/spec/services/grid/breach_phase2b_spec.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BREACH Phase 2B — Encounter Infrastructure" do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "test-deck-2b",
+      name: "Test Deck",
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "firmware_slot_count" => 1, "effects" => {}})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let(:software_def) do
+    create(:grid_item_definition,
+      slug: "test-sw-2b",
+      name: "Test Program",
+      item_type: "software",
+      properties: {"software_category" => "offensive", "slot_cost" => 1, "battery_cost" => 10, "effect_type" => "damage", "effect_magnitude" => 20, "level" => 1})
+  end
+
+  let!(:software) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: software_def, grid_hackr: hackr)
+    item.update!(deck_id: deck.id)
+    item
+  end
+
+  let(:template) { create(:grid_breach_template, cooldown_min: 60, cooldown_max: 120) }
+
+  # Helper: start a breach and return the breach record
+  def start_breach!(enc: nil, tmpl: nil)
+    tmpl ||= template
+    enc ||= create(:grid_breach_encounter, grid_breach_template: tmpl, grid_room: room)
+    result = Grid::BreachService.start!(hackr: hackr, encounter: enc)
+    result.hackr_breach
+  end
+
+  describe "GridBreachEncounter model" do
+    it "validates state inclusion" do
+      enc = build(:grid_breach_encounter, state: "invalid")
+      expect(enc).not_to be_valid
+      expect(enc.errors[:state]).to be_present
+    end
+
+    it "valid with allowed states" do
+      GridBreachEncounter::STATES.each do |s|
+        enc = build(:grid_breach_encounter, state: s)
+        expect(enc).to be_valid
+      end
+    end
+
+    it "delegates name and tier_label to template" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room)
+      expect(enc.name).to eq(template.name)
+      expect(enc.tier_label).to eq(template.tier_label)
+    end
+  end
+
+  describe "GridHackrBreachLog model" do
+    it "validates action_type inclusion" do
+      breach = start_breach!
+      log = GridHackrBreachLog.new(
+        grid_hackr_breach: breach,
+        round: 1,
+        action_type: "invalid",
+        result: {}
+      )
+      expect(log).not_to be_valid
+    end
+
+    it "saves valid log entries" do
+      breach = start_breach!
+      log = GridHackrBreachLog.create!(
+        grid_hackr_breach: breach,
+        round: 1,
+        action_type: "exec",
+        target: "0",
+        program_slug: "test-sw-2b",
+        result: {hit: true, damage: 20}
+      )
+      expect(log).to be_persisted
+    end
+  end
+
+  describe "available_encounters" do
+    it "returns available encounters in a room" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room)
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to include(enc)
+    end
+
+    it "excludes depleted encounters" do
+      create(:grid_breach_encounter, grid_breach_template: template, grid_room: room, state: "depleted")
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to be_empty
+    end
+
+    it "excludes encounters on cooldown" do
+      create(:grid_breach_encounter, grid_breach_template: template, grid_room: room,
+        state: "cooldown", cooldown_until: 10.minutes.from_now)
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to be_empty
+    end
+
+    it "auto-expires cooldowns" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room,
+        state: "cooldown", cooldown_until: 1.minute.ago)
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to include(enc)
+      expect(enc.reload.state).to eq("available")
+    end
+
+    it "filters by hackr clearance" do
+      high_cl = create(:grid_breach_template, min_clearance: 50)
+      create(:grid_breach_encounter, grid_breach_template: high_cl, grid_room: room)
+      result = Grid::BreachService.available_encounters(room: room, hackr: hackr)
+      expect(result).to be_empty
+    end
+
+    it "excludes unpublished templates" do
+      unpub = create(:grid_breach_template, :unpublished)
+      create(:grid_breach_encounter, grid_breach_template: unpub, grid_room: room)
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to be_empty
+    end
+
+    it "returns multiple encounters sorted by template position" do
+      t1 = create(:grid_breach_template, position: 2)
+      t2 = create(:grid_breach_template, position: 1)
+      e1 = create(:grid_breach_encounter, grid_breach_template: t1, grid_room: room)
+      e2 = create(:grid_breach_encounter, grid_breach_template: t2, grid_room: room)
+      result = Grid::BreachService.available_encounters(room: room)
+      expect(result).to eq([e2, e1])
+    end
+  end
+
+  describe "encounter state transitions" do
+    let(:enc) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
+    it "marks encounter active on breach start" do
+      start_breach!(enc: enc)
+      expect(enc.reload.state).to eq("active")
+    end
+
+    it "transitions encounter to cooldown on success" do
+      breach = start_breach!(enc: enc)
+
+      # Destroy all protocols to trigger success
+      breach.grid_breach_protocols.each { |p| p.update_columns(health: 0, state: "destroyed") }
+      Grid::BreachService.resolve_success!(hackr_breach: breach)
+
+      enc.reload
+      expect(enc.state).to eq("cooldown")
+      expect(enc.cooldown_until).to be_present
+      expect(enc.cooldown_until).to be > Time.current
+    end
+
+    it "transitions encounter to cooldown on failure" do
+      breach = start_breach!(enc: enc)
+      Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      enc.reload
+      expect(enc.state).to eq("cooldown")
+    end
+
+    it "transitions encounter to cooldown on jackout" do
+      start_breach!(enc: enc)
+      Grid::BreachService.jackout!(hackr: hackr)
+
+      enc.reload
+      expect(enc.state).to eq("cooldown")
+    end
+
+    it "links breach to encounter" do
+      breach = start_breach!(enc: enc)
+      expect(breach.grid_breach_encounter).to eq(enc)
+    end
+  end
+
+  describe "cooldown randomization" do
+    it "sets cooldown_until within template range" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room)
+      breach = start_breach!(enc: enc)
+
+      # Fail the breach to trigger cooldown
+      Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      enc.reload
+      remaining = enc.cooldown_until - Time.current
+      expect(remaining).to be_between(template.cooldown_min - 1, template.cooldown_max + 1)
+    end
+  end
+
+  describe "cooldown check_cooldown!" do
+    it "transitions from cooldown to available when expired" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room,
+        state: "cooldown", cooldown_until: 1.minute.ago)
+      enc.check_cooldown!
+      expect(enc.state).to eq("available")
+      expect(enc.cooldown_until).to be_nil
+    end
+
+    it "stays in cooldown when not expired" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room,
+        state: "cooldown", cooldown_until: 10.minutes.from_now)
+      enc.check_cooldown!
+      expect(enc.state).to eq("cooldown")
+    end
+  end
+
+  describe "breach action logging" do
+    let(:enc) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+    let!(:breach) { start_breach!(enc: enc) }
+
+    it "logs exec actions" do
+      Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Test Program",
+        target_position: 0
+      )
+
+      logs = GridHackrBreachLog.where(grid_hackr_breach: breach)
+      expect(logs.count).to eq(1)
+      log = logs.first
+      expect(log.action_type).to eq("exec")
+      expect(log.round).to eq(1)
+      expect(log.target).to eq("0")
+      expect(log.program_slug).to eq("test-sw-2b")
+      expect(log.result["hit"]).to be true
+    end
+
+    it "logs analyze actions" do
+      Grid::BreachActionService.analyze!(hackr: hackr, target_position: 0)
+
+      log = GridHackrBreachLog.last
+      expect(log.action_type).to eq("analyze")
+      expect(log.target).to eq("0")
+      expect(log.result["level_reached"]).to eq(1)
+    end
+
+    it "logs reroute actions" do
+      # Need an active protocol
+      protocol = breach.grid_breach_protocols.find_by(position: 0)
+      protocol.update_columns(state: "active") if protocol.state != "active"
+
+      Grid::BreachActionService.reroute!(hackr: hackr, target_position: 0)
+
+      log = GridHackrBreachLog.last
+      expect(log.action_type).to eq("reroute")
+      expect(log.target).to eq("0")
+    end
+
+    it "logs jackout actions" do
+      Grid::BreachService.jackout!(hackr: hackr)
+
+      log = GridHackrBreachLog.last
+      expect(log.action_type).to eq("jackout")
+      expect(log.result["clean"]).to be true
+    end
+
+    it "cascades log deletion with breach" do
+      Grid::BreachActionService.exec!(hackr: hackr, program_name: "Test Program", target_position: 0)
+      expect { breach.destroy! }.to change(GridHackrBreachLog, :count).by(-1)
+    end
+  end
+
+  describe "multi-encounter room selection" do
+    let(:t1) { create(:grid_breach_template) }
+    let(:t2) { create(:grid_breach_template) }
+    let!(:enc1) { create(:grid_breach_encounter, grid_breach_template: t1, grid_room: room) }
+    let!(:enc2) { create(:grid_breach_encounter, grid_breach_template: t2, grid_room: room) }
+
+    it "room.breachable? returns true with encounters" do
+      expect(room.breachable?).to be true
+    end
+
+    it "room.breachable? returns false without encounters" do
+      empty_room = create(:grid_room, grid_zone: zone)
+      expect(empty_room.breachable?).to be false
+    end
+  end
+
+  describe "encounter concurrency" do
+    it "prevents concurrent breach start on same encounter" do
+      enc = create(:grid_breach_encounter, grid_breach_template: template, grid_room: room)
+      start_breach!(enc: enc)
+
+      # Encounter should be active, not available for another hackr
+      expect(enc.reload.state).to eq("active")
+      expect(enc).not_to be_available
+    end
+  end
+end

--- a/spec/services/grid/breach_service_spec.rb
+++ b/spec/services/grid/breach_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Grid::BreachService do
   let(:room) { create(:grid_room, grid_zone: zone) }
   let(:hackr) { create(:grid_hackr, current_room: room) }
   let(:template) { create(:grid_breach_template) }
+  let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
 
   let(:deck_def) do
     create(:grid_item_definition, :gear,
@@ -23,7 +24,7 @@ RSpec.describe Grid::BreachService do
 
   describe ".start!" do
     it "creates an active breach with protocols" do
-      result = described_class.start!(hackr: hackr, template: template)
+      result = described_class.start!(hackr: hackr, encounter: encounter)
 
       expect(result.hackr_breach).to be_a(GridHackrBreach)
       expect(result.hackr_breach.state).to eq("active")
@@ -35,36 +36,38 @@ RSpec.describe Grid::BreachService do
     end
 
     it "raises AlreadyInBreach when hackr has an active breach" do
-      described_class.start!(hackr: hackr, template: template)
+      described_class.start!(hackr: hackr, encounter: encounter)
       expect {
-        described_class.start!(hackr: hackr, template: template)
+        described_class.start!(hackr: hackr, encounter: encounter)
       }.to raise_error(Grid::BreachService::AlreadyInBreach)
     end
 
     it "raises NoDeckEquipped when no deck is equipped" do
       deck.update!(equipped_slot: nil)
       expect {
-        described_class.start!(hackr: hackr, template: template)
+        described_class.start!(hackr: hackr, encounter: encounter)
       }.to raise_error(Grid::BreachService::NoDeckEquipped)
     end
 
     it "raises ClearanceBlocked when hackr clearance is insufficient" do
       high_cl_template = create(:grid_breach_template, min_clearance: 50)
+      high_cl_encounter = create(:grid_breach_encounter, grid_breach_template: high_cl_template, grid_room: room)
       expect {
-        described_class.start!(hackr: hackr, template: high_cl_template)
+        described_class.start!(hackr: hackr, encounter: high_cl_encounter)
       }.to raise_error(Grid::BreachService::ClearanceBlocked)
     end
 
     it "raises TemplateGated for unpublished templates" do
       unpub = create(:grid_breach_template, :unpublished)
+      unpub_encounter = create(:grid_breach_encounter, grid_breach_template: unpub, grid_room: room)
       expect {
-        described_class.start!(hackr: hackr, template: unpub)
+        described_class.start!(hackr: hackr, encounter: unpub_encounter)
       }.to raise_error(Grid::BreachService::TemplateGated)
     end
   end
 
   describe ".end_round!" do
-    let!(:breach_result) { described_class.start!(hackr: hackr, template: template) }
+    let!(:breach_result) { described_class.start!(hackr: hackr, encounter: encounter) }
     let(:breach) { breach_result.hackr_breach }
 
     before do
@@ -97,7 +100,7 @@ RSpec.describe Grid::BreachService do
   end
 
   describe ".resolve_success!" do
-    let!(:breach_result) { described_class.start!(hackr: hackr, template: template) }
+    let!(:breach_result) { described_class.start!(hackr: hackr, encounter: encounter) }
     let(:breach) { breach_result.hackr_breach }
 
     it "grants XP and CRED rewards" do
@@ -112,7 +115,7 @@ RSpec.describe Grid::BreachService do
   end
 
   describe ".resolve_failure!" do
-    let!(:breach_result) { described_class.start!(hackr: hackr, template: template) }
+    let!(:breach_result) { described_class.start!(hackr: hackr, encounter: encounter) }
     let(:breach) { breach_result.hackr_breach }
 
     it "drains vitals and sets failure state" do
@@ -135,14 +138,15 @@ RSpec.describe Grid::BreachService do
 
     it "does not apply zone lockout for ambient tier" do
       ambient_template = create(:grid_breach_template, :ambient)
-      ambient_breach = described_class.start!(hackr: hackr.tap { |h| breach.update!(state: "failure") }, template: ambient_template)
+      ambient_encounter = create(:grid_breach_encounter, grid_breach_template: ambient_template, grid_room: room)
+      ambient_breach = described_class.start!(hackr: hackr.tap { |h| breach.update!(state: "failure") }, encounter: ambient_encounter)
       result = described_class.resolve_failure!(hackr_breach: ambient_breach.hackr_breach)
       expect(result.zone_lockout_minutes).to be_nil
     end
   end
 
   describe ".jackout!" do
-    let!(:breach_result) { described_class.start!(hackr: hackr, template: template) }
+    let!(:breach_result) { described_class.start!(hackr: hackr, encounter: encounter) }
 
     it "clean jackout before PNR" do
       result = described_class.jackout!(hackr: hackr)


### PR DESCRIPTION
  Replace breach_template_slug on grid_rooms with a proper encounter
  placement system. Encounters are now join-table records between templates
  and rooms, supporting multiple breach targets per room with per-encounter
  cooldown state machines.

  New tables:
  - grid_breach_encounters: template→room placement with state machine (available→active→cooldown→available, depleted for one-shot)
  - grid_hackr_breach_logs: append-only action log per breach recording exec/analyze/reroute/jackout with round, target, program, result JSON

  Key changes:
  - BreachService.start! now accepts encounter: instead of template:
  - BreachService.available_encounters(room:, hackr:) filters by published, state, clearance; auto-expires cooldowns via lazy expiration
  - Per-encounter cooldown via rand(cooldown_min..cooldown_max) from template
  - Multi-target rooms: look shows numbered targets, breach accepts name or number with partial match
  - Action logging inside transactions for atomicity (exec, analyze, reroute, jackout)
  - Encounter state transitions on success/failure/jackout with defensive rescue on cooldown transition failure
  - Migration backfills existing breach_template_slug rooms into encounter rows, then drops the column

  Admin: full CRUD at /root/grid_breach_encounters with Versionable.
  Seeds: breach_encounters.yml + data:breach_encounters rake task.