### PR TITLE
[TPG] BREACH Phase 2C - Item Systems

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -186,7 +186,8 @@ class Api::GridController < ApplicationController
         battery_max: deck.deck_battery_max,
         slot_count: deck.deck_slot_count,
         slots_used: deck.deck_slots_used,
-        firmware_slot_count: deck.deck_firmware_slot_count
+        module_slot_count: deck.deck_module_slot_count,
+        modules_used: deck.deck_modules_used
       },
       software: loaded.map { |s| software_item_json(s) },
       inventory_software: inventory_sw.map { |s| software_item_json(s) }

--- a/app/javascript/components/pages/grid/DeckPage.tsx
+++ b/app/javascript/components/pages/grid/DeckPage.tsx
@@ -30,7 +30,8 @@ interface DeckInfo {
   battery_max: number
   slot_count: number
   slots_used: number
-  firmware_slot_count: number
+  module_slot_count: number
+  modules_used: number
 }
 
 interface DeckResponse {
@@ -162,7 +163,7 @@ const DeckPage: React.FC = () => {
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                     <div style={{ color: '#9ca3af', fontSize: '0.9em' }}>
-                      <span style={{ color: '#fbbf24' }}>Firmware Slots:</span> {deck.firmware_slot_count}
+                      <span style={{ color: '#fbbf24' }}>Module Slots:</span> {deck.modules_used}/{deck.module_slot_count}
                     </div>
                     <div style={{ color: '#6b7280', fontSize: '0.85em', marginTop: 4 }}>
                       Terminal: <span style={{ color: '#22d3ee' }}>deck load &lt;name&gt;</span> / <span style={{ color: '#22d3ee' }}>deck unload &lt;name&gt;</span>

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -73,6 +73,7 @@ class GridAchievement < ApplicationRecord
     breach_completed
     breaches_completed_count
     protocols_dismantled
+    data_extracted
   ].freeze
 
   CATEGORIES = %w[grid music social meta progression].freeze
@@ -95,6 +96,7 @@ class GridAchievement < ApplicationRecord
     fixtures_placed
     breaches_completed_count
     protocols_dismantled
+    data_extracted
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy

--- a/app/models/grid_hackr_breach.rb
+++ b/app/models/grid_hackr_breach.rb
@@ -11,6 +11,7 @@
 #  detection_level          :integer          default(0), not null
 #  ended_at                 :datetime
 #  inspiration              :integer          default(0), not null
+#  meta                     :json             not null
 #  pnr_threshold            :integer          default(75), not null
 #  reward_multiplier        :decimal(5, 4)    default(1.0), not null
 #  round_number             :integer          default(1), not null

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -39,7 +39,7 @@
 class GridItem < ApplicationRecord
   has_paper_trail
 
-  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material fixture gear software firmware].freeze
+  ITEM_TYPES = %w[tool consumable data faction collectible rig_component material fixture gear software firmware module].freeze
   GEAR_SLOTS = %w[deck back chest head ears eyes left_wrist right_wrist hands neck waist legs feet].freeze
   VISIBLE_SLOTS = %w[head eyes chest legs feet].freeze
   RARITIES = %w[scrap ubiquitous common uncommon rare ultra_rare unicorn].freeze
@@ -74,6 +74,7 @@ class GridItem < ApplicationRecord
   belongs_to :deck_item, class_name: "GridItem", foreign_key: :deck_id, optional: true
   has_many :stored_items, class_name: "GridItem", foreign_key: :container_id, dependent: :restrict_with_error
   has_many :loaded_software, -> { where(item_type: "software") }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
+  has_many :installed_modules, -> { where(item_type: "module") }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
 
   validates :name, presence: true
   validates :item_type, inclusion: {in: ITEM_TYPES, allow_nil: true}
@@ -161,6 +162,10 @@ class GridItem < ApplicationRecord
     item_type == "firmware"
   end
 
+  def deck_module?
+    item_type == "module"
+  end
+
   def deck_item?
     gear? && slot == "deck"
   end
@@ -182,8 +187,8 @@ class GridItem < ApplicationRecord
     properties&.dig("slot_count").to_i
   end
 
-  def deck_firmware_slot_count
-    properties&.dig("firmware_slot_count").to_i
+  def deck_module_slot_count
+    properties&.dig("module_slot_count").to_i
   end
 
   def deck_slots_used
@@ -192,6 +197,19 @@ class GridItem < ApplicationRecord
 
   def deck_slots_available
     [deck_slot_count - deck_slots_used, 0].max
+  end
+
+  def deck_modules_used
+    installed_modules.count
+  end
+
+  def deck_modules_available
+    [deck_module_slot_count - deck_modules_used, 0].max
+  end
+
+  def has_module?(module_slug)
+    installed_modules.joins(:grid_item_definition)
+      .exists?(grid_item_definitions: {slug: module_slug})
   end
 
   alias_method :gear_slot, :slot
@@ -222,8 +240,8 @@ class GridItem < ApplicationRecord
 
   def deck_id_requirements
     return if deck_id.nil?
-    unless software? || firmware?
-      errors.add(:deck_id, "can only be set on software or firmware items")
+    unless software? || deck_module?
+      errors.add(:deck_id, "can only be set on software or module items")
     end
   end
 end

--- a/app/models/grid_mission.rb
+++ b/app/models/grid_mission.rb
@@ -48,6 +48,7 @@ class GridMission < ApplicationRecord
     fabricate_item
     complete_breach
     dismantle_protocols
+    extract_data
   ].freeze
 
   # Reward type allowlist. `amount` is the scalar for XP/CRED/rep deltas;

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -48,7 +48,7 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital],
+    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor],
     allow_nil: true
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -118,6 +118,8 @@ module Grid
         derive(@hackr.stat("breach_completed_count").to_i, data[:count].to_i)
       when "protocols_dismantled"
         derive(@hackr.stat("protocols_dismantled_count").to_i, data[:count].to_i)
+      when "data_extracted"
+        derive(@hackr.stat("data_extracted_count").to_i, data[:count].to_i)
       end
     end
 

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -3,9 +3,10 @@
 module Grid
   class BreachActionService
     ExecResult = Data.define(:hit, :damage_dealt, :program_name, :target_position,
-      :protocol_destroyed, :battery_consumed, :all_destroyed)
+      :protocol_destroyed, :battery_consumed, :all_destroyed, :exploit, :fragment)
     AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action)
     RerouteResult = Data.define(:target_position, :protocol_type_label)
+    UseItemResult = Data.define(:item_name, :effect_output, :emergency_jackout)
 
     class NotInBreach < StandardError; end
     class NoActionsRemaining < StandardError; end
@@ -14,6 +15,7 @@ module Grid
     class InvalidTarget < StandardError; end
     class ProtocolAlreadyDestroyed < StandardError; end
     class AlreadyRerouted < StandardError; end
+    class ItemNotFound < StandardError; end
 
     def self.exec!(hackr:, program_name:, target_position:)
       new(hackr).exec!(program_name, target_position)
@@ -26,6 +28,12 @@ module Grid
     def self.reroute!(hackr:, target_position:)
       new(hackr).reroute!(target_position)
     end
+
+    def self.use_item!(hackr:, item_name:)
+      new(hackr).use_item!(item_name)
+    end
+
+    include Grid::ItemEffectApplier
 
     def initialize(hackr)
       @hackr = hackr
@@ -44,6 +52,23 @@ module Grid
 
       protocol = find_protocol(breach, target_position)
 
+      # Module gate: some software requires a specific module installed in DECK
+      required_module = program.properties&.dig("requires_module")
+      if required_module.present? && !deck.has_module?(required_module)
+        raise ProgramNotLoaded, "#{program.name} requires module '#{required_module}' installed in DECK."
+      end
+
+      is_exploit = program.properties&.dig("software_category") == "exploit"
+
+      # Exploit type-guard: check target_types BEFORE consuming action
+      if is_exploit
+        target_types = program.properties&.dig("target_types")
+        if target_types.is_a?(Array) && target_types.any? && !target_types.include?(protocol.protocol_type)
+          # Mismatch — action NOT consumed, exploit NOT destroyed
+          raise InvalidTarget, "Exploit incompatible with #{protocol.type_label} protocol. Requires: #{target_types.map(&:upcase).join(", ")}."
+        end
+      end
+
       battery_cost = (program.properties&.dig("battery_cost") || 10).to_i
       if deck.deck_battery < battery_cost
         raise InsufficientBattery, "Insufficient battery. Need #{battery_cost}, have #{deck.deck_battery}."
@@ -52,6 +77,7 @@ module Grid
       damage = 0
       destroyed = false
       all_destroyed = false
+      fragment_extracted = nil
 
       ActiveRecord::Base.transaction do
         breach.lock!
@@ -65,18 +91,23 @@ module Grid
         # Re-check battery after lock
         raise InsufficientBattery, "Insufficient battery. Need #{battery_cost}, have #{deck.deck_battery}." if deck.deck_battery < battery_cost
 
-        # Compute damage
-        damage = compute_damage(program, protocol)
+        if is_exploit
+          # Exploit: instant kill — protocol destroyed regardless of health
+          damage = protocol.health
+          destroyed = true
+          protocol.update_columns(health: 0, state: "destroyed")
+        else
+          # Standard: compute damage normally
+          damage = compute_damage(program, protocol)
 
-        # Apply damage
-        new_health = [protocol.health - damage, 0].max
-        destroyed = new_health <= 0
-        attrs = {health: new_health}
-        attrs[:state] = "destroyed" if destroyed
-        protocol.update_columns(attrs)
+          new_health = [protocol.health - damage, 0].max
+          destroyed = new_health <= 0
+          attrs = {health: new_health}
+          attrs[:state] = "destroyed" if destroyed
+          protocol.update_columns(attrs)
+        end
 
         if destroyed
-
           # Increment cumulative stat
           count = @hackr.stat("protocols_dismantled_count").to_i
           @hackr.set_stat!("protocols_dismantled_count", count + 1)
@@ -89,6 +120,17 @@ module Grid
         # Consume action
         breach.update!(actions_remaining: breach.actions_remaining - 1)
 
+        # Exploit consumed from DECK after successful use (one-shot)
+        if is_exploit
+          program.destroy!
+        end
+
+        # Utility fragment extraction: roll for fragment drop
+        is_utility = program.properties&.dig("software_category") == "utility"
+        if is_utility && damage > 0
+          fragment_extracted = roll_fragment_extraction!(breach, protocol, program)
+        end
+
         # Inspiration bump on successful hit
         bump_inspiration!(breach) if damage > 0
 
@@ -99,7 +141,9 @@ module Grid
           hit: damage > 0,
           damage: damage,
           destroyed: destroyed,
-          battery_consumed: battery_cost
+          battery_consumed: battery_cost,
+          exploit: is_exploit,
+          fragment: fragment_extracted
         })
       end
 
@@ -110,7 +154,9 @@ module Grid
         target_position: target_position,
         protocol_destroyed: destroyed,
         battery_consumed: battery_cost,
-        all_destroyed: all_destroyed
+        all_destroyed: all_destroyed,
+        exploit: is_exploit,
+        fragment: fragment_extracted
       )
     end
 
