### PR TITLE
 [TPG] BREACH Phase 2D - World Layer (ambient encounters)

### DIFF
--- a/app/controllers/admin/grid_breach_templates_controller.rb
+++ b/app/controllers/admin/grid_breach_templates_controller.rb
@@ -96,6 +96,7 @@ class Admin::GridBreachTemplatesController < Admin::ApplicationController
       :pnr_threshold, :base_detection_rate,
       :cooldown_min, :cooldown_max, :xp_reward, :cred_reward,
       :requires_mission_slug, :requires_item_slug,
+      :danger_level_min,
       :published, :position,
       :protocol_composition_json, :reward_table_json
     )
@@ -103,6 +104,10 @@ class Admin::GridBreachTemplatesController < Admin::ApplicationController
 
   # Returns true on success, false on parse error (with error added to @template)
   def parse_json_fields!
+    # Parse zone_slugs from CSV text field (splitting "" yields [])
+    csv = params[:grid_breach_template].delete(:zone_slugs_csv)
+    @template.zone_slugs = csv.split(",").map(&:strip).reject(&:blank?) unless csv.nil?
+
     if params[:grid_breach_template][:protocol_composition_json].present?
       parsed = JSON.parse(params[:grid_breach_template][:protocol_composition_json])
       unless parsed.is_a?(Array)

--- a/app/controllers/admin/grid_zones_controller.rb
+++ b/app/controllers/admin/grid_zones_controller.rb
@@ -66,7 +66,7 @@ class Admin::GridZonesController < Admin::ApplicationController
 
   def zone_params
     params.require(:grid_zone).permit(
-      :name, :slug, :description, :zone_type, :color_scheme, :grid_region_id, :grid_faction_id, :ambient_playlist_id
+      :name, :slug, :description, :zone_type, :color_scheme, :danger_level, :grid_region_id, :grid_faction_id, :ambient_playlist_id
     )
   end
 end

--- a/app/models/grid_breach_template.rb
+++ b/app/models/grid_breach_template.rb
@@ -10,6 +10,7 @@
 #  cooldown_max          :integer          default(600), not null
 #  cooldown_min          :integer          default(300), not null
 #  cred_reward           :integer          default(0), not null
+#  danger_level_min      :integer          default(0), not null
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
@@ -23,6 +24,7 @@
 #  slug                  :string           not null
 #  tier                  :string           default("standard"), not null
 #  xp_reward             :integer          default(0), not null
+#  zone_slugs            :json             not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #
@@ -53,9 +55,11 @@ class GridBreachTemplate < ApplicationRecord
   validates :cooldown_max, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validate :cooldown_range_valid
   validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :danger_level_min, numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
   scope :published, -> { where(published: true) }
   scope :ordered, -> { order(:position, :name) }
+  scope :ambient, -> { where(tier: "ambient") }
 
   def to_param
     slug
@@ -71,6 +75,12 @@ class GridBreachTemplate < ApplicationRecord
     composition = protocol_composition
     return [] unless composition.is_a?(Array)
     composition
+  end
+
+  # Does this template's zone constraint match the given zone?
+  # Empty zone_slugs = matches any zone.
+  def matches_zone?(zone)
+    zone_slugs.empty? || zone_slugs.include?(zone.slug)
   end
 
   # reward_table: Phase 2 — will drive variable loot drops on breach completion.

--- a/app/models/grid_zone.rb
+++ b/app/models/grid_zone.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  color_scheme        :string
+#  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string
@@ -40,4 +41,5 @@ class GridZone < ApplicationRecord
     in: %w[faction_base govcorp residential transit special danger_zone],
     allow_nil: true
   }
+  validates :danger_level, numericality: {only_integer: true, in: 0..10}
 end

