### PR TITLE
 [TPG] BREACH 2E: Failure tier 3-4, DECK repair, circumvention gates

### DIFF
--- a/app/models/grid_breach_template.rb
+++ b/app/models/grid_breach_template.rb
@@ -18,6 +18,7 @@
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null
 #  published             :boolean          default(FALSE), not null
+#  puzzle_gates          :json             not null
 #  requires_item_slug    :string
 #  requires_mission_slug :string
 #  reward_table          :json             not null
@@ -75,6 +76,14 @@ class GridBreachTemplate < ApplicationRecord
     composition = protocol_composition
     return [] unless composition.is_a?(Array)
     composition
+  end
+
+  # Parse the puzzle_gates JSON into a usable array of hashes.
+  # Expected shape: [{"id": "A", "type": "sequence", "difficulty": 3, "depends_on": null}, ...]
+  def puzzle_gate_definitions
+    gates = puzzle_gates
+    return [] unless gates.is_a?(Array)
+    gates
   end
 
   # Does this template's zone constraint match the given zone?

--- a/app/models/grid_hackr_breach.rb
+++ b/app/models/grid_hackr_breach.rb
@@ -68,6 +68,27 @@ class GridHackrBreach < ApplicationRecord
   end
 
   def all_protocols_destroyed?
-    grid_breach_protocols.where.not(state: "destroyed").none?
+    grid_breach_protocols.exists? &&
+      grid_breach_protocols.where.not(state: "destroyed").none?
+  end
+
+  def all_circumvention_gates_solved?
+    ps = meta&.dig("puzzle_state")
+    return false unless ps
+    required = ps["required_count"].to_i
+    return false if required == 0
+    ps["solved_count"].to_i >= required
+  end
+
+  def breach_won?
+    has_protocols = grid_breach_protocols.exists?
+    has_gates = puzzle_gates_exist?
+    return false unless has_protocols || has_gates
+
+    all_protocols_destroyed? || (has_gates && all_circumvention_gates_solved?)
+  end
+
+  def puzzle_gates_exist?
+    meta&.dig("puzzle_state", "gates")&.any? || false
   end
 end

--- a/app/models/grid_hackr_breach_log.rb
+++ b/app/models/grid_hackr_breach_log.rb
@@ -24,7 +24,7 @@
 #  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => cascade
 #
 class GridHackrBreachLog < ApplicationRecord
-  ACTION_TYPES = %w[exec analyze reroute jackout use system].freeze
+  ACTION_TYPES = %w[exec analyze reroute jackout use system interface].freeze
 
   belongs_to :grid_hackr_breach
 

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -207,6 +207,14 @@ class GridItem < ApplicationRecord
     [deck_module_slot_count - deck_modules_used, 0].max
   end
 
+  def deck_fried?
+    properties&.dig("fried_level").to_i > 0
+  end
+
+  def deck_fried_level
+    properties&.dig("fried_level").to_i
+  end
+
   def has_module?(module_slug)
     installed_modules.joins(:grid_item_definition)
       .exists?(grid_item_definitions: {slug: module_slug})

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -48,7 +48,7 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor],
+    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor repair_service],
     allow_nil: true
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -7,6 +7,7 @@ module Grid
     AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action)
     RerouteResult = Data.define(:target_position, :protocol_type_label)
     UseItemResult = Data.define(:item_name, :effect_output, :emergency_jackout)
+    InterfaceResult = Data.define(:gate_id, :correct, :gate_state, :attempts_remaining, :all_solved, :feedback)
 
     class NotInBreach < StandardError; end
     class NoActionsRemaining < StandardError; end
@@ -16,6 +17,10 @@ module Grid
     class ProtocolAlreadyDestroyed < StandardError; end
     class AlreadyRerouted < StandardError; end
     class ItemNotFound < StandardError; end
+    class GateNotFound < StandardError; end
+    class GateLocked < StandardError; end
+    class GateAlreadySolved < StandardError; end
+    class GateFailed < StandardError; end
 
     def self.exec!(hackr:, program_name:, target_position:)
       new(hackr).exec!(program_name, target_position)
@@ -31,6 +36,10 @@ module Grid
 
     def self.use_item!(hackr:, item_name:)
       new(hackr).use_item!(item_name)
+    end
+
+    def self.interface!(hackr:, gate_id:, answer:)
+      new(hackr).interface!(gate_id, answer)
     end
 
     include Grid::ItemEffectApplier
@@ -347,6 +356,87 @@ module Grid
       )
     end
 
+    def interface!(gate_id, answer)
+      gate_id = gate_id.to_s.upcase
+
+      breach = @hackr.active_breach
+      raise NotInBreach, "You are not in a BREACH encounter." unless breach
+      raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+
+      puzzle_state = breach.meta&.dig("puzzle_state")
+      raise GateNotFound, "No circumvention gates in this encounter." unless puzzle_state&.dig("gates")&.any?
+
+      gate = puzzle_state["gates"][gate_id]
+      raise GateNotFound, "No gate [#{gate_id}]." unless gate
+      validate_gate_state!(gate_id, gate)
+
+      # If breach is already won (e.g., protocols destroyed), don't waste the action
+      raise GateAlreadySolved, "Encounter already complete." if breach.breach_won?
+
+      correct = false
+      gate_state = nil
+      attempts_remaining = 0
+      all_solved = false
+      feedback = nil
+
+      ActiveRecord::Base.transaction do
+        breach.lock!
+        @hackr.lock!
+
+        raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
+
+        # Re-read puzzle state after lock and re-validate
+        puzzle_state = breach.meta["puzzle_state"]
+        gate = puzzle_state["gates"][gate_id]
+        validate_gate_state!(gate_id, gate)
+
+        correct = answers_match?(gate["type"], gate["solution"], answer)
+
+        if correct
+          gate["state"] = "solved"
+          puzzle_state["solved_count"] = puzzle_state["solved_count"].to_i + 1
+          feedback = "ACCESS GRANTED"
+          unlock_dependent_gates!(puzzle_state, gate_id)
+        else
+          gate["attempts_remaining"] = gate["attempts_remaining"].to_i - 1
+          if gate["attempts_remaining"] <= 0
+            gate["state"] = "failed"
+            feedback = "LOCKED OUT — all attempts exhausted"
+          else
+            hint = sequence_position_hint(gate, answer)
+            feedback = "Incorrect — #{gate["attempts_remaining"]} attempt(s) remaining"
+            feedback = "#{feedback}. #{hint}" if hint
+          end
+        end
+
+        gate_state = gate["state"]
+        attempts_remaining = gate["attempts_remaining"].to_i
+
+        breach.update!(
+          meta: breach.meta.merge("puzzle_state" => puzzle_state),
+          actions_remaining: breach.actions_remaining - 1
+        )
+
+        all_solved = breach.all_circumvention_gates_solved?
+
+        log_action!(breach, "interface", gate_id, nil, {
+          gate_id: gate_id,
+          correct: correct,
+          gate_state: gate_state,
+          attempts_remaining: attempts_remaining
+        })
+      end
+
+      InterfaceResult.new(
+        gate_id: gate_id.upcase,
+        correct: correct,
+        gate_state: gate_state,
+        attempts_remaining: attempts_remaining,
+        all_solved: all_solved,
+        feedback: feedback
+      )
+    end
+
     private
 
     attr_reader :hackr
@@ -398,6 +488,81 @@ module Grid
       breach.update!(meta: breach.meta.merge("pending_fragments" => pending))
 
       fragment_slug
+    end
+
+    # Compare player answer to stored solution. Normalization varies by puzzle type.
+    def answers_match?(type, stored_solution, provided_answer)
+      case type
+      when "sequence"
+        # Case-insensitive, space-separated tokens
+        normalize_tokens(provided_answer) == normalize_tokens(stored_solution)
+      when "logic_gate"
+        # Evaluate any valid input combination — stored solution is "GATE_TYPE:TARGET:INPUT_COUNT"
+        validate_logic_gate_answer(stored_solution, provided_answer)
+      when "circuit"
+        # Sort pairs before compare (order doesn't matter)
+        normalize_circuit(provided_answer) == normalize_circuit(stored_solution)
+      when "credential"
+        # Exact match (case-sensitive — passwords are case-sensitive)
+        provided_answer.strip == stored_solution
+      else
+        provided_answer.strip.upcase == stored_solution.strip.upcase
+      end
+    end
+
+    def validate_logic_gate_answer(stored_solution, provided_answer)
+      gate_type, target, input_count_str = stored_solution.split(":")
+      input_count = input_count_str.to_i
+      tokens = provided_answer.strip.upcase.split
+      return false unless tokens.size == input_count
+      return false unless tokens.all? { |t| %w[HIGH LOW].include?(t) }
+
+      bools = tokens.map { |t| t == "HIGH" }
+      result = Grid::PuzzleGeneratorService.evaluate_gate(gate_type, bools)
+      (result ? "HIGH" : "LOW") == target
+    end
+
+    def normalize_tokens(str)
+      str.to_s.strip.upcase.split.join(" ")
+    end
+
+    def normalize_circuit(str)
+      str.to_s.strip.upcase.split.map { |pair|
+        pair.split("-").sort.join("-")
+      }.sort.join(" ")
+    end
+
+    def validate_gate_state!(gate_id, gate)
+      raise GateAlreadySolved, "Gate [#{gate_id}] is already complete." if gate["state"] == "solved" || gate["state"] == "bypassed"
+      raise GateFailed, "Gate [#{gate_id}] is locked out — all attempts exhausted." if gate["state"] == "failed"
+      raise GateLocked, "Gate [#{gate_id}] is locked — solve #{gate["depends_on"]} first." if gate["state"] == "locked"
+    end
+
+    # Wordle-style progressive hint for sequence puzzles.
+    # Shows which positions are correct (✓) and which are wrong (✗).
+    def sequence_position_hint(gate, answer)
+      return nil unless gate["type"] == "sequence"
+
+      solution_tokens = gate["solution"].to_s.strip.upcase.split
+      answer_tokens = answer.to_s.strip.upcase.split
+      return nil if answer_tokens.empty?
+
+      hints = solution_tokens.each_with_index.map do |node, i|
+        if i < answer_tokens.size && answer_tokens[i] == node
+          "\u2713#{node}"
+        else
+          "\u2717"
+        end
+      end
+      "Positions: #{hints.join(" ")}"
+    end
+
+    def unlock_dependent_gates!(puzzle_state, solved_gate_id)
+      puzzle_state["gates"].each do |_id, gate|
+        next unless gate["state"] == "locked"
+        next unless gate["depends_on"] == solved_gate_id
+        gate["state"] = "active"
+      end
     end
 
     def compute_damage(program, protocol)

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -28,6 +28,8 @@ module Grid
         reroute_command(args.first)
       when "use"
         use_command(args.join(" "))