@@ -204,6 +250,61 @@ module Grid
       )
     end
 
+    def use_item!(item_name)
+      breach = @hackr.active_breach
+      raise NotInBreach, "You are not in a BREACH encounter." unless breach
+      raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+
+      item = @hackr.grid_items.in_inventory(@hackr)
+        .where(item_type: "consumable")
+        .find_by("LOWER(name) = ?", item_name.to_s.downcase)
+      raise ItemNotFound, "No consumable named '#{item_name}' in your inventory." unless item
+
+      effect_output = nil
+      emergency_jackout = false
+      saved_name = item.name
+
+      ActiveRecord::Base.transaction do
+        breach.lock!
+        @hackr.lock!
+
+        raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+
+        # Apply item effect (from ItemEffectApplier module)
+        result = apply_item_effect(item, breach: breach)
+
+        if result == :emergency_jackout
+          emergency_jackout = true
+          effect_output = "<span style='color: #22d3ee; font-weight: bold;'>EMERGENCY JACK-OUT INITIATED — PNR override engaged.</span>"
+        else
+          effect_output = result
+        end
+
+        # Consume the item
+        if item.quantity > 1
+          item.update!(quantity: item.quantity - 1)
+        else
+          item.destroy!
+        end
+
+        # Consume action
+        breach.update!(actions_remaining: breach.actions_remaining - 1)
+
+        log_action!(breach, "use", nil, nil, {
+          item_name: saved_name,
+          item_slug: item.grid_item_definition&.slug,
+          effect_type: item.properties&.dig("effect_type"),
+          emergency_jackout: emergency_jackout
+        })
+      end
+
+      UseItemResult.new(
+        item_name: saved_name,
+        effect_output: effect_output,
+        emergency_jackout: emergency_jackout
+      )
+    end
+
     def reroute!(target_position)
       breach = @hackr.active_breach
       raise NotInBreach, "You are not in a BREACH encounter." unless breach
@@ -248,6 +349,12 @@ module Grid
 
     private
 
+    attr_reader :hackr
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+
     def log_action!(breach, action_type, target_position, program_slug, result_data)
       GridHackrBreachLog.create!(
         grid_hackr_breach: breach,
@@ -276,6 +383,21 @@ module Grid
       max_inspiration = ceiling * 10
       new_inspiration = [breach.inspiration + 1, max_inspiration].min
       breach.update!(inspiration: new_inspiration)
+    end
+
+    # Roll for fragment drop from utility software execution.
+    # Fragments are pending on the breach — only granted on success.
+    def roll_fragment_extraction!(breach, protocol, program)
+      chance = (program.properties&.dig("fragment_chance") || 0.25).to_f
+      return nil unless rand < chance
+
+      # Determine fragment type from the protocol being targeted
+      fragment_slug = "#{protocol.protocol_type}-fragment"
+      pending = breach.meta["pending_fragments"] || []
+      pending << fragment_slug
+      breach.update!(meta: breach.meta.merge("pending_fragments" => pending))
+
+      fragment_slug
     end
 
     def compute_damage(program, protocol)

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -26,6 +26,8 @@ module Grid
         analyze_command(args.first)
       when "reroute", "rr"
         reroute_command(args.first)
+      when "use"
+        use_command(args.join(" "))
       when "jackout", "jo"
         jackout_command
       when "status", "st"
@@ -61,7 +63,11 @@ module Grid
       )
 
       output = []
-      if result.hit
+      if result.exploit && result.protocol_destroyed
+        output << "<span style='color: #fbbf24; font-weight: bold;'>⚡ EXPLOIT → Protocol [#{result.target_position + 1}]: INSTANT KILL — DESTROYED</span>"
+        output << "<span style='color: #6b7280;'>#{h(result.program_name)} consumed.</span>"
+        output << "<span style='color: #6b7280;'>Battery: -#{result.battery_consumed}</span>"
+      elsif result.hit
         damage_color = result.protocol_destroyed ? "#34d399" : "#22d3ee"
         output << "<span style='color: #{damage_color};'>#{h(result.program_name)} → Protocol [#{result.target_position + 1}]: #{result.damage_dealt} damage#{" — DESTROYED" if result.protocol_destroyed}</span>"
         output << "<span style='color: #6b7280;'>Battery: -#{result.battery_consumed}</span>"
@@ -69,11 +75,21 @@ module Grid
         output << "<span style='color: #9ca3af;'>#{h(result.program_name)} → Protocol [#{result.target_position + 1}]: no effect.</span>"
       end
 
+      # Fragment extraction notification
+      if result.fragment
+        output << "<span style='color: #a78bfa;'>  ▸ Fragment extracted: #{h(result.fragment)} (pending — granted on success)</span>"
+      end
+
       # Achievement/mission hooks
       notifications = []
       if result.protocol_destroyed
         notifications += achievement_checker.check(:protocols_dismantled)
         notifications += mission_progressor.record(:dismantle_protocols, protocol_type: breach.grid_breach_protocols.find_by(position: target_position)&.protocol_type)
+      end
+
+      if result.fragment
+        notifications += achievement_checker.check(:data_extracted)
+        notifications += mission_progressor.record(:extract_data, fragment_slug: result.fragment)
       end
 
       if result.all_destroyed
@@ -164,6 +180,43 @@ module Grid
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
+    def use_command(item_name)
+      if item_name.empty?
+        return "<span style='color: #fbbf24;'>Usage: use &lt;item&gt;</span>"
+      end
+
+      result = Grid::BreachActionService.use_item!(
+        hackr: hackr,
+        item_name: item_name
+      )
+
+      output = []
+      output << result.effect_output
+
+      # Achievement/mission hooks for item usage
+      notifications = []
+      notifications += achievement_checker.check(:use_item, item_name: result.item_name)
+      notifications += mission_progressor.record(:use_item, item_name: result.item_name)
+
+      if result.emergency_jackout
+        # Trigger clean jackout (bypasses PNR via emergency override)
+        jackout_result = Grid::BreachService.jackout!(hackr: hackr, emergency: true)
+        output << jackout_result.display
+        output << "<span style='color: #34d399;'>You disconnect cleanly.</span>"
+      else
+        # Check if round should end
+        breach.reload
+        round_output = maybe_end_round
+        output << round_output if round_output
+      end
+
+      append_notifications(output, notifications)
+      output.join("\n")
+    rescue Grid::BreachActionService::NoActionsRemaining,
+      Grid::BreachActionService::ItemNotFound => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
     def jackout_command
       result = Grid::BreachService.jackout!(hackr: hackr)
 
@@ -219,6 +272,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>exec &lt;program&gt; &lt;target#&gt;</span>  <span style='color: #9ca3af;'>Run software against a protocol (1 action + battery)</span>"
       output << "<span style='color: #fbbf24;'>analyze &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Scan a protocol for intel (1 action)</span>"
       output << "<span style='color: #fbbf24;'>reroute &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Delay a protocol 1 round (1 action, 30% chance protocol fizzles on retry)</span>"
+      output << "<span style='color: #fbbf24;'>use &lt;item&gt;</span>                   <span style='color: #9ca3af;'>Use a consumable from inventory (1 action)</span>"
       output << "<span style='color: #fbbf24;'>jackout</span>                      <span style='color: #9ca3af;'>Abort the encounter</span>"
       output << ""
       output << "<span style='color: #6b7280;'>Free commands (no action cost):</span>"

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -58,7 +58,7 @@ module Grid
       lines.join("\n")
     end
 
-    def render_success(xp_awarded, cred_awarded, template_name)
+    def render_success(xp_awarded, cred_awarded, template_name, fragments_granted = [])
       lines = []
       lines << ""
       lines << "<span style='color: #34d399; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
@@ -67,6 +67,13 @@ module Grid
       lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #d0d0d0;'>#{h(template_name)}</span>"
       lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #fbbf24;'>XP:</span> <span style='color: #34d399;'>+#{xp_awarded}</span>" if xp_awarded > 0
       lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #fbbf24;'>CRED:</span> <span style='color: #34d399;'>+#{cred_awarded}</span>" if cred_awarded > 0
+      if fragments_granted.any?
+        lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #a78bfa;'>FRAGMENTS:</span>"
+        fragments_granted.each do |frag|
+          qty_label = (frag[:quantity] > 1) ? " \u00d7#{frag[:quantity]}" : ""
+          lines << "<span style='color: #34d399;'>\u2551</span>    <span style='color: #a78bfa;'>#{h(frag[:name])}#{qty_label}</span>"
+        end
+      end
       lines << "<span style='color: #34d399; font-weight: bold;'>\u255a#{SEPARATOR}\u255d</span>"
       lines.join("\n")
     end

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -52,8 +52,8 @@ module Grid
       new(hackr_breach.grid_hackr).resolve_failure!(hackr_breach)
     end
 
-    def self.jackout!(hackr:)
-      new(hackr).jackout!
+    def self.jackout!(hackr:, emergency: false)
+      new(hackr).jackout!(emergency: emergency)
     end
 
     # List voluntary encounters in a room, respecting cooldowns and gates.
@@ -257,6 +257,7 @@ module Grid
       cred_awarded = (template.cred_reward * hackr_breach.reward_multiplier).floor
 
       xp_result = nil
+      fragments_granted = []
 
       ActiveRecord::Base.transaction do
         hackr_breach.lock!
@@ -273,6 +274,9 @@ module Grid
         # Increment breach completed stat
         current = @hackr.stat("breach_completed_count").to_i
         @hackr.set_stat!("breach_completed_count", current + 1)
+
+        # Grant pending fragments from utility software extraction
+        fragments_granted = grant_pending_fragments!(hackr_breach)
       end
 
       # Grant CRED outside transaction (TransactionService has its own mutex)
@@ -289,7 +293,7 @@ module Grid
         end
       end
 
-      display = Grid::BreachRenderer.new(hackr_breach).render_success(xp_awarded, cred_awarded, template.name)
+      display = Grid::BreachRenderer.new(hackr_breach).render_success(xp_awarded, cred_awarded, template.name, fragments_granted)
       ResolveResult.new(
         hackr_breach: hackr_breach,
         xp_awarded: xp_awarded,
@@ -358,11 +362,11 @@ module Grid
       )
     end
 
-    def jackout!
+    def jackout!(emergency: false)
       hackr_breach = @hackr.active_breach
       raise NotInBreach, "You are not in a BREACH encounter." unless hackr_breach
 
-      clean = !hackr_breach.pnr_crossed?
+      clean = emergency || !hackr_breach.pnr_crossed?
       vitals_hit = []
 
       ActiveRecord::Base.transaction do
@@ -471,6 +475,38 @@ module Grid
       rescue
         nil
       end