--- a/app/services/grid/breach_generator_service.rb
+++ b/app/services/grid/breach_generator_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Grid
+  # Handles ambient (random) encounter generation on room entry.
+  # Called from CommandParser#go_command when a hackr enters a room
+  # in a zone with danger_level > 0.
+  class BreachGeneratorService
+    AmbientResult = Data.define(:display, :ejected)
+
+    def self.ambient_check!(hackr:, room:)
+      new(hackr, room).ambient_check!
+    end
+
+    def initialize(hackr, room)
+      @hackr = hackr
+      @room = room
+    end
+
+    # Returns AmbientResult if an encounter triggered, nil otherwise.
+    def ambient_check!
+      zone = @room.grid_zone
+      return nil if zone.danger_level == 0
+      return nil if @hackr.in_breach?
+
+      # Roll against danger level: danger_level * 5% chance per room entry
+      return nil unless rand < (zone.danger_level * 0.05)
+
+      # Find a matching ambient template for this zone
+      template = find_ambient_template(zone)
+      return nil unless template
+
+      # No DECK equipped → auto-fail at tier 1 (vitals drain + eject)
+      unless @hackr.equipped_deck
+        return auto_fail_no_deck!(template)
+      end
+
+      # Start the ambient BREACH
+      start_ambient!(template)
+    end
+
+    private
+
+    def find_ambient_template(zone)
+      templates = GridBreachTemplate.published.ambient
+        .where("danger_level_min <= ?", zone.danger_level)
+        .where("min_clearance <= ?", @hackr.stat("clearance"))
+        .to_a
+
+      # Filter by zone_slugs (empty = any zone)
+      templates.select! { |t| t.matches_zone?(zone) }
+
+      templates.sample
+    end
+
+    def start_ambient!(template)
+      result = Grid::BreachService.start_ambient!(hackr: @hackr, template: template)
+
+      display = []
+      display << ""
+      display << "<span style='color: #ef4444; font-weight: bold;'>\u26a0 AMBIENT BREACH \u2014 you've been detected!</span>"
+      display << ""
+      display << result.display
+      display << ""
+      display << "<span style='color: #6b7280;'>Type 'help' for BREACH commands.</span>"
+
+      AmbientResult.new(display: display.join("\n"), ejected: false)
+    rescue Grid::BreachService::AlreadyInBreach
+      nil # Race condition — another breach started between check and start
+    end
+
+    def auto_fail_no_deck!(template)
+      eject_room_id = nil
+      ejected = false
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        # Tier 1 failure: vitals drain
+        @hackr.adjust_vital!("energy", -20)
+        @hackr.adjust_vital!("psyche", -20)
+
+        # Eject to zone entry room (if available)
+        eject_room_id = @hackr.zone_entry_room_id
+        if eject_room_id && eject_room_id != @hackr.current_room_id
+          @hackr.update!(current_room_id: eject_room_id)
+          ejected = true
+        end
+      end
+
+      display = []
+      display << ""
+      display << "<span style='color: #ef4444; font-weight: bold;'>\u26a0 AMBIENT BREACH \u2014 #{ERB::Util.html_escape(template.name)}</span>"
+      display << "<span style='color: #f87171;'>No DECK equipped \u2014 system scan overwhelms your unshielded neural link.</span>"
+      display << ""
+      display << "<span style='color: #f87171;'>ENERGY -20 | PSYCHE -20</span>"
+      if ejected
+        eject_room = GridRoom.find_by(id: eject_room_id)
+        display << "<span style='color: #f87171;'>Ejected to #{ERB::Util.html_escape(eject_room&.name || "unknown")}.</span>"
+      end
+      display << "<span style='color: #6b7280;'>Equip a DECK to survive ambient encounters.</span>"
+
+      AmbientResult.new(display: display.join("\n"), ejected: ejected)
+    end
+  end
+end

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -40,6 +40,10 @@ module Grid
       new(hackr).start!(encounter)
     end
 
+    def self.start_ambient!(hackr:, template:)
+      new(hackr).start_ambient!(template)
+    end
+
     def self.end_round!(hackr_breach:)
       new(hackr_breach.grid_hackr).end_round!(hackr_breach)
     end
@@ -142,6 +146,53 @@ module Grid
           inspiration: 0,
           actions_this_round: initial_actions,
           actions_remaining: initial_actions,