+      when "interface", "if"
+        interface_command(args)
       when "jackout", "jo"
         jackout_command
       when "status", "st"
@@ -217,6 +219,62 @@ module Grid
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
+    def interface_command(args)
+      if args.nil? || args.length < 2
+        return "<span style='color: #fbbf24;'>Usage: interface &lt;gate&gt; &lt;answer...&gt;</span>"
+      end
+
+      gate_id = args[0].upcase
+      answer = args[1..].join(" ")
+
+      result = Grid::BreachActionService.interface!(
+        hackr: hackr,
+        gate_id: gate_id,
+        answer: answer
+      )
+
+      output = []
+      if result.correct
+        output << "<span style='color: #34d399; font-weight: bold;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
+      elsif result.gate_state == "failed"
+        output << "<span style='color: #f87171; font-weight: bold;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
+      else
+        output << "<span style='color: #f87171;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
+        output << "<span style='color: #9ca3af;'>  Review the gate with 'status'.</span>"
+      end
+
+      notifications = []
+
+      if result.all_solved
+        # Resolve success — circumvention gates completed (OR win condition)
+        resolve_result = Grid::BreachService.resolve_success!(hackr_breach: breach)
+        output << resolve_result.display
+
+        template = breach.grid_breach_template
+        notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
+        notifications += achievement_checker.check(:breaches_completed_count)
+        notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
+
+        if resolve_result.xp_result[:leveled_up]
+          output << "<span style='color: #fbbf24; font-weight: bold;'>\u25b2 CLEARANCE UP \u2192 #{resolve_result.xp_result[:new_clearance]}</span>"
+        end
+      else
+        # Check if round should end
+        breach.reload
+        round_output = maybe_end_round
+        output << round_output if round_output
+      end
+
+      append_notifications(output, notifications)
+      output.join("\n")
+    rescue Grid::BreachActionService::NoActionsRemaining,
+      Grid::BreachActionService::GateNotFound,
+      Grid::BreachActionService::GateLocked,
+      Grid::BreachActionService::GateAlreadySolved,
+      Grid::BreachActionService::GateFailed => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
     def jackout_command
       result = Grid::BreachService.jackout!(hackr: hackr)
 
@@ -273,6 +331,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>analyze &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Scan a protocol for intel (1 action)</span>"
       output << "<span style='color: #fbbf24;'>reroute &lt;target#&gt;</span>           <span style='color: #9ca3af;'>Delay a protocol 1 round (1 action, 30% chance protocol fizzles on retry)</span>"
       output << "<span style='color: #fbbf24;'>use &lt;item&gt;</span>                   <span style='color: #9ca3af;'>Use a consumable from inventory (1 action)</span>"
+      output << "<span style='color: #fbbf24;'>interface &lt;gate&gt; &lt;answer&gt;</span>    <span style='color: #9ca3af;'>Submit answer to a circumvention gate (1 action)</span>"
       output << "<span style='color: #fbbf24;'>jackout</span>                      <span style='color: #9ca3af;'>Abort the encounter</span>"
       output << ""
       output << "<span style='color: #6b7280;'>Free commands (no action cost):</span>"
@@ -280,7 +339,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>deck</span>                         <span style='color: #9ca3af;'>Show loaded software + battery</span>"
       output << "<span style='color: #fbbf24;'>help</span>                         <span style='color: #9ca3af;'>This reference</span>"
       output << ""
-      output << "<span style='color: #6b7280;'>Aliases: sh=exec, an=analyze, rr=reroute, jo=jackout, st=status, dk=deck, ?=help</span>"
+      output << "<span style='color: #6b7280;'>Aliases: sh=exec, an=analyze, rr=reroute, if=interface, jo=jackout, st=status, dk=deck, ?=help</span>"
       output.join("\n")
     end
 

--- a/app/services/grid/breach_generator_service.rb
+++ b/app/services/grid/breach_generator_service.rb
@@ -30,8 +30,14 @@ module Grid
       return nil unless template
 
       # No DECK equipped → auto-fail at tier 1 (vitals drain + eject)
-      unless @hackr.equipped_deck
+      deck = @hackr.equipped_deck
+      unless deck
         return auto_fail_no_deck!(template)
+      end
+
+      # Fried DECK → auto-fail at tier 1 (prevents loophole of equipping fried DECK to dodge encounters)
+      if deck.deck_fried?
+        return auto_fail_fried_deck!(template)
       end
 
       # Start the ambient BREACH
@@ -69,17 +75,32 @@ module Grid
     end
 
     def auto_fail_no_deck!(template)
+      auto_fail_ambient!(
+        template,
+        reason: "No DECK equipped \u2014 system scan overwhelms your unshielded neural link.",
+        hint: "Equip a DECK to survive ambient encounters."
+      )
+    end
+
+    def auto_fail_fried_deck!(template)
+      auto_fail_ambient!(
+        template,
+        reason: "DECK is fried \u2014 system scan overwhelms your damaged hardware.",
+        hint: "Repair your DECK at a repair service node or with a DECK Repair Kit."
+      )
+    end
+
+    # Shared tier 1 ambient auto-fail: vitals drain + eject + display.
+    def auto_fail_ambient!(template, reason:, hint:)
       eject_room_id = nil
       ejected = false
 
       ActiveRecord::Base.transaction do
         @hackr.lock!
 
-        # Tier 1 failure: vitals drain
         @hackr.adjust_vital!("energy", -20)
         @hackr.adjust_vital!("psyche", -20)
 
-        # Eject to zone entry room (if available)
         eject_room_id = @hackr.zone_entry_room_id
         if eject_room_id && eject_room_id != @hackr.current_room_id
           @hackr.update!(current_room_id: eject_room_id)
@@ -90,14 +111,14 @@ module Grid
       display = []
       display << ""
       display << "<span style='color: #ef4444; font-weight: bold;'>\u26a0 AMBIENT BREACH \u2014 #{ERB::Util.html_escape(template.name)}</span>"
-      display << "<span style='color: #f87171;'>No DECK equipped \u2014 system scan overwhelms your unshielded neural link.</span>"
+      display << "<span style='color: #f87171;'>#{ERB::Util.html_escape(reason)}</span>"
       display << ""
       display << "<span style='color: #f87171;'>ENERGY -20 | PSYCHE -20</span>"
       if ejected
         eject_room = GridRoom.find_by(id: eject_room_id)
         display << "<span style='color: #f87171;'>Ejected to #{ERB::Util.html_escape(eject_room&.name || "unknown")}.</span>"
       end
-      display << "<span style='color: #6b7280;'>Equip a DECK to survive ambient encounters.</span>"
+      display << "<span style='color: #6b7280;'>#{ERB::Util.html_escape(hint)}</span>"
 
       AmbientResult.new(display: display.join("\n"), ejected: ejected)
     end

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -35,7 +35,7 @@ module Grid
     end
 
     def render_full
-      [header_block, meters_block, protocols_block, footer_block].join("\n")
+      [header_block, meters_block, protocols_block, circumvention_gates_block, footer_block].compact.join("\n")
     end
 
     def render_action_result(action_message)
@@ -43,7 +43,7 @@ module Grid
     end
 
     def render_compact_status
-      [meters_block, protocols_block, footer_block].join("\n")
+      [meters_block, protocols_block, circumvention_gates_block, footer_block].compact.join("\n")
     end
 
     def render_round_end(protocol_messages)
@@ -78,18 +78,34 @@ module Grid
       lines.join("\n")
     end
 
-    def render_failure(vitals_hit, zone_lockout_minutes = nil)
+    def render_failure(vitals_hit, zone_lockout_minutes = nil, fried_level: nil, software_wiped: false, failure_mode: :detection_overflow)
+      border_red = "<span style='color: #f87171;'>\u2551</span>"
       lines = []
       lines << ""
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2551  B R E A C H   F A I L E D                                   \u2551</span>"
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
-      lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #d0d0d0;'>Detection reached 100% \u2014 system countermeasures engaged.</span>"
+      cause = if failure_mode == :health_zero
+        "Neural link severed \u2014 vitals critical."
+      else
+        "Detection reached 100% \u2014 system countermeasures engaged."
+      end
+      lines << "#{border_red}  <span style='color: #d0d0d0;'>#{cause}</span>"
       vitals_hit.each do |hit|
-        lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #f87171;'>#{hit[:vital].upcase} -#{hit[:amount]}</span>"
+        lines << "#{border_red}  <span style='color: #f87171;'>#{hit[:vital].upcase} -#{hit[:amount]}</span>"
       end
       if zone_lockout_minutes
-        lines << "<span style='color: #f87171;'>\u2551</span>  <span style='color: #ef4444;'>Zone lockout: #{zone_lockout_minutes} minute(s)</span>"
+        lines << "#{border_red}  <span style='color: #ef4444;'>Zone lockout: #{zone_lockout_minutes} minute(s)</span>"
+      end
+      if fried_level
+        lines << border_red
+        lines << "#{border_red}  <span style='color: #ef4444; font-weight: bold;'>\u26a0 DECK FRIED \u2014 neural feedback cascade (level #{fried_level}/5)</span>"
+        lines << "#{border_red}  <span style='color: #f87171;'>All loaded software destroyed.</span>"
+        lines << "#{border_red}  <span style='color: #9ca3af;'>Repair at a service node or craft a DECK Repair Kit (Mk.#{fried_level}+).</span>"
+      elsif software_wiped
+        lines << border_red
+        lines << "#{border_red}  <span style='color: #ef4444; font-weight: bold;'>\u26a0 DECK OVERLOADED \u2014 all loaded software wiped.</span>"
+        lines << "#{border_red}  <span style='color: #9ca3af;'>Reload software from inventory before your next BREACH.</span>"
       end
       lines << "<span style='color: #f87171; font-weight: bold;'>\u255a#{SEPARATOR}\u255d</span>"
       lines.join("\n")
@@ -196,6 +212,34 @@ module Grid
         end
 
         lines << "  <span style='color: #9ca3af;'>[#{p.position + 1}]</span> #{health_bar}  #{type_hint}  <span style='color: #9ca3af;'>#{state_label}#{state_info}</span>  <span style='color: #6b7280;'>weak:</span> #{weakness_hint}"
