### PR TITLE
[TPG] BREACH Phase 3: Stakes - GovCorp capture, gear impound

### DIFF
--- a/app/controllers/admin/grid_regions_controller.rb
+++ b/app/controllers/admin/grid_regions_controller.rb
@@ -4,6 +4,7 @@ class Admin::GridRegionsController < Admin::ApplicationController
   versionable GridRegion
 
   before_action :set_region, only: %i[edit update destroy]
+  before_action :load_selects, only: %i[new edit create update]
 
   def index
     @regions = GridRegion.includes(:grid_zones).order(:name)
@@ -54,7 +55,13 @@ class Admin::GridRegionsController < Admin::ApplicationController
     @region = GridRegion.find(params[:id])
   end
 
+  def load_selects
+    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+  end
+
   def region_params
-    params.require(:grid_region).permit(:name, :slug, :description)
+    params.require(:grid_region).permit(:name, :slug, :description,
+      :hospital_room_id, :containment_room_id,
+      :facility_exit_room_id, :facility_bribe_exit_room_id)
   end
 end

--- a/app/models/grid_breach_template.rb
+++ b/app/models/grid_breach_template.rb
@@ -14,6 +14,7 @@
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
+#  no_clearance_bypass   :boolean          default(FALSE), not null
 #  pnr_threshold         :integer          default(75), not null
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -113,6 +113,7 @@ class GridHackr < ApplicationRecord
   has_many :hackr_vod_watches, dependent: :destroy
   has_many :hackr_radio_tunes, dependent: :destroy
   has_many :grid_hackr_missions, dependent: :destroy
+  has_many :grid_impound_records, dependent: :destroy
   has_many :grid_missions, through: :grid_hackr_missions
   has_one :den, class_name: "GridRoom", foreign_key: :owner_id
   has_many :den_invites_received, class_name: "GridDenInvite", foreign_key: :guest_id, dependent: :destroy

--- a/app/models/grid_impound_record.rb
+++ b/app/models/grid_impound_record.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_impound_records
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  bribe_cost           :integer          default(0), not null
+#  status               :string           default("impounded"), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  grid_hackr_breach_id :integer
+#  grid_hackr_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_impound_records_on_grid_hackr_breach_id      (grid_hackr_breach_id)
+#  index_grid_impound_records_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_impound_records_on_grid_hackr_id_and_status  (grid_hackr_id,status)
+#
+# Foreign Keys
+#
+#  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => nullify
+#  grid_hackr_id         (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#
+class GridImpoundRecord < ApplicationRecord
+  STATUSES = %w[impounded recovered forfeited].freeze
+
+  has_paper_trail
+
+  belongs_to :grid_hackr
+  belongs_to :grid_hackr_breach, optional: true
+  has_many :impounded_items,
+    class_name: "GridItem",
+    foreign_key: :grid_impound_record_id,
+    dependent: :nullify
+
+  validates :status, inclusion: {in: STATUSES}
+  validates :bribe_cost, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :impounded, -> { where(status: "impounded") }
+  scope :recovered, -> { where(status: "recovered") }
+  scope :forfeited, -> { where(status: "forfeited") }
+  scope :for_hackr, ->(hackr) { where(grid_hackr: hackr) }
+
+  def impounded?
+    status == "impounded"
+  end
+
+  def recovered?
+    status == "recovered"
+  end
+
+  def forfeited?
+    status == "forfeited"
+  end
+end

--- a/app/models/grid_item.rb
+++ b/app/models/grid_item.rb
@@ -17,6 +17,7 @@
 #  container_id            :integer
 #  deck_id                 :integer
 #  grid_hackr_id           :integer
+#  grid_impound_record_id  :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
 #  room_id                 :integer
@@ -26,6 +27,7 @@
 #  index_grid_items_on_container_id                (container_id)
 #  index_grid_items_on_deck_id                     (deck_id)
 #  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_impound_record_id      (grid_impound_record_id)
 #  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
 #  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
@@ -34,6 +36,7 @@
 #
 #  container_id             (container_id => grid_items.id)
 #  deck_id                  (deck_id => grid_items.id) ON DELETE => nullify
+#  grid_impound_record_id   (grid_impound_record_id => grid_impound_records.id) ON DELETE => nullify
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 class GridItem < ApplicationRecord
@@ -72,9 +75,10 @@ class GridItem < ApplicationRecord
   belongs_to :grid_mining_rig, optional: true
   belongs_to :container, class_name: "GridItem", optional: true
   belongs_to :deck_item, class_name: "GridItem", foreign_key: :deck_id, optional: true
+  belongs_to :grid_impound_record, optional: true
   has_many :stored_items, class_name: "GridItem", foreign_key: :container_id, dependent: :restrict_with_error
-  has_many :loaded_software, -> { where(item_type: "software") }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
-  has_many :installed_modules, -> { where(item_type: "module") }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
+  has_many :loaded_software, -> { where(item_type: "software", grid_impound_record_id: nil) }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
+  has_many :installed_modules, -> { where(item_type: "module", grid_impound_record_id: nil) }, class_name: "GridItem", foreign_key: :deck_id, dependent: :nullify
 
   validates :name, presence: true
   validates :item_type, inclusion: {in: ITEM_TYPES, allow_nil: true}
@@ -86,13 +90,13 @@ class GridItem < ApplicationRecord
   validate :deck_id_requirements
 
   scope :in_room, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
-  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil, equipped_slot: nil, deck_id: nil) }
-  scope :equipped_by, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil).where.not(equipped_slot: nil) }
+  scope :in_inventory, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil, equipped_slot: nil, deck_id: nil, grid_impound_record_id: nil) }
+  scope :equipped_by, ->(hackr) { where(grid_hackr: hackr, grid_mining_rig: nil, container_id: nil, grid_impound_record_id: nil).where.not(equipped_slot: nil) }
   scope :installed_in, ->(rig) { where(grid_mining_rig: rig, grid_hackr: nil, room: nil) }
-  scope :on_floor, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil).where.not(item_type: "fixture") }
+  scope :on_floor, ->(room) { where(room: room, grid_hackr: nil, grid_mining_rig: nil, container_id: nil, grid_impound_record_id: nil).where.not(item_type: "fixture") }
   scope :placed_fixtures, ->(room) { where(room: room, item_type: "fixture", grid_hackr: nil, grid_mining_rig: nil, container_id: nil) }
-  scope :in_fixture, ->(fixture) { where(container: fixture) }
-  scope :loaded_in_deck, ->(deck) { where(deck_id: deck.id, item_type: "software") }
+  scope :in_fixture, ->(fixture) { where(container: fixture, grid_impound_record_id: nil) }
+  scope :loaded_in_deck, ->(deck) { where(deck_id: deck.id, item_type: "software", grid_impound_record_id: nil) }
 
   RAINBOW_COLORS = %w[#ff6b6b #fbbf24 #34d399 #22d3ee #60a5fa #a78bfa].freeze
 

--- a/app/models/grid_region.rb
+++ b/app/models/grid_region.rb
@@ -3,27 +3,39 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  description      :text
-#  name             :string           not null
-#  slug             :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  hospital_room_id :integer
+#  id                          :integer          not null, primary key
+#  description                 :text
+#  name                        :string           not null
+#  slug                        :string           not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  containment_room_id         :integer
+#  facility_bribe_exit_room_id :integer
+#  facility_exit_room_id       :integer
+#  hospital_room_id            :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
-#  index_grid_regions_on_slug              (slug) UNIQUE
+#  index_grid_regions_on_containment_room_id          (containment_room_id)
+#  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
+#  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
+#  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
-#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 class GridRegion < ApplicationRecord
   has_paper_trail
 
   belongs_to :hospital_room, class_name: "GridRoom", optional: true
+  belongs_to :containment_room, class_name: "GridRoom", optional: true
+  belongs_to :facility_exit_room, class_name: "GridRoom", optional: true
+  belongs_to :facility_bribe_exit_room, class_name: "GridRoom", optional: true
 
   has_many :grid_zones, dependent: :restrict_with_error
   has_many :grid_rooms, through: :grid_zones

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -48,13 +48,27 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor repair_service],
+    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor repair_service containment impound sally_port sally_port_anteroom],
     allow_nil: true
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :owner_id, uniqueness: {allow_nil: true}
 
-  filter_profanity :name, :description
+  # Profanity filter: only for dens (user-controlled name + description).
+  # Non-den rooms are admin-seeded — no filter needed.
+  # Uses ProfanityFilterable#profane_content? to stay in sync with the concern.
+  validate :filter_den_profanity
+
+  def filter_den_profanity
+    return unless den?
+    %i[name description].each do |attr|
+      value = public_send(attr)
+      next if value.blank?
+      if profane_content?(value)
+        errors.add(attr, ProfanityFilterable.rejection_message)
+      end
+    end
+  end
 
   # Delegate to zone for convenience
   delegate :faction, :color_scheme, to: :grid_zone

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -397,6 +397,11 @@ module Grid
           puzzle_state["solved_count"] = puzzle_state["solved_count"].to_i + 1
           feedback = "ACCESS GRANTED"
           unlock_dependent_gates!(puzzle_state, gate_id)
+        elsif gate["attempts_remaining"].to_i == Grid::BreachService::UNLIMITED_ATTEMPTS
+          # Infinite attempts (facility BREACHes): never decrement, never fail
+          hint = sequence_position_hint(gate, answer)
+          feedback = "Incorrect — try again"
+          feedback = "#{feedback}. #{hint}" if hint
         else
           gate["attempts_remaining"] = gate["attempts_remaining"].to_i - 1
           if gate["attempts_remaining"] <= 0

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -107,6 +107,9 @@ module Grid
         if resolve_result.xp_result[:leveled_up]
           output << "<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE UP → #{resolve_result.xp_result[:new_clearance]}</span>"
         end
+
+        # Facility BREACH hooks (captured mode)
+        output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
       else
         # Check if round should end
         breach.reload
@@ -258,6 +261,9 @@ module Grid
         if resolve_result.xp_result[:leveled_up]
           output << "<span style='color: #fbbf24; font-weight: bold;'>\u25b2 CLEARANCE UP \u2192 #{resolve_result.xp_result[:new_clearance]}</span>"
         end
+
+        # Facility BREACH hooks (captured mode)
+        output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
       else
         # Check if round should end
         breach.reload
@@ -266,7 +272,7 @@ module Grid
       end
 
       append_notifications(output, notifications)
-      output.join("\n")
+      output.compact.join("\n")
     rescue Grid::BreachActionService::NoActionsRemaining,
       Grid::BreachActionService::GateNotFound,
       Grid::BreachActionService::GateLocked,
@@ -345,6 +351,41 @@ module Grid
 
     def blocked_command(command)
       "<span style='color: #f87171;'>Cannot use '#{h(command)}' during BREACH. Type <span style='color: #22d3ee;'>help</span> for available commands.</span>"
+    end
+
+    # Post-BREACH-success actions when captured in a GovCorp facility.
+    # Handles cell escape (teleport to corridor), sally port progression,
+    # and alert reduction for voluntary targets.
+    def facility_breach_success_hook
+      room = hackr.current_room
+      return nil unless room
+
+      # Reduce facility alert for any successful BREACH in the facility
+      Grid::ContainmentService.alert_reduce!(hackr: hackr)
+
+      case room.room_type
+      when "containment"
+        # Cell escape — teleport to the processing corridor (slug convention: *-processing-corridor)
+        corridor = room.grid_zone.grid_rooms.find_by("slug LIKE ?", "%-pac-processing-corridor")
+        corridor ||= room.grid_zone.grid_rooms.where.not(room_type: "containment").order(:id).first
+        if corridor
+          hackr.update!(current_room_id: corridor.id)
+          "<span style='color: #34d399; font-weight: bold;'>Cell seal breached. You slip into the corridor.</span>"
+        end
+      when "sally_port"
+        # Inner sally port door — escape the facility entirely
+        escape_result = Grid::ContainmentService.escape_facility!(hackr: hackr, via: :sally_port)
+        escape_result.display
+      when "sally_port_anteroom"
+        # Outer door BREACH success = move to the sally_port room in the same zone.
+        sally_port = room.grid_zone.grid_rooms.find_by(room_type: "sally_port")
+        if sally_port
+          hackr.update!(current_room_id: sally_port.id)
+          "<span style='color: #34d399; font-weight: bold;'>Outer door seal breached. You enter the sally port.</span>"
+        end
+      else
+        nil # Regular voluntary target — alert reduction already handled above
+      end
     end
 
     def maybe_end_round

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -236,7 +236,12 @@ module Grid
         when "locked"
           ["#6b7280", "\u25a1", "locked (solve #{gate["depends_on"]} first)"]
         else # active
-          ["#d0d0d0", "\u25cb", "#{gate["attempts_remaining"]}/#{gate["max_attempts"]} attempts"]
+          attempts_text = if gate["max_attempts"].to_i == Grid::BreachService::UNLIMITED_ATTEMPTS
+            "unlimited attempts"
+          else
+            "#{gate["attempts_remaining"]}/#{gate["max_attempts"]} attempts"
+          end
+          ["#d0d0d0", "\u25cb", attempts_text]
         end
 
         lines << "#{border}  <span style='color: #9ca3af;'>[#{gate_id}]</span> <span style='color: #d0d0d0;'>#{h(type_label)}</span>  <span style='color: #{state_color};'>#{icon} #{h(status_text)}</span>"

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -5,7 +5,7 @@ module Grid
     StartResult = Data.define(:hackr_breach, :protocols, :display)
     EndRoundResult = Data.define(:hackr_breach, :state, :protocol_messages, :display, :failure_display)
     ResolveResult = Data.define(:hackr_breach, :xp_awarded, :cred_awarded, :xp_result, :display)
-    FailureResult = Data.define(:hackr_breach, :vitals_hit, :zone_lockout_minutes, :fried_level, :software_wiped, :display)
+    FailureResult = Data.define(:hackr_breach, :vitals_hit, :zone_lockout_minutes, :fried_level, :software_wiped, :captured, :display)
     JackoutResult = Data.define(:hackr_breach, :clean, :vitals_hit, :display)
 
     class AlreadyInBreach < StandardError; end