+          reward_multiplier: 1.0,
+          started_at: Time.current
+        )
+
+        protocols = generate_protocols!(breach, template)
+      end
+
+      display = Grid::BreachRenderer.new(breach, protocols).render_full
+      StartResult.new(hackr_breach: breach, protocols: protocols, display: display)
+    rescue ActiveRecord::RecordNotUnique
+      raise AlreadyInBreach, "You are already in a BREACH encounter."
+    end
+
+    # Start an ambient encounter (no persistent GridBreachEncounter record).
+    # Called by BreachGeneratorService when a random encounter triggers.
+    def start_ambient!(template)
+      raise AlreadyInBreach, "You are already in a BREACH encounter." if @hackr.in_breach?
+
+      deck = @hackr.equipped_deck
+      raise NoDeckEquipped, "No DECK equipped." unless deck
+
+      cl = @hackr.stat("clearance")
+      if cl < template.min_clearance
+        raise ClearanceBlocked, "Requires CLEARANCE #{template.min_clearance}. You are CLEARANCE #{cl}."
+      end
+
+      breach = nil
+      protocols = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        # Re-check after lock (another request may have started a breach)
+        raise AlreadyInBreach, "You are already in a BREACH encounter." if @hackr.in_breach?
+
+        breach = GridHackrBreach.create!(
+          grid_hackr: @hackr,
+          grid_breach_template: template,
+          grid_breach_encounter: nil,
+          origin_room_id: @hackr.current_room_id,
+          state: "active",
+          detection_level: 0,
+          pnr_threshold: template.pnr_threshold,
+          round_number: 1,
+          inspiration: 0,
+          actions_this_round: 1,
+          actions_remaining: 1,
           reward_multiplier: 1.0,
           started_at: Time.current
         )

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -372,6 +372,16 @@ module Grid
       notifications += mission_progressor.record(:reach_clearance, clearance: hackr.stat("clearance").to_i)
       look_output = append_notifications(look_output, notifications)
 