+      end
+      lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
+      lines.join("\n")
+    end
+
+    def circumvention_gates_block
+      ps = @breach.meta&.dig("puzzle_state")
+      return nil unless ps&.dig("gates")&.any?
+
+      lines = ["#{border}  <span style='color: #fbbf24; font-weight: bold;'>PROTOCOL CIRCUMVENTION GATES</span>"]
+      ps["gates"].each do |gate_id, gate|
+        state = gate["state"]
+        type_label = gate["type"].to_s.tr("_", " ").split.map(&:capitalize).join(" ")
+
+        state_color, icon, status_text = case state
+        when "solved"
+          ["#34d399", "\u2713", "COMPLETE"]
+        when "bypassed"
+          ["#34d399", "\u2713", "BYPASSED"]
+        when "failed"
+          ["#f87171", "\u2717", "FAILED"]
+        when "locked"
+          ["#6b7280", "\u25a1", "locked (solve #{gate["depends_on"]} first)"]
+        else # active
+          ["#d0d0d0", "\u25cb", "#{gate["attempts_remaining"]}/#{gate["max_attempts"]} attempts"]
+        end
+
+        lines << "#{border}  <span style='color: #9ca3af;'>[#{gate_id}]</span> <span style='color: #d0d0d0;'>#{h(type_label)}</span>  <span style='color: #{state_color};'>#{icon} #{h(status_text)}</span>"
       end
       lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       lines.join("\n")

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -5,11 +5,12 @@ module Grid
     StartResult = Data.define(:hackr_breach, :protocols, :display)
     EndRoundResult = Data.define(:hackr_breach, :state, :protocol_messages, :display, :failure_display)
     ResolveResult = Data.define(:hackr_breach, :xp_awarded, :cred_awarded, :xp_result, :display)
-    FailureResult = Data.define(:hackr_breach, :vitals_hit, :zone_lockout_minutes, :display)
+    FailureResult = Data.define(:hackr_breach, :vitals_hit, :zone_lockout_minutes, :fried_level, :software_wiped, :display)
     JackoutResult = Data.define(:hackr_breach, :clean, :vitals_hit, :display)
 
     class AlreadyInBreach < StandardError; end
     class NoDeckEquipped < StandardError; end
+    class DeckFried < StandardError; end
     class ClearanceBlocked < StandardError; end
     class NotInBreach < StandardError; end
     class TemplateGated < StandardError; end
@@ -52,8 +53,8 @@ module Grid
       new(hackr_breach.grid_hackr).resolve_success!(hackr_breach)
     end
 
-    def self.resolve_failure!(hackr_breach:)
-      new(hackr_breach.grid_hackr).resolve_failure!(hackr_breach)
+    def self.resolve_failure!(hackr_breach:, failure_mode: :detection_overflow)
+      new(hackr_breach.grid_hackr).resolve_failure!(hackr_breach, failure_mode: failure_mode)
     end
 
     def self.jackout!(hackr:, emergency: false)
@@ -103,6 +104,7 @@ module Grid
 
       deck = @hackr.equipped_deck
       raise NoDeckEquipped, "No DECK equipped. Equip a DECK before initiating a BREACH." unless deck
+      raise DeckFried, "DECK is fried (level #{deck.deck_fried_level}/5). Repair it before initiating a BREACH." if deck.deck_fried?
 
       breach = nil
       protocols = nil
@@ -151,6 +153,7 @@ module Grid
         )
 
         protocols = generate_protocols!(breach, template)
+        generate_puzzle_gates!(breach, template)
       end
 
       display = Grid::BreachRenderer.new(breach, protocols).render_full
@@ -166,6 +169,7 @@ module Grid
 
       deck = @hackr.equipped_deck
       raise NoDeckEquipped, "No DECK equipped." unless deck
+      raise DeckFried, "DECK is fried. Repair it before initiating a BREACH." if deck.deck_fried?
 
       cl = @hackr.stat("clearance")
       if cl < template.min_clearance
@@ -198,6 +202,7 @@ module Grid
         )
 
         protocols = generate_protocols!(breach, template)
+        generate_puzzle_gates!(breach, template)
       end
 
       display = Grid::BreachRenderer.new(breach, protocols).render_full
@@ -232,7 +237,7 @@ module Grid
         # 1b. Health-at-zero check
         @hackr.reload
         if @hackr.stat("health") <= 0
-          failure_result = resolve_failure!(hackr_breach)
+          failure_result = resolve_failure!(hackr_breach, failure_mode: :health_zero)
           state = :health_zero
           failure_display = failure_result.display
         end
@@ -273,8 +278,8 @@ module Grid
             failure_display = failure_result.display
           end
 
-          # 5. Check win condition (all protocols destroyed)
-          if state == :ongoing && hackr_breach.all_protocols_destroyed?
+          # 5. Check win condition (all protocols destroyed OR all circumvention gates solved)
+          if state == :ongoing && hackr_breach.breach_won?
             state = :success
           end
         end
@@ -354,14 +359,16 @@ module Grid
       )
     end
 
-    def resolve_failure!(hackr_breach)
+    def resolve_failure!(hackr_breach, failure_mode: :detection_overflow)
       unless hackr_breach.state == "active"
-        return FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, display: "")
+        return FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, fried_level: nil, software_wiped: false, display: "")
       end
 
       template = hackr_breach.grid_breach_template
       vitals_hit = []
       zone_lockout_minutes = nil
+      fried_level_set = nil
+      software_wiped = false
       tier = template.tier
 
       # Wrap in transaction if not already inside one (end_round! calls this inside its own)
@@ -390,6 +397,26 @@ module Grid
           end
         end
 
+        # Tier 3+4: DECK consequences (detection-overflow only, not health-zero)
+        # Tier 3: software wipe (standard+). Tier 4: DECK fried (advanced+).
+        # When tier 4 triggers, software is also wiped (it gets _really_ fried).
+        deck = @hackr.equipped_deck
+        if deck && failure_mode == :detection_overflow
+          if %w[advanced elite world_event].include?(tier)
+            # Tier 4: DECK fried — compute level + wipe software
+            fried_level_set = compute_fried_level(tier)
+            deck.lock!
+            deck.loaded_software.destroy_all
+            deck.update!(properties: deck.properties.merge("fried_level" => fried_level_set))
+            software_wiped = true
+          elsif %w[standard].include?(tier)
+            # Tier 3: software wipe only (no fry)
+            deck.lock!
+            deck.loaded_software.destroy_all
+            software_wiped = true
+          end
+        end
+
         # Eject to zone entry room
         eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
         if eject_room_id && eject_room_id != @hackr.current_room_id
@@ -404,11 +431,17 @@ module Grid
       end
 
       vitals_hit.compact!
-      display = Grid::BreachRenderer.new(hackr_breach).render_failure(vitals_hit, zone_lockout_minutes)
+      display = Grid::BreachRenderer.new(hackr_breach).render_failure(
+        vitals_hit, zone_lockout_minutes,
+        fried_level: fried_level_set, software_wiped: software_wiped,
+        failure_mode: failure_mode
+      )
       FailureResult.new(
         hackr_breach: hackr_breach,
         vitals_hit: vitals_hit,
         zone_lockout_minutes: zone_lockout_minutes,
+        fried_level: fried_level_set,
+        software_wiped: software_wiped,
         display: display
       )
     end
@@ -487,6 +520,63 @@ module Grid
       protocols
     end
 
+    # Generate puzzle circumvention gates from template definition.
+    # Clearance reduces required gate count; psyche grants bonus attempts.
+    def generate_puzzle_gates!(breach, template)
+      gate_defs = template.puzzle_gate_definitions
+      return if gate_defs.empty?
+
+      clearance = @hackr.stat("clearance")
+      psyche = @hackr.stat("psyche")
+      total = gate_defs.size
+      bypass_count = [(clearance / 30).floor, total - 1].min # Always leave at least 1 gate active
+      required_count = [1, total - bypass_count].max
+
+      # Base 3 attempts. Psyche bonus: +1 if psyche >= 50% of max
+      max_psyche = @hackr.effective_max("psyche")
+      psyche_bonus = (max_psyche > 0 && psyche.to_f / max_psyche >= 0.5) ? 1 : 0
+      attempts = 3 + psyche_bonus
+
+      # Last N gates (by template order) are bypassed — hardest gates last convention
+      bypassed_ids = gate_defs.last(bypass_count).map { |g| g["id"] }
+
+      gates = {}
+      gate_defs.each_with_index do |spec, idx|
+        rng = Random.new(breach.id * 31 + idx)
+        generated = Grid::PuzzleGeneratorService.generate(spec, rng)
+
+        is_bypassed = bypassed_ids.include?(spec["id"])
+        dep = spec["depends_on"]
+        dep_is_bypassed = dep && bypassed_ids.include?(dep)
+
+        initial_state = if is_bypassed
+          "bypassed"
+        elsif dep && !dep_is_bypassed
+          "locked"
+        else
+          "active"
+        end
+
+        gates[spec["id"]] = {
+          "type" => spec["type"],
+          "state" => initial_state,
+          "attempts_remaining" => is_bypassed ? 0 : attempts,
+          "max_attempts" => is_bypassed ? 0 : attempts,
+          "depends_on" => dep,
+          "solution" => is_bypassed ? nil : generated[:solution],
+          "display" => generated[:display_data]
+        }
+      end
+
+      puzzle_state = {
+        "required_count" => required_count,
+        "solved_count" => 0,
+        "gates" => gates
+      }
+
+      breach.update!(meta: breach.meta.merge("puzzle_state" => puzzle_state))
+    end
+
     def compute_new_inspiration(hackr_breach)
       # Inspiration increases by 1 per successful offensive action this round,
       # capped at the clearance ceiling. For Phase 1, simple: +2 per round survived.
@@ -558,6 +648,33 @@ module Grid
       end
 
       granted
+    end
+
+    # Compute fried_level based on encounter tier and hackr clearance.
+    # Higher clearance = weighted toward lower fried_level (better at damage control).
+    # Only called for advanced/elite/world_event tiers (standard gets software wipe only, no fry).
+    def compute_fried_level(tier)
+      clearance = @hackr.stat("clearance")
+      case tier
+      when "advanced"
+        # 2-3, weighted toward 2 for high clearance (clearance >= 40 = 70% chance of 2)
+        if rand < ((clearance >= 40) ? 0.7 : 0.4)
+          2
+        else
+          3
+        end
+      when "elite"
+        # 3-4, weighted toward 3 for high clearance
+        if rand < ((clearance >= 60) ? 0.65 : 0.35)
+          3
+        else
+          4
+        end
+      when "world_event"
+        5
+      else
+        1
+      end
     end
 
     def drain_vital!(key, amount)

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -122,6 +122,8 @@ module Grid
         args.empty? ? deck_show_command : deck_subcommand(args)
       when "breach", "br"
         breach_initiate_command(args.join(" "))
+      when "repair"
+        repair_command
       when "den"
         den_command(args)
       when "out"
@@ -1175,6 +1177,11 @@ module Grid
       output << "<span style='color: #22d3ee; font-weight: bold;'>DECK :: #{h(deck.name)}</span> <span style='color: #{deck.rarity_color};'>[#{deck.rarity_label}]</span>"
       output << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
       output << ""
