### PR TITLE
[TPG] Admin Tooling Phase A: Hackr Inspector, Stat Editor, Warp, & More

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,5 +1,6 @@
 class Admin::ApplicationController < ApplicationController
   include GridAuthentication
+  include Admin::DevToolsGate
 
   layout "admin"
 

--- a/app/controllers/admin/grid_hackr_items_controller.rb
+++ b/app/controllers/admin/grid_hackr_items_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Admin::GridHackrItemsController < Admin::ApplicationController
+  before_action :set_hackr
+
+  # GET /root/grid_hackrs/:hackr_id/items
+  def index
+    @inventory = GridItem.in_inventory(@hackr).includes(:grid_item_definition).order(:name)
+    @equipped = GridItem.equipped_by(@hackr).includes(:grid_item_definition)
+    @definitions = GridItemDefinition.ordered
+  end
+
+  # POST /root/grid_hackrs/:hackr_id/items/grant
+  def grant
+    definition = GridItemDefinition.find_by(id: params[:definition_id])
+    unless definition
+      set_flash_error("Item definition not found.")
+      return redirect_to admin_grid_hackr_items_path(@hackr)
+    end
+
+    quantity = [params[:quantity].to_i, 1].max
+
+    ApplicationRecord.transaction do
+      Grid::Inventory.grant_item!(hackr: @hackr, definition: definition, quantity: quantity)
+    end
+
+    set_flash_success("Granted #{quantity}x #{definition.name} to #{@hackr.hackr_alias}.")
+    redirect_to admin_grid_hackr_items_path(@hackr)
+  rescue Grid::InventoryErrors::InventoryFull, Grid::InventoryErrors::StackLimitExceeded => e
+    set_flash_error("Could not grant item: #{e.message}")
+    redirect_to admin_grid_hackr_items_path(@hackr)
+  end
+
+  # DELETE /root/grid_hackrs/:hackr_id/items/:id
+  def remove
+    item = @hackr.grid_items.find_by(id: params[:id])
+    unless item
+      set_flash_error("Item not found in this hackr's possession.")
+      return redirect_to admin_grid_hackr_items_path(@hackr)
+    end
+
+    if item.equipped?
+      set_flash_error("Cannot remove equipped item '#{item.name}'. Hackr must unequip it first.")
+      return redirect_to admin_grid_hackr_items_path(@hackr)
+    end
+
+    if item.grid_mining_rig_id.present?
+      set_flash_error("Cannot remove installed rig component '#{item.name}' via item admin.")
+      return redirect_to admin_grid_hackr_items_path(@hackr)
+    end
+
+    name = item.name
+    item.destroy!
+    set_flash_success("Removed #{name} from #{@hackr.hackr_alias}.")
+    redirect_to admin_grid_hackr_items_path(@hackr)
+  end
+
+  private
+
+  def set_hackr
+    @hackr = GridHackr.find(params[:hackr_id])
+  end
+end

--- a/app/controllers/admin/grid_hackrs_controller.rb
+++ b/app/controllers/admin/grid_hackrs_controller.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+class Admin::GridHackrsController < Admin::ApplicationController
+  before_action :set_hackr, only: %i[show edit_stats update_stats warp perform_warp]
+  before_action :require_dev_tools, only: %i[edit_stats update_stats warp perform_warp]
+
+  # GET /root/grid_hackrs
+  def index
+    @hackrs = GridHackr.includes(:current_room).order(:hackr_alias)
+    if params[:q].present?
+      @hackrs = @hackrs.where("LOWER(hackr_alias) LIKE ?", "%#{params[:q].downcase}%")
+    end
+  end
+
+  # GET /root/grid_hackrs/:id
+  def show
+    @stats = @hackr.current_stats
+    @inventory = GridItem.in_inventory(@hackr).includes(:grid_item_definition).order(:name)
+    @equipped = GridItem.equipped_by(@hackr).includes(:grid_item_definition)
+    @loadout = @hackr.loadout_by_slot
+    @cache = @hackr.default_cache
+    @cred_balance = @cache&.balance || 0
+    @active_breach = @hackr.active_breach
+    @mining_rig = @hackr.grid_mining_rig
+    @reputations = @hackr.grid_hackr_reputations
+      .for_subject_type("GridFaction")
+      .includes(:subject)
+      .order(:subject_id)
+    @active_missions = @hackr.grid_hackr_missions
+      .where(status: "active")
+      .includes(grid_mission: :grid_mission_arc)
+      .order(:accepted_at)
+    @feature_grants = @hackr.feature_grants.order(:feature)
+  end
+
+  # GET /root/grid_hackrs/:id/edit_stats
+  def edit_stats
+  end
+
+  # PATCH /root/grid_hackrs/:id/update_stats
+  def update_stats
+    if params[:raw_json].present?
+      begin
+        parsed = JSON.parse(params[:raw_json])
+        @hackr.update_column(:stats, parsed)
+        @hackr.stats = parsed
+        set_flash_success("Stats updated (raw JSON) for #{@hackr.hackr_alias}.")
+        return redirect_to admin_grid_hackr_path(@hackr)
+      rescue JSON::ParserError => e
+        flash.now[:error] = "Invalid JSON: #{e.message}"
+        return render :edit_stats, status: :unprocessable_entity
+      end
+    end
+
+    sp = stat_params
+    changes = {}
+
+    # XP / clearance sync — XP takes priority when both change.
+    xp_changed = sp[:xp].present? && sp[:xp].to_i != @hackr.stat("xp")
+    cl_changed = sp[:clearance].present? && sp[:clearance].to_i != @hackr.stat("clearance")
+
+    if xp_changed
+      xp = sp[:xp].to_i.clamp(0, 999_999_999)
+      changes["xp"] = xp
+      changes["clearance"] = @hackr.clearance_for_xp(xp)
+    elsif cl_changed
+      cl = sp[:clearance].to_i.clamp(0, GridHackr::Stats::MAX_CLEARANCE)
+      changes["clearance"] = cl
+      changes["xp"] = GridHackr::Stats.xp_for_clearance(cl)
+    end
+
+    # Vitals
+    %w[health energy psyche].each do |key|
+      changes[key] = sp[key].to_i.clamp(0, 999) if sp[key].present?
+    end
+
+    # Other numeric stats
+    %w[inspiration bonus_inventory_slots govcorp_debt facility_alert_level].each do |key|
+      changes[key] = sp[key].to_i if sp[key].present?
+    end
+
+    # Boolean: captured
+    if sp.key?(:captured)
+      captured = sp[:captured] == "1"
+      changes["captured"] = captured
+      unless captured
+        changes["captured_origin_room_id"] = nil
+        changes["facility_alert_level"] = 0
+      end
+    end
+
+    if changes.any?
+      new_stats = (@hackr.stats || {}).merge(changes)
+      @hackr.update_column(:stats, new_stats)
+      @hackr.stats = new_stats
+    end
+
+    set_flash_success("Stats updated for #{@hackr.hackr_alias}.")
+    redirect_to admin_grid_hackr_path(@hackr)
+  end
+
+  # GET /root/grid_hackrs/:id/warp
+  def warp
+    load_rooms
+  end
+
+  # POST /root/grid_hackrs/:id/perform_warp
+  def perform_warp
+    room = GridRoom.find_by(id: params[:room_id])
+    unless room
+      flash.now[:error] = "Room not found."
+      load_rooms
+      return render :warp, status: :unprocessable_entity
+    end
+
+    if @hackr.in_breach?
+      flash.now[:error] = "Cannot warp #{@hackr.hackr_alias} — active BREACH in progress. Abort the breach first."
+      load_rooms
+      return render :warp, status: :unprocessable_entity
+    end
+
+    # Clear containment state if captured (batched write)
+    if @hackr.stat("captured")
+      new_stats = (@hackr.stats || {}).merge(
+        "captured" => false,
+        "captured_origin_room_id" => nil,
+        "facility_alert_level" => 0
+      )
+      @hackr.update_column(:stats, new_stats)
+      @hackr.stats = new_stats
+    end
+
+    @hackr.update!(current_room_id: room.id, zone_entry_room_id: room.id)
+
+    zone_name = room.grid_zone&.name || "unknown zone"
+    set_flash_success("#{@hackr.hackr_alias} warped to #{room.name} (#{zone_name}).")
+    redirect_to admin_grid_hackr_path(@hackr)
+  end
+
+  private
+
+  def set_hackr
+    @hackr = GridHackr.find(params[:id])
+  end
+
+  def load_rooms
+    @rooms = GridRoom.joins(grid_zone: :grid_region)
+      .includes(grid_zone: :grid_region)
+      .order("grid_regions.name, grid_zones.name, grid_rooms.name")
+  end
+
+  def stat_params
+    params.require(:stats).permit(
+      :health, :energy, :psyche, :inspiration,
+      :xp, :clearance, :bonus_inventory_slots,
+      :govcorp_debt, :facility_alert_level, :captured
+    )
+  end
+end