+      # Ambient encounter check — random BREACH trigger based on zone danger_level
+      ambient_result = Grid::BreachGeneratorService.ambient_check!(hackr: hackr, room: new_room)
+      if ambient_result
+        look_output += "\n" + ambient_result.display
+        if ambient_result.ejected
+          hackr.reload
+          look_output += "\n" + look_command
+        end
+      end
+
       {
         output: look_output,
         event: {

--- a/app/views/admin/grid_breach_templates/_form.html.erb
+++ b/app/views/admin/grid_breach_templates/_form.html.erb
@@ -75,6 +75,23 @@
     </div>
   </div>
 
+  <h3 class="cyan-255-text" style="margin: 25px 0 15px 0;">[:: AMBIENT ENCOUNTER TARGETING ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 2fr; gap: 20px;">
+    <div>
+      <%= f.label :danger_level_min, "MIN DANGER LEVEL", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :danger_level_min, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0, max: 10 %>
+      <small style="color: #888;">Zone danger_level must be >= this to spawn</small>
+    </div>
+    <div>
+      <%= f.label :zone_slugs_csv, "ZONE SLUGS", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :zone_slugs_csv,
+            value: (template.zone_slugs.is_a?(Array) ? template.zone_slugs.join(", ") : ""),
+            class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">Comma-separated zone slugs. Empty = any zone.</small>
+    </div>
+  </div>
+
   <h3 class="cyan-255-text" style="margin: 25px 0 15px 0;">[:: PROTOCOL COMPOSITION (JSON) ::]</h3>
   <div style="margin-top: 10px;">
     <%= f.text_area :protocol_composition_json,

--- a/app/views/admin/grid_zones/_form.html.erb
+++ b/app/views/admin/grid_zones/_form.html.erb
@@ -36,6 +36,11 @@
     <%= f.label :color_scheme, "COLOR SCHEME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.text_field :color_scheme, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>
+  <div style="flex: 1; min-width: 200px;">
+    <%= f.label :danger_level, "DANGER LEVEL", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.number_field :danger_level, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0, max: 10 %>
+    <small style="color: #888;">0 = safe, 10 = max ambient encounters</small>
+  </div>
 </div>
 
 <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">

--- a/app/views/admin/grid_zones/index.html.erb
+++ b/app/views/admin/grid_zones/index.html.erb
@@ -31,6 +31,7 @@
                 <th style="text-align: left;">Type</th>
                 <th style="text-align: left;">Faction</th>
                 <th style="text-align: left;">Ambient Playlist</th>
+                <th style="text-align: center;">Danger</th>
                 <th style="text-align: center;">Rooms</th>
                 <th style="text-align: right;">Actions</th>
               </tr>
@@ -48,6 +49,13 @@
                       <span class="purple-255-text"><%= zone.ambient_playlist.name %></span>
                     <% else %>
                       <span style="color: #666;">—</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% if zone.danger_level > 0 %>
+                      <span style="color: #ef4444;"><%= zone.danger_level %></span>
+                    <% else %>
+                      <span style="color: #666;">0</span>
                     <% end %>
                   </td>
                   <td style="text-align: center;"><%= zone.grid_rooms.size %></td>

--- a/data/world/breach_templates.yml
+++ b/data/world/breach_templates.yml
@@ -142,6 +142,123 @@ breach_templates:
         charge_rounds: 1
         weakness: offensive
 
+  # ── AMBIENT TEMPLATES ──────────────────────────────────────
+
+  - slug: ambient-scan-ping
+    name: "GovCorp Scan Ping"
+    description: "A routine GovCorp surveillance ping sweeps the area. Low threat — but it knows you're here."
+    tier: ambient
+    min_clearance: 0
+    danger_level_min: 1
+    zone_slugs: []
+    pnr_threshold: 80
+    base_detection_rate: 8
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 40
+    cred_reward: 15
+    published: true
+    position: 100
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 25
+        max_health: 25
+        charge_rounds: 0
+        weakness: offensive
+
+  - slug: ambient-rainn-sweep
+    name: "RAINN Patrol Sweep"
+    description: "A RAINN patrol unit locks onto your signal. It's fast, but fragile."
+    tier: ambient
+    min_clearance: 0
+    danger_level_min: 2
+    zone_slugs: []
+    pnr_threshold: 75
+    base_detection_rate: 7
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 60
+    cred_reward: 25
+    published: true
+    position: 101
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 30
+        max_health: 30
+        charge_rounds: 0
+      - type: feedback
+        count: 1
+        health: 35
+        max_health: 35
+        charge_rounds: 1
+        weakness: offensive
+
+  - slug: ambient-govcorp-interceptor
+    name: "GovCorp Signal Interceptor"
+    description: "A GovCorp interception node has triangulated your position. SPIKE protocol targets your neural link directly."
+    tier: ambient
+    min_clearance: 5
+    danger_level_min: 4
+    zone_slugs:
+      - govcorp-surveillance
+    pnr_threshold: 70
+    base_detection_rate: 8
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 100
+    cred_reward: 40
+    published: true
+    position: 102
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 35
+        max_health: 35
+        charge_rounds: 0
+      - type: spike
+        count: 1
+        health: 30
+        max_health: 30
+        charge_rounds: 1
+        weakness: defensive
+
+  - slug: ambient-underbelly-wraith
+    name: "Underbelly Wraith Process"
+    description: "Something old lurks in the unregistered passages. A rogue process, mutated beyond its original purpose. It's been waiting."
+    tier: ambient
+    min_clearance: 10
+    danger_level_min: 5
+    zone_slugs:
+      - the-underbelly
+    pnr_threshold: 65
+    base_detection_rate: 9
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 150
+    cred_reward: 60
+    published: true
+    position: 103
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 40
+        max_health: 40
+        charge_rounds: 0
+      - type: feedback
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 1
+      - type: lock
+        count: 1
+        health: 35
+        max_health: 35
+        charge_rounds: 2
+
+  # ── STANDARD+ TEMPLATES ─────────────────────────────────────
+
   - slug: rainn-command-relay
     name: "RAINN Command Relay"
     description: "A RAINN command-and-control relay node. Heavy protocol synergies — dual TRACE accelerates detection, ADAPT mutates weaknesses, SPIKE punishes hesitation."

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -8,6 +8,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
+    danger_level: 0
 
   - name: Sector X
     slug: sector-x
@@ -17,6 +18,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: xeraen
     ambient_playlist_slug: fracture-network-ambience
+    danger_level: 0
 
   - name: Transit Network
     slug: transit-network
@@ -26,6 +28,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: transit-network-ambience
+    danger_level: 2
 
   - name: GovCorp Surveillance District
     slug: govcorp-surveillance
@@ -35,6 +38,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: govcorp
     ambient_playlist_slug: govcorp-surveillance-ambience
+    danger_level: 5
 
   - name: The Underbelly
     slug: the-underbelly
@@ -44,6 +48,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
+    danger_level: 7
 
   - name: Residential District
     slug: residential-district
@@ -53,6 +58,7 @@ zones:
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
+    danger_level: 0
 
   - name: The Hackr Hangar
     slug: hackr-hangar
@@ -62,6 +68,7 @@ zones:
     region_slug: the-riverlands
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
+    danger_level: 0
 
   - name: "GovCorp RestorePoint\u2122 — Lakeshore"
     slug: restorepoint-lakeshore
@@ -71,3 +78,4 @@ zones:
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
+    danger_level: 0

--- a/db/migrate/20260424031949_add_danger_level_to_grid_zones_and_breach_templates.rb
+++ b/db/migrate/20260424031949_add_danger_level_to_grid_zones_and_breach_templates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddDangerLevelToGridZonesAndBreachTemplates < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_zones, :danger_level, :integer, null: false, default: 0
+    add_column :grid_breach_templates, :danger_level_min, :integer, null: false, default: 0
+    add_column :grid_breach_templates, :zone_slugs, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_024043) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_031949) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -210,6 +210,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_024043) do
     t.integer "cooldown_min", default: 300, null: false
     t.datetime "created_at", null: false
     t.integer "cred_reward", default: 0, null: false