@@ -32,6 +32,7 @@ module Grid
     }.freeze
 
     TRACE_DETECTION_BONUS = 4
+    UNLIMITED_ATTEMPTS = -1 # Sentinel for infinite puzzle gate attempts (facility BREACHes)
 
     def self.breach_rank(clearance)
       BREACH_RANK_TABLE.find { |range, _| range.include?(clearance.to_i) }&.last
@@ -86,6 +87,43 @@ module Grid
       encounters.sort_by { |enc| enc.grid_breach_template.position }
     end
 
+    # Returns all non-depleted encounters in room for display, including locked ones.
+    # Each entry: { encounter:, template:, available:, locked_reason: }
+    # Used by look_command to show "[LOCKED]" indicators on gated encounters.
+    def self.listed_encounters(room:, hackr: nil)
+      encounters = room.grid_breach_encounters
+        .not_depleted
+        .includes(:grid_breach_template)
+        .select { |enc| enc.grid_breach_template.published? }
+
+      encounters.each(&:check_cooldown!)
+      encounters = encounters.reject(&:active?)
+
+      cl = hackr ? hackr.stat("clearance") : 0
+
+      encounters.sort_by { |enc| enc.grid_breach_template.position }.map do |enc|
+        t = enc.grid_breach_template
+        locked_reason = nil
+
+        if !enc.available?
+          locked_reason = "ON COOLDOWN"
+        elsif hackr && cl < t.min_clearance
+          locked_reason = "CLEARANCE #{t.min_clearance} REQUIRED"
+        elsif t.requires_mission_slug.present? && hackr
+          completed = hackr.grid_hackr_missions
+            .joins(:grid_mission)
+            .exists?(grid_missions: {slug: t.requires_mission_slug}, status: "completed")
+          locked_reason = "MISSION REQUIRED" unless completed
+        elsif t.requires_item_slug.present? && hackr
+          has_item = hackr.grid_items.joins(:grid_item_definition)
+            .exists?(grid_item_definitions: {slug: t.requires_item_slug})
+          locked_reason = "KEY ITEM REQUIRED" unless has_item
+        end
+
+        {encounter: enc, template: t, available: locked_reason.nil?, locked_reason: locked_reason}
+      end
+    end
+
     def initialize(hackr)
       @hackr = hackr
     end
@@ -118,9 +156,9 @@ module Grid
 
         # Mission prerequisite gate
         if template.requires_mission_slug.present?
-          completed = @hackr.grid_mission_progresses
+          completed = @hackr.grid_hackr_missions
             .joins(:grid_mission)
-            .exists?(grid_missions: {slug: template.requires_mission_slug}, state: "completed")
+            .exists?(grid_missions: {slug: template.requires_mission_slug}, status: "completed")
           raise TemplateGated, "Requires completed mission: #{template.requires_mission_slug}." unless completed
         end
 
@@ -361,7 +399,7 @@ module Grid
 
     def resolve_failure!(hackr_breach, failure_mode: :detection_overflow)
       unless hackr_breach.state == "active"
-        return FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, fried_level: nil, software_wiped: false, display: "")
+        return FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, fried_level: nil, software_wiped: false, captured: false, display: "")
       end
 
       template = hackr_breach.grid_breach_template
@@ -369,7 +407,12 @@ module Grid
       zone_lockout_minutes = nil
       fried_level_set = nil
       software_wiped = false
+      captured = false
       tier = template.tier
+
+      # Determine failure path: standard consequences OR GovCorp capture.
+      # Capture replaces lockout + DECK consequences — you're in custody instead.
+      govcorp_capture = should_capture?(tier, failure_mode)
 
       # Wrap in transaction if not already inside one (end_round! calls this inside its own)
       wrap = !ActiveRecord::Base.connection.transaction_open?
@@ -386,42 +429,45 @@ module Grid
         vitals_hit << drain_vital!("energy", 20)
         vitals_hit << drain_vital!("psyche", 20)
 
-        # Tier 2: zone lockout (standard+ encounters)
-        unless tier == "ambient"
-          zone_lockout_minutes = (1 + (hackr_breach.round_number / 3.0).floor).clamp(1, 10)
+        unless govcorp_capture
+          # Standard failure path: lockout + DECK consequences + eject
 
-          zone = GridRoom.find_by(id: hackr_breach.origin_room_id)&.grid_zone
-          if zone
-            lockout_until = (Time.current + zone_lockout_minutes.minutes).to_i
-            @hackr.set_stat!("zone_lockout_#{zone.id}", lockout_until)
+          # Tier 2: zone lockout (standard+ encounters)
+          unless tier == "ambient"
+            zone_lockout_minutes = (1 + (hackr_breach.round_number / 3.0).floor).clamp(1, 10)
+
+            zone = GridRoom.find_by(id: hackr_breach.origin_room_id)&.grid_zone
+            if zone
+              lockout_until = (Time.current + zone_lockout_minutes.minutes).to_i
+              @hackr.set_stat!("zone_lockout_#{zone.id}", lockout_until)
+            end
+          end
+
+          # Tier 3+4: DECK consequences (detection-overflow only, not health-zero)
+          deck = @hackr.equipped_deck
+          if deck && failure_mode == :detection_overflow
+            if %w[advanced elite world_event].include?(tier)
+              # Tier 4: DECK fried — compute level + wipe software
+              fried_level_set = compute_fried_level(tier)
+              deck.lock!
+              deck.loaded_software.destroy_all
+              deck.update!(properties: deck.properties.merge("fried_level" => fried_level_set))
+              software_wiped = true
+            elsif tier == "standard"
+              # Tier 3: software wipe only (no fry)
+              deck.lock!
+              deck.loaded_software.destroy_all
+              software_wiped = true
+            end
+          end
+
+          # Eject to zone entry room
+          eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
+          if eject_room_id && eject_room_id != @hackr.current_room_id
+            @hackr.update!(current_room_id: eject_room_id)
           end
         end
-
-        # Tier 3+4: DECK consequences (detection-overflow only, not health-zero)
-        # Tier 3: software wipe (standard+). Tier 4: DECK fried (advanced+).
-        # When tier 4 triggers, software is also wiped (it gets _really_ fried).
-        deck = @hackr.equipped_deck
-        if deck && failure_mode == :detection_overflow
-          if %w[advanced elite world_event].include?(tier)
-            # Tier 4: DECK fried — compute level + wipe software
-            fried_level_set = compute_fried_level(tier)
-            deck.lock!
-            deck.loaded_software.destroy_all
-            deck.update!(properties: deck.properties.merge("fried_level" => fried_level_set))
-            software_wiped = true
-          elsif %w[standard].include?(tier)
-            # Tier 3: software wipe only (no fry)
-            deck.lock!
-            deck.loaded_software.destroy_all
-            software_wiped = true
-          end
-        end
-
-        # Eject to zone entry room
-        eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
-        if eject_room_id && eject_room_id != @hackr.current_room_id
-          @hackr.update!(current_room_id: eject_room_id)
-        end
+        # Capture path is handled outside the transaction (ContainmentService has its own)
       end
 
       if wrap
@@ -430,18 +476,42 @@ module Grid
         run.call
       end
 
+      # Tier 5+6: GovCorp capture (outside main transaction)
+      capture_result = nil
+      if govcorp_capture
+        captured = true
+        impound = %w[elite world_event].include?(tier) ||
+          (tier == "advanced" && rand < Grid::ContainmentService::ADVANCED_IMPOUND_CHANCE)
+        begin
+          capture_result = Grid::ContainmentService.capture!(
+            hackr: @hackr, breach: hackr_breach, impound: impound
+          )
+        rescue Grid::ContainmentService::AlreadyCaptured, Grid::ContainmentService::NoContainmentRoom => e
+          Rails.logger.warn("[BreachService] Capture failed: #{e.message} — applying standard failure consequences")
+          captured = false
+          apply_standard_failure!(hackr_breach, tier, failure_mode, vitals_hit) do |result|
+            zone_lockout_minutes = result[:zone_lockout_minutes]
+            fried_level_set = result[:fried_level]
+            software_wiped = result[:software_wiped]
+          end
+        end
+      end
+
       vitals_hit.compact!
       display = Grid::BreachRenderer.new(hackr_breach).render_failure(
         vitals_hit, zone_lockout_minutes,
         fried_level: fried_level_set, software_wiped: software_wiped,
         failure_mode: failure_mode
       )
+      display = [display, capture_result&.display].compact.join("\n") if capture_result
+
       FailureResult.new(
         hackr_breach: hackr_breach,
         vitals_hit: vitals_hit,
         zone_lockout_minutes: zone_lockout_minutes,
         fried_level: fried_level_set,
         software_wiped: software_wiped,
+        captured: captured,
         display: display
       )
     end
@@ -529,13 +599,19 @@ module Grid
       clearance = @hackr.stat("clearance")
       psyche = @hackr.stat("psyche")
       total = gate_defs.size
-      bypass_count = [(clearance / 30).floor, total - 1].min # Always leave at least 1 gate active
-      required_count = [1, total - bypass_count].max
 
-      # Base 3 attempts. Psyche bonus: +1 if psyche >= 50% of max
-      max_psyche = @hackr.effective_max("psyche")
-      psyche_bonus = (max_psyche > 0 && psyche.to_f / max_psyche >= 0.5) ? 1 : 0
-      attempts = 3 + psyche_bonus
+      # no_clearance_bypass: facility containment locks — all gates must be solved
+      if template.no_clearance_bypass
+        bypass_count = 0
+        attempts = UNLIMITED_ATTEMPTS
+      else
+        bypass_count = [(clearance / 30).floor, total - 1].min # Always leave at least 1 gate active
+        # Base 3 attempts. Psyche bonus: +1 if psyche >= 50% of max
+        max_psyche = @hackr.effective_max("psyche")
+        psyche_bonus = (max_psyche > 0 && psyche.to_f / max_psyche >= 0.5) ? 1 : 0
+        attempts = 3 + psyche_bonus
+      end
+      required_count = [1, total - bypass_count].max
 
       # Last N gates (by template order) are bypassed — hardest gates last convention
       bypassed_ids = gate_defs.last(bypass_count).map { |g| g["id"] }
@@ -674,6 +750,71 @@ module Grid
         5
       else
         1
+      end
+    end
+
+    # Apply standard failure consequences (lockout + DECK + eject).
+    # Used as fallback when capture attempt fails.
+    def apply_standard_failure!(hackr_breach, tier, failure_mode, vitals_hit)
+      zone_lockout_minutes = nil
+      fried_level_set = nil
+      software_wiped = false
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        # Tier 2: zone lockout
+        unless tier == "ambient"
+          zone_lockout_minutes = (1 + (hackr_breach.round_number / 3.0).floor).clamp(1, 10)
+          zone = GridRoom.find_by(id: hackr_breach.origin_room_id)&.grid_zone
+          if zone
+            lockout_until = (Time.current + zone_lockout_minutes.minutes).to_i
+            @hackr.set_stat!("zone_lockout_#{zone.id}", lockout_until)
+          end
+        end
+
+        # Tier 3+4: DECK consequences
+        deck = @hackr.equipped_deck
+        if deck && failure_mode == :detection_overflow
+          if %w[advanced elite world_event].include?(tier)
+            fried_level_set = compute_fried_level(tier)
+            deck.lock!
+            deck.loaded_software.destroy_all
+            deck.update!(properties: deck.properties.merge("fried_level" => fried_level_set))
+            software_wiped = true
+          elsif tier == "standard"
+            deck.lock!
+            deck.loaded_software.destroy_all
+            software_wiped = true
+          end
+        end
+
+        # Eject to zone entry room
+        eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
+        if eject_room_id && eject_room_id != @hackr.current_room_id
+          @hackr.update!(current_room_id: eject_room_id)
+        end
+      end
+
+      yield({zone_lockout_minutes: zone_lockout_minutes, fried_level: fried_level_set, software_wiped: software_wiped})
+    end
+
+    # Determine whether this failure results in GovCorp capture.
+    # Capture only happens on detection-overflow, never health-zero.
+    # Probabilistic: standard 25%, advanced 50%, elite+ 100%.
+    def should_capture?(tier, failure_mode)
+      return false unless failure_mode == :detection_overflow
+      return false if Grid::ContainmentService.captured?(@hackr)
+
+      case tier
+      when "standard"
+        rand < Grid::ContainmentService::STANDARD_CAPTURE_CHANCE
+      when "advanced"
+        rand < Grid::ContainmentService::ADVANCED_CAPTURE_CHANCE
+      when "elite", "world_event"
+        true
+      else
+        false
       end
     end
 