+      if deck.deck_fried?
+        output << "<span style='color: #ef4444; font-weight: bold;'>STATUS: FRIED (level #{deck.deck_fried_level}/5) \u2014 unusable in BREACH</span>"
+        output << "<span style='color: #9ca3af;'>Repair at a service node or use a DECK Repair Kit.</span>"
+        output << ""
+      end
       output << "<span style='color: #fbbf24;'>Battery:</span> <span style='color: #d0d0d0;'>#{deck.deck_battery}/#{deck.deck_battery_max}</span>"
       output << "<span style='color: #fbbf24;'>Software Slots:</span> <span style='color: #d0d0d0;'>#{deck.deck_slots_used}/#{deck.deck_slot_count}</span>"
       output << "<span style='color: #fbbf24;'>Module Slots:</span> <span style='color: #d0d0d0;'>#{deck.deck_modules_used}/#{deck.deck_module_slot_count}</span>"
@@ -1279,6 +1286,19 @@ module Grid
       end
 
       "<span style='color: #34d399;'>Unloaded #{h(software.name)} from DECK.</span>"
+    end
+
+    def repair_command
+      result = Grid::DeckRepairService.repair_at_npc!(hackr: hackr)
+      result.display
+    rescue Grid::DeckRepairService::NotAtRepairService => e
+      "<span style='color: #9ca3af;'>#{h(e.message)}</span>"
+    rescue Grid::DeckRepairService::NoDeckEquipped => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::DeckRepairService::DeckNotFried => e
+      "<span style='color: #9ca3af;'>#{h(e.message)}</span>"
+    rescue Grid::DeckRepairService::InsufficientBalance => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def deck_charge_command

--- a/app/services/grid/deck_repair_service.rb
+++ b/app/services/grid/deck_repair_service.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Grid
+  class DeckRepairService
+    Result = Data.define(:deck_name, :fried_level_cleared, :cred_paid, :display)
+
+    class NoDeckEquipped < StandardError; end
+    class DeckNotFried < StandardError; end
+    class InsufficientBalance < StandardError; end
+    class NotAtRepairService < StandardError; end
+
+    # Quality multiplier based on DECK rarity — better DECKs cost more to repair
+    RARITY_QUALITY = {
+      "scrap" => 1,
+      "ubiquitous" => 1,
+      "common" => 2,
+      "uncommon" => 3,
+      "rare" => 5,
+      "ultra_rare" => 8,
+      "unicorn" => 12
+    }.freeze
+
+    BASE_COST_PER_LEVEL = 150 # CRED — Basic DECK at level 1 = 150 CRED
+
+    def self.repair_at_npc!(hackr:)
+      new(hackr).repair_at_npc!
+    end
+
+    def self.repair_cost(deck)
+      fried = deck.deck_fried_level
+      quality = RARITY_QUALITY.fetch(deck.rarity.to_s, 1)
+      BASE_COST_PER_LEVEL * fried * quality
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def repair_at_npc!
+      room = @hackr.current_room
+      raise NotAtRepairService, "There's no repair service here." unless room&.room_type == "repair_service"
+
+      deck = @hackr.equipped_deck
+      raise NoDeckEquipped, "No DECK equipped." unless deck
+      raise DeckNotFried, "Your DECK is not damaged." unless deck.deck_fried?
+
+      cost = self.class.repair_cost(deck)
+      cache = @hackr.default_cache
+      raise InsufficientBalance, "Need #{cost} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= cost
+
+      fried_level = nil
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        deck.lock!
+
+        # Re-check after lock
+        raise DeckNotFried, "Your DECK is not damaged." unless deck.deck_fried?
+
+        # Re-check balance after lock (prevent TOCTOU race)
+        cost = self.class.repair_cost(deck)
+        cache = @hackr.default_cache
+        raise InsufficientBalance, "Need #{cost} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= cost
+
+        fried_level = deck.deck_fried_level
+        deck.update!(properties: deck.properties.merge("fried_level" => 0))
+      end
+
+      # CRED payment outside transaction (TransactionService has its own mutex).
+      # If payment fails, restore the fried_level to prevent free repairs.
+      begin
+        split_repair_payment!(from_cache: cache, amount: cost, deck_name: deck.name)
+      rescue => e
+        deck.update!(properties: deck.properties.merge("fried_level" => fried_level))
+        raise InsufficientBalance, "Payment failed — DECK damage restored. #{e.message}"
+      end
+
+      display = render_repair(deck.name, fried_level, cost)
+      Result.new(deck_name: deck.name, fried_level_cleared: fried_level, cred_paid: cost, display: display)
+    end
+
+    private
+
+    def split_repair_payment!(from_cache:, amount:, deck_name:)
+      burn_amt = (amount * EconomyConfig::SHOP_BURN_RATIO).floor
+      recycle_amt = amount - burn_amt
+
+      if burn_amt > 0
+        Grid::TransactionService.burn!(
+          from_cache: from_cache,
+          amount: burn_amt,
+          memo: "DECK repair: #{deck_name}"
+        )
+      end
+
+      if recycle_amt > 0
+        Grid::TransactionService.recycle!(
+          from_cache: from_cache,
+          amount: recycle_amt,
+          memo: "DECK repair: #{deck_name}"
+        )
+      end
+    end
+
+    def render_repair(deck_name, fried_level, cost)
+      h = ->(text) { ERB::Util.html_escape(text.to_s) }
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>[ DECK REPAIR COMPLETE ]</span>"
+      lines << "<span style='color: #d0d0d0;'>  DECK: #{h.call(deck_name)}</span>"
+      lines << "<span style='color: #9ca3af;'>  Damage cleared: level #{fried_level}/5</span>"
+      lines << "<span style='color: #fbbf24;'>  Cost: #{cost} CRED</span>"
+      lines.join("\n")
+    end
+  end
+end

--- a/app/services/grid/item_effect_applier.rb
+++ b/app/services/grid/item_effect_applier.rb
@@ -41,6 +41,8 @@ module Grid
         result = hackr.grant_xp!(amount)
         level_msg = result[:leveled_up] ? "\n<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE INCREASED TO #{result[:new_clearance]}!</span>" : ""
         "<span style='color: #fbbf24;'>You use #{h(item.name)}. +#{amount} XP.#{level_msg}</span>"
+      when "repair_deck"
+        apply_repair_deck(item, props)
       when "redeem_den"
         apply_redeem_den(item)
       else
@@ -93,6 +95,25 @@ module Grid
       end
       # Returns a sentinel that the caller checks to trigger a clean jackout
       :emergency_jackout
+    end
+
+    def apply_repair_deck(item, props)
+      deck = hackr.equipped_deck
+      unless deck
+        return "<span style='color: #f87171;'>No DECK equipped.</span>"
+      end
+      unless deck.deck_fried?
+        return "<span style='color: #9ca3af;'>Your DECK doesn't need repair.</span>"
+      end
+
+      kit_level = props[:kit_level].to_i
+      fried = deck.deck_fried_level
+      if kit_level < fried
+        return "<span style='color: #f87171;'>Repair Kit Mk.#{kit_level} is insufficient for damage level #{fried}. Need Mk.#{fried}+ kit.</span>"
+      end
+
+      deck.update!(properties: deck.properties.merge("fried_level" => 0))
+      "<span style='color: #34d399; font-weight: bold;'>You use #{h(item.name)}. DECK repaired \u2014 damage cleared (was level #{fried}/5).</span>"
     end
 
     def apply_redeem_den(item)