+    end
+
+    # Grant pending fragments accumulated during the breach via utility software.
+    # Called inside the success transaction. Returns array of granted fragment slugs.
+    def grant_pending_fragments!(hackr_breach)
+      pending = hackr_breach.meta&.dig("pending_fragments")
+      return [] if pending.blank?
+
+      granted = []
+      pending.tally.each do |fragment_slug, qty|
+        definition = GridItemDefinition.find_by(slug: fragment_slug)
+        next unless definition
+
+        granted_qty = 0
+        qty.times do
+          Grid::Inventory.grant_item!(hackr: @hackr, definition: definition)
+          granted_qty += 1
+        rescue Grid::InventoryErrors::InventoryFull
+          Rails.logger.warn("[BreachService] Inventory full — fragment #{fragment_slug} skipped for hackr #{@hackr.id}")
+          break
+        end
+        granted << {slug: fragment_slug, name: definition.name, quantity: granted_qty} if granted_qty > 0
+      end
+
+      # Update data_extracted stat
+      total = pending.size
+      if total > 0
+        current = @hackr.stat("data_extracted_count").to_i
+        @hackr.set_stat!("data_extracted_count", current + total)
+      end
+
+      granted
     end
 
     def drain_vital!(key, amount)

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -1,6 +1,7 @@
 module Grid
   class CommandParser
     include CodexHelper
+    include ItemEffectApplier
 
     attr_reader :hackr, :input, :event
 
@@ -1166,8 +1167,20 @@ module Grid
       output << ""
       output << "<span style='color: #fbbf24;'>Battery:</span> <span style='color: #d0d0d0;'>#{deck.deck_battery}/#{deck.deck_battery_max}</span>"
       output << "<span style='color: #fbbf24;'>Software Slots:</span> <span style='color: #d0d0d0;'>#{deck.deck_slots_used}/#{deck.deck_slot_count}</span>"
-      output << "<span style='color: #fbbf24;'>Firmware Slots:</span> <span style='color: #d0d0d0;'>#{deck.deck_firmware_slot_count}</span>"
+      output << "<span style='color: #fbbf24;'>Module Slots:</span> <span style='color: #d0d0d0;'>#{deck.deck_modules_used}/#{deck.deck_module_slot_count}</span>"
       output << ""
+
+      # Installed modules
+      modules = deck.installed_modules.order(:name)
+      if modules.any?
+        output << "<span style='color: #fbbf24;'>Installed Modules:</span>"
+        modules.each do |mod|
+          firmware_slug = mod.properties&.dig("firmware_slug")
+          firmware_label = firmware_slug ? "<span style='color: #34d399;'>firmware: #{h(firmware_slug)}</span>" : "<span style='color: #f87171;'>RAW — needs firmware</span>"
+          output << "  <span style='color: #{mod.rarity_color};'>#{h(mod.name)}</span> #{firmware_label}"
+        end
+        output << ""
+      end
 
       loaded = deck.loaded_software.order(:name)
       if loaded.any?
@@ -1199,8 +1212,14 @@ module Grid
         deck_unload_command(name)
       when "charge"
         deck_charge_command
+      when "flash"
+        deck_flash_command(args[1..])
+      when "install"
+        deck_install_command(name)
+      when "uninstall"
+        deck_uninstall_command(name)
       else
-        "<span style='color: #fbbf24;'>Usage: deck [load|unload|charge] &lt;name&gt;</span>"
+        "<span style='color: #fbbf24;'>Usage: deck [load|unload|charge|flash|install|uninstall] &lt;name&gt;</span>"
       end
     end
 
@@ -1220,15 +1239,18 @@ module Grid
         return "<span style='color: #f87171;'>Not enough DECK slots. Need #{slot_cost}, have #{deck.deck_slots_available} available.</span>"
       end
 
+      error = nil
       ActiveRecord::Base.transaction do
         hackr.lock!
         deck.lock!
         if deck.deck_slots_available < slot_cost
-          return "<span style='color: #f87171;'>Not enough DECK slots. Need #{slot_cost}, have #{deck.deck_slots_available} available.</span>"
+          error = "<span style='color: #f87171;'>Not enough DECK slots. Need #{slot_cost}, have #{deck.deck_slots_available} available.</span>"
+          raise ActiveRecord::Rollback
         end
         software.update!(deck_id: deck.id)
       end
 
+      return error if error
       "<span style='color: #34d399;'>Loaded #{h(software.name)} into DECK.</span> <span style='color: #6b7280;'>(#{deck.deck_slots_used}/#{deck.deck_slot_count} slots)</span>"
     end
 
@@ -1271,6 +1293,174 @@ module Grid
       end
 
       "<span style='color: #34d399;'>DECK fully charged.</span> <span style='color: #d0d0d0;'>#{deck.deck_battery_max}/#{deck.deck_battery_max}</span>"
+    end
+
+    # ── Module flash/install/uninstall ───────────────────
+
+    def deck_flash_command(args)
+      # Syntax: deck flash <firmware> onto <module>
+      # At firmware_vendor room: firmware bought + flashed in one step
+      # With EEPROM Flasher tool: firmware from inventory + flash anywhere
+      args ||= []
+      raw = args.join(" ")
+
+      # Parse "firmware onto module" syntax
+      parts = raw.split(/\s+onto\s+/i, 2)
+      if parts.length != 2 || parts.any?(&:blank?)
+        return "<span style='color: #fbbf24;'>Usage: deck flash &lt;firmware&gt; onto &lt;module&gt;</span>"
+      end
+
+      firmware_name = parts[0].strip
+      module_name = parts[1].strip
+
+      deck = hackr.equipped_deck
+      return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
+
+      # Find the module in inventory (must be unflashed OR reflash overwrites)
+      mod = hackr.grid_items.in_inventory(hackr)
+        .where(item_type: "module")
+        .find_by("LOWER(name) = ?", module_name.downcase)
+      return "<span style='color: #f87171;'>No module named '#{h(module_name)}' in your inventory.</span>" unless mod
+
+      room = hackr.current_room
+      at_vendor = room&.room_type == "firmware_vendor"
+      has_flasher = hackr.grid_items.in_inventory(hackr)
+        .joins(:grid_item_definition)
+        .exists?(grid_item_definitions: {slug: "eeprom-flasher"})
+
+      unless at_vendor || has_flasher
+        return "<span style='color: #f87171;'>You need an EEPROM Flasher tool or a Firmware Vending Machine to flash firmware.</span>"
+      end
+
+      # Find firmware
+      firmware = if at_vendor
+        # At vendor: firmware available from vendor catalog (just need definition)
+        GridItemDefinition.where(item_type: "firmware")
+          .find_by("LOWER(name) = ?", firmware_name.downcase)
+      else
+        # DIY: firmware must be in inventory
+        hackr.grid_items.in_inventory(hackr)
+          .where(item_type: "firmware")
+          .find_by("LOWER(name) = ?", firmware_name.downcase)
+      end
+
+      if firmware.nil?
+        location_hint = at_vendor ? "available at this vendor" : "in your inventory"
+        return "<span style='color: #f87171;'>No firmware named '#{h(firmware_name)}' #{location_hint}.</span>"
+      end
+
+      firmware_def = at_vendor ? firmware : firmware.grid_item_definition
+
+      # Check compatibility: firmware's compatible_modules must include module definition slug
+      compatible = firmware_def.properties&.dig("compatible_modules")
+      mod_slug = mod.grid_item_definition.slug
+      if compatible.is_a?(Array) && compatible.any? && !compatible.include?(mod_slug)
+        return "<span style='color: #f87171;'>#{h(firmware_def.name)} is not compatible with #{h(mod.name)}.</span>"
+      end
+
+      # Vendor cost check
+      if at_vendor
+        cost = firmware_def.value
+        cache = hackr.default_cache
+        if cost > 0 && (!cache&.active? || cache.balance < cost)
+          return "<span style='color: #f87171;'>Insufficient CRED. Cost: #{cost}.</span>"
+        end
+      end
+
+      old_firmware = mod.properties&.dig("firmware_slug")
+      ActiveRecord::Base.transaction do
+        hackr.lock!
+        mod.lock!
+
+        # Pay at vendor
+        if at_vendor
+          cost = firmware_def.value
+          if cost > 0
+            Grid::TransactionService.burn!(
+              from_cache: hackr.default_cache,
+              amount: cost,
+              memo: "Firmware: #{firmware_def.name}"
+            )
+          end
+        elsif firmware.quantity > 1
+          # DIY: consume firmware item from inventory
+          firmware.update!(quantity: firmware.quantity - 1)
+        else
+          firmware.destroy!
+        end
+
+        # Flash firmware onto module (overwrites previous)
+        mod.update!(properties: (mod.properties || {}).merge(
+          "flashed" => true,
+          "firmware_slug" => firmware_def.slug,
+          "firmware_name" => firmware_def.name
+        ))
+      end
+
+      output = "<span style='color: #34d399;'>Firmware flashed: #{h(firmware_def.name)} → #{h(mod.name)}.</span>"
+      output += " <span style='color: #6b7280;'>Previous firmware overwritten.</span>" if old_firmware.present?
+      output
+    end
+
+    def deck_install_command(module_name)
+      return "<span style='color: #fbbf24;'>Install what? Usage: deck install &lt;module name&gt;</span>" if module_name.blank?
+
+      if hackr.in_breach?
+        return "<span style='color: #f87171;'>Cannot install modules during a BREACH.</span>"
+      end
+
+      deck = hackr.equipped_deck
+      return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
+
+      mod = hackr.grid_items.in_inventory(hackr)
+        .where(item_type: "module")
+        .find_by("LOWER(name) = ?", module_name.downcase)
+      return "<span style='color: #f87171;'>No module named '#{h(module_name)}' in your inventory.</span>" unless mod
+
+      unless mod.properties&.dig("flashed")
+        return "<span style='color: #f87171;'>#{h(mod.name)} has no firmware. Flash firmware onto it first.</span>"
+      end
+
+      if deck.deck_modules_available <= 0
+        return "<span style='color: #f87171;'>No module slots available. Uninstall a module first. (#{deck.deck_modules_used}/#{deck.deck_module_slot_count})</span>"
+      end
+
+      error = nil
+      ActiveRecord::Base.transaction do
+        hackr.lock!
+        deck.lock!
+
+        if deck.deck_modules_available <= 0
+          error = "<span style='color: #f87171;'>No module slots available.</span>"
+          raise ActiveRecord::Rollback
+        end
+
+        mod.update!(deck_id: deck.id)
+      end
+
+      return error if error
+      "<span style='color: #34d399;'>Installed #{h(mod.name)} into DECK.</span> <span style='color: #6b7280;'>(#{deck.deck_modules_used}/#{deck.deck_module_slot_count} module slots)</span>"
+    end
+
+    def deck_uninstall_command(module_name)
+      return "<span style='color: #fbbf24;'>Uninstall what? Usage: deck uninstall &lt;module name&gt;</span>" if module_name.blank?
+
+      if hackr.in_breach?
+        return "<span style='color: #f87171;'>Cannot uninstall modules during a BREACH.</span>"
+      end
+
+      deck = hackr.equipped_deck
+      return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
+
+      mod = deck.installed_modules.find_by("LOWER(name) = ?", module_name.downcase)
+      return "<span style='color: #f87171;'>No module named '#{h(module_name)}' installed in your DECK.</span>" unless mod
+
+      ActiveRecord::Base.transaction do
+        hackr.lock!
+        mod.update!(deck_id: nil)
+      end
+
+      "<span style='color: #34d399;'>Uninstalled #{h(mod.name)} from DECK.</span>"
     end
 
     # ── BREACH initiation (outside BREACH) ───────────────────