+    t.integer "danger_level_min", default: 0, null: false
     t.text "description"
     t.integer "min_clearance", default: 0, null: false
     t.string "name", null: false
@@ -224,6 +225,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_024043) do
     t.string "tier", default: "standard", null: false
     t.datetime "updated_at", null: false
     t.integer "xp_reward", default: 0, null: false
+    t.json "zone_slugs", default: [], null: false
     t.index ["published"], name: "index_grid_breach_templates_on_published"
     t.index ["slug"], name: "index_grid_breach_templates_on_slug", unique: true
     t.index ["tier"], name: "index_grid_breach_templates_on_tier"
@@ -732,6 +734,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_024043) do
     t.integer "ambient_playlist_id"
     t.string "color_scheme"
     t.datetime "created_at", null: false
+    t.integer "danger_level", default: 0, null: false
     t.text "description"
     t.integer "grid_faction_id"
     t.integer "grid_region_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -565,6 +565,7 @@ namespace :data do
         description: attrs["description"],
         zone_type: attrs["zone_type"],
         color_scheme: attrs["color_scheme"],
+        danger_level: attrs["danger_level"] || 0,
         grid_region: region,
         grid_faction: faction,
         ambient_playlist: playlist
@@ -864,6 +865,8 @@ namespace :data do
         cred_reward: attrs["cred_reward"] || 0,
         requires_mission_slug: attrs["requires_mission_slug"],
         requires_item_slug: attrs["requires_item_slug"],
+        danger_level_min: attrs["danger_level_min"] || 0,
+        zone_slugs: attrs["zone_slugs"] || [],
         published: attrs["published"] || false,
         position: attrs["position"] || 0,
         protocol_composition: attrs["protocol_composition"] || [],

--- a/spec/factories/grid_breach_templates.rb
+++ b/spec/factories/grid_breach_templates.rb
@@ -10,6 +10,7 @@
 #  cooldown_max          :integer          default(600), not null
 #  cooldown_min          :integer          default(300), not null
 #  cred_reward           :integer          default(0), not null