--- a/app/services/grid/puzzle_generator_service.rb
+++ b/app/services/grid/puzzle_generator_service.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module Grid
+  # Generates puzzle content for BREACH circumvention gates.
+  # Stateless — given a gate spec and seeded RNG, returns display data + solution.
+  # Called from BreachService#generate_puzzle_gates! during encounter start.
+  class PuzzleGeneratorService
+    PUZZLE_TYPES = %w[sequence logic_gate circuit credential].freeze
+
+    # Themed node labels for sequence and circuit puzzles
+    NODE_POOL = %w[ALPHA BRAVO CRYPT DELTA ECHO FLUX GATE HELIX ION JAM KILO LINK MAST NODE OMNI PRISM QUAD RELAY SYNC TERM UNIT VECT WIRE XFER].freeze
+
+    # Themed words for credential puzzles
+    CREDENTIAL_WORDS = %w[
+      SiliconRanger NeonCipher VaultKeeper DataWraith GridHunter
+      PulseRunner ByteGhost NodeWalker CryptHawk SignalDrift
+      NetShade CorePhase WaveJack LinkBreak TraceNull
+    ].freeze
+
+    CREDENTIAL_SUFFIXES = %w[1@3 _7x !99 #42 .0x $88 &v2 ^9k].freeze
+
+    # Character substitution map for credential encryption
+    SUBSTITUTION_MAP = {
+      "S" => "$", "i" => "!", "o" => "0", "a" => "@", "e" => "3",
+      "n" => "^", "l" => "1", "t" => "+", "r" => "2", "g" => "9",
+      "k" => "K", "d" => "6", "u" => "v", "B" => "8", "c" => "("
+    }.freeze
+
+    # Generate a puzzle for a given gate spec.
+    # Returns { display_data: Hash, solution: String }
+    def self.generate(gate_spec, rng)
+      type = gate_spec["type"]
+      difficulty = (gate_spec["difficulty"] || 2).to_i.clamp(1, 5)
+
+      case type
+      when "sequence" then generate_sequence(difficulty, rng)
+      when "logic_gate" then generate_logic_gate(difficulty, rng)
+      when "circuit" then generate_circuit(difficulty, rng)
+      when "credential" then generate_credential(difficulty, rng)
+      else
+        raise ArgumentError, "Unknown puzzle type: #{type}"
+      end
+    end
+
+    class << self
+      private
+
+      # Sequence: reorder scrambled nodes into correct initialization order
+      # Difficulty 1=4 nodes, 2=5, 3=6, 4=7, 5=8
+      def generate_sequence(difficulty, rng)
+        count = 3 + difficulty
+        nodes = NODE_POOL.sample(count, random: rng)
+        solution_order = nodes.dup
+        display_order = nodes.shuffle(random: rng)
+
+        # Ensure display is actually scrambled
+        display_order = nodes.shuffle(random: rng) while display_order == solution_order && count > 1
+
+        {
+          display_data: {
+            "type" => "sequence",
+            "prompt" => "Reorder the boot sequence nodes into correct initialization order.",
+            "nodes" => display_order
+          },
+          solution: solution_order.join(" ")
+        }
+      end
+
+      # Logic gate: determine correct input values to produce target output
+      # Difficulty 1=2 inputs, 2=3, 3=4, 4=5, 5=6
+      # Answer validation uses evaluate_logic_gate to accept ANY valid input combo.
+      def generate_logic_gate(difficulty, rng)
+        input_count = 1 + difficulty
+        inputs = (1..input_count).map { |i| "IN#{i}" }
+
+        # Pick a gate type randomly, weighted by difficulty tier
+        gate_pool = case difficulty
+        when 1 then %w[OR AND]
+        when 2 then %w[OR AND XOR]
+        when 3 then %w[AND XOR NAND]
+        when 4 then %w[XOR NAND NOR]
+        else %w[NAND NOR XOR]
+        end
+        gate_type = gate_pool[rng.rand(gate_pool.size)]
+
+        # Generate one known-good solution and compute target output
+        values = inputs.map { (rng.rand(2) == 1) ? "HIGH" : "LOW" }
+        bools = values.map { |v| v == "HIGH" }
+        target = evaluate_gate(gate_type, bools) ? "HIGH" : "LOW"
+
+        # Store gate_type and target in solution for validation — any valid combo accepted
+        solution = "#{gate_type}:#{target}:#{input_count}"
+
+        {
+          display_data: {
+            "type" => "logic_gate",
+            "prompt" => "Set input signals to produce the target output.",
+            "gate_type" => gate_type,
+            "inputs" => inputs,
+            "target_output" => target,
+            "diagram" => "#{gate_type}(#{inputs.join(", ")}) \u2192 TARGET: #{target}"
+          },
+          solution: solution
+        }
+      end
+
+      # Circuit: connect node pairs to restore signal paths
+      # Difficulty 1=2 pairs, 2=3, 3=4, 4=5, 5=6
+      def generate_circuit(difficulty, rng)
+        pair_count = 1 + difficulty
+        all_nodes = NODE_POOL.sample(pair_count * 2, random: rng)
+        left = all_nodes[0, pair_count]
+        right = all_nodes[pair_count, pair_count]
+
+        # Build correct pairings and sort canonically
+        pairs = left.zip(right).map { |l, r| [l, r].sort.join("-") }.sort
+
+        # Scramble display
+        display_left = left.shuffle(random: rng)
+        display_right = right.shuffle(random: rng)
+
+        {
+          display_data: {
+            "type" => "circuit",
+            "prompt" => "Connect open circuit nodes to restore signal path.",
+            "left_nodes" => display_left,
+            "right_nodes" => display_right,
+            "pair_count" => pair_count
+          },
+          solution: pairs.join(" ")
+        }
+      end
+
+      # Credential: decrypt an encrypted string using a partial cipher hint
+      # Difficulty 1=1 substitution, 2=2, 3=3, 4=4, 5=5
+      def generate_credential(difficulty, rng)
+        word = CREDENTIAL_WORDS[rng.rand(CREDENTIAL_WORDS.size)]
+        suffix = CREDENTIAL_SUFFIXES[rng.rand(CREDENTIAL_SUFFIXES.size)]
+        plaintext = word + suffix
+
+        encrypted = plaintext.dup
+        hint_parts = []
+
+        # Apply substitutions at random positions (shift ensures no duplicates)
+        eligible = plaintext.chars.each_with_index.select { |ch, _| SUBSTITUTION_MAP.key?(ch) }
+        eligible.shuffle!(random: rng)
+
+        [difficulty, eligible.size].min.times do
+          char, pos = eligible.shift
+          sub = SUBSTITUTION_MAP[char]
+          encrypted[pos] = sub
+          hint_parts << "pos #{pos + 1}: #{sub}\u2192#{char}"
+        end
+
+        {
+          display_data: {
+            "type" => "credential",
+            "prompt" => "Decrypt the access credential.",
+            "encrypted" => encrypted,
+            "cipher_hint" => hint_parts.join(", ")
+          },
+          solution: plaintext
+        }
+      end
+    end
+
+    def self.evaluate_gate(gate_type, bools)
+      case gate_type
+      when "AND" then bools.all?
+      when "OR" then bools.any?
+      when "XOR" then bools.count(true).odd?
+      when "NAND" then !bools.all?
+      when "NOR" then bools.none?
+      else bools.any?
+      end
+    end
+  end
+end

--- a/data/world/breach_encounters.yml
+++ b/data/world/breach_encounters.yml
@@ -7,3 +7,24 @@ breach_encounters:
   - template_slug: patrol-node-alpha
     room_slug: govcorp-surveillance-node
     state: available
+
+  # Puzzle encounter placements
+  - template_slug: cipher-lock-station
+    room_slug: transit-corridor-alpha
+    state: available
+
+  - template_slug: fortified-relay-node
+    room_slug: govcorp-surveillance-node
+    state: available
+
+  - template_slug: govcorp-auth-node
+    room_slug: govcorp-surveillance-node
+    state: available
+
+  - template_slug: sector-7-maintenance-node
+    room_slug: transit-corridor-alpha
+    state: available
+
+  - template_slug: vault-core-epsilon
+    room_slug: govcorp-surveillance-node
+    state: available

--- a/data/world/breach_templates.yml
+++ b/data/world/breach_templates.yml
@@ -300,3 +300,195 @@ breach_templates:
         health: 40
         max_health: 40
         charge_rounds: 3
+
+  # ── PUZZLE TEMPLATES ─────────────────────────────────────────
+
+  # Pure puzzle — ambient
+  - slug: access-terminal-echo
+    name: "Access Terminal Echo"
+    description: "A dormant access terminal flickers to life. Its authentication protocols are degraded but still functional. A single credential stands between you and its data."
+    tier: ambient
+    min_clearance: 0
+    danger_level_min: 1
+    zone_slugs: []
+    pnr_threshold: 85
+    base_detection_rate: 4
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 60
+    cred_reward: 15
+    published: true
+    position: 110
+    protocol_composition: []
+    puzzle_gates:
+      - id: "A"
+        type: credential
+        difficulty: 1
+        depends_on: null
+
+  # Pure puzzle — standard
+  - slug: cipher-lock-station
+    name: "Cipher Lock Station"
+    description: "A GovCorp data terminal secured behind layered authentication. Sequence locks guard the outer shell; encrypted credentials protect the core."
+    tier: standard
+    min_clearance: 5
+    danger_level_min: 0
+    pnr_threshold: 80
+    base_detection_rate: 3
+    cooldown_min: 240
+    cooldown_max: 480
+    xp_reward: 150
+    cred_reward: 50
+    published: true
+    position: 30
+    protocol_composition: []
+    puzzle_gates:
+      - id: "A"
+        type: sequence
+        difficulty: 2
+        depends_on: null
+      - id: "B"
+        type: credential
+        difficulty: 2
+        depends_on: "A"
+
+  # Mixed — standard (protocols + gates, two paths to win)
+  - slug: fortified-relay-node
+    name: "Fortified Relay Node"
+    description: "A communications relay with redundant security layers. Brute-force through the protocols or bypass via the circumvention gates — your choice."
+    tier: standard
+    min_clearance: 10
+    danger_level_min: 0
+    pnr_threshold: 70
+    base_detection_rate: 6
+    cooldown_min: 300
+    cooldown_max: 600
+    xp_reward: 220
+    cred_reward: 80
+    published: true
+    position: 31
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 55
+        max_health: 55
+        charge_rounds: 0
+      - type: feedback
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 1
+    puzzle_gates:
+      - id: "A"
+        type: logic_gate
+        difficulty: 2
+        depends_on: null
+      - id: "B"
+        type: circuit
+        difficulty: 2
+        depends_on: "A"
+
+  # Mixed — advanced (protocols + deep gate chain)
+  - slug: govcorp-auth-node
+    name: "GovCorp Authorization Node"
+    description: "A heavily fortified GovCorp authentication node. Dual TRACE protocols accelerate detection. The circumvention path requires logic and decryption."
+    tier: advanced
+    min_clearance: 15
+    danger_level_min: 0
+    pnr_threshold: 65
+    base_detection_rate: 8
+    cooldown_min: 480
+    cooldown_max: 900
+    xp_reward: 400
+    cred_reward: 150
+    published: true
+    position: 32
+    protocol_composition:
+      - type: trace
+        count: 2
+        health: 60
+        max_health: 60
+        charge_rounds: 0
+      - type: spike
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 2
+    puzzle_gates:
+      - id: "A"
+        type: logic_gate
+        difficulty: 3
+        depends_on: null
+      - id: "B"
+        type: credential
+        difficulty: 3
+        depends_on: "A"
+
+  # Mixed — advanced (parallel gates)
+  - slug: sector-7-maintenance-node
+    name: "Sector 7 Maintenance Node"
+    description: "A maintenance access node with LOCK protocols that shut down your options. Three independent circumvention gates offer an alternate path."
+    tier: advanced
+    min_clearance: 20
+    danger_level_min: 0
+    pnr_threshold: 65
+    base_detection_rate: 7
+    cooldown_min: 360
+    cooldown_max: 720
+    xp_reward: 350
+    cred_reward: 120
+    published: true
+    position: 33
+    protocol_composition:
+      - type: lock
+        count: 2
+        health: 70
+        max_health: 70
+        charge_rounds: 1
+    puzzle_gates:
+      - id: "A"
+        type: circuit
+        difficulty: 3
+        depends_on: null
+      - id: "B"
+        type: sequence
+        difficulty: 3
+        depends_on: null
+      - id: "C"
+        type: logic_gate
+        difficulty: 3
+        depends_on: null
+
+  # Pure puzzle — elite (deep dependency chain)
+  - slug: vault-core-epsilon
+    name: "Vault Core Epsilon"
+    description: "A high-security vault with four-layer circumvention. Each gate unlocks the next. High CLEARANCE hackrs bypass the deepest layers."
+    tier: elite
+    min_clearance: 30
+    danger_level_min: 0
+    pnr_threshold: 60
+    base_detection_rate: 8
+    cooldown_min: 600
+    cooldown_max: 1200
+    xp_reward: 600
+    cred_reward: 250
+    published: true
+    position: 34
+    protocol_composition: []
+    puzzle_gates:
+      - id: "A"
+        type: sequence
+        difficulty: 4
+        depends_on: null
+      - id: "B"
+        type: logic_gate
+        difficulty: 4
+        depends_on: "A"
+      - id: "C"
+        type: circuit
+        difficulty: 5
+        depends_on: "B"
+      - id: "D"
+        type: credential
+        difficulty: 5
+        depends_on: "C"

--- a/data/world/exits.yml
+++ b/data/world/exits.yml
@@ -73,3 +73,13 @@ exits:
     to_room_slug: hackr-tv-broadcast-station
     direction: east
     locked: false
+
+  - from_room_slug: transit-corridor-alpha
+    to_room_slug: techmed-repair-bay
+    direction: northwest
+    locked: false
+
+  - from_room_slug: techmed-repair-bay
+    to_room_slug: transit-corridor-alpha
+    direction: southeast
+    locked: false

--- a/data/world/item_definitions.yml
+++ b/data/world/item_definitions.yml
@@ -766,6 +766,62 @@ item_definitions:
     max_stack: 8
     properties: {}
 
+  # ── DECK Repair Kits ────────────────────────────────────────────
+  - slug: deck-repair-kit-1
+    name: DECK Repair Kit (Mk.I)
+    description: "A basic field repair kit for minor DECK damage. Clears fried level 1."
+    item_type: consumable
+    rarity: common
+    value: 300
+    max_stack: 1
+    properties:
+      effect_type: repair_deck
+      kit_level: 1
+
+  - slug: deck-repair-kit-2
+    name: DECK Repair Kit (Mk.II)
+    description: "A reinforced repair kit for moderate DECK damage. Clears fried level 1-2."
+    item_type: consumable
+    rarity: uncommon
+    value: 900
+    max_stack: 1
+    properties:
+      effect_type: repair_deck
+      kit_level: 2
+
+  - slug: deck-repair-kit-3
+    name: DECK Repair Kit (Mk.III)
+    description: "An advanced repair kit for serious DECK damage. Clears fried level 1-3."
+    item_type: consumable
+    rarity: uncommon
+    value: 2400
+    max_stack: 1
+    properties:
+      effect_type: repair_deck
+      kit_level: 3
+
+  - slug: deck-repair-kit-4
+    name: DECK Repair Kit (Mk.IV)
+    description: "A precision repair kit for severe DECK damage. Clears fried level 1-4."
+    item_type: consumable
+    rarity: rare
+    value: 6000
+    max_stack: 1
+    properties:
+      effect_type: repair_deck
+      kit_level: 4
+
+  - slug: deck-repair-kit-5
+    name: DECK Repair Kit (Mk.V)
+    description: "A military-grade repair kit for catastrophic DECK damage. Clears any fried level."
+    item_type: consumable
+    rarity: ultra_rare
+    value: 15000
+    max_stack: 1
+    properties:
+      effect_type: repair_deck
+      kit_level: 5
+
   # ── Faction Items ──────────────────────────────────────────────
   - slug: fracture-beacon
     name: Fracture Beacon

--- a/data/world/mobs.yml
+++ b/data/world/mobs.yml
@@ -64,3 +64,19 @@ mobs:
         ride: "The RIDE - Reality Interference and Dictation Environment. Worldwide reality manipulation, centrally controlled. GovCorp's masterpiece. And our primary target."
         synthia: "Synthia is... anomalous. An AI consciousness that emerged somehow, communicating through frequency modulation. She helps us, but her origins remain mysterious."
         discovery: "The 100-year limitation is precise. Exactly 100 years - not 99, not 101. We don't know why. The universe has rules we don't understand. We just exploit them."
+
+  - name: Wrench
+    room_slug: techmed-repair-bay
+    faction_slug: null
+    description: "A hooded technician with cybernetic hands and a magnifying visor fused to their skull. They work in silence, each movement precise and economical. A bandolier of micro-tools hangs across their chest."
+    mob_type: vendor
+    vendor_config:
+      shop_type: standard
+      restock_interval_hours: 24
+    dialogue_tree:
+      greeting: "DECK trouble? You're in the right place. I fix what GovCorp fries. Type 'repair' if your DECK needs work."
+      topics:
+        repair: "Just type 'repair' and I'll assess the damage. Cost depends on how bad it is and what you're running. Better hardware costs more to fix. That's just physics."
+        deck: "Your DECK is your lifeline in the Grid. When it fries, you're vulnerable. Don't walk around with a fried DECK — ambient sweeps will eat you alive."
+        cost: "I'm not cheap, but I'm cheaper than buying a new DECK. If you're handy with a soldering iron, fabricate a repair kit yourself — saves CRED."
+        kits: "DECK Repair Kits come in five marks. Match or exceed your damage level. You can fabricate them from salvaged components — check your schematics."

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -54,3 +54,9 @@ rooms:
     description: "You wake on a padded recovery slab under painfully neutral lighting. A holographic GovCorp logo rotates slowly overhead. A soothing voice intones: 'Welcome back to consciousness. Your RestorePoint\u2122 recovery fee has been automatically assessed. GovCorp cares.' The exit is to the south."
     zone_slug: restorepoint-lakeshore
     room_type: hospital
+
+  - name: "TechMed Repair Bay"
+    slug: techmed-repair-bay
+    description: "A clean workshop smelling of flux and machine oil. Robotic arms hang from ceiling rails, calibrated for precision DECK repair. A hooded technician stands behind a reinforced workbench, diagnostic tools laid out in precise rows. A sign reads: 'TechMed — We fix what GovCorp fries. No questions asked.'"
+    zone_slug: transit-network
+    room_type: repair_service

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -433,3 +433,101 @@ schematics:
       - input_slug: cipher-chip
         quantity: 3
         position: 2
+
+  # ── DECK Repair Kit Schematics ────────────────────────────────
+  - slug: fab-deck-repair-kit-1
+    name: Fabricate DECK Repair Kit (Mk.I)
+    description: "Assemble a basic DECK repair kit from salvaged components."
+    output_slug: deck-repair-kit-1
+    output_quantity: 1
+    xp_reward: 20
+    required_clearance: 0
+    published: true
+    position: 400
+    ingredients:
+      - input_slug: scrap-wire
+        quantity: 3
+        position: 0
+      - input_slug: scrap-chip
+        quantity: 2
+        position: 1
+
+  - slug: fab-deck-repair-kit-2
+    name: Fabricate DECK Repair Kit (Mk.II)
+    description: "Build a reinforced repair kit for moderate DECK damage."
+    output_slug: deck-repair-kit-2
+    output_quantity: 1
+    xp_reward: 50
+    required_clearance: 10
+    published: true
+    position: 410
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 3
+        position: 0
+      - input_slug: logic-core
+        quantity: 2
+        position: 1
+      - input_slug: synth-fiber
+        quantity: 2
+        position: 2
+
+  - slug: fab-deck-repair-kit-3
+    name: Fabricate DECK Repair Kit (Mk.III)
+    description: "Construct an advanced repair kit using precision components."
+    output_slug: deck-repair-kit-3
+    output_quantity: 1
+    xp_reward: 120
+    required_clearance: 20
+    published: true
+    position: 420
+    ingredients:
+      - input_slug: alloy-plate
+        quantity: 5
+        position: 0
+      - input_slug: quantum-shard
+        quantity: 2
+        position: 1
+      - input_slug: cipher-chip
+        quantity: 2
+        position: 2
+
+  - slug: fab-deck-repair-kit-4
+    name: Fabricate DECK Repair Kit (Mk.IV)
+    description: "Engineer a precision repair kit for severe DECK damage."
+    output_slug: deck-repair-kit-4
+    output_quantity: 1
+    xp_reward: 280
+    required_clearance: 35
+    published: true
+    position: 430
+    ingredients:
+      - input_slug: quantum-shard
+        quantity: 4
+        position: 0
+      - input_slug: cipher-chip
+        quantity: 4
+        position: 1
+      - input_slug: logic-core
+        quantity: 3
+        position: 2
+
+  - slug: fab-deck-repair-kit-5
+    name: Fabricate DECK Repair Kit (Mk.V)
+    description: "Military-grade repair kit requiring the rarest components."
+    output_slug: deck-repair-kit-5
+    output_quantity: 1
+    xp_reward: 600
+    required_clearance: 55
+    published: true
+    position: 440
+    ingredients:
+      - input_slug: quantum-shard
+        quantity: 8
+        position: 0
+      - input_slug: cipher-chip
+        quantity: 6
+        position: 1
+      - input_slug: alloy-plate
+        quantity: 10
+        position: 2

--- a/db/migrate/20260424200840_add_puzzle_gates_to_grid_breach_templates.rb
+++ b/db/migrate/20260424200840_add_puzzle_gates_to_grid_breach_templates.rb
@@ -1,0 +1,5 @@
+class AddPuzzleGatesToGridBreachTemplates < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_breach_templates, :puzzle_gates, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_031949) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -218,6 +218,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_031949) do
     t.integer "position", default: 0, null: false
     t.json "protocol_composition", default: {}, null: false
     t.boolean "published", default: false, null: false