@@ -1363,7 +1553,7 @@ module Grid
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       saved_name = item.name
-      result = apply_item_effect(item)
+      result = apply_item_effect_with_notifications(item)
       increment_stat!("use_count")
 
       # Consume if consumable
@@ -1599,57 +1789,18 @@ module Grid
       {output: output, event: nil}
     end
 
-    def apply_item_effect(item)
-      props = (item.properties || {}).with_indifferent_access
-      effect_type = props[:effect_type]
+    # Delegates to Grid::ItemEffectApplier#apply_item_effect.
+    # Wraps redeem_den to add achievement notifications (CommandParser-specific).
+    def apply_item_effect_with_notifications(item)
+      result = apply_item_effect(item)
 
-      case effect_type
-      when "heal"
-        amount = props[:amount].to_i
-        new_val = hackr.adjust_vital!("health", amount)
-        "<span style='color: #34d399;'>You use #{h(item.name)}. Health restored by #{amount}. (#{new_val}/100)</span>"
-      when "energize"
-        amount = props[:amount].to_i
-        new_val = hackr.adjust_vital!("energy", amount)
-        "<span style='color: #60a5fa;'>You use #{h(item.name)}. Energy restored by #{amount}. (#{new_val}/100)</span>"
-      when "psyche_boost"
-        amount = props[:amount].to_i
-        new_val = hackr.adjust_vital!("psyche", amount)
-        "<span style='color: #c084fc;'>You use #{h(item.name)}. Psyche boosted by #{amount}. (#{new_val}/100)</span>"
-      when "deck_recharge"
-        amount = props[:amount].to_i
-        deck = hackr.equipped_deck
-        unless deck
-          return "<span style='color: #f87171;'>No DECK equipped.</span>"
-        end
-        old_battery = deck.deck_battery
-        new_battery = [old_battery + amount, deck.deck_battery_max].min
-        deck.update!(properties: deck.properties.merge("battery_current" => new_battery))
-        "<span style='color: #fbbf24;'>You use #{h(item.name)}. DECK battery restored by #{new_battery - old_battery}. (#{new_battery}/#{deck.deck_battery_max})</span>"
-      when "inspire"
-        # Inspiration is now BREACH-scoped (lives on breach row, not hackr stats).
-        # inspire items have no effect outside of BREACH.
-        "<span style='color: #9ca3af;'>You use #{h(item.name)}... but the effect fizzles. Nothing to inspire outside a BREACH.</span>"
-      when "xp_boost"
-        amount = props[:amount].to_i
-        result = hackr.grant_xp!(amount)
-        level_msg = result[:leveled_up] ? "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{result[:new_clearance]}!</span>" : ""
-        "<span style='color: #fbbf24;'>You use #{h(item.name)}. +#{amount} XP.#{level_msg}</span>"
-      when "redeem_den"
-        begin
-          den = Grid::DenService.new(hackr).create_den!(consume_item: item)
-          notifications = achievement_checker.check(:den_created)
-          output = "<span style='color: #a78bfa; font-weight: bold;'>DEN PROVISIONED.</span> " \
-            "<span style='color: #d0d0d0;'>Your private node is ready in the Residential District.</span>\n" \
-            "<span style='color: #9ca3af;'>Navigate to the Residential Corridor and enter: </span>" \
-            "<span style='color: #22d3ee;'>go #{den.slug}</span>"
-          append_notifications(output, notifications)
-        rescue Grid::DenService::DenAlreadyExists
-          "<span style='color: #f87171;'>You already have a den. The chip sizzles uselessly.</span>"
-        end
-      else
-        "<span style='color: #9ca3af;'>You use #{h(item.name)}. Nothing happens.</span>"
+      # Den creation triggers achievements (only relevant outside BREACH)
+      if item.properties&.dig("effect_type") == "redeem_den" && result.is_a?(String) && result.include?("DEN PROVISIONED")
+        notifications = achievement_checker.check(:den_created)
+        return append_notifications(result, notifications)
       end
+
+      result
     end
 
     def examine_hackr(target_hackr)

--- a/app/services/grid/item_effect_applier.rb
+++ b/app/services/grid/item_effect_applier.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Grid
+  # Shared item-effect logic used by both CommandParser (outside BREACH)
+  # and BreachCommandParser (inside BREACH). Includer must provide:
+  #   - hackr   (GridHackr)
+  #   - h(text) (HTML escape helper)
+  module ItemEffectApplier
+    # Apply the effect of an item. Returns display string.
+    # Pass breach: to enable BREACH-scoped effects (signal_flare, emergency_jackout, inspire).
+    def apply_item_effect(item, breach: nil)
+      props = (item.properties || {}).with_indifferent_access
+      effect_type = props[:effect_type]
+
+      case effect_type
+      when "heal"
+        amount = props[:amount].to_i
+        new_val = hackr.adjust_vital!("health", amount)
+        max_val = hackr.effective_max("health")
+        "<span style='color: #34d399;'>You use #{h(item.name)}. Health restored by #{amount}. (#{new_val}/#{max_val})</span>"
+      when "energize"
+        amount = props[:amount].to_i
+        new_val = hackr.adjust_vital!("energy", amount)
+        max_val = hackr.effective_max("energy")
+        "<span style='color: #60a5fa;'>You use #{h(item.name)}. Energy restored by #{amount}. (#{new_val}/#{max_val})</span>"
+      when "psyche_boost"
+        amount = props[:amount].to_i
+        new_val = hackr.adjust_vital!("psyche", amount)
+        max_val = hackr.effective_max("psyche")
+        "<span style='color: #c084fc;'>You use #{h(item.name)}. Psyche boosted by #{amount}. (#{new_val}/#{max_val})</span>"
+      when "deck_recharge"
+        apply_deck_recharge(item, props)
+      when "inspire"
+        apply_inspire(item, props, breach)
+      when "signal_flare"
+        apply_signal_flare(item, props, breach)
+      when "emergency_jackout"
+        apply_emergency_jackout(item, props, breach)
+      when "xp_boost"
+        amount = props[:amount].to_i
+        result = hackr.grant_xp!(amount)
+        level_msg = result[:leveled_up] ? "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{result[:new_clearance]}!</span>" : ""
+        "<span style='color: #fbbf24;'>You use #{h(item.name)}. +#{amount} XP.#{level_msg}</span>"
+      when "redeem_den"
+        apply_redeem_den(item)
+      else
+        "<span style='color: #9ca3af;'>You use #{h(item.name)}. Nothing happens.</span>"
+      end
+    end
+
+    private
+
+    def apply_deck_recharge(item, props)
+      amount = props[:amount].to_i
+      deck = hackr.equipped_deck
+      unless deck
+        return "<span style='color: #f87171;'>No DECK equipped.</span>"
+      end
+      old_battery = deck.deck_battery
+      new_battery = [old_battery + amount, deck.deck_battery_max].min
+      deck.update!(properties: deck.properties.merge("battery_current" => new_battery))
+      "<span style='color: #fbbf24;'>You use #{h(item.name)}. DECK battery restored by #{new_battery - old_battery}. (#{new_battery}/#{deck.deck_battery_max})</span>"
+    end
+
+    def apply_inspire(item, props, breach)
+      unless breach
+        return "<span style='color: #9ca3af;'>You use #{h(item.name)}... but the effect fizzles. Nothing to inspire outside a BREACH.</span>"
+      end
+      amount = props[:amount].to_i
+      ceiling = Grid::BreachService.breach_rank(hackr.stat("clearance"))&.dig(:ceiling) || 1
+      max_inspiration = ceiling * 10
+      new_inspiration = [breach.inspiration + amount, max_inspiration].min
+      gained = new_inspiration - breach.inspiration
+      breach.update!(inspiration: new_inspiration)
+      "<span style='color: #a78bfa;'>You use #{h(item.name)}. INSPIRATION +#{gained}. (#{new_inspiration}/#{max_inspiration})</span>"
+    end
+
+    def apply_signal_flare(item, props, breach)
+      unless breach
+        return "<span style='color: #9ca3af;'>You use #{h(item.name)}... but there's no signal to disrupt outside a BREACH.</span>"
+      end
+      amount = props[:amount].to_i
+      old_detection = breach.detection_level
+      new_detection = [old_detection - amount, 0].max
+      reduction = old_detection - new_detection
+      breach.update!(detection_level: new_detection)
+      "<span style='color: #22d3ee;'>You use #{h(item.name)}. Detection reduced by #{reduction}%. (#{new_detection}%)</span>"
+    end
+
+    def apply_emergency_jackout(item, _props, breach)
+      unless breach
+        return "<span style='color: #9ca3af;'>You use #{h(item.name)}... but there's nothing to jack out of.</span>"
+      end
+      # Returns a sentinel that the caller checks to trigger a clean jackout
+      :emergency_jackout
+    end
+
+    def apply_redeem_den(item)
+      den = Grid::DenService.new(hackr).create_den!(consume_item: item)
+      "<span style='color: #a78bfa; font-weight: bold;'>DEN PROVISIONED.</span> " \
+        "<span style='color: #d0d0d0;'>Your private node is ready in the Residential District.</span>\n" \
+        "<span style='color: #9ca3af;'>Navigate to the Residential Corridor and enter: </span>" \
+        "<span style='color: #22d3ee;'>go #{den.slug}</span>"
+    rescue Grid::DenService::DenAlreadyExists
+      "<span style='color: #f87171;'>You already have a den. The chip sizzles uselessly.</span>"
+    end
+  end
+end

--- a/app/services/grid/mission_progressor.rb
+++ b/app/services/grid/mission_progressor.rb
@@ -119,6 +119,8 @@ module Grid
         target.blank? || target.casecmp?(context[:template_slug].to_s)
       when "dismantle_protocols"
         target.blank? || target.casecmp?(context[:protocol_type].to_s)
+      when "extract_data"
+        target.blank? || target.casecmp?(context[:fragment_slug].to_s)
       when "talk_npc", "use_item", "salvage_item", "salvage_yield_received", "buy_item", "collect_item", "fabricate_item", "place_fixture", "equip_item"
         target.blank? || target.casecmp?(name_context(context).to_s)
       when "deliver_item"
@@ -155,7 +157,7 @@ module Grid
       case trigger_type.to_s
       when "visit_room", "talk_npc", "use_item", "fabricate_item", "place_fixture", "equip_item", "complete_breach"
         [current + 1, target_count].min
-      when "collect_item", "deliver_item", "buy_item", "salvage_item", "salvage_yield_received", "dismantle_protocols"
+      when "collect_item", "deliver_item", "buy_item", "salvage_item", "salvage_yield_received", "dismantle_protocols", "extract_data"
         [current + context.fetch(:amount, 1).to_i, target_count].min
       when "spend_cred"
         [current + context[:amount].to_i, target_count].min

--- a/data/world/item_definitions.yml
+++ b/data/world/item_definitions.yml
@@ -459,7 +459,7 @@ item_definitions:
       slot_count: 4
       battery_max: 64
       battery_current: 64
-      firmware_slot_count: 1
+      module_slot_count: 1
       effects: {}
 
   - slug: advanced-deck