--- a/app/controllers/concerns/admin/dev_tools_gate.rb
+++ b/app/controllers/concerns/admin/dev_tools_gate.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin::DevToolsGate
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :dev_tools_enabled?
+  end
+
+  private
+
+  def dev_tools_enabled?
+    ENV["ADMIN_DEV_TOOLS"].to_s.downcase == "true"
+  end
+
+  def require_dev_tools
+    return if dev_tools_enabled?
+
+    set_flash_error("DEV TOOLS DISABLED. Set ADMIN_DEV_TOOLS=true to enable.")
+    redirect_to admin_root_path
+  end
+end

--- a/app/views/admin/grid_hackr_items/index.html.erb
+++ b/app/views/admin/grid_hackr_items/index.html.erb
@@ -1,0 +1,170 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackrs/<%= @hackr.hackr_alias %>/items :: INVENTORY MANAGER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= link_to "All Hackrs", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%# === GRANT ITEM === %>
+      <div style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: GRANT ITEM ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+          <%= form_with url: admin_grant_grid_hackr_item_path(@hackr), method: :post, local: true, id: "grant-form", style: "display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;" do %>
+            <div style="flex: 1; min-width: 300px;">
+              <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">ITEM DEFINITION</label>
+
+              <input type="hidden" name="definition_id" id="grant-def-id" value="">
+
+              <div class="admin-combobox">
+                <input type="text" id="grant-input" class="admin-combobox-input" autocomplete="off"
+                  placeholder="Type to search items... (name, type, or rarity)">
+                <div id="grant-dropdown" class="admin-combobox-dropdown"></div>
+              </div>
+            </div>
+            <div style="width: 80px;">
+              <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">QTY</label>
+              <input type="number" name="quantity" value="1" min="1" max="99"
+                class="tui-input" style="width: 100%; padding: 8px;">
+            </div>
+            <div>
+              <%= submit_tag "GRANT", class: "tui-button green-168", style: "padding: 8px 20px; font-weight: bold;" %>
+            </div>
+          <% end %>
+          <p style="color: #666; margin-top: 8px; font-size: 0.85em;" id="grant-status">
+            Capacity: <%= @inventory.size %> / <%= @hackr.inventory_capacity %> slots used
+          </p>
+        </div>
+      </div>
+
+      <%# === EQUIPPED GEAR === %>
+      <% if @equipped.any? %>
+        <div style="margin-bottom: 30px;">
+          <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: EQUIPPED (<%= @equipped.size %>) ::]</h3>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Slot</th>
+                  <th style="text-align: left;">Name</th>
+                  <th style="text-align: left;">Type</th>
+                  <th style="text-align: left;">Rarity</th>
+                  <th style="text-align: center;">Value</th>
+                  <th style="text-align: right;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @equipped.each do |item| %>
+                  <tr>
+                    <td style="color: #888;"><%= GridHackr::Loadout::GEAR_SLOT_LABELS[item.equipped_slot] || item.equipped_slot %></td>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.name %></td>
+                    <td style="color: #888;"><%= item.item_type %></td>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.rarity_label %></td>
+                    <td style="text-align: center; color: #888;"><%= item.value %></td>
+                    <td style="text-align: right;">
+                      <span style="color: #666; font-size: 0.8em;">EQUIPPED</span>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <% end %>
+
+      <%# === INVENTORY === %>
+      <div style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: INVENTORY (<%= @inventory.size %> / <%= @hackr.inventory_capacity %>) ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <% if @inventory.any? %>
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Name</th>
+                  <th style="text-align: left;">Type</th>
+                  <th style="text-align: left;">Rarity</th>
+                  <th style="text-align: center;">Qty</th>
+                  <th style="text-align: center;">Value</th>
+                  <th style="text-align: right;">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @inventory.each do |item| %>
+                  <tr>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.name %></td>
+                    <td style="color: #888;"><%= item.item_type %></td>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.rarity_label %></td>
+                    <td style="text-align: center;"><%= item.quantity %></td>
+                    <td style="text-align: center; color: #888;"><%= item.value %></td>
+                    <td style="text-align: right; white-space: nowrap;">
+                      <%= button_to "Remove", admin_remove_grid_hackr_item_path(@hackr, item),
+                            method: :delete,
+                            form: { style: "display: inline;" },
+                            class: "tui-button red-168",
+                            style: "padding: 2px 8px; font-size: 0.8em;",
+                            data: { confirm: "Remove #{item.name} (x#{item.quantity}) from #{@hackr.hackr_alias}?" } %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <p style="color: #666; padding: 15px;">Inventory empty</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    function ready(fn) {
+      if (document.readyState !== 'loading') fn();
+      else document.addEventListener('DOMContentLoaded', fn);
+    }
+    ready(function() {
+      AdminCombobox.init({
+        inputId: 'grant-input',
+        hiddenId: 'grant-def-id',
+        dropdownId: 'grant-dropdown',
+        statusId: 'grant-status',
+        formId: 'grant-form',
+        items: <%= raw json_escape(@definitions.map { |d|
+          {
+            id: d.id,
+            name: d.name,
+            type: d.item_type,
+            rarity: d.rarity_label,
+            rarityColor: d.rarity_color,
+            value: d.value
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) { return (r.type + ' ' + r.name + ' ' + r.rarity).toLowerCase(); },
+        getGroupKey: function(r) { return r.type; },
+        renderOption: function(r, esc) { return '<span class="cb-name" style="color:' + r.rarityColor + ';">' + esc(r.name) + '</span> <span class="cb-meta">' + esc(r.rarity) + ', ' + r.value + 'cr</span>'; },
+        getLabel: function(r) { return r.type + ' > ' + r.name; },
+        emptyText: 'No items match',
+        selectedText: 'Selected — ready to grant',
+        submitError: 'Select an item definition first'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/grid_hackrs/edit_stats.html.erb
+++ b/app/views/admin/grid_hackrs/edit_stats.html.erb
@@ -1,0 +1,111 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackrs/<%= @hackr.hackr_alias %>/stats :: STAT EDITOR</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 25px;">
+        <span class="yellow-255-text" style="font-weight: bold;">DEV TOOL</span>
+        <span style="color: #ccc;"> — Direct stat mutation bypasses game logic. Use with care.</span>
+      </div>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%# === NAMED FIELDS MODE === %>
+      <div id="fields-mode">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: STAT FIELDS ::]</h3>
+        <%= form_with url: update_stats_admin_grid_hackr_path(@hackr), method: :patch, local: true do %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 15px;">
+
+              <%# Vitals %>
+              <% %w[health energy psyche].each do |vital| %>
+                <div>
+                  <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;"><%= vital.upcase %></label>
+                  <input type="number" name="stats[<%= vital %>]" value="<%= @hackr.stat(vital) %>"
+                    class="tui-input" style="width: 100%; padding: 6px 10px;" min="0" max="999">
+                  <small style="color: #666;">max: <%= @hackr.effective_max(vital) %></small>
+                </div>
+              <% end %>
+
+              <%# Progression %>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">CLEARANCE</label>
+                <input type="number" name="stats[clearance]" value="<%= @hackr.stat("clearance") %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0" max="99">
+                <small style="color: #fbbf24;">Sets XP to minimum for this level</small>
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">XP</label>
+                <input type="number" name="stats[xp]" value="<%= @hackr.stat("xp") %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0">
+                <small style="color: #fbbf24;">Overrides clearance field if both set</small>
+              </div>
+
+              <%# Other numeric %>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">INSPIRATION</label>
+                <input type="number" name="stats[inspiration]" value="<%= @hackr.stat("inspiration") %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0">
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">BONUS INV SLOTS</label>
+                <input type="number" name="stats[bonus_inventory_slots]" value="<%= @hackr.stat("bonus_inventory_slots") %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0">
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">GOVCORP DEBT</label>
+                <input type="number" name="stats[govcorp_debt]" value="<%= @hackr.stat("govcorp_debt").to_i %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0">
+              </div>
+              <div>
+                <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold;">ALERT LEVEL</label>
+                <input type="number" name="stats[facility_alert_level]" value="<%= @hackr.stat("facility_alert_level").to_i %>"
+                  class="tui-input" style="width: 100%; padding: 6px 10px;" min="0" max="100">
+              </div>
+            </div>
+
+            <%# Boolean: captured %>
+            <div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #333;">
+              <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                <input type="hidden" name="stats[captured]" value="0">
+                <input type="checkbox" name="stats[captured]" value="1"
+                  <%= @hackr.stat("captured") ? "checked" : "" %>
+                  style="width: 18px; height: 18px;">
+                <span class="red-255-text" style="font-weight: bold;">CAPTURED</span>
+                <span style="color: #888;">(unchecking clears containment state)</span>
+              </label>
+            </div>
+          </div>
+
+          <div style="margin-top: 20px;">
+            <%= submit_tag "WRITE STATS", class: "tui-button red-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Overwrite stats for #{@hackr.hackr_alias}?" } %>
+          </div>
+        <% end %>
+      </div>
+
+      <%# === RAW JSON MODE === %>
+      <div style="margin-top: 40px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: RAW JSON ::]</h3>
+        <p style="color: #888; margin-bottom: 10px;">Full stats JSON. Replaces entire stats column.</p>
+        <%= form_with url: update_stats_admin_grid_hackr_path(@hackr), method: :patch, local: true do %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+            <textarea name="raw_json" class="tui-input"
+              style="width: 100%; min-height: 200px; padding: 10px; font-family: monospace; font-size: 0.9em;"
+            ><%= JSON.pretty_generate(@hackr.current_stats) %></textarea>
+          </div>
+          <div style="margin-top: 15px;">
+            <%= submit_tag "WRITE RAW JSON", class: "tui-button red-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Replace ALL stats for #{@hackr.hackr_alias} with raw JSON?" } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_hackrs/index.html.erb
+++ b/app/views/admin/grid_hackrs/index.html.erb
@@ -1,0 +1,74 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackrs :: HACKR INSPECTOR</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= form_with url: admin_grid_hackrs_path, method: :get, local: true, style: "display: inline-flex; gap: 8px; align-items: center; margin-bottom: 20px;" do %>
+        <label class="white-text" style="font-weight: bold;">SEARCH:</label>
+        <%= text_field_tag :q, params[:q], class: "tui-input", style: "padding: 6px 10px; width: 250px;", placeholder: "hackr alias..." %>
+        <%= submit_tag "Find", class: "tui-button green-168", style: "padding: 6px 14px;" %>
+        <% if params[:q].present? %>
+          <%= link_to "Clear", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+        <% end %>
+      <% end %>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+        <table class="tui-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Alias</th>
+              <th style="text-align: left;">Role</th>
+              <th style="text-align: center;">CLR</th>
+              <th style="text-align: center;">XP</th>
+              <th style="text-align: center;">HP</th>
+              <th style="text-align: left;">Location</th>
+              <th style="text-align: center;">Online</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @hackrs.each do |hackr| %>
+              <tr>
+                <td class="cyan-255-text"><%= hackr.hackr_alias %></td>
+                <td style="color: #888;"><%= hackr.role %></td>
+                <td style="text-align: center;" class="cyan-255-text"><%= hackr.stat("clearance") %></td>
+                <td style="text-align: center; color: #888;"><%= hackr.stat("xp") %></td>
+                <td style="text-align: center;">
+                  <span style="color: <%= hackr.stat("health") > 50 ? '#34d399' : '#f87171' %>;"><%= hackr.stat("health") %></span>
+                </td>
+                <td style="color: #888; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                  <%= hackr.current_room&.name || "—" %>
+                </td>
+                <td style="text-align: center;">
+                  <% if hackr.last_activity_at && hackr.last_activity_at > 15.minutes.ago %>
+                    <span class="green-255-text">ON</span>
+                  <% else %>
+                    <span style="color: #444;">—</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Inspect", admin_grid_hackr_path(hackr), class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Items", admin_grid_hackr_items_path(hackr), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <p style="color: #666; margin-top: 15px;"><%= @hackrs.size %> hackr<%= @hackrs.size == 1 ? "" : "s" %> found</p>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_hackrs/show.html.erb
+++ b/app/views/admin/grid_hackrs/show.html.erb
@@ -1,0 +1,315 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackrs/<%= @hackr.hackr_alias %> :: HACKR INSPECTOR</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%# === ACTION BAR === %>
+      <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px;">
+        <%= link_to "<- All Hackrs", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= link_to "Items", admin_grid_hackr_items_path(@hackr), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+        <% if dev_tools_enabled? %>
+          <%= link_to "Edit Stats", edit_stats_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
+          <%= link_to "Warp", warp_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
+        <% end %>
+      </div>
+
+      <%# === SECTION NAV === %>
+      <div style="display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 25px; padding: 8px; border: 1px solid #333; background: #0a0a0a;">
+        <a href="#identity" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">IDENTITY</a>
+        <a href="#vitals" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">VITALS</a>
+        <a href="#location" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">LOCATION</a>
+        <a href="#economy" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">ECONOMY</a>
+        <a href="#breach" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">BREACH</a>
+        <a href="#loadout" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">LOADOUT</a>
+        <a href="#inventory" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">INVENTORY</a>
+        <a href="#mining" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">MINING</a>
+        <a href="#reputation" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">REPUTATION</a>
+        <a href="#missions" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">MISSIONS</a>
+        <a href="#features" class="cyan-168-text" style="text-decoration: none; font-size: 0.85em;">FEATURES</a>
+      </div>
+
+      <%# === IDENTITY === %>
+      <div id="identity" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: IDENTITY ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
+            <div><span style="color: #888;">ID:</span> <span class="white-text"><%= @hackr.id %></span></div>
+            <div><span style="color: #888;">Alias:</span> <span class="cyan-255-text" style="font-weight: bold;"><%= @hackr.hackr_alias %></span></div>
+            <div><span style="color: #888;">Email:</span> <span class="white-text"><%= @hackr.email || "—" %></span></div>
+            <div><span style="color: #888;">Role:</span> <span style="color: <%= @hackr.admin? ? '#fbbf24' : '#888' %>;"><%= @hackr.role.upcase %></span></div>
+            <div><span style="color: #888;">Clearance:</span> <span class="cyan-255-text" style="font-weight: bold;"><%= @stats["clearance"] %></span></div>
+            <div><span style="color: #888;">XP:</span> <span class="white-text"><%= @stats["xp"] %></span></div>
+            <div><span style="color: #888;">Registered:</span> <span style="color: #888;"><%= @hackr.created_at.strftime("%Y-%m-%d") %></span></div>
+            <div><span style="color: #888;">Last Active:</span> <span style="color: #888;"><%= @hackr.last_activity_at&.strftime("%Y-%m-%d %H:%M") || "never" %></span></div>
+            <div><span style="color: #888;">2FA:</span> <span style="color: <%= @hackr.otp_required_for_login? ? '#34d399' : '#666' %>;"><%= @hackr.otp_required_for_login? ? "ENABLED" : "off" %></span></div>
+            <div><span style="color: #888;">Login:</span> <span style="color: <%= @hackr.login_disabled? ? '#f87171' : '#34d399' %>;"><%= @hackr.login_disabled? ? "DISABLED" : "enabled" %></span></div>
+          </div>
+        </div>
+      </div>
+
+      <%# === VITALS === %>
+      <div id="vitals" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: VITALS ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px;">
+            <% %w[health energy psyche].each do |vital| %>
+              <% val = @stats[vital].to_i %>
+              <% max = @hackr.effective_max(vital) %>
+              <% pct = max > 0 ? (val.to_f / max * 100).round : 0 %>
+              <% color = vital == "health" ? "#f87171" : vital == "energy" ? "#fbbf24" : "#a78bfa" %>
+              <div>
+                <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
+                  <span style="color: <%= color %>; font-weight: bold;"><%= vital.upcase %></span>
+                  <span class="white-text"><%= val %> / <%= max %></span>
+                </div>
+                <div style="background: #1a1a1a; height: 12px; border: 1px solid #333;">
+                  <div style="background: <%= color %>; height: 100%; width: <%= pct %>%;"></div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px; margin-top: 15px;">
+            <div><span style="color: #888;">Inspiration:</span> <span class="white-text"><%= @stats["inspiration"] %></span></div>
+            <div><span style="color: #888;">Bonus Inv Slots:</span> <span class="white-text"><%= @stats["bonus_inventory_slots"] %></span></div>
+          </div>
+        </div>
+      </div>
+
+      <%# === LOCATION === %>
+      <div id="location" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: LOCATION ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <% room = @hackr.current_room %>
+          <% if room %>
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
+              <div><span style="color: #888;">Room:</span> <span class="white-text"><%= room.name %></span></div>
+              <div><span style="color: #888;">Zone:</span> <span class="white-text"><%= room.grid_zone&.name || "—" %></span></div>
+              <div><span style="color: #888;">Region:</span> <span class="white-text"><%= room.grid_zone&.grid_region&.name || "—" %></span></div>
+              <div><span style="color: #888;">Room Type:</span> <span style="color: #888;"><%= room.room_type || "—" %></span></div>
+            </div>
+          <% else %>
+            <p style="color: #666;">Not in any room (nil current_room_id)</p>
+          <% end %>
+          <% if @hackr.stat("captured") %>
+            <div style="margin-top: 10px; padding: 8px; border: 2px solid #f87171; background: #330000;">
+              <span class="red-255-text" style="font-weight: bold;">CAPTURED</span>
+              <span style="color: #888;"> | Alert Level: </span>
+              <span class="yellow-255-text"><%= @hackr.stat("facility_alert_level") %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === ECONOMY === %>
+      <div id="economy" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: ECONOMY ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <% if @cache %>
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px;">
+              <div><span style="color: #888;">CRED Balance:</span> <span class="green-255-text" style="font-weight: bold;"><%= @cred_balance %></span></div>
+              <div><span style="color: #888;">Cache Address:</span> <span style="color: #888; font-family: monospace; font-size: 0.85em;"><%= @cache.address %></span></div>
+              <div><span style="color: #888;">Cache Status:</span> <span class="white-text"><%= @cache.status %></span></div>
+            </div>
+          <% else %>
+            <p style="color: #666;">No economy cache provisioned</p>
+          <% end %>
+          <% debt = @hackr.stat("govcorp_debt").to_i %>
+          <% if debt > 0 %>
+            <div style="margin-top: 10px; padding: 8px; border: 2px solid #f87171; background: #330000;">
+              <span class="red-255-text" style="font-weight: bold;">GovCorp DEBT:</span>
+              <span class="red-255-text"><%= debt %> CRED</span>
+              <span style="color: #888;"> (50% garnishment active)</span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === BREACH === %>
+      <div id="breach" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: ACTIVE BREACH ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <% if @active_breach %>
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px;">
+              <div><span style="color: #888;">Template:</span> <span class="cyan-255-text"><%= @active_breach.grid_breach_template&.name || "—" %></span></div>
+              <div><span style="color: #888;">State:</span> <span class="yellow-255-text"><%= @active_breach.state %></span></div>
+              <div><span style="color: #888;">Round:</span> <span class="white-text"><%= @active_breach.round_number %></span></div>
+              <div><span style="color: #888;">Detection:</span> <span style="color: <%= @active_breach.detection_level > 70 ? '#f87171' : '#fbbf24' %>;"><%= @active_breach.detection_level %>/100</span></div>
+              <div><span style="color: #888;">Actions Left:</span> <span class="white-text"><%= @active_breach.actions_remaining %></span></div>
+              <div><span style="color: #888;">Started:</span> <span style="color: #888;"><%= @active_breach.created_at.strftime("%Y-%m-%d %H:%M") %></span></div>
+            </div>
+            <% if @active_breach.grid_breach_protocols.any? %>
+              <div style="margin-top: 10px;">
+                <span style="color: #888;">Protocols:</span>
+                <% @active_breach.grid_breach_protocols.each do |proto| %>
+                  <span style="color: <%= proto.state == 'destroyed' ? '#666' : '#60a5fa' %>; margin-left: 8px;"><%= proto.protocol_type.upcase %> (<%= proto.health %>hp, <%= proto.state %>)</span>
+                <% end %>
+              </div>
+            <% end %>
+          <% else %>
+            <p style="color: #666;">No active breach</p>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === LOADOUT === %>
+      <div id="loadout" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: LOADOUT ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px;">
+            <% GridHackr::Loadout::GEAR_SLOT_LABELS.each do |slot, label| %>
+              <% item = @loadout[slot] %>
+              <div style="padding: 6px 10px; border: 1px solid <%= item ? '#333' : '#1a1a1a' %>; background: <%= item ? '#111' : '#0a0a0a' %>;">
+                <span style="color: #666; font-size: 0.8em;"><%= label %></span>
+                <% if item %>
+                  <br><span style="color: <%= item.rarity_color %>; font-size: 0.9em;"><%= item.name %></span>
+                <% else %>
+                  <br><span style="color: #333;">EMPTY</span>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <%# === INVENTORY === %>
+      <div id="inventory" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: INVENTORY (<%= @inventory.size %> / <%= @hackr.inventory_capacity %>) ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <% if @inventory.any? %>
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Name</th>
+                  <th style="text-align: left;">Type</th>
+                  <th style="text-align: left;">Rarity</th>
+                  <th style="text-align: center;">Qty</th>
+                  <th style="text-align: center;">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @inventory.each do |item| %>
+                  <tr>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.name %></td>
+                    <td style="color: #888;"><%= item.item_type %></td>
+                    <td style="color: <%= item.rarity_color %>;"><%= item.rarity_label %></td>
+                    <td style="text-align: center;"><%= item.quantity %></td>
+                    <td style="text-align: center; color: #888;"><%= item.value %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <p style="color: #666; padding: 15px;">Inventory empty</p>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === MINING RIG === %>
+      <div id="mining" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: MINING RIG ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <% if @mining_rig %>
+            <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px;">
+              <div><span style="color: #888;">Status:</span> <span style="color: <%= @mining_rig.active? ? '#34d399' : '#f87171' %>;"><%= @mining_rig.active? ? "ACTIVE" : "INACTIVE" %></span></div>
+              <div><span style="color: #888;">Effective Rate:</span> <span class="green-255-text"><%= @mining_rig.effective_rate %></span></div>
+            </div>
+            <% if @mining_rig.grid_items.any? %>
+              <div style="margin-top: 10px;">
+                <span style="color: #888;">Components:</span>
+                <% @mining_rig.grid_items.each do |comp| %>
+                  <span style="color: <%= comp.rarity_color %>; margin-left: 8px;"><%= comp.name %></span>
+                <% end %>
+              </div>
+            <% end %>
+          <% else %>
+            <p style="color: #666;">No mining rig provisioned</p>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === REPUTATION === %>
+      <div id="reputation" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: FACTION REPUTATION ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <% if @reputations.any? %>
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Faction</th>
+                  <th style="text-align: center;">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @reputations.each do |rep| %>
+                  <tr>
+                    <td><%= rep.subject&.respond_to?(:display_name) ? rep.subject.display_name : rep.subject&.name || "—" %></td>
+                    <td style="text-align: center;">
+                      <span style="color: <%= rep.value > 0 ? '#34d399' : rep.value < 0 ? '#f87171' : '#888' %>;"><%= rep.value %></span>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <p style="color: #666; padding: 15px;">No faction reputation records</p>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === MISSIONS === %>
+      <div id="missions" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: ACTIVE MISSIONS (<%= @active_missions.size %>) ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <% if @active_missions.any? %>
+            <table class="tui-table" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th style="text-align: left;">Mission</th>
+                  <th style="text-align: left;">Arc</th>
+                  <th style="text-align: left;">Accepted</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @active_missions.each do |hm| %>
+                  <tr>
+                    <td class="cyan-255-text"><%= hm.grid_mission.name %></td>
+                    <td style="color: #888;"><%= hm.grid_mission.grid_mission_arc&.name || "—" %></td>
+                    <td style="color: #888;"><%= hm.accepted_at&.strftime("%Y-%m-%d %H:%M") %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <p style="color: #666; padding: 15px;">No active missions</p>
+          <% end %>
+        </div>
+      </div>
+
+      <%# === FEATURE GRANTS === %>
+      <div id="features" style="margin-bottom: 30px;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: FEATURE GRANTS ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px;">
+          <% if @feature_grants.any? %>
+            <% @feature_grants.each do |grant| %>
+              <span style="display: inline-block; padding: 4px 10px; margin: 3px; border: 1px solid #333; color: #fbbf24;"><%= grant.feature %></span>
+            <% end %>
+          <% else %>
+            <p style="color: #666;">No feature grants (admin role has all features)</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_hackrs/warp.html.erb
+++ b/app/views/admin/grid_hackrs/warp.html.erb
@@ -1,0 +1,101 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/hackrs/<%= @hackr.hackr_alias %>/warp :: ADMIN WARP</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 25px;">
+        <span class="yellow-255-text" style="font-weight: bold;">DEV TOOL</span>
+        <span style="color: #ccc;"> — Bypasses clearance gates, locks, and zone restrictions. Clears containment if captured.</span>
+      </div>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%# Current location %>
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px; margin-bottom: 20px;">
+        <span style="color: #888;">Current Location:</span>
+        <% if @hackr.current_room %>
+          <span class="cyan-255-text"><%= @hackr.current_room.name %></span>
+          <span style="color: #888;"> (<%= @hackr.current_room.grid_zone&.name %>, <%= @hackr.current_room.grid_zone&.grid_region&.name %>)</span>
+        <% else %>
+          <span style="color: #666;">Nowhere (nil)</span>
+        <% end %>
+        <% if @hackr.in_breach? %>
+          <br>
+          <span class="red-255-text" style="font-weight: bold;">WARNING: Active BREACH in progress. Warp is blocked.</span>
+        <% end %>
+        <% if @hackr.stat("captured") %>
+          <br>
+          <span class="yellow-255-text">Captured — warp will clear containment state.</span>
+        <% end %>
+      </div>
+
+      <%# Warp form %>
+      <%= form_with url: perform_warp_admin_grid_hackr_path(@hackr), method: :post, local: true, id: "warp-form" do %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+          <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">DESTINATION ROOM</label>
+
+          <input type="hidden" name="room_id" id="warp-room-id" value="">
+
+          <div class="admin-combobox">
+            <input type="text" id="warp-input" class="admin-combobox-input" autocomplete="off"
+              placeholder="Type to search... (region, zone, or room name)">
+            <div id="warp-dropdown" class="admin-combobox-dropdown"></div>
+          </div>
+
+          <p style="color: #666; margin-top: 6px; font-size: 0.85em;" id="warp-status">
+            <%= @rooms.size %> rooms — start typing to filter
+          </p>
+        </div>
+
+        <div style="margin-top: 20px;">
+          <%= submit_tag "WARP", class: "tui-button yellow-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Warp #{@hackr.hackr_alias} to selected room?" } %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    function ready(fn) {
+      if (document.readyState !== 'loading') fn();
+      else document.addEventListener('DOMContentLoaded', fn);
+    }
+    ready(function() {
+      AdminCombobox.init({
+        inputId: 'warp-input',
+        hiddenId: 'warp-room-id',
+        dropdownId: 'warp-dropdown',
+        statusId: 'warp-status',
+        formId: 'warp-form',
+        items: <%= raw json_escape(@rooms.map { |r|
+          {
+            id: r.id,
+            name: r.name,
+            type: r.room_type || "default",
+            zone: r.grid_zone.name,
+            region: r.grid_zone.grid_region&.name || "Unknown"
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) { return (r.region + ' ' + r.zone + ' ' + r.name + ' ' + r.type).toLowerCase(); },
+        getGroupKey: function(r) { return r.region + ' > ' + r.zone; },
+        renderOption: function(r, esc) { return '<span class="cb-name">' + esc(r.name) + '</span> <span class="cb-meta">(' + esc(r.type) + ')</span>'; },
+        getLabel: function(r) { return r.region + ' > ' + r.zone + ' > ' + r.name; },
+        emptyText: 'No rooms match',
+        selectedText: 'Selected — ready to warp',
+        submitError: 'Select a destination room first'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/shared/_combobox.html.erb
+++ b/app/views/admin/shared/_combobox.html.erb
@@ -1,0 +1,228 @@
+<style>
+  .admin-combobox {
+    position: relative;
+  }
+  .admin-combobox-input {
+    width: 100%;
+    padding: 8px;
+    font-family: "Terminus", monospace;
+    font-size: inherit;
+    background: #0a0a0a;
+    border: 1px solid #333;
+    color: #fbbf24;
+  }
+  .admin-combobox-input:focus {
+    outline: none;
+    border-color: #fbbf24;
+  }
+  .admin-combobox-input.selected {
+    color: #34d399;
+    border-color: #34d399;
+  }
+  .admin-combobox-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    max-height: 350px;
+    overflow-y: auto;
+    background: #111;
+    border: 1px solid #333;
+    border-top: none;
+    font-family: "Terminus", monospace;
+  }
+  .admin-combobox-dropdown.open {
+    display: block;
+    border-color: #fbbf24;
+  }
+  .admin-combobox-group {
+    padding: 4px 12px;
+    color: #888;
+    font-size: 0.75em;
+    background: #0a0a0a;
+    border-top: 1px solid #1a1a1a;
+    position: sticky;
+    top: 0;
+  }
+  .admin-combobox-option {
+    padding: 5px 12px 5px 20px;
+    cursor: pointer;
+    color: #ccc;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .admin-combobox-option:hover,
+  .admin-combobox-option.active {
+    background: #1a1a1a;
+  }
+  .admin-combobox-option .cb-name {
+    color: #fbbf24;
+  }
+  .admin-combobox-option .cb-meta {
+    color: #555;
+    font-size: 0.85em;
+  }
+  .admin-combobox-empty {
+    padding: 8px 12px;
+    color: #555;
+    font-style: italic;
+  }
+</style>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  window.AdminCombobox = (function() {
+    function esc(s) {
+      var d = document.createElement('span');
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    function init(cfg) {
+      var input = document.getElementById(cfg.inputId);
+      var hidden = document.getElementById(cfg.hiddenId);
+      var dropdown = document.getElementById(cfg.dropdownId);
+      var statusEl = document.getElementById(cfg.statusId);
+      var form = cfg.formId ? document.getElementById(cfg.formId) : null;
+      var items = cfg.items;
+      var activeIdx = -1;
+      var filtered = [];
+
+      function doFilter(q) {
+        if (!q) return items;
+        var words = q.toLowerCase().split(/\s+/);
+        return items.filter(function(r) {
+          var hay = cfg.getSearchText(r);
+          for (var i = 0; i < words.length; i++) {
+            if (words[i] && hay.indexOf(words[i]) === -1) return false;
+          }
+          return true;
+        });
+      }
+
+      function showDropdown() {
+        dropdown.innerHTML = '';
+        activeIdx = -1;
+
+        if (filtered.length === 0) {
+          dropdown.innerHTML = '<div class="admin-combobox-empty">' + esc(cfg.emptyText || 'No matches') + '</div>';
+          dropdown.classList.add('open');
+          statusEl.textContent = '0 matches';
+          return;
+        }
+
+        var lastGroup = '';
+        for (var i = 0; i < filtered.length; i++) {
+          var r = filtered[i];
+          var group = cfg.getGroupKey(r);
+
+          if (group !== lastGroup) {
+            lastGroup = group;
+            var hdr = document.createElement('div');
+            hdr.className = 'admin-combobox-group';
+            hdr.textContent = group;
+            dropdown.appendChild(hdr);
+          }
+
+          var row = document.createElement('div');
+          row.className = 'admin-combobox-option';
+          row.setAttribute('data-idx', String(i));
+          row.innerHTML = cfg.renderOption(r, esc);
+          dropdown.appendChild(row);
+        }
+
+        dropdown.classList.add('open');
+        statusEl.textContent = filtered.length + ' match' + (filtered.length === 1 ? '' : 'es');
+        statusEl.style.color = '#666';
+      }
+
+      function hideDropdown() {
+        dropdown.classList.remove('open');
+        activeIdx = -1;
+      }
+
+      function highlightIdx(idx) {
+        var opts = dropdown.querySelectorAll('.admin-combobox-option');
+        for (var j = 0; j < opts.length; j++) { opts[j].classList.remove('active'); }
+        activeIdx = idx;
+        if (idx >= 0 && idx < opts.length) {
+          opts[idx].classList.add('active');
+          opts[idx].scrollIntoView({block: 'nearest'});
+        }
+      }
+
+      function pickItem(idx) {
+        if (idx < 0 || idx >= filtered.length) return;
+        var r = filtered[idx];
+        hidden.value = cfg.getId(r);
+        input.value = cfg.getLabel(r);
+        input.classList.add('selected');
+        hideDropdown();
+        statusEl.textContent = cfg.selectedText || 'Selected';
+        statusEl.style.color = '#34d399';
+      }
+
+      dropdown.addEventListener('mouseover', function(e) {
+        var opt = e.target.closest('.admin-combobox-option');
+        if (opt) highlightIdx(parseInt(opt.getAttribute('data-idx'), 10));
+      });
+
+      dropdown.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        var opt = e.target.closest('.admin-combobox-option');
+        if (opt) pickItem(parseInt(opt.getAttribute('data-idx'), 10));
+      });
+
+      input.addEventListener('input', function() {
+        hidden.value = '';
+        input.classList.remove('selected');
+        filtered = doFilter(this.value.trim());
+        showDropdown();
+      });
+
+      input.addEventListener('focus', function() {
+        if (!dropdown.classList.contains('open')) {
+          filtered = doFilter(this.value.trim());
+          showDropdown();
+        }
+      });
+
+      input.addEventListener('keydown', function(e) {
+        if (!dropdown.classList.contains('open')) return;
+
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          highlightIdx(activeIdx + 1 >= filtered.length ? 0 : activeIdx + 1);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          highlightIdx(activeIdx - 1 < 0 ? filtered.length - 1 : activeIdx - 1);
+        } else if (e.key === 'Tab' || e.key === 'Enter') {
+          if (activeIdx >= 0) { e.preventDefault(); pickItem(activeIdx); }
+          else if (filtered.length === 1) { e.preventDefault(); pickItem(0); }
+        } else if (e.key === 'Escape') {
+          hideDropdown();
+        }
+      });
+
+      document.addEventListener('click', function(e) {
+        if (e.target !== input && !dropdown.contains(e.target)) hideDropdown();
+      });
+
+      if (form) {
+        form.addEventListener('submit', function(e) {
+          if (!hidden.value) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            statusEl.textContent = cfg.submitError || 'Select an option first';
+            statusEl.style.color = '#f87171';
+            input.focus();
+          }
+        });
+      }
+    }
+
+    return { init: init, esc: esc };
+  })();
+</script>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -101,6 +101,11 @@
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
         </div>
       </div>
+      <% if dev_tools_enabled? %>
+        <%= link_to "Hackrs", admin_grid_hackrs_path, class: "yellow-168-text", style: "text-decoration: none;", title: "DEV TOOLS ON" %>
+      <% else %>
+        <%= link_to "Hackrs", admin_grid_hackrs_path, class: "green-168-text", style: "text-decoration: none;" %>
+      <% end %>
       <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text", style: "text-decoration: none;" %>
       <span style="color: #333;">|</span>
       <%= link_to "← Exit", root_path, class: "red-168-text", style: "text-decoration: none;" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -344,6 +344,20 @@ Rails.application.routes.draw do
     # Grid economy (read-only admin dashboard)
     get "grid_economy", to: "grid_economy#index", as: :grid_economy
 
+    # Hackr inspector + dev tools (per-hackr)
+    resources :grid_hackrs, only: %i[index show] do
+      member do
+        get :edit_stats
+        patch :update_stats
+        get :warp
+        post :perform_warp
+      end
+    end
+    # Hackr item management (prod-safe)
+    get "grid_hackrs/:hackr_id/items", to: "grid_hackr_items#index", as: :grid_hackr_items
+    post "grid_hackrs/:hackr_id/items/grant", to: "grid_hackr_items#grant", as: :grant_grid_hackr_item
+    delete "grid_hackrs/:hackr_id/items/:id", to: "grid_hackr_items#remove", as: :remove_grid_hackr_item
+
     # Grid achievements (runtime CRUD + manual award)
     resources :grid_achievements do
       member do


### PR DESCRIPTION
  Also: Item Management/Granting

  Add per-hackr admin tooling suite for inspecting game state and manual testing of THE PULSE GRID systems.

  Feature flag: ADMIN_DEV_TOOLS env var (defaults to false) gates dev-only tools via Admin::DevToolsGate concern.
  Prod-safe tools (inspector, item grant/remove) are always available to admins.

  Hackr Inspector — god-view of any hackr: identity, vitals (with bars), location, CRED balance + debt/garnishment
  status, active breach state + protocols, equipped loadout (13 slots), inventory, mining rig, faction reputation,
  active missions, feature grants. Searchable index with online/offline indicators.

  Stat Editor (DEV-ONLY) — named fields for all game stats (health, energy, psyche, clearance, XP, inspiration, debt,
  alert level, captured) plus raw JSON mode. XP/clearance sync: detects which field changed, keeps them consistent.
  Captured unchecked clears containment state. Batched single update_column write.

  Admin Warp (DEV-ONLY) — teleport any hackr to any room. Blocks if active BREACH. Clears containment state if
  captured. Batched stat write for containment clearing.

  Item Management (PROD-SAFE) — grant items from definition catalog to any hackr via Grid::Inventory.grant_item!.
  Remove items with equipped + rig-component guards. Rescues InventoryFull and StackLimitExceeded.

  Shared admin combobox widget (_combobox.html.erb) with TUI-styled type-ahead dropdown, keyboard nav
  (arrows/Tab/Enter/Escape), grouped results, json_escape for script-safe data embedding.

  New "Hackrs" nav link (yellow when dev tools active).