+    t.json "puzzle_gates", default: [], null: false
     t.string "requires_item_slug"
     t.string "requires_mission_slug"
     t.json "reward_table", default: {}, null: false

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -870,6 +870,7 @@ namespace :data do
         published: attrs["published"] || false,
         position: attrs["position"] || 0,
         protocol_composition: attrs["protocol_composition"] || [],
+        puzzle_gates: attrs["puzzle_gates"] || [],
         reward_table: attrs["reward_table"] || {}
       )
       template.save!

--- a/spec/factories/grid_breach_templates.rb
+++ b/spec/factories/grid_breach_templates.rb
@@ -18,6 +18,7 @@
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null
 #  published             :boolean          default(FALSE), not null
+#  puzzle_gates          :json             not null
 #  requires_item_slug    :string
 #  requires_mission_slug :string
 #  reward_table          :json             not null
@@ -56,6 +57,7 @@ FactoryBot.define do
       ]
     end
     reward_table { {} }
+    puzzle_gates { [] }
 
     trait :unpublished do
       published { false }

--- a/spec/models/grid_breach_template_spec.rb
+++ b/spec/models/grid_breach_template_spec.rb
@@ -18,6 +18,7 @@
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null
 #  published             :boolean          default(FALSE), not null
+#  puzzle_gates          :json             not null
 #  requires_item_slug    :string
 #  requires_mission_slug :string
 #  reward_table          :json             not null