--- a/app/services/grid/captured_command_parser.rb
+++ b/app/services/grid/captured_command_parser.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Grid
+  # Handles command dispatch when a hackr is captured in a GovCorp facility.
+  # Restricts available commands to facility-appropriate actions.
+  # The main CommandParser gates into this class when hackr.stat("captured") is true.
+  class CapturedCommandParser
+    ALLOWED_COMMANDS = %w[
+      look l go move north n south s east e west w up u down d out
+      stat stats st inventory inv i help ?
+      breach br bribe talk examine ex x who clear cls cl say
+    ].freeze
+
+    attr_reader :hackr, :input, :parser
+
+    def initialize(hackr, input, parser)
+      @hackr = hackr
+      @input = input.to_s.strip
+      @parser = parser
+    end
+
+    def execute
+      return {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", event: nil} if input.empty?
+
+      parts = input.split
+      command = parts.first&.downcase
+      args = parts[1..]
+
+      unless ALLOWED_COMMANDS.include?(command)
+        return {output: restricted_message(command), event: nil}
+      end
+
+      result = case command
+      when "bribe"
+        bribe_command(args.join(" "))
+      when "help", "?"
+        captured_help_command
+      else
+        # Delegate allowed commands to the main CommandParser
+        parser.send(:dispatch_command, command, args)
+      end
+
+      result.is_a?(Hash) ? result : {output: result, event: nil}
+    end
+
+    private
+
+    def bribe_command(target_name)
+      parts = target_name.to_s.strip.split
+      confirming = parts.last&.downcase == "confirm"
+      mob_name = confirming ? parts[0..-2].join(" ") : parts.join(" ")
+      return "<span style='color: #fbbf24;'>Bribe whom? Specify a name.</span>" if mob_name.empty?
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere.</span>" unless room
+
+      mob = room.grid_mobs.find_by("LOWER(name) = ?", mob_name.downcase)
+      return "<span style='color: #f87171;'>You don't see '#{h(mob_name)}' here.</span>" unless mob
+
+      case mob.mob_type
+      when "special"
+        # Determine if this is an impound clerk or exit agent based on room type
+        if room.room_type == "impound"
+          bribe_clerk(mob)
+        else
+          bribe_agent(mob, confirming: confirming)
+        end
+      else
+        "<span style='color: #9ca3af;'>#{h(mob.name)} doesn't seem interested in that.</span>"
+      end
+    end
+
+    def bribe_clerk(mob)
+      records = hackr.grid_impound_records.impounded
+      if records.empty?
+        return "<span style='color: #9ca3af;'>#{h(mob.name)} checks the system. No impounded items found under your ID.</span>"
+      end
+
+      # Recover impound sets one at a time. If funds run out mid-loop,
+      # show what was recovered + the failure for the remaining set.
+      output = []
+      records.each do |record|
+        result = Grid::ImpoundService.recover_gear!(hackr: hackr, impound_record: record)
+        output << result.display
+      rescue Grid::ImpoundService::InsufficientBalance => e
+        output << "<span style='color: #f87171;'>#{h(e.message)}</span>"
+        remaining = hackr.grid_impound_records.impounded.count
+        output << "<span style='color: #9ca3af;'>#{remaining} impound set(s) still held.</span>" if remaining > 0
+        break
+      end
+      output.join("\n")
+    end
+
+    def bribe_agent(mob, confirming: false)
+      fee = Grid::ContainmentService.compute_exit_bribe(hackr)
+      impound_count = hackr.grid_impound_records.impounded.count
+
+      if confirming
+        result = Grid::ContainmentService.bribe_exit!(hackr: hackr)
+        return result.display
+      end
+
+      # Show fee preview
+      output = []
+      output << "<span style='color: #fbbf24;'>#{h(mob.name)} reviews your file.</span>"
+      gear_note = if impound_count > 0
+        "#{impound_count} impound set(s) will be forfeited."
+      else
+        "No impounded gear on file."
+      end
+      output << "<span style='color: #fbbf24;'>Resolution fee: #{fee} CRED. #{gear_note}</span>"
+      output << "<span style='color: #9ca3af;'>Type 'bribe #{mob.name.downcase} confirm' to proceed.</span>"
+      output.join("\n")
+    rescue Grid::ContainmentService::InsufficientFunds => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def captured_help_command
+      output = []
+      output << "<span style='color: #ef4444; font-weight: bold;'>══ GovCorp FACILITY — RESTRICTED COMMANDS ══</span>"
+      output << ""
+      output << "<span style='color: #fbbf24;'>look</span>                  <span style='color: #9ca3af;'>Look around</span>"
+      output << "<span style='color: #fbbf24;'>go &lt;direction&gt;</span>        <span style='color: #9ca3af;'>Move (increases alert)</span>"
+      output << "<span style='color: #fbbf24;'>breach</span>                <span style='color: #9ca3af;'>Initiate BREACH encounter</span>"
+      output << "<span style='color: #fbbf24;'>bribe &lt;npc&gt;</span>           <span style='color: #9ca3af;'>Negotiate with facility staff</span>"
+      output << "<span style='color: #fbbf24;'>talk &lt;npc&gt;</span>            <span style='color: #9ca3af;'>Talk to someone</span>"
+      output << "<span style='color: #fbbf24;'>examine &lt;target&gt;</span>      <span style='color: #9ca3af;'>Examine something</span>"
+      output << "<span style='color: #fbbf24;'>stat</span>                  <span style='color: #9ca3af;'>View your stats</span>"
+      output << "<span style='color: #fbbf24;'>inventory</span>             <span style='color: #9ca3af;'>Check inventory</span>"
+      output << "<span style='color: #fbbf24;'>who</span>                   <span style='color: #9ca3af;'>See who's here</span>"
+      output << ""
+      output << "<span style='color: #ef4444;'>All other commands restricted by GovCorp facility protocol.</span>"
+      output.join("\n")
+    end
+
+    def restricted_message(command)
+      "<span style='color: #f87171;'>GovCorp facility restrictions in effect. '#{h(command)}' unavailable. Type <span style='color: #22d3ee;'>help</span> for available commands.</span>"
+    end
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+  end
+end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -24,16 +24,30 @@ module Grid
         return Grid::BreachCommandParser.new(hackr, input, active_breach).execute
       end
 
+      # Captured mode: restricted command set in GovCorp facility
+      if Grid::ContainmentService.captured?(hackr)
+        return Grid::CapturedCommandParser.new(hackr, input, self).execute
+      end
+
       # Split input but preserve case in arguments
       parts = input.split
       command = parts.first&.downcase
       args = parts[1..]
 
-      result = case command
+      result = dispatch_command(command, args)
+
+      # Normalize result to hash format
+      result.is_a?(Hash) ? result : {output: result, event: nil}
+    end
+
+    # Extracted for delegation by CapturedCommandParser.
+    # Accepts pre-parsed command + args and returns raw result.
+    def dispatch_command(command, args)
+      case command
       when "look", "l"
         look_command
       when "go", "move"
-        go_command(args.first)
+        go_command(args&.first)
       when "north", "n"
         go_command("north")
       when "south", "s"
@@ -47,17 +61,17 @@ module Grid
       when "down", "d"
         go_command("down")
       when "say"
-        say_command(args.join(" "))
+        say_command(args&.join(" "))
       when "inventory", "inv", "i"
         inventory_command
       when "take", "get"
-        take_command(args.join(" "))
+        take_command(args&.join(" "))
       when "drop"
-        drop_command(args.join(" "))
+        drop_command(args&.join(" "))
       when "examine", "ex", "x"
-        examine_command(args.join(" "))
+        examine_command(args&.join(" "))
       when "talk"
-        talk_command(args.join(" "))
+        talk_command(args&.join(" "))
       when "ask"
         ask_command(args)
       when "stat", "stats", "st"
@@ -65,11 +79,11 @@ module Grid
       when "rep", "reputation", "standing"
         rep_command
       when "use"
-        use_command(args.join(" "))
+        use_command(args&.join(" "))
       when "salvage", "sal"
-        salvage_command(args.join(" "))
+        salvage_command(args&.join(" "))
       when "analyze", "an"
-        analyze_command(args.join(" "))
+        analyze_command(args&.join(" "))
       when "cache"
         cache_command(args)
       when "caches", "cred"
@@ -81,47 +95,47 @@ module Grid
       when "shop", "browse"
         shop_command
       when "buy", "purchase"
-        buy_command(args.join(" "))
+        buy_command(args&.join(" "))
       when "sell"
-        sell_command(args.join(" "))
+        sell_command(args&.join(" "))
       when "missions", "quests"
         missions_command
       when "mission", "quest"
-        mission_detail_command(args.first)
+        mission_detail_command(args&.first)
       when "accept", "acc", "ac"
-        accept_mission_command(args.first)
+        accept_mission_command(args&.first)
       when "abandon"
-        abandon_mission_command(args.first)
+        abandon_mission_command(args&.first)
       when "turn_in", "turnin", "ti"
-        turn_in_command(args.first)
+        turn_in_command(args&.first)
       when "give"
         give_command(args)
       when "fabricate", "fab"
-        fabricate_command(args.first)
+        fabricate_command(args&.first)
       when "schematics", "schem", "sch"
-        args.any? ? schematic_detail_command(args.first) : schematics_command
+        args&.any? ? schematic_detail_command(args.first) : schematics_command
       when "schematic"
-        schematic_detail_command(args.first)
+        schematic_detail_command(args&.first)
       when "place", "install"
-        place_fixture_command(args.join(" "))
+        place_fixture_command(args&.join(" "))
       when "unplace", "uninstall"
-        unplace_fixture_command(args.join(" "))
+        unplace_fixture_command(args&.join(" "))
       when "store", "put"
         store_in_fixture_command(args)
       when "retrieve"
         retrieve_from_fixture_command(args)
       when "peek", "search"
-        peek_fixture_command(args.join(" "))
+        peek_fixture_command(args&.join(" "))
       when "equip", "wear"
-        equip_command(args.join(" "))
+        equip_command(args&.join(" "))
       when "unequip", "remove"
-        unequip_command(args.join(" "))
+        unequip_command(args&.join(" "))
       when "loadout", "lo"
         loadout_command
       when "deck", "dk"
-        args.empty? ? deck_show_command : deck_subcommand(args)
+        args&.empty? ? deck_show_command : deck_subcommand(args)
       when "breach", "br"
-        breach_initiate_command(args.join(" "))
+        breach_initiate_command(args&.join(" "))
       when "repair"
         repair_command
       when "den"
@@ -139,9 +153,6 @@ module Grid
       else
         "<span style='color: #f87171;'>Unknown command: #{h(command)}. Type 'help' for a list of commands.</span>"
       end
-
-      # Normalize result to hash format
-      result.is_a?(Hash) ? result : {output: result, event: nil}
     end
 
     private
@@ -269,6 +280,12 @@ module Grid
         output << "<span style='color: #fbbf24;'>Hackrs:</span> #{hackr_entries.join(", ")}"
       end
 
+      # Facility alert HUD (captured mode)
+      if Grid::ContainmentService.captured?(hackr)
+        output << ""
+        output << Grid::ContainmentService.render_alert_bar(hackr.stat("facility_alert_level").to_i)
+      end
+
       output.join("\n")
     end
 
@@ -373,6 +390,18 @@ module Grid
       # that track reach_clearance too (cheap — progressor no-ops if none exist).
       notifications += mission_progressor.record(:reach_clearance, clearance: hackr.stat("clearance").to_i)
       look_output = append_notifications(look_output, notifications)
+
+      # Facility alert check (captured mode) — increments alert on each move,
+      # returns to containment cell if threshold reached
+      if Grid::ContainmentService.captured?(hackr)
+        alert_result = Grid::ContainmentService.alert_increment!(hackr: hackr)
+        if alert_result.caught
+          hackr.reload
+          return {output: alert_result.display + "\n" + look_command, event: nil}
+        elsif alert_result.display
+          look_output += "\n" + alert_result.display
+        end
+      end
 
       # Ambient encounter check — random BREACH trigger based on zone danger_level
       ambient_result = Grid::BreachGeneratorService.ambient_check!(hackr: hackr, room: new_room)

--- a/app/services/grid/containment_service.rb
+++ b/app/services/grid/containment_service.rb
@@ -1,0 +1,342 @@
+# frozen_string_literal: true
+
+module Grid
+  # Manages the GovCorp Perception Alignment Center lifecycle:
+  # capture → alert tracking → escape (Sally Port or agent bribe).
+  # All formula values are named constants for future admin abstraction.
+  class ContainmentService
+    CaptureResult = Data.define(:hackr, :containment_room, :impound_result, :display)
+    AlertResult = Data.define(:hackr, :alert_level, :caught, :display)
+    EscapeResult = Data.define(:hackr, :destination_room, :display)
+    BribeExitResult = Data.define(:hackr, :fee_paid, :forfeit_results, :destination_room, :display)
+
+    class AlreadyCaptured < StandardError; end
+    class NotCaptured < StandardError; end
+    class NotAtFacility < StandardError; end
+    class InsufficientFunds < StandardError; end
+    class NoContainmentRoom < StandardError; end
+
+    # Alert system constants
+    ALERT_PER_MOVE = 12
+    ALERT_BREACH_REDUCTION = 25
+    ALERT_THRESHOLD = 100
+
+    # Agent bribe (exit facility, forfeit all gear)
+    EXIT_BRIBE_BASE_FEE = 250
+    EXIT_BRIBE_CL_MULT = 15
+
+    # Failure tier capture chances (detection-overflow only)
+    STANDARD_CAPTURE_CHANCE = 0.25
+    ADVANCED_CAPTURE_CHANCE = 0.50
+
+    # Chance that advanced-tier capture also impounds gear (separate from capture chance)
+    ADVANCED_IMPOUND_CHANCE = 0.50
+
+    # Room types that don't increment alert
+    SAFE_ROOM_TYPES = %w[containment impound].freeze
+
+    def self.capture!(hackr:, breach:, impound: false)
+      new(hackr).capture!(breach, impound: impound)
+    end
+
+    def self.alert_increment!(hackr:)
+      new(hackr).alert_increment!
+    end
+
+    def self.alert_reduce!(hackr:, amount: ALERT_BREACH_REDUCTION)
+      new(hackr).alert_reduce!(amount)
+    end
+
+    def self.escape_facility!(hackr:, via: :sally_port)
+      new(hackr).escape_facility!(via: via)
+    end
+
+    def self.bribe_exit!(hackr:)
+      new(hackr).bribe_exit!
+    end
+
+    def self.compute_exit_bribe(hackr)
+      (EXIT_BRIBE_BASE_FEE + hackr.stat("clearance") * EXIT_BRIBE_CL_MULT).to_i
+    end
+
+    def self.captured?(hackr)
+      hackr.stat("captured") == true
+    end
+
+    # Render alert bar for look_command HUD.
+    def self.render_alert_bar(level)
+      width = 20
+      filled = [(level.to_f / ALERT_THRESHOLD * width).round, width].min
+      empty = width - filled
+      color = if level >= 70 then "#f87171"
+      elsif level >= 40 then "#fbbf24"
+      else "#34d399"
+      end
+      "<span style='color: #9ca3af;'>\u26a0 FACILITY ALERT:</span> " \
+        "<span style='color: #{color};'>#{"█" * filled}#{"░" * empty}</span> " \
+        "<span style='color: #{color};'>#{level}%</span>"
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Capture a hackr and teleport to containment cell.
+    # Called from BreachService#resolve_failure! for tiers 5+6.
+    def capture!(breach, impound: false)
+      raise AlreadyCaptured, "Already in GovCorp custody." if self.class.captured?(@hackr)
+
+      containment_room = find_containment_room
+      raise NoContainmentRoom, "No containment facility available." unless containment_room
+
+      impound_result = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        @hackr.set_stat!("captured", true)
+        @hackr.set_stat!("captured_origin_room_id", @hackr.current_room_id)
+        @hackr.set_stat!("facility_alert_level", 0)
+        @hackr.update!(current_room_id: containment_room.id)
+      end
+
+      # Impound gear outside main transaction (ImpoundService has its own)
+      if impound
+        begin
+          impound_result = Grid::ImpoundService.impound_gear!(hackr: @hackr, breach: breach)
+        rescue Grid::ImpoundService::NoEquippedGear
+          # Nothing to impound — captured without gear
+        rescue => e
+          Rails.logger.error("[ContainmentService] impound_gear! failed: #{e.message} — hackr #{@hackr.id} captured without impound")
+          # Gear stays equipped rather than being orphaned
+        end
+      end
+
+      display = render_capture(containment_room, impound_result)
+      CaptureResult.new(
+        hackr: @hackr,
+        containment_room: containment_room,
+        impound_result: impound_result,
+        display: display
+      )
+    end
+
+    # Increment alert on room move within facility. Returns AlertResult.
+    # Called from go_command when captured.
+    def alert_increment!
+      raise NotCaptured, "Not in custody." unless self.class.captured?(@hackr)
+
+      room = @hackr.current_room
+      # Safe rooms don't increment
+      if room && SAFE_ROOM_TYPES.include?(room.room_type)
+        level = @hackr.stat("facility_alert_level").to_i
+        return AlertResult.new(hackr: @hackr, alert_level: level, caught: false, display: nil)
+      end
+
+      caught = false
+      level = 0
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        level = @hackr.stat("facility_alert_level").to_i + ALERT_PER_MOVE
+        level = [level, ALERT_THRESHOLD].min
+        @hackr.set_stat!("facility_alert_level", level)
+
+        if level >= ALERT_THRESHOLD
+          caught = true
+          alert_catch!
+        end
+      end
+
+      display = if caught
+        render_caught
+      else
+        self.class.render_alert_bar(level)
+      end
+
+      AlertResult.new(hackr: @hackr, alert_level: level, caught: caught, display: display)
+    end
+
+    # Reduce alert after successful BREACH in facility.
+    def alert_reduce!(amount)
+      return unless self.class.captured?(@hackr)
+
+      level = @hackr.stat("facility_alert_level").to_i
+      new_level = [level - amount, 0].max
+      @hackr.set_stat!("facility_alert_level", new_level)
+    end
+
+    # Exit facility via Sally Port or after cell BREACH.
+    # `via` determines which exit room is used.
+    def escape_facility!(via: :sally_port)
+      raise NotCaptured, "Not in custody." unless self.class.captured?(@hackr)
+
+      region = find_current_region
+      destination = case via
+      when :sally_port
+        region&.facility_exit_room
+      when :bribe
+        region&.facility_bribe_exit_room
+      end
+      destination ||= fallback_exit_room
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        @hackr.set_stat!("captured", nil)
+        @hackr.set_stat!("captured_origin_room_id", nil)
+        @hackr.set_stat!("facility_alert_level", nil)
+        @hackr.update!(current_room_id: destination.id)
+      end
+
+      display = render_escape(destination)
+      EscapeResult.new(hackr: @hackr, destination_room: destination, display: display)
+    end
+
+    # Bribe a GovCorp agent to exit facility. Forfeits ALL impounded gear.
+    def bribe_exit!
+      raise NotCaptured, "Not in custody." unless self.class.captured?(@hackr)
+
+      fee = self.class.compute_exit_bribe(@hackr)
+      cache = @hackr.default_cache
+      raise InsufficientFunds, "Need #{fee} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= fee
+
+      # Pay bribe FIRST — gear destruction is irreversible, so payment must succeed first.
+      burn_amt = (fee * EconomyConfig::SHOP_BURN_RATIO).floor
+      recycle_amt = fee - burn_amt
+      Grid::TransactionService.burn!(from_cache: cache, amount: burn_amt, memo: "GovCorp compliance resolution") if burn_amt > 0
+      Grid::TransactionService.recycle!(from_cache: cache, amount: recycle_amt, memo: "GovCorp compliance resolution") if recycle_amt > 0
+
+      # Forfeit all impounded gear sets (payment already succeeded)
+      forfeit_results = []
+      @hackr.grid_impound_records.impounded.each do |record|
+        result = Grid::ImpoundService.forfeit!(impound_record: record)
+        forfeit_results << result
+      end
+
+      # Exit facility
+      escape_result = escape_facility!(via: :bribe)
+
+      display = render_bribe_exit(fee, forfeit_results, escape_result.destination_room)
+      BribeExitResult.new(
+        hackr: @hackr,
+        fee_paid: fee,
+        forfeit_results: forfeit_results,
+        destination_room: escape_result.destination_room,
+        display: display
+      )
+    end
+
+    private
+
+    # Return to containment cell when alert threshold reached.
+    def alert_catch!
+      containment_room = find_containment_room
+      return unless containment_room
+
+      @hackr.set_stat!("facility_alert_level", 0)
+      @hackr.update!(current_room_id: containment_room.id)
+    end
+
+    def find_containment_room
+      region = find_current_region
+      region&.containment_room
+    end
+
+    def find_current_region
+      @hackr.current_room&.grid_zone&.grid_region
+    end
+
+    def fallback_exit_room
+      origin_id = @hackr.stat("captured_origin_room_id")
+      GridRoom.find_by(id: origin_id) || @hackr.current_room
+    end
+
+    # --- Renderers ---
+
+    def render_capture(containment_room, impound_result)
+      h = method(:h)
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #ef4444;'>\u2551</span>"
+      lines = []
+      lines << ""
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2551  \u26a0 DETAINED \u2014 GovCorp Perception Alignment Center       \u2551</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>GovCorp countermeasures have locked your position.</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>Neural trace confirmed. Physical extraction complete.</span>"
+      lines << border
+
+      zone_name = containment_room.grid_zone&.name || "Unknown"
+      lines << "#{border}  <span style='color: #9ca3af;'>Location: #{h.call(zone_name)} \u2014 #{h.call(containment_room.name)}</span>"
+
+      if impound_result
+        lines << border
+        lines << "#{border}  <span style='color: #ef4444; font-weight: bold;'>All equipped gear has been confiscated.</span>"
+        lines << "#{border}  <span style='color: #fbbf24;'>Recovery bribe: #{impound_result.bribe_cost} CRED</span>"
+      end
+
+      lines << border
+      lines << "#{border}  <span style='color: #9ca3af;'>The cell door is BREACH-locked. Solve the gates to escape.</span>"
+      lines << "#{border}  <span style='color: #6b7280;'>Type 'breach' to attempt the containment seal.</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def render_caught
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #ef4444;'>\u2551</span>"
+      lines = []
+      lines << ""
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2551  APPREHENDED                                               \u2551</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>GovCorp security detected your movement.</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>Returned to containment. Alert level reset.</span>"
+      lines << border
+      lines << "#{border}  <span style='color: #9ca3af;'>The cell door is BREACH-locked. Try again.</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def render_escape(destination)
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #34d399;'>\u2551</span>"
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2551  EXTRACTION SUCCESSFUL                                      \u2551</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>Facility containment cleared. GovCorp trace broken.</span>"
+      zone_name = destination.grid_zone&.name || "Unknown"
+      lines << "#{border}  <span style='color: #9ca3af;'>Location: #{h(zone_name)}</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def render_bribe_exit(fee, forfeit_results, destination)
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #fbbf24;'>\u2551</span>"
+      total_items = forfeit_results.sum(&:items_destroyed)
+      lines = []
+      lines << ""
+      lines << "<span style='color: #fbbf24; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #fbbf24; font-weight: bold;'>\u2551  COMPLIANCE RESOLUTION \u2014 Administrative Release             \u2551</span>"
+      lines << "<span style='color: #fbbf24; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #fbbf24;'>Resolution fee: #{fee} CRED</span>"
+      if total_items > 0
+        lines << "#{border}  <span style='color: #ef4444;'>#{total_items} impounded item(s) forfeited to GovCorp.</span>"
+      end
+      lines << border
+      zone_name = destination.grid_zone&.name || "Unknown"
+      lines << "#{border}  <span style='color: #d0d0d0;'>Escorted to #{h(zone_name)}.</span>"
+      lines << "#{border}  <span style='color: #9ca3af;'>Your record has been flagged as 'administratively resolved.'</span>"
+      lines << "<span style='color: #fbbf24; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+  end
+end

--- a/app/services/grid/impound_service.rb
+++ b/app/services/grid/impound_service.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+module Grid
+  # Manages gear confiscation during BREACH failure (tiers 5+6).
+  # Items move to an impound record — recoverable via bribe or forfeitable.
+  # All formula values are named constants for future admin abstraction.
+  class ImpoundService
+    ImpoundResult = Data.define(:impound_record, :items_seized, :bribe_cost, :display)
+    RecoverResult = Data.define(:impound_record, :items_returned, :cred_paid, :display)
+    ForfeitResult = Data.define(:impound_record, :items_destroyed, :display)
+
+    class NoEquippedGear < StandardError; end
+    class RecordNotImpounded < StandardError; end
+    class InsufficientBalance < StandardError; end
+    class NotOwner < StandardError; end
+
+    # Gear recovery bribe constants
+    GEAR_BRIBE_BASE_FEE = 500
+    GEAR_BRIBE_CL_MULT = 25
+    GEAR_BRIBE_VALUE_MULT = 0.10
+
+    def self.impound_gear!(hackr:, breach:)
+      new(hackr).impound_gear!(breach)
+    end
+
+    def self.recover_gear!(hackr:, impound_record:)
+      new(hackr).recover_gear!(impound_record)
+    end
+
+    def self.forfeit!(impound_record:)
+      new(impound_record.grid_hackr).forfeit!(impound_record)
+    end
+
+    def self.compute_bribe(hackr:, items:)
+      clearance = hackr.stat("clearance")
+      gear_value = items.sum(&:value)
+      (GEAR_BRIBE_BASE_FEE + clearance * GEAR_BRIBE_CL_MULT + (gear_value * GEAR_BRIBE_VALUE_MULT).floor).to_i
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Confiscate all equipped gear (including DECK with loaded software intact).
+    # Called from BreachService#resolve_failure! for tier 6 failures.
+    def impound_gear!(breach)
+      record = nil
+      items = []
+      bribe = 0
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        items = @hackr.grid_items.equipped_by(@hackr).to_a
+        raise NoEquippedGear, "No equipped gear to confiscate." if items.empty?
+
+        bribe = self.class.compute_bribe(hackr: @hackr, items: items)
+
+        record = GridImpoundRecord.create!(
+          grid_hackr: @hackr,
+          grid_hackr_breach: breach,
+          status: "impounded",
+          bribe_cost: bribe
+        )
+
+        items.each do |item|
+          item.update!(
+            equipped_slot: nil,
+            grid_impound_record_id: record.id
+          )
+
+          # Impound software loaded in DECK and modules installed in DECK.
+          # They travel with the DECK as a unit — not destroyed, recoverable.
+          if item.deck_item?
+            item.loaded_software.update_all(grid_impound_record_id: record.id)
+            item.installed_modules.update_all(grid_impound_record_id: record.id)
+          end
+        end
+
+        @hackr.reset_loadout_cache!
+        clamp_vitals!
+      end
+
+      display = render_impound(items, bribe)
+      ImpoundResult.new(
+        impound_record: record,
+        items_seized: items,
+        bribe_cost: bribe,
+        display: display
+      )
+    end
+
+    # Pay bribe to recover a specific impound set. Items return to inventory
+    # (unequipped — player must re-equip manually via LoadoutService).
+    def recover_gear!(impound_record)
+      raise NotOwner, "That impound record doesn't belong to you." unless impound_record.grid_hackr_id == @hackr.id
+      raise RecordNotImpounded, "This impound set has already been resolved." unless impound_record.impounded?
+
+      cost = impound_record.bribe_cost
+      cache = @hackr.default_cache
+      raise InsufficientBalance, "Need #{cost} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= cost
+
+      items = []
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        impound_record.lock!
+
+        raise RecordNotImpounded, "This impound set has already been resolved." unless impound_record.impounded?
+
+        cache = @hackr.default_cache
+        raise InsufficientBalance, "Need #{cost} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= cost
+
+        items = impound_record.impounded_items.to_a
+
+        items.each do |item|
+          item.update!(grid_impound_record_id: nil)
+        end
+
+        impound_record.update!(status: "recovered")
+        @hackr.reset_loadout_cache!
+      end
+
+      # CRED payment outside transaction (TransactionService has its own mutex).
+      # If payment fails, roll back recovery to prevent free gear.
+      begin
+        split_bribe_payment!(from_cache: cache, amount: cost, record_id: impound_record.id)
+      rescue => e
+        begin
+          ActiveRecord::Base.transaction do
+            items.each { |item| item.update!(grid_impound_record_id: impound_record.id) }
+            impound_record.update!(status: "impounded")
+            @hackr.reset_loadout_cache!
+          end
+        rescue => rollback_error
+          Rails.logger.error("[ImpoundService] CRITICAL: payment failed AND rollback failed for record #{impound_record.id}: #{rollback_error.message}")
+        end
+        raise InsufficientBalance, "Payment failed — gear re-impounded. #{e.message}"
+      end
+
+      display = render_recovery(items, cost)
+      RecoverResult.new(
+        impound_record: impound_record,
+        items_returned: items,
+        cred_paid: cost,
+        display: display
+      )
+    end
+
+    # Permanently destroy all items in an impound set.
+    # Called when hackr bribes agent for direct exit (forfeit path).
+    def forfeit!(impound_record)
+      raise NotOwner, "That impound record doesn't belong to you." unless impound_record.grid_hackr_id == @hackr.id
+      raise RecordNotImpounded, "This impound set has already been resolved." unless impound_record.impounded?
+
+      items_destroyed = 0
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        impound_record.lock!
+        raise RecordNotImpounded, "This impound set has already been resolved." unless impound_record.impounded?
+
+        items_destroyed = impound_record.impounded_items.count
+        impound_record.impounded_items.destroy_all
+        impound_record.update!(status: "forfeited")
+      end
+
+      display = render_forfeit(items_destroyed)
+      ForfeitResult.new(
+        impound_record: impound_record,
+        items_destroyed: items_destroyed,
+        display: display
+      )
+    end
+
+    private
+
+    def split_bribe_payment!(from_cache:, amount:, record_id:)
+      burn_amt = (amount * EconomyConfig::SHOP_BURN_RATIO).floor
+      recycle_amt = amount - burn_amt
+
+      if burn_amt > 0
+        Grid::TransactionService.burn!(
+          from_cache: from_cache,
+          amount: burn_amt,
+          memo: "IMPOUND bribe: record ##{record_id}"
+        )
+      end
+
+      if recycle_amt > 0
+        Grid::TransactionService.recycle!(
+          from_cache: from_cache,
+          amount: recycle_amt,
+          memo: "IMPOUND bribe: record ##{record_id}"
+        )
+      end
+    end
+
+    # Clamp vitals to new effective max after gear bonuses removed.
+    def clamp_vitals!
+      %w[health energy psyche].each do |key|
+        cap = @hackr.effective_max(key)
+        current = @hackr.stat(key)
+        @hackr.set_stat!(key, cap) if current > cap
+      end
+    end
+
+    def render_impound(items, bribe)
+      h = method(:h)
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #ef4444;'>\u2551</span>"
+      lines = []
+      lines << ""
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2551  GEAR CONFISCATED \u2014 GovCorp Impound Notice               \u2551</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #d0d0d0;'>GovCorp Compliance Division has seized your loadout.</span>"
+      lines << border
+      items.each do |item|
+        lines << "#{border}  <span style='color: #f87171;'>\u2717 #{h.call(item.name)}</span>"
+      end
+      lines << border
+      lines << "#{border}  <span style='color: #fbbf24;'>Recovery bribe: #{bribe} CRED</span>"
+      lines << "#{border}  <span style='color: #9ca3af;'>Visit an Impound Bay to negotiate recovery.</span>"
+      lines << "<span style='color: #ef4444; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def render_recovery(items, cost)
+      h = method(:h)
+      separator = Grid::BreachRenderer::SEPARATOR
+      border = "<span style='color: #34d399;'>\u2551</span>"
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2554#{separator}\u2557</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2551  GEAR RECOVERED                                            \u2551</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2560#{separator}\u2563</span>"
+      lines << "#{border}  <span style='color: #fbbf24;'>Bribe paid: #{cost} CRED</span>"
+      lines << border
+      items.each do |item|
+        lines << "#{border}  <span style='color: #d0d0d0;'>\u2713 #{h.call(item.name)} \u2014 returned to inventory</span>"
+      end
+      lines << border
+      lines << "#{border}  <span style='color: #9ca3af;'>Re-equip your gear manually.</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u255a#{separator}\u255d</span>"
+      lines.join("\n")
+    end
+
+    def render_forfeit(count)
+      lines = []
+      lines << ""
+      lines << "<span style='color: #6b7280; font-weight: bold;'>[ IMPOUND FORFEITED ]</span>"
+      lines << "<span style='color: #6b7280;'>  #{count} item(s) permanently destroyed by GovCorp.</span>"
+      lines.join("\n")
+    end
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+  end
+end

--- a/app/services/grid/inventory.rb
+++ b/app/services/grid/inventory.rb
@@ -19,7 +19,7 @@ module Grid
     # Acquires an exclusive lock on the hackr row to serialize concurrent grants.
     def check_capacity!(hackr)
       hackr.lock!
-      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil).count
+      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil, grid_impound_record_id: nil).count
       if used >= hackr.inventory_capacity
         raise Grid::InventoryErrors::InventoryFull,
           "Inventory full (#{used}/#{hackr.inventory_capacity} slots). Drop, sell, or store items to make room."