@@ -475,7 +475,7 @@ item_definitions:
       slot_count: 8
       battery_max: 128
       battery_current: 128
-      firmware_slot_count: 1
+      module_slot_count: 1
       effects: {}
 
   # ── Software (BREACH Programs) ────────────────────────────────
@@ -544,6 +544,227 @@ item_definitions:
       effect_type: analyze_boost
       effect_magnitude: 1
       level: 1
+
+  # ── Exploit Software (One-Shot BREACH Programs) ───────────────
+  - slug: rainn-killswitch
+    name: RAINN Killswitch
+    description: "Targets ADAPT protocols with a neural feedback loop that collapses the protocol's decision engine. One shot. One kill. If it matches."
+    item_type: software
+    rarity: rare
+    value: 400
+    max_stack: 1
+    properties:
+      software_category: exploit
+      slot_cost: 2
+      battery_cost: 20
+      complexity_tier: 2
+      target_types:
+        - adapt
+      effect_type: instant_kill
+      effect_magnitude: 999
+      level: 2
+
+  - slug: firewall-bypass
+    name: Firewall Bypass
+    description: "Injects a precision zero-day into LOCK protocol firmware. Instantly dismantles the lock — but burns itself in the process."
+    item_type: software
+    rarity: rare
+    value: 400
+    max_stack: 1
+    properties:
+      software_category: exploit
+      slot_cost: 2
+      battery_cost: 20
+      complexity_tier: 2
+      target_types:
+        - lock
+      effect_type: instant_kill
+      effect_magnitude: 999
+      level: 2
+
+  - slug: trace-purge
+    name: Trace Purge
+    description: "Floods the TRACE protocol with false positives until its own detection matrix collapses. Single use."
+    item_type: software
+    rarity: uncommon
+    value: 250
+    max_stack: 1
+    properties:
+      software_category: exploit
+      slot_cost: 1
+      battery_cost: 16
+      complexity_tier: 1
+      target_types:
+        - trace
+      effect_type: instant_kill
+      effect_magnitude: 999
+      level: 1
+
+  # ── Utility Software (Fragment Extraction) ───────────────────
+  - slug: fragment-extractor
+    name: Fragment Extractor
+    description: "Siphons protocol data during execution. Each hit has a chance to extract a software fragment. Fragments are pending until breach success."
+    item_type: software
+    rarity: uncommon
+    value: 200
+    max_stack: 1
+    properties:
+      software_category: utility
+      slot_cost: 1
+      battery_cost: 10
+      complexity_tier: 1
+      effect_type: damage
+      effect_magnitude: 15
+      fragment_chance: 0.30
+      level: 1
+
+  - slug: data-siphon
+    name: Data Siphon
+    description: "Advanced extraction tool. Higher fragment yield, lower damage output. The trade-off of a specialist."
+    item_type: software
+    rarity: rare
+    value: 500
+    max_stack: 1
+    properties:
+      software_category: utility
+      slot_cost: 2
+      battery_cost: 14
+      complexity_tier: 2
+      effect_type: damage
+      effect_magnitude: 10
+      fragment_chance: 0.50
+      level: 2
+
+  # ── BREACH Consumables (In-Encounter) ───────────────────────
+  - slug: signal-flare
+    name: Signal Flare
+    description: "Emits a burst of electromagnetic noise that temporarily blinds nearby surveillance systems. Reduces detection level during BREACH."
+    item_type: consumable
+    rarity: uncommon
+    value: 200
+    max_stack: 4
+    properties:
+      effect_type: signal_flare
+      amount: 15
+
+  - slug: emergency-jackout-chip
+    name: Emergency Jack-Out Chip
+    description: "One-use neural bypass chip. Forces a clean disconnect even past the Point of No Return. Don't leave home without one."
+    item_type: consumable
+    rarity: rare
+    value: 750
+    max_stack: 2
+    properties:
+      effect_type: emergency_jackout
+
+  # ── DECK Modules (Hardware Peripherals) ─────────────────────
+  - slug: breach-amplifier
+    name: BREACH Amplification Antenna
+    description: "A compact directional antenna that boosts signal penetration during BREACH encounters. Requires firmware to operate."
+    item_type: module
+    rarity: uncommon
+    value: 300
+    max_stack: 1
+    properties:
+      flashed: false
+
+  - slug: signal-intercept-array
+    name: Signal Intercept Array
+    description: "A passive signal capture array that enables advanced exploit software to interface with hostile protocols. Firmware required."
+    item_type: module
+    rarity: rare
+    value: 600
+    max_stack: 1
+    properties:
+      flashed: false
+
+  # ── Firmware (Module Software) ──────────────────────────────
+  - slug: amplifier-firmware-v1
+    name: Amplifier Firmware v1.0
+    description: "Basic firmware package for BREACH Amplification Antennas. Enables signal boost capabilities."
+    item_type: firmware
+    rarity: uncommon
+    value: 150
+    max_stack: 4
+    properties:
+      compatible_modules:
+        - breach-amplifier
+
+  - slug: intercept-protocol-loader
+    name: Intercept Protocol Loader
+    description: "Firmware package for Signal Intercept Arrays. Activates passive capture and exploit interface protocols."
+    item_type: firmware
+    rarity: rare
+    value: 350
+    max_stack: 4
+    properties:
+      compatible_modules:
+        - signal-intercept-array
+
+  # ── Tools (BREACH) ──────────────────────────────────────────
+  - slug: eeprom-flasher
+    name: EEPROM Flasher
+    description: "Portable firmware programming tool. Flash firmware onto DECK modules anywhere, anytime. Beats making the trip to a Vending Machine."
+    item_type: tool
+    rarity: rare
+    value: 800
+    max_stack: 1
+    properties: {}
+
+  # ── Protocol Fragments (Extracted Data) ─────────────────────
+  - slug: trace-fragment
+    name: TRACE Fragment
+    description: "A data shard extracted from a TRACE protocol during BREACH. Contains partial detection algorithm signatures. Used in software fabrication."
+    item_type: data
+    rarity: uncommon
+    value: 25
+    max_stack: 16
+    properties: {}
+
+  - slug: feedback-fragment
+    name: FEEDBACK Fragment
+    description: "A data shard extracted from a FEEDBACK protocol during BREACH. Contains neural drain waveform patterns. Used in software fabrication."
+    item_type: data
+    rarity: uncommon
+    value: 25
+    max_stack: 16
+    properties: {}
+
+  - slug: lock-fragment
+    name: LOCK Fragment
+    description: "A data shard extracted from a LOCK protocol during BREACH. Contains access control bypass signatures. Used in software fabrication."
+    item_type: data
+    rarity: uncommon
+    value: 30
+    max_stack: 16
+    properties: {}
+
+  - slug: adapt-fragment
+    name: ADAPT Fragment
+    description: "A data shard extracted from an ADAPT protocol during BREACH. Contains mutation algorithm core logic. Rare and valuable."
+    item_type: data
+    rarity: rare
+    value: 50
+    max_stack: 8
+    properties: {}
+
+  - slug: spike-fragment
+    name: SPIKE Fragment
+    description: "A data shard extracted from a SPIKE protocol during BREACH. Contains counter-intrusion payload signatures. Dangerous to handle."
+    item_type: data
+    rarity: rare
+    value: 50
+    max_stack: 8
+    properties: {}
+
+  - slug: purge-fragment
+    name: PURGE Fragment
+    description: "A data shard extracted from a PURGE protocol during BREACH. Contains reward degradation algorithms. Useful for reverse-engineering countermeasures."
+    item_type: data
+    rarity: rare
+    value: 50
+    max_stack: 8
+    properties: {}
 
   # ── Faction Items ──────────────────────────────────────────────
   - slug: fracture-beacon

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -293,3 +293,143 @@ schematics:
       - input_slug: logic-core
         quantity: 1
         position: 1
+
+  # ── BREACH: Fragment → Software Schematics ──────────────────
+  - slug: fab-fragment-extractor
+    name: Fabricate Fragment Extractor
+    description: "Build a utility program that siphons protocol data fragments during BREACH."
+    output_slug: fragment-extractor
+    output_quantity: 1
+    xp_reward: 60
+    required_clearance: 5
+    required_room_type: den
+    published: true
+    position: 300
+    ingredients:
+      - input_slug: cipher-chip
+        quantity: 2
+        position: 0
+      - input_slug: trace-fragment
+        quantity: 2
+        position: 1
+
+  - slug: fab-data-siphon
+    name: Fabricate Data Siphon
+    description: "Assemble an advanced fragment extraction tool with higher yield rates."
+    output_slug: data-siphon
+    output_quantity: 1
+    xp_reward: 100
+    required_clearance: 10
+    required_room_type: den
+    published: true
+    position: 310
+    ingredients:
+      - input_slug: cipher-chip
+        quantity: 3
+        position: 0
+      - input_slug: logic-core
+        quantity: 2
+        position: 1
+      - input_slug: feedback-fragment
+        quantity: 3
+        position: 2
+
+  - slug: fab-trace-purge
+    name: Fabricate Trace Purge
+    description: "Compile a one-shot exploit that collapses TRACE protocols. Requires extracted TRACE fragments."
+    output_slug: trace-purge
+    output_quantity: 1
+    xp_reward: 80
+    required_clearance: 5
+    required_room_type: den
+    published: true
+    position: 320
+    ingredients:
+      - input_slug: trace-fragment
+        quantity: 4
+        position: 0
+      - input_slug: cipher-chip
+        quantity: 1
+        position: 1
+
+  - slug: fab-firewall-bypass
+    name: Fabricate Firewall Bypass
+    description: "Build a precision zero-day exploit for LOCK protocols. Requires extracted LOCK fragments."
+    output_slug: firewall-bypass
+    output_quantity: 1
+    xp_reward: 120
+    required_clearance: 10
+    required_room_type: den
+    published: true
+    position: 330
+    ingredients:
+      - input_slug: lock-fragment
+        quantity: 4
+        position: 0
+      - input_slug: adapt-fragment
+        quantity: 2
+        position: 1
+
+  - slug: fab-rainn-killswitch
+    name: Fabricate RAINN Killswitch
+    description: "Assemble a neural feedback exploit that collapses ADAPT protocols. The ultimate one-shot."
+    output_slug: rainn-killswitch
+    output_quantity: 1
+    xp_reward: 150
+    required_clearance: 15
+    required_room_type: den
+    published: true
+    position: 340
+    ingredients:
+      - input_slug: adapt-fragment
+        quantity: 4
+        position: 0
+      - input_slug: spike-fragment
+        quantity: 2
+        position: 1
+      - input_slug: quantum-shard
+        quantity: 1
+        position: 2
+
+  # ── BREACH: Module + Firmware Schematics ────────────────────
+  - slug: fab-breach-amplifier
+    name: Fabricate BREACH Amplifier
+    description: "Build a BREACH Amplification Antenna from salvaged components."
+    output_slug: breach-amplifier
+    output_quantity: 1
+    xp_reward: 80
+    required_clearance: 5
+    required_room_type: den
+    published: true
+    position: 350
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 4
+        position: 0
+      - input_slug: synth-fiber
+        quantity: 3
+        position: 1
+      - input_slug: logic-core
+        quantity: 1
+        position: 2
+
+  - slug: fab-signal-intercept-array
+    name: Fabricate Signal Intercept Array
+    description: "Assemble a passive signal capture array for advanced BREACH exploits."
+    output_slug: signal-intercept-array
+    output_quantity: 1
+    xp_reward: 150
+    required_clearance: 10
+    required_room_type: den
+    published: true
+    position: 360
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 6
+        position: 0
+      - input_slug: quantum-shard
+        quantity: 2
+        position: 1
+      - input_slug: cipher-chip
+        quantity: 3
+        position: 2