+#  danger_level_min      :integer          default(0), not null
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
@@ -23,6 +24,7 @@
 #  slug                  :string           not null
 #  tier                  :string           default("standard"), not null
 #  xp_reward             :integer          default(0), not null
+#  zone_slugs            :json             not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #
@@ -61,6 +63,10 @@ FactoryBot.define do
 
     trait :ambient do
       tier { "ambient" }
+      danger_level_min { 1 }
+      zone_slugs { [] }
+      cooldown_min { 0 }
+      cooldown_max { 0 }
     end
   end
 end

--- a/spec/factories/grid_zones.rb
+++ b/spec/factories/grid_zones.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  color_scheme        :string
+#  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string

--- a/spec/models/grid_breach_template_spec.rb
+++ b/spec/models/grid_breach_template_spec.rb
@@ -10,6 +10,7 @@
 #  cooldown_max          :integer          default(600), not null
 #  cooldown_min          :integer          default(300), not null
 #  cred_reward           :integer          default(0), not null
+#  danger_level_min      :integer          default(0), not null
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
@@ -23,6 +24,7 @@
 #  slug                  :string           not null
 #  tier                  :string           default("standard"), not null
 #  xp_reward             :integer          default(0), not null
+#  zone_slugs            :json             not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #

--- a/spec/models/grid_zone_spec.rb
+++ b/spec/models/grid_zone_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  color_scheme        :string
+#  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string