--- a/app/views/admin/grid_regions/_form.html.erb
+++ b/app/views/admin/grid_regions/_form.html.erb
@@ -25,6 +25,28 @@
   <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
 </div>
 
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :hospital_room_id, "RESTOREPOINT ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :hospital_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :containment_room_id, "CONTAINMENT CELL", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :containment_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
+<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :facility_exit_room_id, "FACILITY EXIT (SALLY PORT)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :facility_exit_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+  <div style="flex: 1; min-width: 250px;">
+    <%= f.label :facility_bribe_exit_room_id, "FACILITY EXIT (BRIBE)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.collection_select :facility_bribe_exit_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+</div>
+
 <div style="margin-top: 30px; display: flex; gap: 10px;">
   <%= f.submit @region.new_record? ? "Create Region" : "Update Region", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
   <%= link_to "Cancel", admin_grid_regions_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>

--- a/app/views/admin/grid_rooms/_form.html.erb
+++ b/app/views/admin/grid_rooms/_form.html.erb
@@ -29,7 +29,7 @@
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :room_type, "ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.select :room_type,
-          [["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Prism", "prism"], ["Dream", "dream"]],
+          [["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Prism", "prism"], ["Dream", "dream"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
           { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>
   <div style="flex: 1; min-width: 200px;">

--- a/data/world/breach_templates.yml
+++ b/data/world/breach_templates.yml
@@ -492,3 +492,153 @@ breach_templates:
         type: credential
         difficulty: 5
         depends_on: "C"
+
+  # ═══════════════════════════════════════════════════════════════
+  # PAC TEMPLATES — Shared across all 14 Perception Alignment Facilities
+  # ═══════════════════════════════════════════════════════════════
+
+  # Pure puzzle — containment cell escape (no cooldown, infinite retry)
+  - slug: pac-cell-escape
+    name: "Containment Cell Seal"
+    description: "A BREACH-locked ferrocarbon door. Four authentication gates — credential, sequence, circuit, logic. No protocols. No detection pressure. Just the lock, and your skill."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 90
+    base_detection_rate: 2
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 180
+    cred_reward: 0
+    published: true
+    position: 50
+    no_clearance_bypass: true
+    protocol_composition: []
+    puzzle_gates:
+      - id: "A"
+        type: credential
+        difficulty: 2
+        depends_on: null
+      - id: "B"
+        type: sequence
+        difficulty: 2
+        depends_on: "A"
+      - id: "C"
+        type: circuit
+        difficulty: 3
+        depends_on: "B"
+      - id: "D"
+        type: logic_gate
+        difficulty: 3
+        depends_on: "C"
+
+  # Voluntary target — surveillance hub (reduces facility alert)
+  - slug: pac-surveillance-node
+    name: "PAC Surveillance Array"
+    description: "The facility's camera monitoring cluster. Breach it and the feeds cycle to a recorded loop — a window where movement through the facility goes unlogged."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 78
+    base_detection_rate: 5
+    cooldown_min: 480
+    cooldown_max: 720
+    xp_reward: 140
+    cred_reward: 50
+    published: true
+    position: 51
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 40
+        max_health: 40
+        charge_rounds: 0
+        weakness: offensive
+      - type: feedback
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 1
+
+  # Voluntary target — security checkpoint auth node
+  - slug: pac-checkpoint-auth
+    name: "Checkpoint Authentication Node"
+    description: "The credential verification terminal controlling the security checkpoint. Take it down and the scanner arch goes offline."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 75
+    base_detection_rate: 5
+    cooldown_min: 600
+    cooldown_max: 900
+    xp_reward: 160
+    cred_reward: 60
+    published: true
+    position: 52
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 0
+      - type: lock
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 2
+
+  # Sally port — outer door
+  - slug: pac-sally-port-outer
+    name: "PAC Outer Door Seal"
+    description: "The outer door of the sally port anteroom. A standard GovCorp perimeter node — TRACE/FEEDBACK combination."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 75
+    base_detection_rate: 6
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 120
+    cred_reward: 0
+    published: true
+    position: 53
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 0
+        weakness: offensive
+      - type: feedback
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 1
+
+  # Sally port — inner door (zone exit)
+  - slug: pac-sally-port-inner
+    name: "PAC Perimeter Seal"
+    description: "The innermost door of the sally port. A GovCorp Perimeter Seal — TRACE, FEEDBACK, and a LOCK protocol. This is the last gate between you and the transit corridor."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 72
+    base_detection_rate: 6
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 200
+    cred_reward: 0
+    published: true
+    position: 54
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 50
+        max_health: 50
+        charge_rounds: 0
+        weakness: offensive
+      - type: feedback
+        count: 1
+        health: 55
+        max_health: 55
+        charge_rounds: 1
+      - type: lock
+        count: 1
+        health: 45
+        max_health: 45
+        charge_rounds: 2

--- a/data/world/pac_facilities.yml
+++ b/data/world/pac_facilities.yml
@@ -1,0 +1,187 @@
+# GovCorp Perception Alignment Center — template layout.
+# Stamped per region by: rails data:pac_facilities
+# Slugs are prefixed with the region slug (e.g., the-lakeshore-pac-containment-cell).
+# One template, 14 instances. Change the layout here, re-run the task.
+
+zone:
+  name: "GovCorp Perception Alignment Center"
+  description: "A sanitized GovCorp containment facility. Neutral walls, filtered air, and the quiet hum of compliance infrastructure. Somewhere behind these walls is a processing corridor that leads to daylight — if you can reach it."
+  zone_type: govcorp
+  color_scheme: white/red
+  faction_slug: govcorp
+  danger_level: 5
+
+rooms:
+  - suffix: containment-cell
+    name_template: "Containment Cell %{cell_id}"
+    description: "A featureless white room, two meters by three. A cot bolted to the wall. A ceiling-mounted camera with a blinking red light. The door — reinforced ferrocarbon with a BREACH-locked panel flush to the frame — has no handle on this side. You were brought here. You will not leave the same way."
+    room_type: containment
+
+  - suffix: processing-corridor
+    name_template: "Processing Corridor"
+    description: "A long corridor with overhead strip lighting that hums at a frequency designed to discourage extended thought. Numbered cell doors line one side. A floor-mounted stripe leads toward processing in one direction, intake in the other. GovCorp signage recommends cooperation."
+    room_type: govcorp
+
+  - suffix: intake-junction
+    name_template: "Intake Junction"
+    description: "A junction node where intake processing meets the main corridor. A terminal mounted to the wall runs identity verification loops. The junction connects to the administrative wing and the impound bay."
+    room_type: govcorp
+
+  - suffix: surveillance-hub
+    name_template: "Surveillance Hub"
+    description: "A circular room dominated by a central monitoring array — sixteen feeds, all facility cameras, cycling in ten-second intervals. A RAINN node cluster pulses in the corner, its access port just visible behind a cable conduit. Breach it and the feeds go dark. Temporarily."
+    room_type: govcorp
+
+  - suffix: security-checkpoint
+    name_template: "Security Checkpoint"
+    description: "A hardened checkpoint with a manual scanner arch and a GovCorp authentication terminal. Both doors are locked from this side. The authentication node is clearly a BREACH target — disabling it would kill credential verification across the checkpoint for a window long enough to matter."
+    room_type: govcorp
+
+  - suffix: impound-bay
+    name_template: "Impound Bay"
+    description: "Floor-to-ceiling wire shelving holds labeled bins of confiscated gear. Everything is tagged, logged, and technically retrievable — for a fee. A clerk sits behind reinforced plexi, expression professionally neutral, processing forms with the efficiency of someone who has processed many forms."
+    room_type: impound
+
+  - suffix: administrative-wing
+    name_template: "Administrative Wing"
+    description: "A carpeted corridor that smells of recycled air and bureaucratic permanence. A GovCorp agent occupies a desk at the far end, surrounded by physical paperwork — a deliberate choice in an era of digital records. The agent handles 'compliance resolution services.' The price list is not posted."
+    room_type: govcorp
+
+  - suffix: sally-port-anteroom
+    name_template: "Sally Port Anteroom"
+    description: "A small anteroom between the facility interior and the sally port proper. Two doors, never both open simultaneously. A GovCorp protocol panel controls the outer door. You are, technically, almost outside."
+    room_type: sally_port_anteroom
+
+  - suffix: sally-port
+    name_template: "Sally Port"
+    description: "The final controlled threshold. A reinforced chamber with an inner door behind you and an outer door ahead. The outer door is BREACH-locked — a GovCorp Perimeter Seal, two protocols deep. The transit corridor is visible through the outer door's narrow observation slit. Exit is ten meters away."
+    room_type: sally_port
+
+  - suffix: external-corridor
+    name_template: "PAC External Corridor"
+    description: "A dim service corridor outside the Perception Alignment Center. The heavy door behind you seals shut."
+    room_type: govcorp
+
+  - suffix: admin-discharge
+    name_template: "Administrative Discharge Exit"
+    description: "A side door marked 'ADMINISTRATIVE USE ONLY.' A narrow alley leads away from the facility. The door locks behind you."
+    room_type: govcorp
+
+# Exits: hub-and-spoke around processing-corridor.
+# Containment cell has NO exits (BREACH escape only).
+# Sally port anteroom → sally port: NO exit (BREACH only). Sally port → anteroom: YES (retreat).
+exits:
+  - from: processing-corridor
+    to: intake-junction
+    direction: north
+  - from: intake-junction
+    to: processing-corridor
+    direction: south
+  - from: processing-corridor
+    to: surveillance-hub
+    direction: east
+  - from: surveillance-hub
+    to: processing-corridor
+    direction: west
+  - from: processing-corridor
+    to: security-checkpoint
+    direction: west
+  - from: security-checkpoint
+    to: processing-corridor
+    direction: east
+  - from: intake-junction
+    to: impound-bay
+    direction: west
+  - from: impound-bay
+    to: intake-junction
+    direction: east
+  - from: intake-junction
+    to: administrative-wing
+    direction: north
+  - from: administrative-wing
+    to: intake-junction
+    direction: south
+  - from: security-checkpoint
+    to: sally-port-anteroom
+    direction: west
+  - from: sally-port-anteroom
+    to: security-checkpoint
+    direction: east
+  # Sally port chamber → anteroom (retreat option)
+  - from: sally-port
+    to: sally-port-anteroom
+    direction: east
+  # Exit rooms — connect to each other so escaped hackrs aren't stranded.
+  # Per-region transit connections added separately when region graphs are wired.
+  - from: external-corridor
+    to: admin-discharge
+    direction: south
+  - from: admin-discharge
+    to: external-corridor
+    direction: north
+
+mobs:
+  - suffix: impound-bay
+    name: "Compliance Clerk"
+    faction_slug: govcorp
+    description: "A mid-tier GovCorp functionary in a pressed gray uniform. They process impound forms with the detached precision of someone who genuinely enjoys paperwork. Behind the plexi sits a wall of numbered bins. Your gear is in one of them."
+    mob_type: special
+    dialogue_tree:
+      greeting: "Impound Services. Retrieve your items by presenting your case number and the applicable processing fee. GovCorp thanks you for your compliance."
+      topics:
+        fee: "Processing fee is assessed per impound event. Fees are non-negotiable and non-refundable."
+        bribe: "I don't know what you're implying. But hypothetically, a significant CRED transfer could reduce wait times considerably. Hypothetically."
+        release: "Once fees are paid, items are released. Leave promptly."
+
+  - suffix: administrative-wing
+    name: "Agent Harwick"
+    faction_slug: govcorp
+    description: "A senior GovCorp compliance agent in a charcoal suit that costs more than your DECK. Harwick handles what the forms can't — outcomes that GovCorp would prefer not to have formally documented."
+    mob_type: special
+    dialogue_tree:
+      greeting: "Compliance Resolution Services. I handle matters that require discretion. Sit down."
+      topics:
+        options: "You have options. One involves paperwork, hearings, and a formal processing timeline. The other involves a direct resolution fee and you leaving in the next fifteen minutes. I recommend the second option."
+        fee: "Resolution fees are indexed to your CLEARANCE level and the nature of the infraction. I'll give you a number."
+        deal: "Payment handled through an anonymous intermediary. Once it clears, your record is flagged as 'administratively resolved.' You are free to go."
+
+  - suffix: security-checkpoint
+    name: "RAINN Guard — Post 7"
+    faction_slug: govcorp
+    description: "A RAINN unit in full tactical compliance gear. Their visor scans constantly. They don't speak unless activating the checkpoint protocol."
+    mob_type: lore
+    dialogue_tree:
+      greeting: "Halt. Present credentials."
+      topics:
+        credentials: "Credential verification is mandatory. Unauthorized passage triggers automatic lockdown."
+        facility: "This facility operates under GovCorp Directive 44-C. Queries are not encouraged."
+
+# Breach encounter placements (reference shared templates by slug)
+encounters:
+  - template_slug: pac-cell-escape
+    room_suffix: containment-cell
+  - template_slug: pac-surveillance-node
+    room_suffix: surveillance-hub
+  - template_slug: pac-checkpoint-auth
+    room_suffix: security-checkpoint
+  - template_slug: pac-sally-port-outer
+    room_suffix: sally-port-anteroom
+  - template_slug: pac-sally-port-inner
+    room_suffix: sally-port
+
+# Cell IDs per region (cosmetic variation)
+cell_ids:
+  the-lakeshore: "7-L"
+  the-riverlands: "3-R"
+  the-arch: "9-A"
+  the-narrows: "2-N"
+  the-basin: "5-B"
+  the-gate: "1-G"
+  the-front: "4-F"
+  the-straits: "6-S"
+  the-bend: "8-D"
+  the-canopy: "11-C"
+  the-flats: "10-T"
+  the-marshes: "12-M"
+  the-works: "13-W"
+  the-badlands: "14-X"

--- a/db/migrate/20260424211652_create_breach_phase3_infrastructure.rb
+++ b/db/migrate/20260424211652_create_breach_phase3_infrastructure.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateBreachPhase3Infrastructure < ActiveRecord::Migration[8.0]
+  def change
+    # Impound records: tracks gear confiscated during BREACH failure (tier 5+6).
+    # Multiple captures = multiple records, each paid/forfeited independently.
+    create_table :grid_impound_records do |t|
+      t.references :grid_hackr, null: false, foreign_key: {on_delete: :cascade}
+      t.references :grid_hackr_breach, null: true, foreign_key: {on_delete: :nullify}
+      t.string :status, null: false, default: "impounded"
+      t.integer :bribe_cost, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :grid_impound_records, [:grid_hackr_id, :status]
+
+    # Items with non-null impound FK are confiscated — excluded from all
+    # player-facing scopes. ON DELETE nullify = admin cleanup safety net.
+    add_reference :grid_items, :grid_impound_record, null: true,
+      foreign_key: {on_delete: :nullify}, index: true
+
+    # Per-region containment room + facility exit rooms.
+    # Mirrors the existing hospital_room_id pattern.
+    add_reference :grid_regions, :containment_room, null: true,
+      foreign_key: {to_table: :grid_rooms, on_delete: :nullify}, index: true
+    add_reference :grid_regions, :facility_exit_room, null: true,
+      foreign_key: {to_table: :grid_rooms, on_delete: :nullify}, index: true
+    add_reference :grid_regions, :facility_bribe_exit_room, null: true,
+      foreign_key: {to_table: :grid_rooms, on_delete: :nullify}, index: true
+
+    # Puzzle gate override: disables clearance-based gate bypass.
+    # Used for containment cell + sally port BREACHes.
+    add_column :grid_breach_templates, :no_clearance_bypass, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_211652) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -214,6 +214,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
     t.text "description"
     t.integer "min_clearance", default: 0, null: false
     t.string "name", null: false
+    t.boolean "no_clearance_bypass", default: false, null: false
     t.integer "pnr_threshold", default: 75, null: false
     t.integer "position", default: 0, null: false
     t.json "protocol_composition", default: {}, null: false
@@ -425,6 +426,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
     t.index ["role"], name: "index_grid_hackrs_on_role"
   end
 
+  create_table "grid_impound_records", force: :cascade do |t|
+    t.integer "bribe_cost", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_breach_id"
+    t.integer "grid_hackr_id", null: false
+    t.string "status", default: "impounded", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_breach_id"], name: "index_grid_impound_records_on_grid_hackr_breach_id"
+    t.index ["grid_hackr_id", "status"], name: "index_grid_impound_records_on_grid_hackr_id_and_status"
+    t.index ["grid_hackr_id"], name: "index_grid_impound_records_on_grid_hackr_id"
+  end
+
   create_table "grid_item_definitions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
@@ -447,6 +460,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
     t.text "description"
     t.string "equipped_slot"
     t.integer "grid_hackr_id"
+    t.integer "grid_impound_record_id"
     t.integer "grid_item_definition_id", null: false
     t.integer "grid_mining_rig_id"
     t.string "item_type"
@@ -461,6 +475,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
     t.index ["deck_id"], name: "index_grid_items_on_deck_id"
     t.index ["grid_hackr_id", "equipped_slot"], name: "index_grid_items_on_hackr_equipped_slot_unique", unique: true, where: "equipped_slot IS NOT NULL"
     t.index ["grid_hackr_id"], name: "index_grid_items_on_grid_hackr_id"
+    t.index ["grid_impound_record_id"], name: "index_grid_items_on_grid_impound_record_id"
     t.index ["grid_item_definition_id"], name: "index_grid_items_on_grid_item_definition_id"
     t.index ["grid_mining_rig_id"], name: "index_grid_items_on_grid_mining_rig_id"
   end
@@ -555,12 +570,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
   end
 
   create_table "grid_regions", force: :cascade do |t|
+    t.integer "containment_room_id"
     t.datetime "created_at", null: false
     t.text "description"
+    t.integer "facility_bribe_exit_room_id"
+    t.integer "facility_exit_room_id"
     t.integer "hospital_room_id"
     t.string "name", null: false
     t.string "slug", null: false
     t.datetime "updated_at", null: false
+    t.index ["containment_room_id"], name: "index_grid_regions_on_containment_room_id"
+    t.index ["facility_bribe_exit_room_id"], name: "index_grid_regions_on_facility_bribe_exit_room_id"
+    t.index ["facility_exit_room_id"], name: "index_grid_regions_on_facility_exit_room_id"
     t.index ["hospital_room_id"], name: "index_grid_regions_on_hospital_room_id"
     t.index ["slug"], name: "index_grid_regions_on_slug", unique: true
   end
@@ -1236,6 +1257,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
   add_foreign_key "grid_hackr_track_plays", "grid_hackrs"
   add_foreign_key "grid_hackr_track_plays", "tracks"
   add_foreign_key "grid_hackrs", "grid_rooms", column: "zone_entry_room_id", on_delete: :nullify
+  add_foreign_key "grid_impound_records", "grid_hackr_breaches", on_delete: :nullify
+  add_foreign_key "grid_impound_records", "grid_hackrs", on_delete: :cascade
+  add_foreign_key "grid_items", "grid_impound_records", on_delete: :nullify
   add_foreign_key "grid_items", "grid_item_definitions"
   add_foreign_key "grid_items", "grid_items", column: "container_id"
   add_foreign_key "grid_items", "grid_items", column: "deck_id", on_delete: :nullify
@@ -1245,6 +1269,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_200840) do
   add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "containment_room_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "facility_bribe_exit_room_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "facility_exit_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "hospital_room_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "grid_hackrs", column: "owner_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -189,7 +189,7 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, regions, zones, rooms, etc.)"
-  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics, :breach_templates, :breach_encounters]
+  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics, :breach_templates, :breach_encounters, :pac_facilities]
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -871,7 +871,8 @@ namespace :data do
         position: attrs["position"] || 0,
         protocol_composition: attrs["protocol_composition"] || [],
         puzzle_gates: attrs["puzzle_gates"] || [],