--- a/db/migrate/20260423223838_add_meta_to_grid_hackr_breaches.rb
+++ b/db/migrate/20260423223838_add_meta_to_grid_hackr_breaches.rb
@@ -1,0 +1,5 @@
+class AddMetaToGridHackrBreaches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackr_breaches, :meta, :json, null: false, default: {}
+  end
+end

--- a/db/migrate/20260424024043_rename_firmware_slot_count_to_module_slot_count_in_grid_items.rb
+++ b/db/migrate/20260424024043_rename_firmware_slot_count_to_module_slot_count_in_grid_items.rb
@@ -1,0 +1,17 @@
+class RenameFirmwareSlotCountToModuleSlotCountInGridItems < ActiveRecord::Migration[8.1]
+  def up
+    GridItem.where(item_type: "gear").where("properties->>'firmware_slot_count' IS NOT NULL").find_each do |item|
+      val = item.properties.delete("firmware_slot_count")
+      item.properties["module_slot_count"] = val
+      item.save!
+    end
+  end
+
+  def down
+    GridItem.where(item_type: "gear").where("properties->>'module_slot_count' IS NOT NULL").find_each do |item|
+      val = item.properties.delete("module_slot_count")
+      item.properties["firmware_slot_count"] = val
+      item.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_024043) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -331,6 +331,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_120001) do
     t.integer "grid_breach_template_id", null: false
     t.integer "grid_hackr_id", null: false
     t.integer "inspiration", default: 0, null: false
+    t.json "meta", default: {}, null: false
     t.integer "origin_room_id"
     t.integer "pnr_threshold", default: 75, null: false
     t.decimal "reward_multiplier", precision: 5, scale: 4, default: "1.0", null: false

--- a/spec/factories/grid_hackr_breaches.rb
+++ b/spec/factories/grid_hackr_breaches.rb
@@ -11,6 +11,7 @@
 #  detection_level          :integer          default(0), not null
 #  ended_at                 :datetime
 #  inspiration              :integer          default(0), not null
+#  meta                     :json             not null
 #  pnr_threshold            :integer          default(75), not null
 #  reward_multiplier        :decimal(5, 4)    default(1.0), not null
 #  round_number             :integer          default(1), not null

--- a/spec/models/grid_hackr_breach_spec.rb
+++ b/spec/models/grid_hackr_breach_spec.rb
@@ -11,6 +11,7 @@
 #  detection_level          :integer          default(0), not null
 #  ended_at                 :datetime
 #  inspiration              :integer          default(0), not null
+#  meta                     :json             not null
 #  pnr_threshold            :integer          default(75), not null
 #  reward_multiplier        :decimal(5, 4)    default(1.0), not null
 #  round_number             :integer          default(1), not null

--- a/spec/services/grid/breach_action_service_spec.rb
+++ b/spec/services/grid/breach_action_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Grid::BreachActionService do
     create(:grid_item_definition, :gear,
       slug: "test-deck-action",
       name: "Test Deck",
-      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "firmware_slot_count" => 1, "effects" => {}})
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
   end
 
   let!(:deck) do

--- a/spec/services/grid/breach_phase2a_spec.rb
+++ b/spec/services/grid/breach_phase2a_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "BREACH Phase 2A" do
     create(:grid_item_definition, :gear,
       slug: "test-deck-2a",
       name: "Test Deck",
-      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "firmware_slot_count" => 1, "effects" => {}})
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "module_slot_count" => 1, "effects" => {}})
   end
 
   let!(:deck) do

--- a/spec/services/grid/breach_phase2b_spec.rb
+++ b/spec/services/grid/breach_phase2b_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "BREACH Phase 2B — Encounter Infrastructure" do
     create(:grid_item_definition, :gear,
       slug: "test-deck-2b",
       name: "Test Deck",
-      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "firmware_slot_count" => 1, "effects" => {}})
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 128, "battery_current" => 128, "module_slot_count" => 1, "effects" => {}})
   end
 
   let!(:deck) do