--- a/spec/services/grid/breach_phase2e_spec.rb
+++ b/spec/services/grid/breach_phase2e_spec.rb
@@ -1,0 +1,546 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BREACH Phase 2E: Failure + Puzzles" do
+  let(:zone) { create(:grid_zone, danger_level: 5) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "test-deck-2e",
+      name: "Test Deck",
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let(:sw_def) do
+    create(:grid_item_definition, slug: "test-sw-2e", name: "Test Software", item_type: "software",
+      properties: {"software_category" => "offensive", "slot_cost" => 1, "battery_cost" => 10, "effect_magnitude" => 20})
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # FAILURE TIERS 3-4
+  # ═══════════════════════════════════════════════════════════════
+
+  describe "Failure Tier 3: DECK software wipe" do
+    let(:template) { create(:grid_breach_template, tier: "standard") }
+    let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
+    it "wipes loaded software on standard tier failure" do
+      # Load software into DECK
+      software = create(:grid_item, :in_inventory, grid_item_definition: sw_def, grid_hackr: hackr, item_type: "software")
+      software.update!(deck_id: deck.id)
+      expect(deck.loaded_software.count).to eq(1)
+
+      result = Grid::BreachService.start!(hackr: hackr, encounter: encounter)
+      breach = result.hackr_breach
+
+      # Force detection to 100 and trigger failure
+      failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      expect(failure_result.software_wiped).to be true
+      expect(failure_result.fried_level).to be_nil
+      expect(deck.reload.loaded_software.count).to eq(0)
+      expect(failure_result.display).to include("DECK OVERLOADED")
+    end
+  end
+
+  describe "Failure Tier 4: DECK fried" do
+    let(:template) { create(:grid_breach_template, tier: "advanced") }
+    let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
+    it "fries DECK on advanced tier failure" do
+      software = create(:grid_item, :in_inventory, grid_item_definition: sw_def, grid_hackr: hackr, item_type: "software")
+      software.update!(deck_id: deck.id)
+
+      result = Grid::BreachService.start!(hackr: hackr, encounter: encounter)
+      breach = result.hackr_breach
+      failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      expect(failure_result.fried_level).to be_between(2, 3)
+      expect(failure_result.software_wiped).to be true
+      expect(deck.reload.deck_fried?).to be true
+      expect(deck.deck_fried_level).to be_between(2, 3)
+      expect(deck.loaded_software.count).to eq(0)
+      expect(failure_result.display).to include("DECK FRIED")
+    end
+
+    it "fries DECK at level 5 on world_event tier" do
+      we_template = create(:grid_breach_template, tier: "world_event")
+      we_encounter = create(:grid_breach_encounter, grid_breach_template: we_template, grid_room: room)
+      result = Grid::BreachService.start!(hackr: hackr, encounter: we_encounter)
+      breach = result.hackr_breach
+      failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      expect(failure_result.fried_level).to eq(5)
+      expect(deck.reload.deck_fried_level).to eq(5)
+    end
+
+    it "does not fry DECK on ambient tier failure" do
+      amb_template = create(:grid_breach_template, :ambient)
+      result = Grid::BreachService.start_ambient!(hackr: hackr, template: amb_template)
+      breach = result.hackr_breach
+      failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach)
+
+      expect(failure_result.fried_level).to be_nil
+      expect(failure_result.software_wiped).to be false
+      expect(deck.reload.deck_fried?).to be false
+    end
+  end
+
+  describe "DECK fried guards" do
+    let(:template) { create(:grid_breach_template) }
+    let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
+    before { deck.update!(properties: deck.properties.merge("fried_level" => 3)) }
+
+    it "blocks start! with fried DECK" do
+      expect {
+        Grid::BreachService.start!(hackr: hackr, encounter: encounter)
+      }.to raise_error(Grid::BreachService::DeckFried, /fried/)
+    end
+
+    it "blocks start_ambient! with fried DECK" do
+      amb_template = create(:grid_breach_template, :ambient)
+      expect {
+        Grid::BreachService.start_ambient!(hackr: hackr, template: amb_template)
+      }.to raise_error(Grid::BreachService::DeckFried, /fried/)
+    end
+  end
+
+  describe "Ambient fried-DECK auto-fail" do
+    let(:amb_template) { create(:grid_breach_template, :ambient) }
+
+    before do
+      deck.update!(properties: deck.properties.merge("fried_level" => 2))
+      allow(GridBreachTemplate).to receive_message_chain(:published, :ambient, :where, :where, :to_a).and_return([amb_template])
+    end
+
+    it "auto-fails with tier 1 consequences when ambient triggers with fried DECK" do
+      # Manually call the auto-fail path
+      service = Grid::BreachGeneratorService.new(hackr, room)
+      result = service.send(:auto_fail_fried_deck!, amb_template)
+
+      expect(result).to be_a(Grid::BreachGeneratorService::AmbientResult)
+      expect(result.display).to include("DECK is fried")
+      expect(result.display).to include("Repair your DECK")
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # DECK REPAIR
+  # ═══════════════════════════════════════════════════════════════
+
+  describe Grid::DeckRepairService do
+    let(:repair_room) { create(:grid_room, grid_zone: zone, room_type: "repair_service") }
+
+    describe ".repair_cost" do
+      it "scales with fried_level and DECK rarity" do
+        deck.update!(properties: deck.properties.merge("fried_level" => 3))
+        # Default rarity from factory is "common" → quality multiplier 2
+        quality = Grid::DeckRepairService::RARITY_QUALITY.fetch(deck.rarity.to_s, 1)
+        cost = described_class.repair_cost(deck)
+        expect(cost).to eq(150 * 3 * quality)
+      end
+    end
+
+    describe ".repair_at_npc!" do
+      it "raises DeckNotFried when DECK is not fried" do
+        hackr.update!(current_room: repair_room)
+        expect {
+          described_class.repair_at_npc!(hackr: hackr)
+        }.to raise_error(Grid::DeckRepairService::DeckNotFried)
+      end
+
+      it "raises error when not at repair_service room" do
+        deck.update!(properties: deck.properties.merge("fried_level" => 2))
+        hackr.update!(current_room: room) # not a repair_service room
+        expect {
+          described_class.repair_at_npc!(hackr: hackr)
+        }.to raise_error(StandardError, /repair service/)
+      end
+
+      it "raises NoDeckEquipped when no deck is equipped" do
+        hackr.update!(current_room: repair_room)
+        deck.update!(equipped_slot: nil)
+        expect {
+          described_class.repair_at_npc!(hackr: hackr)
+        }.to raise_error(Grid::DeckRepairService::NoDeckEquipped)
+      end
+
+      it "repairs fried DECK and charges CRED" do
+        deck.update!(properties: deck.properties.merge("fried_level" => 2))
+        hackr.update!(current_room: repair_room)
+        cost = described_class.repair_cost(deck)
+
+        # Stub CRED balance and payment
+        cache = instance_double("GridCache", balance: cost + 100, active?: true)
+        allow(hackr).to receive(:default_cache).and_return(cache)
+        allow(Grid::TransactionService).to receive(:burn!)
+        allow(Grid::TransactionService).to receive(:recycle!)
+
+        result = described_class.repair_at_npc!(hackr: hackr)
+
+        expect(result.fried_level_cleared).to eq(2)
+        expect(result.cred_paid).to eq(cost)
+        expect(deck.reload.deck_fried?).to be false
+        expect(result.display).to include("DECK REPAIR COMPLETE")
+        expect(Grid::TransactionService).to have_received(:burn!)
+        expect(Grid::TransactionService).to have_received(:recycle!)
+      end
+    end
+  end
+
+  describe "repair_deck item effect" do
+    let(:kit_def) do
+      create(:grid_item_definition, slug: "test-repair-kit", name: "Test Repair Kit", item_type: "consumable",
+        properties: {"effect_type" => "repair_deck", "kit_level" => 3})
+    end
+
+    let(:kit) { create(:grid_item, :in_inventory, grid_item_definition: kit_def, grid_hackr: hackr, item_type: "consumable") }
+
+    before { deck.update!(properties: deck.properties.merge("fried_level" => 2)) }
+
+    it "clears fried_level when kit_level >= fried_level" do
+      the_hackr = hackr
+      applier = Object.new
+      applier.extend(Grid::ItemEffectApplier)
+      applier.define_singleton_method(:hackr) { the_hackr }
+      applier.define_singleton_method(:h) { |t| ERB::Util.html_escape(t.to_s) }
+
+      result = applier.apply_item_effect(kit)
+      expect(result).to include("DECK repaired")
+      expect(deck.reload.deck_fried?).to be false
+    end
+
+    it "rejects kit when kit_level < fried_level" do
+      deck.update!(properties: deck.properties.merge("fried_level" => 5))
+      the_hackr = hackr
+      applier = Object.new
+      applier.extend(Grid::ItemEffectApplier)
+      applier.define_singleton_method(:hackr) { the_hackr }
+      applier.define_singleton_method(:h) { |t| ERB::Util.html_escape(t.to_s) }
+
+      result = applier.apply_item_effect(kit)
+      expect(result).to include("insufficient")
+      expect(deck.reload.deck_fried?).to be true
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # PUZZLE GENERATOR
+  # ═══════════════════════════════════════════════════════════════
+
+  describe Grid::PuzzleGeneratorService do
+    let(:rng) { Random.new(42) }
+
+    it "generates a sequence puzzle" do
+      result = described_class.generate({"type" => "sequence", "difficulty" => 3}, rng)
+      expect(result[:display_data]["type"]).to eq("sequence")
+      expect(result[:display_data]["nodes"]).to be_an(Array)
+      expect(result[:display_data]["nodes"].size).to eq(6)
+      expect(result[:solution]).to be_a(String)
+      expect(result[:solution].split.size).to eq(6)
+    end
+
+    it "generates a logic_gate puzzle" do
+      result = described_class.generate({"type" => "logic_gate", "difficulty" => 2}, rng)
+      expect(result[:display_data]["type"]).to eq("logic_gate")
+      expect(result[:display_data]["gate_type"]).to be_a(String)
+      expect(result[:display_data]["inputs"]).to be_an(Array)
+      # Solution format: "GATE_TYPE:TARGET:INPUT_COUNT" for dynamic validation
+      expect(result[:solution]).to match(/\A[A-Z]+:(HIGH|LOW):\d+\z/)
+    end
+
+    it "generates a circuit puzzle" do
+      result = described_class.generate({"type" => "circuit", "difficulty" => 2}, rng)
+      expect(result[:display_data]["type"]).to eq("circuit")
+      expect(result[:display_data]["left_nodes"]).to be_an(Array)
+      expect(result[:display_data]["right_nodes"]).to be_an(Array)
+      expect(result[:solution]).to be_a(String)
+    end
+
+    it "generates a credential puzzle" do
+      result = described_class.generate({"type" => "credential", "difficulty" => 3}, rng)
+      expect(result[:display_data]["type"]).to eq("credential")
+      expect(result[:display_data]["encrypted"]).to be_a(String)
+      expect(result[:display_data]["cipher_hint"]).to be_a(String)
+      expect(result[:solution]).to be_a(String)
+    end
+
+    it "is deterministic with same seed" do
+      r1 = described_class.generate({"type" => "sequence", "difficulty" => 2}, Random.new(99))
+      r2 = described_class.generate({"type" => "sequence", "difficulty" => 2}, Random.new(99))
+      expect(r1[:solution]).to eq(r2[:solution])
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # PUZZLE INTEGRATION
+  # ═══════════════════════════════════════════════════════════════
+
+  describe "Puzzle gate generation in BreachService.start!" do
+    let(:puzzle_template) do
+      create(:grid_breach_template,
+        protocol_composition: [],
+        puzzle_gates: [
+          {"id" => "A", "type" => "sequence", "difficulty" => 2, "depends_on" => nil},
+          {"id" => "B", "type" => "credential", "difficulty" => 1, "depends_on" => "A"}
+        ])
+    end
+    let(:puzzle_encounter) { create(:grid_breach_encounter, grid_breach_template: puzzle_template, grid_room: room) }
+
+    it "generates puzzle state in meta" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: puzzle_encounter)
+      breach = result.hackr_breach
+
+      ps = breach.meta["puzzle_state"]
+      expect(ps).to be_present
+      expect(ps["gates"]).to have_key("A")
+      expect(ps["gates"]).to have_key("B")
+      expect(ps["gates"]["A"]["state"]).to eq("active")
+      expect(ps["gates"]["B"]["state"]).to eq("locked")
+      expect(ps["gates"]["A"]["solution"]).to be_a(String)
+      expect(ps["required_count"]).to be >= 1
+    end
+
+    it "bypasses gates when clearance is high" do
+      hackr.set_stat!("clearance", 60) # bypass_count = 60/30 = 2
+      result = Grid::BreachService.start!(hackr: hackr, encounter: puzzle_encounter)
+      breach = result.hackr_breach
+
+      ps = breach.meta["puzzle_state"]
+      bypassed = ps["gates"].values.count { |g| g["state"] == "bypassed" }
+      expect(bypassed).to be >= 1
+      expect(ps["required_count"]).to eq(1)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # INTERFACE ACTION
+  # ═══════════════════════════════════════════════════════════════
+
+  describe Grid::BreachActionService, ".interface!" do
+    let(:puzzle_template) do
+      create(:grid_breach_template,
+        protocol_composition: [],
+        puzzle_gates: [
+          {"id" => "A", "type" => "sequence", "difficulty" => 1, "depends_on" => nil}
+        ])
+    end
+    let(:puzzle_encounter) { create(:grid_breach_encounter, grid_breach_template: puzzle_template, grid_room: room) }
+
+    let!(:breach) do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: puzzle_encounter)
+      result.hackr_breach
+    end
+
+    it "solves a gate with correct answer" do
+      solution = breach.meta["puzzle_state"]["gates"]["A"]["solution"]
+      result = described_class.interface!(hackr: hackr, gate_id: "A", answer: solution)
+
+      expect(result.correct).to be true
+      expect(result.gate_state).to eq("solved")
+      expect(result.feedback).to eq("ACCESS GRANTED")
+    end
+
+    it "decrements attempts on wrong answer" do
+      result = described_class.interface!(hackr: hackr, gate_id: "A", answer: "WRONG ANSWER")
+
+      expect(result.correct).to be false
+      expect(result.gate_state).to eq("active")
+      expect(result.attempts_remaining).to be < breach.meta["puzzle_state"]["gates"]["A"]["max_attempts"]
+    end
+
+    it "locks gate when all attempts exhausted" do
+      max_attempts = breach.meta["puzzle_state"]["gates"]["A"]["max_attempts"]
+      max_attempts.times do
+        described_class.interface!(hackr: hackr, gate_id: "A", answer: "WRONG")
+        breach.reload
+        # Restore action
+        breach.update!(actions_remaining: 1) if breach.actions_remaining <= 0
+      end
+
+      breach.reload
+      expect(breach.meta["puzzle_state"]["gates"]["A"]["state"]).to eq("failed")
+    end
+
+    it "raises GateNotFound for invalid gate ID" do
+      expect {
+        described_class.interface!(hackr: hackr, gate_id: "Z", answer: "test")
+      }.to raise_error(Grid::BreachActionService::GateNotFound)
+    end
+
+    it "raises NoActionsRemaining when no actions left" do
+      breach.update!(actions_remaining: 0)
+      expect {
+        described_class.interface!(hackr: hackr, gate_id: "A", answer: "test")
+      }.to raise_error(Grid::BreachActionService::NoActionsRemaining)
+    end
+
+    it "consumes one action" do
+      initial = breach.actions_remaining
+      solution = breach.meta["puzzle_state"]["gates"]["A"]["solution"]
+      described_class.interface!(hackr: hackr, gate_id: "A", answer: solution)
+      expect(breach.reload.actions_remaining).to eq(initial - 1)
+    end
+
+    it "logs the interface action" do
+      solution = breach.meta["puzzle_state"]["gates"]["A"]["solution"]
+      described_class.interface!(hackr: hackr, gate_id: "A", answer: solution)
+
+      log = GridHackrBreachLog.last
+      expect(log.action_type).to eq("interface")
+      expect(log.result["gate_id"]).to eq("A")
+      expect(log.result["correct"]).to be true
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # OR WIN CONDITION
+  # ═══════════════════════════════════════════════════════════════
+
+  describe "OR win condition" do
+    let(:mixed_template) do
+      create(:grid_breach_template,
+        protocol_composition: [
+          {"type" => "trace", "count" => 1, "health" => 10, "max_health" => 10, "charge_rounds" => 0}
+        ],
+        puzzle_gates: [
+          {"id" => "A", "type" => "sequence", "difficulty" => 1, "depends_on" => nil}
+        ])
+    end
+    let(:mixed_encounter) { create(:grid_breach_encounter, grid_breach_template: mixed_template, grid_room: room) }
+
+    it "wins via puzzle gates even with protocols alive" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: mixed_encounter)
+      breach = result.hackr_breach
+
+      solution = breach.meta["puzzle_state"]["gates"]["A"]["solution"]
+      interface_result = Grid::BreachActionService.interface!(hackr: hackr, gate_id: "A", answer: solution)
+
+      expect(interface_result.all_solved).to be true
+      expect(breach.reload.breach_won?).to be true
+    end
+
+    it "wins via protocols even with gates unsolved" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: mixed_encounter)
+      breach = result.hackr_breach
+
+      # Destroy all protocols
+      breach.grid_breach_protocols.update_all(state: "destroyed", health: 0)
+      expect(breach.reload.breach_won?).to be true
+    end
+
+    it "does not win when neither condition is met" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: mixed_encounter)
+      breach = result.hackr_breach
+
+      expect(breach.breach_won?).to be false
+    end
+
+    it "triggers success via end_round! when gates are solved mid-round" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: mixed_encounter)
+      breach = result.hackr_breach
+
+      # Solve the gate directly (simulating interface! already consumed the action)
+      ps = breach.meta["puzzle_state"]
+      ps["gates"]["A"]["state"] = "solved"
+      ps["solved_count"] = 1
+      breach.update!(meta: breach.meta.merge("puzzle_state" => ps), actions_remaining: 0)
+
+      # end_round! should detect breach_won? and resolve success
+      round_result = Grid::BreachService.end_round!(hackr_breach: breach)
+      expect(round_result.state).to eq(:success)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # RENDERER
+  # ═══════════════════════════════════════════════════════════════
+
+  describe Grid::BreachRenderer do
+    let(:puzzle_template) do
+      create(:grid_breach_template,
+        protocol_composition: [],
+        puzzle_gates: [
+          {"id" => "A", "type" => "sequence", "difficulty" => 1, "depends_on" => nil}
+        ])
+    end
+    let(:puzzle_encounter) { create(:grid_breach_encounter, grid_breach_template: puzzle_template, grid_room: room) }
+
+    it "includes circumvention gates block when gates exist" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: puzzle_encounter)
+      breach = result.hackr_breach
+
+      renderer = described_class.new(breach)
+      output = renderer.render_full
+
+      expect(output).to include("PROTOCOL CIRCUMVENTION GATES")
+      expect(output).to include("[A]")
+      expect(output).to include("Sequence")
+    end
+
+    it "omits circumvention gates block when no gates exist" do
+      std_template = create(:grid_breach_template)
+      std_encounter = create(:grid_breach_encounter, grid_breach_template: std_template, grid_room: room)
+      result = Grid::BreachService.start!(hackr: hackr, encounter: std_encounter)
+      breach = result.hackr_breach
+
+      renderer = described_class.new(breach)
+      output = renderer.render_full
+
+      expect(output).not_to include("PROTOCOL CIRCUMVENTION GATES")
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # GRID ITEM HELPERS
+  # ═══════════════════════════════════════════════════════════════
+
+  describe "GridItem DECK fried helpers" do
+    it "deck_fried? returns true when fried_level > 0" do
+      deck.update!(properties: deck.properties.merge("fried_level" => 3))
+      expect(deck.deck_fried?).to be true
+    end
+
+    it "deck_fried? returns false when fried_level is 0 or absent" do
+      expect(deck.deck_fried?).to be false
+    end
+
+    it "deck_fried_level returns the fried_level value" do
+      deck.update!(properties: deck.properties.merge("fried_level" => 4))
+      expect(deck.deck_fried_level).to eq(4)
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════
+  # HACKR BREACH MODEL HELPERS
+  # ═══════════════════════════════════════════════════════════════
+
+  describe "GridHackrBreach helpers" do
+    let(:template) { create(:grid_breach_template) }
+    let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }
+
+    it "puzzle_gates_exist? returns false when no puzzle state" do
+      result = Grid::BreachService.start!(hackr: hackr, encounter: encounter)
+      expect(result.hackr_breach.puzzle_gates_exist?).to be false
+    end
+
+    it "puzzle_gates_exist? returns true when puzzle state has gates" do
+      puzzle_template = create(:grid_breach_template,
+        protocol_composition: [],
+        puzzle_gates: [{"id" => "A", "type" => "sequence", "difficulty" => 1, "depends_on" => nil}])
+      puzzle_encounter = create(:grid_breach_encounter, grid_breach_template: puzzle_template, grid_room: room)
+      result = Grid::BreachService.start!(hackr: hackr, encounter: puzzle_encounter)
+      expect(result.hackr_breach.puzzle_gates_exist?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Adds escalating DECK consequences for failed breaches, a two-path repair
  system, and a four-type puzzle system with procedurally generated gates
  as an alternate encounter win condition.

  Failure Tiers 3-4 (detection-overflow only, not health-zero):
  - Tier 3 (standard+): all loaded software destroyed from DECK
  - Tier 4 (advanced+): software wiped + DECK fried (fried_level 1-5, clearance-weighted). Fried DECK stays equipped but blocks BREACH. Ambient encounters auto-fail at tier 1 with fried DECK.

  DECK Repair System:
  - DeckRepairService for NPC repair at repair_service rooms. Cost scales with fried_level x DECK rarity. Payment failure restores fried_level.
  - DECK Repair Kit consumables (Mk.I-V, max_stack 1) via ItemEffectApplier. Kit level must match or exceed damage level.
  - 5 item definitions, 5 fabrication schematics, TechMed Repair Bay room with Wrench NPC vendor in Transit Network.

  Protocol Circumvention Gates (puzzle system):
  - 4 puzzle types: sequence (Wordle-style position hints on wrong answer), logic gate (dynamic evaluation accepts any valid input combo), circuit (order-independent pair matching), access credential decryption.
  - Procedurally generated per encounter via seeded RNG.
  - puzzle_gates JSON column on grid_breach_templates (1 migration). Puzzle state stored in grid_hackr_breaches.meta.
  - interface/if command (1 action) with gate dependency chains. Clearance bypasses hardest gates; psyche grants bonus attempt.
  - OR win condition: destroy all protocols OR solve all required gates. breach_won? replaces all_protocols_destroyed? checks in end_round!.
  - PROTOCOL CIRCUMVENTION GATES renderer block with letter-indexed gates.