-        reward_table: attrs["reward_table"] || {}
+        reward_table: attrs["reward_table"] || {},
+        no_clearance_bypass: attrs["no_clearance_bypass"] || false
       )
       template.save!
       created += 1
@@ -924,6 +925,140 @@ namespace :data do
     end
 
     puts "BREACH Encounters: #{created} created, #{GridBreachEncounter.count} total"
+  end
+
+  desc "Stamp GovCorp Perception Alignment Facilities per region from template"
+  task pac_facilities: :environment do
+    puts "\n--- Loading PAC Facilities ---"
+    yaml_file = Rails.root.join("data", "world", "pac_facilities.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    zone_tmpl = data["zone"]
+    room_tmpls = data["rooms"]
+    exit_tmpls = data["exits"]
+    mob_tmpls = data["mobs"]
+    encounter_tmpls = data["encounters"]
+    cell_ids = data["cell_ids"] || {}
+
+    regions = GridRegion.all.index_by(&:slug)
+    govcorp_faction = GridFaction.find_by(slug: zone_tmpl["faction_slug"])
+
+    zones_created = rooms_created = exits_created = mobs_created = encounters_created = 0
+
+    regions.each do |region_slug, region|
+      prefix = "#{region_slug}-govcorp-pac"
+      cell_id = cell_ids[region_slug] || "0-X"
+
+      # --- Zone ---
+      zone = GridZone.find_or_initialize_by(slug: prefix)
+      if zone.new_record?
+        zone.assign_attributes(
+          name: zone_tmpl["name"],
+          description: zone_tmpl["description"],
+          zone_type: zone_tmpl["zone_type"],
+          color_scheme: zone_tmpl["color_scheme"],
+          grid_region: region,
+          grid_faction: govcorp_faction,
+          danger_level: zone_tmpl["danger_level"] || 0
+        )
+        zone.save!
+        zones_created += 1
+        puts "  ✓ Zone: #{zone.name} (#{zone.slug})"
+      end
+
+      # --- Rooms ---
+      room_tmpls.each do |rt|
+        slug = "#{region_slug}-pac-#{rt["suffix"]}"
+        room = GridRoom.find_or_initialize_by(slug: slug)
+        next unless room.new_record?
+
+        name = rt["name_template"].gsub("%{cell_id}", cell_id)
+        room.assign_attributes(
+          name: name,
+          description: rt["description"],
+          grid_zone: zone,
+          room_type: rt["room_type"]
+        )
+        room.save!
+        rooms_created += 1
+      end
+
+      # --- Exits ---
+      exit_tmpls.each do |et|
+        from_slug = "#{region_slug}-pac-#{et["from"]}"
+        to_slug = "#{region_slug}-pac-#{et["to"]}"
+        from_room = GridRoom.find_by(slug: from_slug)
+        to_room = GridRoom.find_by(slug: to_slug)
+        next unless from_room && to_room
+
+        exit_record = GridExit.find_or_initialize_by(
+          from_room: from_room, to_room: to_room, direction: et["direction"]
+        )
+        next unless exit_record.new_record?
+
+        exit_record.save!
+        exits_created += 1
+      end
+
+      # --- Mobs ---
+      mob_tmpls.each do |mt|
+        room_slug = "#{region_slug}-pac-#{mt["suffix"]}"
+        mob_room = GridRoom.find_by(slug: room_slug)
+        next unless mob_room
+
+        mob = GridMob.find_or_initialize_by(name: mt["name"], grid_room: mob_room)
+        next unless mob.new_record?
+
+        mob_faction = mt["faction_slug"] ? GridFaction.find_by(slug: mt["faction_slug"]) : nil
+        mob.assign_attributes(
+          description: mt["description"],
+          mob_type: mt["mob_type"],
+          grid_faction: mob_faction,
+          dialogue_tree: mt["dialogue_tree"]
+        )
+        mob.save!
+        mobs_created += 1
+      end
+
+      # --- Breach Encounters ---
+      encounter_tmpls.each do |et|
+        template = GridBreachTemplate.find_by(slug: et["template_slug"])
+        room_slug = "#{region_slug}-pac-#{et["room_suffix"]}"
+        enc_room = GridRoom.find_by(slug: room_slug)
+        next unless template && enc_room
+
+        encounter = GridBreachEncounter.find_or_initialize_by(
+          grid_breach_template: template, grid_room: enc_room
+        )
+        next unless encounter.new_record?
+
+        encounter.assign_attributes(state: "available")
+        encounter.save!
+        encounters_created += 1
+      end
+
+      # --- Region assignments ---
+      containment_room = GridRoom.find_by(slug: "#{region_slug}-pac-containment-cell")
+      exit_room = GridRoom.find_by(slug: "#{region_slug}-pac-external-corridor")
+      bribe_exit_room = GridRoom.find_by(slug: "#{region_slug}-pac-admin-discharge")
+
+      updates = {}
+      updates[:containment_room] = containment_room if containment_room && region.containment_room_id != containment_room.id
+      updates[:facility_exit_room] = exit_room if exit_room && region.facility_exit_room_id != exit_room.id
+      updates[:facility_bribe_exit_room] = bribe_exit_room if bribe_exit_room && region.facility_bribe_exit_room_id != bribe_exit_room.id
+
+      if updates.any?
+        region.update!(updates)
+        puts "  ↻ Region #{region.name}: assigned PAC rooms"
+      end
+    end
+
+    puts "PAC Facilities: #{zones_created} zones, #{rooms_created} rooms, #{exits_created} exits, #{mobs_created} mobs, #{encounters_created} encounters"
   end
 
   desc "Sync existing grid_items with their current definitions"

--- a/spec/factories/grid_breach_templates.rb
+++ b/spec/factories/grid_breach_templates.rb
@@ -14,6 +14,7 @@
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
+#  no_clearance_bypass   :boolean          default(FALSE), not null
 #  pnr_threshold         :integer          default(75), not null
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null

--- a/spec/factories/grid_impound_records.rb
+++ b/spec/factories/grid_impound_records.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_impound_records
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  bribe_cost           :integer          default(0), not null
+#  status               :string           default("impounded"), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  grid_hackr_breach_id :integer
+#  grid_hackr_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_impound_records_on_grid_hackr_breach_id      (grid_hackr_breach_id)
+#  index_grid_impound_records_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_impound_records_on_grid_hackr_id_and_status  (grid_hackr_id,status)
+#
+# Foreign Keys
+#
+#  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => nullify
+#  grid_hackr_id         (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :grid_impound_record do
+    association :grid_hackr
+    status { "impounded" }
+    bribe_cost { 500 }
+
+    trait :recovered do
+      status { "recovered" }
+    end
+
+    trait :forfeited do
+      status { "forfeited" }
+    end
+
+    trait :with_breach do
+      association :grid_hackr_breach
+    end
+  end
+end

--- a/spec/factories/grid_items.rb
+++ b/spec/factories/grid_items.rb
@@ -17,6 +17,7 @@
 #  container_id            :integer
 #  deck_id                 :integer
 #  grid_hackr_id           :integer
+#  grid_impound_record_id  :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
 #  room_id                 :integer
@@ -26,6 +27,7 @@
 #  index_grid_items_on_container_id                (container_id)
 #  index_grid_items_on_deck_id                     (deck_id)
 #  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_impound_record_id      (grid_impound_record_id)
 #  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
 #  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
@@ -34,6 +36,7 @@
 #
 #  container_id             (container_id => grid_items.id)
 #  deck_id                  (deck_id => grid_items.id) ON DELETE => nullify
+#  grid_impound_record_id   (grid_impound_record_id => grid_impound_records.id) ON DELETE => nullify
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 FactoryBot.define do

--- a/spec/factories/grid_regions.rb
+++ b/spec/factories/grid_regions.rb
@@ -3,22 +3,31 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  description      :text
-#  name             :string           not null
-#  slug             :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  hospital_room_id :integer
+#  id                          :integer          not null, primary key
+#  description                 :text
+#  name                        :string           not null
+#  slug                        :string           not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  containment_room_id         :integer
+#  facility_bribe_exit_room_id :integer
+#  facility_exit_room_id       :integer
+#  hospital_room_id            :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
-#  index_grid_regions_on_slug              (slug) UNIQUE
+#  index_grid_regions_on_containment_room_id          (containment_room_id)
+#  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
+#  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
+#  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
-#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 FactoryBot.define do
   factory :grid_region do

--- a/spec/models/grid_breach_template_spec.rb
+++ b/spec/models/grid_breach_template_spec.rb
@@ -14,6 +14,7 @@
 #  description           :text
 #  min_clearance         :integer          default(0), not null
 #  name                  :string           not null
+#  no_clearance_bypass   :boolean          default(FALSE), not null
 #  pnr_threshold         :integer          default(75), not null
 #  position              :integer          default(0), not null
 #  protocol_composition  :json             not null

--- a/spec/models/grid_item_spec.rb
+++ b/spec/models/grid_item_spec.rb
@@ -17,6 +17,7 @@
 #  container_id            :integer
 #  deck_id                 :integer
 #  grid_hackr_id           :integer
+#  grid_impound_record_id  :integer
 #  grid_item_definition_id :integer          not null
 #  grid_mining_rig_id      :integer
 #  room_id                 :integer
@@ -26,6 +27,7 @@
 #  index_grid_items_on_container_id                (container_id)
 #  index_grid_items_on_deck_id                     (deck_id)
 #  index_grid_items_on_grid_hackr_id               (grid_hackr_id)
+#  index_grid_items_on_grid_impound_record_id      (grid_impound_record_id)
 #  index_grid_items_on_grid_item_definition_id     (grid_item_definition_id)
 #  index_grid_items_on_grid_mining_rig_id          (grid_mining_rig_id)
 #  index_grid_items_on_hackr_equipped_slot_unique  (grid_hackr_id,equipped_slot) UNIQUE WHERE equipped_slot IS NOT NULL
@@ -34,6 +36,7 @@
 #
 #  container_id             (container_id => grid_items.id)
 #  deck_id                  (deck_id => grid_items.id) ON DELETE => nullify
+#  grid_impound_record_id   (grid_impound_record_id => grid_impound_records.id) ON DELETE => nullify
 #  grid_item_definition_id  (grid_item_definition_id => grid_item_definitions.id)
 #
 require "rails_helper"

--- a/spec/models/grid_region_spec.rb
+++ b/spec/models/grid_region_spec.rb
@@ -3,22 +3,31 @@
 # Table name: grid_regions
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  description      :text
-#  name             :string           not null
-#  slug             :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  hospital_room_id :integer
+#  id                          :integer          not null, primary key
+#  description                 :text
+#  name                        :string           not null
+#  slug                        :string           not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  containment_room_id         :integer
+#  facility_bribe_exit_room_id :integer
+#  facility_exit_room_id       :integer
+#  hospital_room_id            :integer
 #
 # Indexes
 #
-#  index_grid_regions_on_hospital_room_id  (hospital_room_id)
-#  index_grid_regions_on_slug              (slug) UNIQUE
+#  index_grid_regions_on_containment_room_id          (containment_room_id)
+#  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
+#  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
+#  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
-#  hospital_room_id  (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
+#  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
 #
 require "rails_helper"
 

--- a/spec/services/grid/breach_phase2e_spec.rb
+++ b/spec/services/grid/breach_phase2e_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe "BREACH Phase 2E: Failure + Puzzles" do
   # FAILURE TIERS 3-4
   # ═══════════════════════════════════════════════════════════════
 
+  # Suppress probabilistic capture so these tests exercise the standard/advanced failure path
+  before do
+    allow_any_instance_of(Grid::BreachService).to receive(:should_capture?).and_return(false)
+  end
+
   describe "Failure Tier 3: DECK software wipe" do
     let(:template) { create(:grid_breach_template, tier: "standard") }
     let(:encounter) { create(:grid_breach_encounter, grid_breach_template: template, grid_room: room) }

--- a/spec/services/grid/breach_service_spec.rb
+++ b/spec/services/grid/breach_service_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe Grid::BreachService do
     let!(:breach_result) { described_class.start!(hackr: hackr, encounter: encounter) }
     let(:breach) { breach_result.hackr_breach }
 
+    # Suppress probabilistic capture so existing tests exercise the standard failure path
+    before do
+      allow_any_instance_of(described_class).to receive(:should_capture?).and_return(false)
+    end
+
     it "drains vitals and sets failure state" do
       old_energy = hackr.stat("energy")
       old_psyche = hackr.stat("psyche")

--- a/spec/services/grid/containment_service_spec.rb
+++ b/spec/services/grid/containment_service_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::ContainmentService do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:facility_zone) { create(:grid_zone, grid_region: region) }
+  let(:containment_room) { create(:grid_room, grid_zone: facility_zone, room_type: "containment") }
+  let(:corridor) { create(:grid_room, grid_zone: facility_zone, room_type: "govcorp") }
+  let(:impound_room) { create(:grid_room, grid_zone: facility_zone, room_type: "impound") }
+  let(:exit_room) { create(:grid_room, grid_zone: zone) }
+  let(:bribe_exit_room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:template) { create(:grid_breach_template) }
+  let(:breach) { create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template) }
+
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+  let(:burn_cache) { create(:grid_cache, :burn) }
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  before do
+    cache
+    gameplay_pool
+    burn_cache
+    region.update!(
+      containment_room: containment_room,
+      facility_exit_room: exit_room,
+      facility_bribe_exit_room: bribe_exit_room
+    )
+  end
+
+  describe ".capture!" do
+    it "teleports hackr to containment room" do
+      result = described_class.capture!(hackr: hackr, breach: breach)
+
+      expect(result.containment_room).to eq(containment_room)
+      expect(hackr.reload.current_room).to eq(containment_room)
+      expect(hackr.stat("captured")).to eq(true)
+      expect(hackr.stat("captured_origin_room_id")).to eq(room.id)
+      expect(hackr.stat("facility_alert_level")).to eq(0)
+    end
+
+    it "raises AlreadyCaptured when already captured" do
+      described_class.capture!(hackr: hackr, breach: breach)
+      expect {
+        described_class.capture!(hackr: hackr, breach: breach)
+      }.to raise_error(Grid::ContainmentService::AlreadyCaptured)
+    end
+
+    context "with impound" do
+      let(:deck_def) do
+        create(:grid_item_definition, :gear,
+          slug: "cap-deck-#{SecureRandom.hex(4)}", name: "Test Deck", value: 1000,
+          properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+      end
+
+      let!(:deck) do
+        item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+        item.update!(equipped_slot: "deck")
+        item
+      end
+
+      it "impounds gear when impound: true" do
+        result = described_class.capture!(hackr: hackr, breach: breach, impound: true)
+
+        expect(result.impound_result).to be_present
+        expect(result.impound_result.items_seized).not_to be_empty
+        expect(hackr.grid_impound_records.impounded.count).to eq(1)
+      end
+
+      it "skips impound when impound: false" do
+        result = described_class.capture!(hackr: hackr, breach: breach, impound: false)
+
+        expect(result.impound_result).to be_nil
+        expect(hackr.grid_impound_records.count).to eq(0)
+      end
+    end
+  end
+
+  describe ".alert_increment!" do
+    before { described_class.capture!(hackr: hackr, breach: breach) }
+
+    it "increments alert level on room move" do
+      hackr.update!(current_room: corridor)
+      result = described_class.alert_increment!(hackr: hackr)
+
+      expect(result.alert_level).to eq(described_class::ALERT_PER_MOVE)
+      expect(result.caught).to be false
+    end
+
+    it "does not increment in safe rooms" do
+      hackr.update!(current_room: impound_room)
+      result = described_class.alert_increment!(hackr: hackr)
+
+      expect(result.alert_level).to eq(0)
+      expect(result.caught).to be false
+    end
+
+    it "catches hackr when threshold reached" do
+      hackr.set_stat!("facility_alert_level", described_class::ALERT_THRESHOLD - described_class::ALERT_PER_MOVE)
+      hackr.update!(current_room: corridor)
+      result = described_class.alert_increment!(hackr: hackr)
+
+      expect(result.caught).to be true
+      expect(hackr.reload.current_room).to eq(containment_room)
+      expect(hackr.stat("facility_alert_level")).to eq(0)
+    end
+  end
+
+  describe ".alert_reduce!" do
+    before do
+      described_class.capture!(hackr: hackr, breach: breach)
+      hackr.set_stat!("facility_alert_level", 50)
+    end
+
+    it "reduces alert level" do
+      described_class.alert_reduce!(hackr: hackr, amount: 25)
+      expect(hackr.stat("facility_alert_level")).to eq(25)
+    end
+
+    it "clamps at zero" do
+      described_class.alert_reduce!(hackr: hackr, amount: 100)
+      expect(hackr.stat("facility_alert_level")).to eq(0)
+    end
+  end
+
+  describe ".escape_facility!" do
+    before { described_class.capture!(hackr: hackr, breach: breach) }
+
+    it "clears captured state and teleports to exit room" do
+      result = described_class.escape_facility!(hackr: hackr, via: :sally_port)
+
+      expect(result.destination_room).to eq(exit_room)
+      expect(hackr.reload.current_room).to eq(exit_room)
+      expect(hackr.stat("captured")).to be_nil
+      expect(hackr.stat("facility_alert_level")).to be_nil
+    end
+
+    it "uses bribe exit room for bribe path" do
+      result = described_class.escape_facility!(hackr: hackr, via: :bribe)
+      expect(result.destination_room).to eq(bribe_exit_room)
+    end
+  end
+
+  describe ".bribe_exit!" do
+    before do
+      described_class.capture!(hackr: hackr, breach: breach)
+      fund_cache(cache, 50_000)
+    end
+
+    it "pays fee and exits facility" do
+      result = described_class.bribe_exit!(hackr: hackr)
+
+      expect(result.fee_paid).to be > 0
+      expect(hackr.reload.stat("captured")).to be_nil
+      expect(hackr.current_room).to eq(bribe_exit_room)
+    end
+
+    it "forfeits impounded gear" do
+      # Equip and impound gear first
+      deck_def = create(:grid_item_definition, :gear,
+        slug: "bribe-deck-#{SecureRandom.hex(4)}", name: "Bribe Deck", value: 500,
+        properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+      deck = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+      deck.update!(equipped_slot: "deck")
+      Grid::ImpoundService.impound_gear!(hackr: hackr, breach: breach)
+
+      result = described_class.bribe_exit!(hackr: hackr)
+
+      expect(result.forfeit_results.size).to eq(1)
+      expect(hackr.grid_impound_records.forfeited.count).to eq(1)
+    end
+
+    it "raises InsufficientFunds when hackr can't afford" do
+      poor_hackr = create(:grid_hackr, current_room: room)
+      create(:grid_cache, :default, grid_hackr: poor_hackr)
+      poor_breach = create(:grid_hackr_breach, grid_hackr: poor_hackr, grid_breach_template: template)
+      described_class.capture!(hackr: poor_hackr, breach: poor_breach)
+
+      expect {
+        described_class.bribe_exit!(hackr: poor_hackr)
+      }.to raise_error(Grid::ContainmentService::InsufficientFunds)
+    end
+  end
+
+  describe ".captured?" do
+    it "returns true when captured" do
+      hackr.set_stat!("captured", true)
+      expect(described_class.captured?(hackr)).to be true
+    end
+
+    it "returns false when not captured" do
+      expect(described_class.captured?(hackr)).to be false
+    end
+  end
+
+  describe ".compute_exit_bribe" do
+    it "calculates bribe from constants" do
+      hackr.set_stat!("clearance", 50)
+      cost = described_class.compute_exit_bribe(hackr)
+      # 250 + 50*15 = 1000
+      expect(cost).to eq(1000)
+    end
+  end
+
+  describe ".render_alert_bar" do
+    it "renders green at low alert" do
+      bar = described_class.render_alert_bar(20)
+      expect(bar).to include("FACILITY ALERT")
+      expect(bar).to include("#34d399") # green
+    end
+
+    it "renders amber at medium alert" do
+      bar = described_class.render_alert_bar(50)
+      expect(bar).to include("#fbbf24") # amber
+    end
+
+    it "renders red at high alert" do
+      bar = described_class.render_alert_bar(80)
+      expect(bar).to include("#f87171") # red
+    end
+  end
+end

--- a/spec/services/grid/impound_service_spec.rb
+++ b/spec/services/grid/impound_service_spec.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::ImpoundService do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:template) { create(:grid_breach_template) }
+  let(:breach) { create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template) }
+
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+  let(:burn_cache) { create(:grid_cache, :burn) }
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  before do
+    cache
+    gameplay_pool
+    burn_cache
+  end
+
+  let(:deck_def) do
+    create(:grid_item_definition, :gear,
+      slug: "impound-test-deck-#{SecureRandom.hex(4)}",
+      name: "Test Deck",
+      value: 2000,
+      properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+  end
+
+  let(:chest_def) do
+    create(:grid_item_definition, :gear,
+      slug: "impound-test-chest-#{SecureRandom.hex(4)}",
+      name: "Test Chestplate",
+      value: 1500,
+      properties: {"slot" => "chest", "effects" => {"bonus_max_health" => 20}})
+  end
+
+  let(:software_def) do
+    create(:grid_item_definition,
+      slug: "impound-test-sw-#{SecureRandom.hex(4)}",
+      name: "Test Program",
+      item_type: "software",
+      properties: {"software_category" => "offensive", "slot_cost" => 1, "battery_cost" => 8})
+  end
+
+  let!(:deck) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: deck_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "deck")
+    item
+  end
+
+  let!(:chest) do
+    item = create(:grid_item, :in_inventory, grid_item_definition: chest_def, grid_hackr: hackr)
+    item.update!(equipped_slot: "chest")
+    item
+  end
+
+  let!(:software) do
+    create(:grid_item, grid_item_definition: software_def,
+      grid_hackr: hackr, room: nil, deck_id: deck.id,
+      item_type: "software", name: "Test Program")
+  end
+
+  describe ".compute_bribe" do
+    it "calculates bribe from constants" do
+      hackr.set_stat!("clearance", 20)
+      items = [deck, chest]
+      cost = described_class.compute_bribe(hackr: hackr, items: items)
+      # 500 + 20*25 + (2000+1500)*0.10 = 500 + 500 + 350 = 1350
+      expect(cost).to eq(1350)
+    end
+
+    it "handles zero clearance" do
+      hackr.set_stat!("clearance", 0)
+      cost = described_class.compute_bribe(hackr: hackr, items: [deck])
+      # 500 + 0 + 2000*0.10 = 700
+      expect(cost).to eq(700)
+    end
+  end
+
+  describe ".impound_gear!" do
+    it "confiscates all equipped items" do
+      result = described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      expect(result.impound_record).to be_a(GridImpoundRecord)
+      expect(result.impound_record.status).to eq("impounded")
+      expect(result.items_seized.map(&:name)).to contain_exactly("Test Deck", "Test Chestplate")
+      expect(result.bribe_cost).to be > 0
+      expect(result.display).to include("GEAR CONFISCATED")
+    end
+
+    it "sets impound FK on seized items" do
+      result = described_class.impound_gear!(hackr: hackr, breach: breach)
+      record = result.impound_record
+
+      deck.reload
+      chest.reload
+      expect(deck.grid_impound_record_id).to eq(record.id)
+      expect(chest.grid_impound_record_id).to eq(record.id)
+      expect(deck.equipped_slot).to be_nil
+      expect(chest.equipped_slot).to be_nil
+    end
+
+    it "impounds software loaded in DECK" do
+      result = described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      software.reload
+      expect(software.grid_impound_record_id).to eq(result.impound_record.id)
+    end
+
+    it "excludes impounded items from equipped_by scope" do
+      described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      expect(GridItem.equipped_by(hackr)).to be_empty
+    end
+
+    it "excludes impounded items from in_inventory scope" do
+      described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      inventory_ids = GridItem.in_inventory(hackr).pluck(:id)
+      expect(inventory_ids).not_to include(deck.id, chest.id)
+    end
+
+    it "clears loadout effects" do
+      described_class.impound_gear!(hackr: hackr, breach: breach)
+      hackr.reset_loadout_cache!
+
+      expect(hackr.loadout_effects).to eq(Hash.new(0))
+    end
+
+    it "clamps vitals to new effective max" do
+      hackr.set_stat!("health", 120) # Over base 100, boosted by chest gear
+      described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      expect(hackr.stat("health")).to be <= 100
+    end
+
+    it "raises NoEquippedGear when nothing equipped" do
+      deck.update!(equipped_slot: nil)
+      chest.update!(equipped_slot: nil)
+
+      expect {
+        described_class.impound_gear!(hackr: hackr, breach: breach)
+      }.to raise_error(Grid::ImpoundService::NoEquippedGear)
+    end
+
+    it "freezes bribe cost at capture time" do
+      result = described_class.impound_gear!(hackr: hackr, breach: breach)
+      expect(result.impound_record.bribe_cost).to eq(result.bribe_cost)
+    end
+  end
+
+  describe ".recover_gear!" do
+    let!(:impound_result) { described_class.impound_gear!(hackr: hackr, breach: breach) }
+    let(:record) { impound_result.impound_record }
+
+    before do
+      fund_cache(cache, 50_000)
+    end
+
+    it "returns items to inventory" do
+      result = described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      expect(result.items_returned).not_to be_empty
+      expect(result.impound_record.status).to eq("recovered")
+      expect(result.display).to include("GEAR RECOVERED")
+    end
+
+    it "clears impound FK on items" do
+      described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      deck.reload
+      chest.reload
+      software.reload
+      expect(deck.grid_impound_record_id).to be_nil
+      expect(chest.grid_impound_record_id).to be_nil
+      expect(software.grid_impound_record_id).to be_nil
+    end
+
+    it "items appear in inventory after recovery" do
+      described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      inventory_names = GridItem.in_inventory(hackr).pluck(:name)
+      expect(inventory_names).to include("Test Deck", "Test Chestplate")
+    end
+
+    it "items are unequipped after recovery" do
+      described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      deck.reload
+      expect(deck.equipped_slot).to be_nil
+    end
+
+    it "software stays loaded in DECK after recovery" do
+      described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      software.reload
+      expect(software.deck_id).to eq(deck.id)
+    end
+
+    it "raises InsufficientBalance when hackr can't afford bribe" do
+      # Don't fund the cache — leave it empty
+      poor_hackr = create(:grid_hackr, current_room: room)
+      create(:grid_cache, :default, grid_hackr: poor_hackr)
+      poor_deck_def = create(:grid_item_definition, :gear,
+        slug: "poor-deck-#{SecureRandom.hex(4)}", name: "Poor Deck", value: 100,
+        properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+      poor_deck = create(:grid_item, :in_inventory, grid_item_definition: poor_deck_def, grid_hackr: poor_hackr)
+      poor_deck.update!(equipped_slot: "deck")
+      poor_breach = create(:grid_hackr_breach, grid_hackr: poor_hackr, grid_breach_template: template)
+      poor_result = described_class.impound_gear!(hackr: poor_hackr, breach: poor_breach)
+
+      expect {
+        described_class.recover_gear!(hackr: poor_hackr, impound_record: poor_result.impound_record)
+      }.to raise_error(Grid::ImpoundService::InsufficientBalance)
+    end
+
+    it "raises RecordNotImpounded for already-recovered record" do
+      described_class.recover_gear!(hackr: hackr, impound_record: record)
+
+      expect {
+        described_class.recover_gear!(hackr: hackr, impound_record: record)
+      }.to raise_error(Grid::ImpoundService::RecordNotImpounded)
+    end
+
+    it "raises NotOwner for another hackr's record" do
+      other_hackr = create(:grid_hackr)
+      expect {
+        described_class.recover_gear!(hackr: other_hackr, impound_record: record)
+      }.to raise_error(Grid::ImpoundService::NotOwner)
+    end
+  end
+
+  describe ".forfeit!" do
+    let!(:impound_result) { described_class.impound_gear!(hackr: hackr, breach: breach) }
+    let(:record) { impound_result.impound_record }
+
+    it "permanently destroys impounded items" do
+      item_ids = record.impounded_items.pluck(:id)
+      result = described_class.forfeit!(impound_record: record)
+
+      expect(result.impound_record.status).to eq("forfeited")
+      expect(result.items_destroyed).to be > 0
+      expect(GridItem.where(id: item_ids)).to be_empty
+      expect(result.display).to include("IMPOUND FORFEITED")
+    end
+
+    it "raises RecordNotImpounded for already-forfeited record" do
+      described_class.forfeit!(impound_record: record)
+
+      expect {
+        described_class.forfeit!(impound_record: record)
+      }.to raise_error(Grid::ImpoundService::RecordNotImpounded)
+    end
+  end
+
+  describe "multiple impound sets" do
+    it "tracks separate capture events independently" do
+      result1 = described_class.impound_gear!(hackr: hackr, breach: breach)
+
+      # Mark first breach as completed so unique index allows a new active breach
+      breach.update!(state: "failure", ended_at: Time.current)
+
+      # Hackr gets new gear and gets captured again
+      new_deck_def = create(:grid_item_definition, :gear,
+        slug: "impound-deck2-#{SecureRandom.hex(4)}", name: "Second Deck", value: 3000,
+        properties: {"slot" => "deck", "slot_count" => 4, "battery_max" => 64, "battery_current" => 64, "module_slot_count" => 1, "effects" => {}})
+      new_deck = create(:grid_item, :in_inventory, grid_item_definition: new_deck_def, grid_hackr: hackr)
+      new_deck.update!(equipped_slot: "deck")
+
+      breach2 = create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template)
+      result2 = described_class.impound_gear!(hackr: hackr, breach: breach2)
+
+      expect(result1.impound_record.id).not_to eq(result2.impound_record.id)
+      expect(hackr.grid_impound_records.impounded.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
  Implement failure tiers 5-6 with probabilistic GovCorp capture on BREACH
  detection-overflow (standard 25%, advanced 50%, elite 100%). Capture
  teleports hackr to a per-region GovCorp Perception Alignment Center — a
  multi-room containment facility they must escape via puzzle BREACH, facility
  navigation, and Sally Port hacking, or by bribing a GovCorp agent (forfeiting
  all impounded gear).

  Failure tiers:
  - Tier 5 (capture): replaces lockout + DECK consequences. Hackr teleported to containment cell, marked captured with restricted command set.
  - Tier 6 (gear impound, elite+): all 13 equipped slots + loaded DECK software confiscated to impound record. DECK stays intact (no fry/wipe). Recoverable via bribe at Impound Bay clerk. Cost frozen at capture time.

  GovCorp Perception Alignment Center:
  - Per-region zone (14 total, stamped from pac_facilities.yml template).
  - 11 rooms per facility: containment cell, processing corridor, intake junction, surveillance hub, security checkpoint, impound bay, admin wing, sally port anteroom, sally port, external corridor, admin discharge exit.
  - Alert level system (0-100): +12/move, safe rooms exempt, threshold=caught, -25 on successful BREACH. Voluntary BREACH targets throughout facility.

  Escape paths:
  - Cell puzzle BREACH (4 gates, infinite retry, no clearance bypass) → navigate facility → recover gear at impound → hack Sally Port (2 doors) → exit.
  - Or: bribe GovCorp agent → forfeit all impounded gear → escorted exit.

  Also:
  - ImpoundService: impound/recover/forfeit with named formula constants.
  - ContainmentService: capture/alert/escape lifecycle.
  - CapturedCommandParser: restricted command set + bribe command.
  - Fix latent bug: BreachService#start! mission gate used wrong association (grid_mission_progresses → grid_hackr_missions) + wrong column (state → status).
  - listed_encounters method for locked encounter display with reason.
  - GridRoom profanity filter scoped to dens only (admin-seeded rooms exempt).