--- a/spec/services/grid/breach_generator_service_spec.rb
+++ b/spec/services/grid/breach_generator_service_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::BreachGeneratorService do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region, danger_level: danger_level) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:entry_room) { create(:grid_room, grid_zone: create(:grid_zone, grid_region: region)) }
+  let(:hackr) { create(:grid_hackr, current_room: room, zone_entry_room: entry_room) }
+  let(:danger_level) { 5 }
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "gen-test-deck",
+      name: "Generator Test Deck",
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let!(:ambient_template) do
+    create(:grid_breach_template, :ambient,
+      slug: "ambient-test-scan",
+      name: "Test Ambient Scan",
+      danger_level_min: 1,
+      zone_slugs: [],
+      min_clearance: 0,
+      published: true)
+  end
+
+  describe ".ambient_check!" do
+    context "when zone danger_level is 0" do
+      let(:danger_level) { 0 }
+
+      it "returns nil without rolling" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when hackr is already in breach" do
+      before do
+        encounter = create(:grid_breach_encounter, grid_breach_template: create(:grid_breach_template), grid_room: room)
+        Grid::BreachService.start!(hackr: hackr, encounter: encounter)
+      end
+
+      it "returns nil" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when roll fails (no encounter triggered)" do
+      it "returns nil" do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.99)
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+        expect(result).to be_nil
+      end
+    end
+
+    context "when roll succeeds and DECK equipped" do
+      before do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.01)
+      end
+
+      it "starts an ambient BREACH encounter" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result).to be_a(Grid::BreachGeneratorService::AmbientResult)
+        expect(result.ejected).to be false
+        expect(result.display).to include("AMBIENT BREACH")
+        expect(result.display).to include("B R E A C H")
+        expect(hackr.reload).to be_in_breach
+      end
+
+      it "creates a breach with nil encounter (ambient)" do
+        described_class.ambient_check!(hackr: hackr, room: room)
+
+        breach = hackr.active_breach
+        expect(breach.grid_breach_encounter_id).to be_nil
+        expect(breach.grid_breach_template.tier).to eq("ambient")
+        expect(breach.state).to eq("active")
+      end
+    end
+
+    context "when roll succeeds and no DECK equipped" do
+      before do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.01)
+        deck.update!(equipped_slot: nil)
+      end
+
+      it "auto-fails with tier 1 consequences (vitals drain)" do
+        old_energy = hackr.stat("energy")
+        old_psyche = hackr.stat("psyche")
+
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        hackr.reload
+        expect(result).to be_a(Grid::BreachGeneratorService::AmbientResult)
+        expect(result.display).to include("No DECK equipped")
+        expect(result.display).to include("ENERGY -20")
+        expect(hackr.stat("energy")).to eq([old_energy - 20, 0].max)
+        expect(hackr.stat("psyche")).to eq([old_psyche - 20, 0].max)
+      end
+
+      it "ejects hackr to zone entry room" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result.ejected).to be true
+        expect(hackr.reload.current_room_id).to eq(entry_room.id)
+      end
+
+      it "does not start a BREACH" do
+        described_class.ambient_check!(hackr: hackr, room: room)
+        expect(hackr.reload).not_to be_in_breach
+      end
+    end
+
+    context "when no zone entry room is set" do
+      let(:hackr) { create(:grid_hackr, current_room: room, zone_entry_room: nil) }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.01)
+        deck.update!(equipped_slot: nil)
+      end
+
+      it "does not eject (stays in current room)" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result.ejected).to be false
+        expect(hackr.reload.current_room_id).to eq(room.id)
+      end
+    end
+  end
+
+  describe "template filtering" do
+    before do
+      allow_any_instance_of(described_class).to receive(:rand).and_return(0.01)
+    end
+
+    context "by danger_level_min" do
+      let(:danger_level) { 3 }
+
+      let!(:high_danger_template) do
+        create(:grid_breach_template, :ambient,
+          slug: "ambient-high-danger",
+          danger_level_min: 5,
+          published: true)
+      end
+
+      it "only selects templates with danger_level_min <= zone danger_level" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result).not_to be_nil
+        breach = hackr.active_breach
+        expect(breach.grid_breach_template).to eq(ambient_template)
+      end
+    end
+
+    context "by zone_slugs" do
+      before do
+        # Remove the catch-all template so only the zone-locked one exists
+        ambient_template.update!(published: false)
+      end
+
+      let!(:zone_locked_template) do
+        create(:grid_breach_template, :ambient,
+          slug: "ambient-zone-locked",
+          danger_level_min: 1,
+          zone_slugs: ["some-other-zone"],
+          published: true)
+      end
+
+      it "excludes templates targeting other zones" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result).to be_nil
+        expect(hackr.reload).not_to be_in_breach
+      end
+    end
+
+    context "by min_clearance" do
+      before do
+        # Remove the catch-all template so only the high-clearance one exists
+        ambient_template.update!(published: false)
+      end
+
+      let!(:high_cl_template) do
+        create(:grid_breach_template, :ambient,
+          slug: "ambient-high-cl",
+          danger_level_min: 1,
+          min_clearance: 50,
+          published: true)
+      end
+
+      it "excludes templates requiring higher clearance than hackr has" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+
+        expect(result).to be_nil
+        expect(hackr.reload).not_to be_in_breach
+      end
+    end
+
+    context "when no matching templates exist" do
+      before { ambient_template.update!(published: false) }
+
+      it "returns nil even when roll succeeds" do
+        result = described_class.ambient_check!(hackr: hackr, room: room)
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
  Ambient (random) BREACH encounters now trigger on room entry based on
  zone danger_level. Hackrs exploring dangerous zones risk forced
  encounters — RPG random-encounter style.

  - danger_level (0–10) on grid_zones; roll: rand < (level × 0.05)
  - Grid::BreachGeneratorService.ambient_check! called from go_command
  - BreachService.start_ambient! creates breach with nil encounter FK
  - No-DECK auto-fail: tier 1 consequences (vitals drain + eject)
  - Template filtering: published, ambient tier, danger_level_min, zone_slugs (JSON array, empty = any zone), min_clearance
  - danger_level_min + zone_slugs columns on grid_breach_templates
  - Admin: zone form/index danger_level, template ambient targeting
  - 4 ambient templates: Scan Ping, Patrol Sweep, Signal Interceptor (govcorp-only), Wraith Process (underbelly-only)
  - Zone danger_levels: Transit 2, GovCorp 5, Underbelly 7