--- a/spec/services/grid/breach_phase2c_spec.rb
+++ b/spec/services/grid/breach_phase2c_spec.rb
@@ -1,0 +1,890 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BREACH Phase 2C — Item Systems" do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "test-deck-2c",
+      name: "Test Deck",
+      properties: {"slot" => "deck", "slot_count" => 8, "battery_max" => 128, "battery_current" => 128, "module_slot_count" => 2, "effects" => {}})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let(:software_def) do
+    create(:grid_item_definition,
+      slug: "test-sw-2c",
+      name: "Test Program",
+      item_type: "software",
+      properties: {"software_category" => "offensive", "slot_cost" => 1, "battery_cost" => 10, "effect_type" => "damage", "effect_magnitude" => 30, "level" => 1})
+  end
+
+  let!(:software) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: software_def, grid_hackr: hackr)
+    item.update!(deck_id: deck.id)
+    item
+  end
+
+  let(:template) do
+    create(:grid_breach_template, protocol_composition: [
+      {"type" => "trace", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+    ])
+  end
+
+  def start_breach!(tmpl: nil)
+    tmpl ||= template
+    enc = create(:grid_breach_encounter, grid_breach_template: tmpl, grid_room: room)
+    result = Grid::BreachService.start!(hackr: hackr, encounter: enc)
+    result.hackr_breach
+  end
+
+  # ── In-Encounter Use Command ──────────────────────────────
+
+  describe "in-encounter use <item>" do
+    let(:medpatch_def) do
+      create(:grid_item_definition,
+        slug: "test-medpatch",
+        name: "MedPatch",
+        item_type: "consumable",
+        properties: {"effect_type" => "heal", "amount" => 30})
+    end
+
+    it "uses consumable from inventory during BREACH" do
+      create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr)
+      hackr.set_stat!("health", 50)
+
+      breach = start_breach!
+      result = Grid::BreachActionService.use_item!(hackr: hackr, item_name: "MedPatch")
+
+      expect(result.item_name).to eq("MedPatch")
+      expect(result.effect_output).to include("Health restored")
+      expect(result.emergency_jackout).to be false
+
+      breach.reload
+      expect(breach.actions_remaining).to eq(0) # started with 1 action
+    end
+
+    it "consumes the item after use" do
+      item = create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr, quantity: 2)
+      start_breach!
+
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "MedPatch")
+      expect(item.reload.quantity).to eq(1)
+    end
+
+    it "destroys last-stack item" do
+      item = create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr, quantity: 1)
+      start_breach!
+
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "MedPatch")
+      expect { item.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises when no actions remaining" do
+      create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr)
+      breach = start_breach!
+      breach.update!(actions_remaining: 0)
+
+      expect {
+        Grid::BreachActionService.use_item!(hackr: hackr, item_name: "MedPatch")
+      }.to raise_error(Grid::BreachActionService::NoActionsRemaining)
+    end
+
+    it "raises when item not found" do
+      start_breach!
+
+      expect {
+        Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Nonexistent")
+      }.to raise_error(Grid::BreachActionService::ItemNotFound)
+    end
+
+    it "logs the use action" do
+      create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr)
+      breach = start_breach!
+
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "MedPatch")
+      log = breach.grid_hackr_breach_logs.last
+      expect(log.action_type).to eq("use")
+      expect(log.result["item_name"]).to eq("MedPatch")
+    end
+  end
+
+  # ── Signal Flare ──────────────────────────────────────────
+
+  describe "signal flare (detection reduction)" do
+    let(:flare_def) do
+      create(:grid_item_definition,
+        slug: "test-signal-flare",
+        name: "Signal Flare",
+        item_type: "consumable",
+        properties: {"effect_type" => "signal_flare", "amount" => 15})
+    end
+
+    it "reduces detection level during BREACH" do
+      create(:grid_item, :in_inventory, grid_item_definition: flare_def, grid_hackr: hackr)
+      breach = start_breach!
+      breach.update!(detection_level: 40)
+
+      result = Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Signal Flare")
+      expect(result.effect_output).to include("Detection reduced")
+
+      breach.reload
+      expect(breach.detection_level).to eq(25)
+    end
+
+    it "clamps detection at 0" do
+      create(:grid_item, :in_inventory, grid_item_definition: flare_def, grid_hackr: hackr)
+      breach = start_breach!
+      breach.update!(detection_level: 5)
+
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Signal Flare")
+      breach.reload
+      expect(breach.detection_level).to eq(0)
+    end
+
+    it "fizzles outside BREACH" do
+      flare = create(:grid_item, :in_inventory, grid_item_definition: flare_def, grid_hackr: hackr)
+      applier = Object.new.extend(Grid::ItemEffectApplier)
+      applier.define_singleton_method(:hackr) { hackr }
+      applier.define_singleton_method(:h) { |t| ERB::Util.html_escape(t.to_s) }
+
+      result = applier.apply_item_effect(flare)
+      expect(result).to include("no signal to disrupt")
+    end
+  end
+
+  # ── Emergency Jack-Out ────────────────────────────────────
+
+  describe "emergency jack-out chip" do
+    let(:chip_def) do
+      create(:grid_item_definition,
+        slug: "test-emergency-jackout",
+        name: "Emergency Jack-Out Chip",
+        item_type: "consumable",
+        properties: {"effect_type" => "emergency_jackout"})
+    end
+
+    it "returns emergency_jackout flag" do
+      create(:grid_item, :in_inventory, grid_item_definition: chip_def, grid_hackr: hackr)
+      breach = start_breach!
+      breach.update!(detection_level: 80) # past PNR
+
+      result = Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Emergency Jack-Out Chip")
+      expect(result.emergency_jackout).to be true
+    end
+
+    it "enables clean jackout past PNR" do
+      create(:grid_item, :in_inventory, grid_item_definition: chip_def, grid_hackr: hackr)
+      breach = start_breach!
+      breach.update!(detection_level: 80, pnr_threshold: 75)
+
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Emergency Jack-Out Chip")
+
+      # Emergency jackout should be clean despite PNR
+      result = Grid::BreachService.jackout!(hackr: hackr, emergency: true)
+      expect(result.clean).to be true
+    end
+  end
+
+  # ── Exploit Instant-Kill ──────────────────────────────────
+
+  describe "exploit mechanics" do
+    let(:exploit_def) do
+      create(:grid_item_definition,
+        slug: "test-exploit-trace",
+        name: "Trace Purge",
+        item_type: "software",
+        properties: {
+          "software_category" => "exploit",
+          "slot_cost" => 1,
+          "battery_cost" => 16,
+          "target_types" => ["trace"],
+          "effect_type" => "instant_kill",
+          "effect_magnitude" => 999,
+          "level" => 1
+        })
+    end
+
+    let!(:exploit) do
+      item = create(:grid_item, :in_inventory, grid_item_definition: exploit_def, grid_hackr: hackr)
+      item.update!(deck_id: deck.id)
+      item
+    end
+
+    it "instantly kills matching protocol regardless of health" do
+      tmpl = create(:grid_breach_template, protocol_composition: [
+        {"type" => "trace", "count" => 1, "health" => 999, "max_health" => 999, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(tmpl: tmpl)
+      protocol = breach.grid_breach_protocols.first
+
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Trace Purge",
+        target_position: 0
+      )
+
+      expect(result.exploit).to be true
+      expect(result.protocol_destroyed).to be true
+      expect(result.damage_dealt).to eq(999)
+      expect(protocol.reload.state).to eq("destroyed")
+    end
+
+    it "consumes exploit from DECK after successful use" do
+      start_breach!
+
+      Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Trace Purge",
+        target_position: 0
+      )
+
+      expect { exploit.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "blocks execution against mismatched protocol type without consuming action" do
+      tmpl = create(:grid_breach_template, protocol_composition: [
+        {"type" => "lock", "count" => 1, "health" => 30, "max_health" => 30, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(tmpl: tmpl)
+      actions_before = breach.actions_remaining
+
+      expect {
+        Grid::BreachActionService.exec!(
+          hackr: hackr,
+          program_name: "Trace Purge",
+          target_position: 0
+        )
+      }.to raise_error(Grid::BreachActionService::InvalidTarget, /incompatible/)
+
+      breach.reload
+      expect(breach.actions_remaining).to eq(actions_before) # action NOT consumed
+      expect(exploit.reload).to be_present # exploit NOT destroyed
+    end
+  end
+
+  # ── Utility Fragment Extraction ────────────────────────────
+
+  describe "utility fragment extraction" do
+    let(:utility_def) do
+      create(:grid_item_definition,
+        slug: "test-utility-extractor",
+        name: "Fragment Extractor",
+        item_type: "software",
+        properties: {
+          "software_category" => "utility",
+          "slot_cost" => 1,
+          "battery_cost" => 10,
+          "effect_type" => "damage",
+          "effect_magnitude" => 15,
+          "fragment_chance" => 1.0,
+          "level" => 1
+        })
+    end
+
+    let!(:utility) do
+      item = create(:grid_item, :in_inventory, grid_item_definition: utility_def, grid_hackr: hackr)
+      item.update!(deck_id: deck.id)
+      item
+    end
+
+    it "stores pending fragment on breach meta when roll succeeds" do
+      breach = start_breach!
+
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Fragment Extractor",
+        target_position: 0
+      )
+
+      expect(result.fragment).to eq("trace-fragment")
+      breach.reload
+      expect(breach.meta["pending_fragments"]).to include("trace-fragment")
+    end
+
+    it "does not extract fragment when chance is 0" do
+      utility_def.update!(properties: utility_def.properties.merge("fragment_chance" => 0.0))
+      utility.update!(properties: utility_def.properties.merge("fragment_chance" => 0.0))
+
+      start_breach!
+
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Fragment Extractor",
+        target_position: 0
+      )
+
+      expect(result.fragment).to be_nil
+    end
+
+    it "accumulates multiple fragments across rounds" do
+      tmpl = create(:grid_breach_template, protocol_composition: [
+        {"type" => "trace", "count" => 1, "health" => 200, "max_health" => 200, "charge_rounds" => 0}
+      ])
+      breach = start_breach!(tmpl: tmpl)
+
+      # First exec
+      Grid::BreachActionService.exec!(hackr: hackr, program_name: "Fragment Extractor", target_position: 0)
+
+      # End round to get more actions
+      Grid::BreachService.end_round!(hackr_breach: breach)
+      breach.reload
+
+      # Second exec
+      Grid::BreachActionService.exec!(hackr: hackr, program_name: "Fragment Extractor", target_position: 0)
+
+      breach.reload
+      expect(breach.meta["pending_fragments"].size).to eq(2)
+    end
+
+    context "fragment granting on success" do
+      let(:fragment_def) do
+        create(:grid_item_definition,
+          slug: "trace-fragment",
+          name: "TRACE Fragment",
+          item_type: "data",
+          rarity: "uncommon",
+          max_stack: 16)
+      end
+
+      it "grants pending fragments to inventory on breach success" do
+        fragment_def # ensure definition exists
+
+        breach = start_breach!
+
+        # Extract a fragment
+        Grid::BreachActionService.exec!(hackr: hackr, program_name: "Fragment Extractor", target_position: 0)
+
+        # Manually mark all protocols destroyed for success
+        breach.grid_breach_protocols.update_all(state: "destroyed", health: 0)
+
+        Grid::BreachService.resolve_success!(hackr_breach: breach)
+
+        fragment_item = hackr.grid_items.joins(:grid_item_definition)
+          .find_by(grid_item_definitions: {slug: "trace-fragment"})
+        expect(fragment_item).to be_present
+      end
+
+      it "forfeits fragments on failure" do
+        fragment_def
+
+        breach = start_breach!
+        Grid::BreachActionService.exec!(hackr: hackr, program_name: "Fragment Extractor", target_position: 0)
+
+        breach.reload
+        expect(breach.meta["pending_fragments"]).to be_present
+
+        # Force failure
+        breach.update!(detection_level: 100)
+        Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+        fragment_item = hackr.grid_items.joins(:grid_item_definition)
+          .find_by(grid_item_definitions: {slug: "trace-fragment"})
+        expect(fragment_item).to be_nil
+      end
+
+      it "forfeits fragments on jackout" do
+        fragment_def
+
+        start_breach!
+        Grid::BreachActionService.exec!(hackr: hackr, program_name: "Fragment Extractor", target_position: 0)
+
+        Grid::BreachService.jackout!(hackr: hackr)
+
+        fragment_item = hackr.grid_items.joins(:grid_item_definition)
+          .find_by(grid_item_definitions: {slug: "trace-fragment"})
+        expect(fragment_item).to be_nil
+      end
+    end
+  end
+
+  # ── Module & Firmware System ───────────────────────────────
+
+  describe "module and firmware system" do
+    let(:module_def) do
+      create(:grid_item_definition,
+        slug: "test-module",
+        name: "Test Module",
+        item_type: "module",
+        rarity: "uncommon",
+        properties: {"flashed" => false})
+    end
+
+    let(:firmware_def) do
+      create(:grid_item_definition,
+        slug: "test-firmware",
+        name: "Test Firmware",
+        item_type: "firmware",
+        rarity: "uncommon",
+        value: 100,
+        properties: {"compatible_modules" => ["test-module"]})
+    end
+
+    it "allows module items to be created" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+      expect(mod.deck_module?).to be true
+      expect(mod.item_type).to eq("module")
+    end
+
+    it "allows flashed modules to be installed in DECK" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "test-firmware"})
+
+      mod.update!(deck_id: deck.id)
+      expect(deck.installed_modules.count).to eq(1)
+      expect(deck.deck_modules_used).to eq(1)
+      expect(deck.deck_modules_available).to eq(1) # 2 slots - 1 used
+    end
+
+    it "checks module presence via has_module?" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "test-firmware"})
+      mod.update!(deck_id: deck.id)
+
+      expect(deck.has_module?("test-module")).to be true
+      expect(deck.has_module?("nonexistent")).to be false
+    end
+
+    it "enforces requires_module gate on software exec" do
+      gated_sw_def = create(:grid_item_definition,
+        slug: "test-gated-sw",
+        name: "Gated Program",
+        item_type: "software",
+        properties: {
+          "software_category" => "offensive",
+          "slot_cost" => 1,
+          "battery_cost" => 10,
+          "effect_type" => "damage",
+          "effect_magnitude" => 20,
+          "requires_module" => "test-module",
+          "level" => 1
+        })
+
+      gated_sw = create(:grid_item, :in_inventory, grid_item_definition: gated_sw_def, grid_hackr: hackr)
+      gated_sw.update!(deck_id: deck.id)
+
+      start_breach!
+
+      expect {
+        Grid::BreachActionService.exec!(
+          hackr: hackr,
+          program_name: "Gated Program",
+          target_position: 0
+        )
+      }.to raise_error(Grid::BreachActionService::ProgramNotLoaded, /requires module/)
+    end
+
+    it "allows exec when required module is installed" do
+      gated_sw_def = create(:grid_item_definition,
+        slug: "test-gated-sw-2",
+        name: "Gated Program 2",
+        item_type: "software",
+        properties: {
+          "software_category" => "offensive",
+          "slot_cost" => 1,
+          "battery_cost" => 10,
+          "effect_type" => "damage",
+          "effect_magnitude" => 30,
+          "requires_module" => "test-module",
+          "level" => 1
+        })
+
+      gated_sw = create(:grid_item, :in_inventory, grid_item_definition: gated_sw_def, grid_hackr: hackr)
+      gated_sw.update!(deck_id: deck.id)
+
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "test-firmware"})
+      mod.update!(deck_id: deck.id)
+
+      start_breach!
+
+      result = Grid::BreachActionService.exec!(
+        hackr: hackr,
+        program_name: "Gated Program 2",
+        target_position: 0
+      )
+
+      expect(result.hit).to be true
+    end
+  end
+
+  # ── ItemEffectApplier Module ───────────────────────────────
+
+  describe "ItemEffectApplier" do
+    it "handles deck_recharge effect" do
+      recharge_def = create(:grid_item_definition,
+        slug: "test-power-bank",
+        name: "Power Bank",
+        item_type: "consumable",
+        properties: {"effect_type" => "deck_recharge", "amount" => 32})
+
+      create(:grid_item, :in_inventory, grid_item_definition: recharge_def, grid_hackr: hackr)
+      deck.update!(properties: deck.properties.merge("battery_current" => 50))
+
+      start_breach!
+      Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Power Bank")
+
+      deck.reload
+      expect(deck.deck_battery).to eq(82)
+    end
+
+    it "handles inspire effect during BREACH" do
+      inspire_def = create(:grid_item_definition,
+        slug: "test-muse-chip",
+        name: "Muse Chip",
+        item_type: "consumable",
+        properties: {"effect_type" => "inspire", "amount" => 5})
+
+      create(:grid_item, :in_inventory, grid_item_definition: inspire_def, grid_hackr: hackr)
+
+      breach = start_breach!
+      result = Grid::BreachActionService.use_item!(hackr: hackr, item_name: "Muse Chip")
+
+      expect(result.effect_output).to include("INSPIRATION")
+      breach.reload
+      expect(breach.inspiration).to be > 0
+    end
+  end
+
+  # ── BreachCommandParser Integration ────────────────────────
+
+  describe "BreachCommandParser" do
+    it "routes use command" do
+      medpatch_def = create(:grid_item_definition,
+        slug: "test-medpatch-cmd",
+        name: "MedPatch",
+        item_type: "consumable",
+        properties: {"effect_type" => "heal", "amount" => 30})
+
+      create(:grid_item, :in_inventory, grid_item_definition: medpatch_def, grid_hackr: hackr)
+      hackr.set_stat!("health", 50)
+
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "use MedPatch", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("Health restored")
+    end
+
+    it "shows exploit kill message" do
+      exploit_def = create(:grid_item_definition,
+        slug: "test-exploit-cmd",
+        name: "Test Exploit",
+        item_type: "software",
+        properties: {
+          "software_category" => "exploit",
+          "slot_cost" => 1,
+          "battery_cost" => 10,
+          "target_types" => ["trace"],
+          "effect_type" => "instant_kill",
+          "effect_magnitude" => 999,
+          "level" => 1
+        })
+
+      exploit = create(:grid_item, :in_inventory, grid_item_definition: exploit_def, grid_hackr: hackr)
+      exploit.update!(deck_id: deck.id)
+
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "exec Test Exploit 1", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("EXPLOIT")
+      expect(result[:output]).to include("INSTANT KILL")
+    end
+
+    it "shows fragment extraction in exec output" do
+      utility_def = create(:grid_item_definition,
+        slug: "test-utility-cmd",
+        name: "Test Utility",
+        item_type: "software",
+        properties: {
+          "software_category" => "utility",
+          "slot_cost" => 1,
+          "battery_cost" => 10,
+          "effect_type" => "damage",
+          "effect_magnitude" => 15,
+          "fragment_chance" => 1.0,
+          "level" => 1
+        })
+
+      util = create(:grid_item, :in_inventory, grid_item_definition: utility_def, grid_hackr: hackr)
+      util.update!(deck_id: deck.id)
+
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "exec Test Utility 1", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("Fragment extracted")
+    end
+
+    it "includes use in help output" do
+      breach = start_breach!
+      parser = Grid::BreachCommandParser.new(hackr, "help", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("use")
+      expect(result[:output]).to include("consumable")
+    end
+  end
+
+  # ── Deck Module Commands (CommandParser) ────────────────────
+
+  describe "deck install command" do
+    let(:module_def) do
+      create(:grid_item_definition,
+        slug: "test-install-mod",
+        name: "Test Module",
+        item_type: "module",
+        rarity: "uncommon",
+        properties: {"flashed" => false})
+    end
+
+    it "installs a flashed module into DECK" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+
+      parser = Grid::CommandParser.new(hackr, "deck install Test Module")
+      result = parser.execute
+
+      expect(result[:output]).to include("Installed")
+      expect(mod.reload.deck_id).to eq(deck.id)
+    end
+
+    it "rejects unflashed module" do
+      create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+
+      parser = Grid::CommandParser.new(hackr, "deck install Test Module")
+      result = parser.execute
+
+      expect(result[:output]).to include("no firmware")
+    end
+
+    it "rejects when module slots full" do
+      # Fill both module slots
+      2.times do |i|
+        fill_def = create(:grid_item_definition,
+          slug: "fill-mod-#{i}",
+          name: "Fill Mod #{i}",
+          item_type: "module",
+          rarity: "common",
+          properties: {"flashed" => true})
+        fill = create(:grid_item, :in_inventory, grid_item_definition: fill_def, grid_hackr: hackr,
+          properties: {"flashed" => true})
+        fill.update!(deck_id: deck.id)
+      end
+
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+
+      parser = Grid::CommandParser.new(hackr, "deck install Test Module")
+      result = parser.execute
+
+      expect(result[:output]).to include("No module slots")
+      expect(mod.reload.deck_id).to be_nil
+    end
+
+    it "blocks install during BREACH (routes to BREACH deck view)" do
+      create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+
+      breach = start_breach!
+
+      # During BREACH, all commands route through BreachCommandParser
+      # "deck install ..." shows deck view (no subcommand routing)
+      parser = Grid::BreachCommandParser.new(hackr, "deck install Test Module", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("DECK")
+      expect(result[:output]).not_to include("Installed")
+    end
+  end
+
+  describe "deck uninstall command" do
+    let(:module_def) do
+      create(:grid_item_definition,
+        slug: "test-uninstall-mod",
+        name: "Installed Module",
+        item_type: "module",
+        rarity: "uncommon",
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+    end
+
+    it "uninstalls a module from DECK" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+      mod.update!(deck_id: deck.id)
+
+      parser = Grid::CommandParser.new(hackr, "deck uninstall Installed Module")
+      result = parser.execute
+
+      expect(result[:output]).to include("Uninstalled")
+      expect(mod.reload.deck_id).to be_nil
+    end
+
+    it "blocks uninstall during BREACH (routes to BREACH deck view)" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "some-fw"})
+      mod.update!(deck_id: deck.id)
+
+      breach = start_breach!
+
+      parser = Grid::BreachCommandParser.new(hackr, "deck uninstall Installed Module", breach)
+      result = parser.execute
+
+      expect(result[:output]).to include("DECK")
+      expect(result[:output]).not_to include("Uninstalled")
+      expect(mod.reload.deck_id).to eq(deck.id) # still installed
+    end
+  end
+
+  describe "deck flash command" do
+    let(:module_def) do
+      create(:grid_item_definition,
+        slug: "test-flash-mod",
+        name: "Raw Module",
+        item_type: "module",
+        rarity: "uncommon",
+        properties: {"flashed" => false})
+    end
+
+    let(:firmware_def) do
+      create(:grid_item_definition,
+        slug: "test-flash-fw",
+        name: "Test Firmware",
+        item_type: "firmware",
+        rarity: "uncommon",
+        value: 100,
+        properties: {"compatible_modules" => ["test-flash-mod"]})
+    end
+
+    let(:flasher_def) do
+      create(:grid_item_definition,
+        slug: "eeprom-flasher",
+        name: "EEPROM Flasher",
+        item_type: "tool",
+        rarity: "rare",
+        max_stack: 1,
+        properties: {})
+    end
+
+    context "DIY path (EEPROM Flasher in inventory)" do
+      it "flashes firmware onto module, consuming firmware" do
+        mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+        fw = create(:grid_item, :in_inventory, grid_item_definition: firmware_def, grid_hackr: hackr)
+        create(:grid_item, :in_inventory, grid_item_definition: flasher_def, grid_hackr: hackr)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+        result = parser.execute
+
+        expect(result[:output]).to include("Firmware flashed")
+        mod.reload
+        expect(mod.properties["flashed"]).to be true
+        expect(mod.properties["firmware_slug"]).to eq("test-flash-fw")
+        expect { fw.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "decrements firmware quantity when stacked" do
+        create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+        fw = create(:grid_item, :in_inventory, grid_item_definition: firmware_def, grid_hackr: hackr, quantity: 3)
+        create(:grid_item, :in_inventory, grid_item_definition: flasher_def, grid_hackr: hackr)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+        parser.execute
+
+        expect(fw.reload.quantity).to eq(2)
+      end
+
+      it "rejects incompatible firmware" do
+        create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+        incompat_def = create(:grid_item_definition,
+          slug: "test-incompat-fw",
+          name: "Wrong Firmware",
+          item_type: "firmware",
+          rarity: "uncommon",
+          properties: {"compatible_modules" => ["other-module"]})
+        create(:grid_item, :in_inventory, grid_item_definition: incompat_def, grid_hackr: hackr)
+        create(:grid_item, :in_inventory, grid_item_definition: flasher_def, grid_hackr: hackr)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Wrong Firmware onto Raw Module")
+        result = parser.execute
+
+        expect(result[:output]).to include("not compatible")
+      end
+
+      it "rejects without flasher tool or vendor room" do
+        create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+        create(:grid_item, :in_inventory, grid_item_definition: firmware_def, grid_hackr: hackr)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+        result = parser.execute
+
+        expect(result[:output]).to include("EEPROM Flasher")
+      end
+    end
+
+    context "vendor path (firmware_vendor room)" do
+      let(:vendor_room) { create(:grid_room, grid_zone: zone, room_type: "firmware_vendor") }
+      let(:hackr_cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+      let!(:burn_cache) { create(:grid_cache, :burn) }
+
+      before do
+        hackr.update!(current_room: vendor_room)
+        hackr_cache
+      end
+
+      def fund_cache(target_cache, amount)
+        source = create(:grid_cache)
+        GridTransaction.create!(
+          from_cache: source, to_cache: target_cache, amount: amount,
+          tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+        )
+      end
+
+      it "buys and flashes firmware from vendor catalog" do
+        firmware_def # ensure definition exists in DB
+        mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+        fund_cache(hackr_cache, 500)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+        result = parser.execute
+
+        expect(result[:output]).to include("Firmware flashed")
+        mod.reload
+        expect(mod.properties["flashed"]).to be true
+      end
+
+      it "rejects when insufficient CRED" do
+        firmware_def
+        create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr)
+
+        parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+        result = parser.execute
+
+        expect(result[:output]).to include("Insufficient CRED")
+      end
+    end
+
+    it "overwrites existing firmware with notification" do
+      mod = create(:grid_item, :in_inventory, grid_item_definition: module_def, grid_hackr: hackr,
+        properties: {"flashed" => true, "firmware_slug" => "old-firmware"})
+      create(:grid_item, :in_inventory, grid_item_definition: firmware_def, grid_hackr: hackr)
+      create(:grid_item, :in_inventory, grid_item_definition: flasher_def, grid_hackr: hackr)
+
+      parser = Grid::CommandParser.new(hackr, "deck flash Test Firmware onto Raw Module")
+      result = parser.execute
+
+      expect(result[:output]).to include("Previous firmware overwritten")
+      expect(mod.reload.properties["firmware_slug"]).to eq("test-flash-fw")
+    end
+  end
+end

--- a/spec/services/grid/breach_service_spec.rb
+++ b/spec/services/grid/breach_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Grid::BreachService do
     create(:grid_item_definition, :gear,
       slug: "test-deck",
       name: "Test Deck",
-      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "firmware_slot_count" => 1, "effects" => {}})
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
   end
 
   let!(:deck) do


### PR DESCRIPTION
  In-encounter consumables, module/firmware hardware system, exploit
  instant-kill, and utility fragment extraction loop. Completes the
  core loot cycle: breach → extract fragments → fabricate software →
  harder breaches.

  In-encounter use command:
  - BreachActionService.use_item! (1 action, consumes item, logs action)
  - Grid::ItemEffectApplier extracted from CommandParser as shared module
  - New effects: signal_flare (reduce detection), emergency_jackout (bypass PNR for clean exit), inspire (now works in BREACH)

  Module + firmware system:
  - New `module` item type for hardware peripherals (antennas, arrays)
  - Modules come raw, need firmware flashed before DECK installation
  - Two flash paths: Firmware Vending Machine rooms (buy + flash) or portable EEPROM Flasher tool (DIY anywhere with firmware item)
  - deck flash/install/uninstall commands, module slot enforcement
  - requires_module gate on software exec
  - firmware_slot_count → module_slot_count rename (code + data migration)

  Exploits:
  - software_category "exploit" with type-guarded instant-kill
  - target_types match → protocol destroyed regardless of health
  - Mismatch → blocked without consuming action or destroying exploit
  - Consumed from DECK after successful use (one-shot)

  Fragment extraction:
  - Utility software rolls fragment_chance per exec hit
  - Pending fragments stored in breach.meta["pending_fragments"]
  - Granted to inventory on success, forfeit on failure/jackout
  - InventoryFull gracefully skipped (fragments dropped, not crashed)
  - data_extracted achievement + extract_data mission objective