### PR TITLE
 [TPG] Admin Tooling Phase B1: BREACH Sandbox, Puzzle Rework

### DIFF
--- a/app/controllers/admin/grid_breach_sandbox_controller.rb
+++ b/app/controllers/admin/grid_breach_sandbox_controller.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Admin::GridBreachSandboxController < Admin::ApplicationController
+  before_action :require_dev_tools
+  before_action :set_hackr, only: %i[new create]
+  before_action :set_breach, only: %i[show command abort]
+
+  # GET /root/grid_breach_sandbox/new?hackr_id=N
+  def new
+    load_templates
+  end
+
+  # POST /root/grid_breach_sandbox
+  def create
+    template = GridBreachTemplate.find_by(id: params[:template_id])
+    unless template
+      flash.now[:error] = "Template not found."
+      load_templates
+      return render :new, status: :unprocessable_entity
+    end
+
+    result = Grid::BreachService.start_sandbox!(hackr: @hackr, template: template)
+    redirect_to admin_grid_breach_sandbox_path(result.hackr_breach)
+  rescue Grid::BreachService::AlreadyInBreach => e
+    flash.now[:error] = e.message
+    load_templates
+    render :new, status: :unprocessable_entity
+  rescue Grid::BreachService::NoDeckEquipped, Grid::BreachService::DeckFried => e
+    flash.now[:error] = "#{@hackr.hackr_alias}: #{e.message}"
+    load_templates
+    render :new, status: :unprocessable_entity
+  end
+
+  # GET /root/grid_breach_sandbox/:id
+  def show
+    @hackr = @breach.grid_hackr
+    @initial_display = Grid::BreachRenderer.new(@breach).render_full
+  end
+
+  # POST /root/grid_breach_sandbox/:id/command
+  def command
+    @hackr = @breach.grid_hackr
+
+    unless @breach.active?
+      return render json: {output: sandbox_ended_message, breach_active: false}
+    end
+
+    input = params[:input].to_s.strip
+    if input.empty?
+      return render json: {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", breach_active: true}
+    end
+
+    result = Grid::BreachCommandParser.new(@hackr, input, @breach).execute
+    output = result.is_a?(Hash) ? result[:output] : result
+
+    @breach.reload
+    render json: {output: output, breach_active: @breach.active?}
+  end
+
+  # DELETE /root/grid_breach_sandbox/:id
+  def abort
+    @hackr = @breach.grid_hackr
+
+    if @breach.active?
+      Grid::BreachService.jackout!(hackr: @hackr)
+    end
+
+    set_flash_success("Sandbox breach aborted for #{@hackr.hackr_alias}.")
+    redirect_to admin_grid_hackr_path(@hackr)
+  end
+
+  private
+
+  def set_hackr
+    @hackr = GridHackr.find(params[:hackr_id])
+  end
+
+  def set_breach
+    @breach = GridHackrBreach.find(params[:id])
+    unless @breach.sandbox?
+      set_flash_error("Not a sandbox breach.")
+      redirect_to admin_grid_hackrs_path
+    end
+  end
+
+  def load_templates
+    @templates = GridBreachTemplate.order(:tier, :min_clearance, :name)
+  end
+
+  def sandbox_ended_message
+    "<span style='color: #9ca3af;'>Sandbox breach has ended. Return to the hackr inspector.</span>"
+  end
+end

--- a/app/models/grid_hackr_breach.rb
+++ b/app/models/grid_hackr_breach.rb
@@ -63,6 +63,10 @@ class GridHackrBreach < ApplicationRecord
     state == "active"
   end
 
+  def sandbox?
+    meta&.dig("sandbox") == true
+  end
+
   def pnr_crossed?
     detection_level >= pnr_threshold
   end

--- a/app/models/grid_hackr_breach_log.rb
+++ b/app/models/grid_hackr_breach_log.rb
@@ -24,7 +24,7 @@
 #  grid_hackr_breach_id  (grid_hackr_breach_id => grid_hackr_breaches.id) ON DELETE => cascade
 #
 class GridHackrBreachLog < ApplicationRecord
-  ACTION_TYPES = %w[exec analyze reroute jackout use system interface].freeze
+  ACTION_TYPES = %w[exec analyze reroute jackout use system interface probe].freeze
 
   belongs_to :grid_hackr_breach
 

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -8,6 +8,7 @@ module Grid
     RerouteResult = Data.define(:target_position, :protocol_type_label)
     UseItemResult = Data.define(:item_name, :effect_output, :emergency_jackout)
     InterfaceResult = Data.define(:gate_id, :correct, :gate_state, :attempts_remaining, :all_solved, :feedback)
+    CircuitProbeResult = Data.define(:gate_id, :probe_pair, :connected, :probes_remaining, :feedback)
 
     class NotInBreach < StandardError; end
     class NoActionsRemaining < StandardError; end
@@ -21,6 +22,9 @@ module Grid
     class GateLocked < StandardError; end
     class GateAlreadySolved < StandardError; end
     class GateFailed < StandardError; end
+    class NoProbesRemaining < StandardError; end
+
+    WRONG_ANSWER_DETECTION_BUMP = 5
 
     def self.exec!(hackr:, program_name:, target_position:)
       new(hackr).exec!(program_name, target_position)
@@ -40,6 +44,10 @@ module Grid
 
     def self.interface!(hackr:, gate_id:, answer:)
       new(hackr).interface!(gate_id, answer)
+    end
+
+    def self.circuit_probe!(hackr:, gate_id:, probe_pair:)
+      new(hackr).circuit_probe!(gate_id, probe_pair)
     end
 
     include Grid::ItemEffectApplier
@@ -417,9 +425,14 @@ module Grid
         gate_state = gate["state"]
         attempts_remaining = gate["attempts_remaining"].to_i
 
+        # Wrong answers raise the alarm — detection bump per failed attempt
+        detection_bump = correct ? 0 : WRONG_ANSWER_DETECTION_BUMP
+        new_detection = [breach.detection_level + detection_bump, 100].min
+
         breach.update!(
           meta: breach.meta.merge("puzzle_state" => puzzle_state),
-          actions_remaining: breach.actions_remaining - 1
+          actions_remaining: breach.actions_remaining - 1,
+          detection_level: new_detection
         )
 
         all_solved = breach.all_circumvention_gates_solved?
@@ -439,6 +452,94 @@ module Grid
         attempts_remaining: attempts_remaining,
         all_solved: all_solved,
         feedback: feedback
+      )
+    end
+
+    # Test a single circuit connection without consuming an action.
+    # Costs 1 probe from the gate's budget. Re-probing a cached pair is free.
+    def circuit_probe!(gate_id, probe_pair)
+      gate_id = gate_id.to_s.upcase
+
+      breach = @hackr.active_breach
+      raise NotInBreach, "You are not in a BREACH encounter." unless breach
+
+      puzzle_state = breach.meta&.dig("puzzle_state")
+      raise GateNotFound, "No circumvention gates in this encounter." unless puzzle_state&.dig("gates")&.any?
+
+      gate = puzzle_state["gates"][gate_id]
+      raise GateNotFound, "No gate [#{gate_id}]." unless gate
+      validate_gate_state!(gate_id, gate)
+
+      raise InvalidTarget, "Probes are only available for circuit gates." unless gate["type"] == "circuit"
+
+      # Normalize pair: upcase, sort halves canonically
+      parts = probe_pair.to_s.strip.upcase.split("-")
+      raise InvalidTarget, "Invalid probe format. Use: interface #{gate_id} probe NODE1-NODE2" unless parts.size == 2
+
+      # Validate both nodes exist in the circuit
+      display = gate["display"] || {}
+      valid_nodes = ((display["left_nodes"] || []) + (display["right_nodes"] || [])).map(&:upcase)
+      parts.each do |node|
+        raise InvalidTarget, "Unknown node '#{node}'. Check the circuit layout with 'status'." unless valid_nodes.include?(node)
+      end
+
+      normalized = parts.sort.join("-")
+
+      # Return cached result for already-probed pairs (no budget cost)
+      probe_results = gate["probe_results"] || {}
+      if probe_results.key?(normalized)
+        prev = probe_results[normalized]
+        label = prev ? "CONNECTED \u2713" : "NO SIGNAL \u2717"
+        return CircuitProbeResult.new(
+          gate_id: gate_id, probe_pair: normalized, connected: prev,
+          probes_remaining: gate["probes_remaining"].to_i,
+          feedback: "Already probed: #{label}"
+        )
+      end
+
+      raise NoProbesRemaining, "No probes remaining for gate [#{gate_id}]. Submit your answer." if gate["probes_remaining"].to_i <= 0
+
+      connected = false
+
+      ActiveRecord::Base.transaction do
+        breach.lock!
+
+        # Re-read state after lock — another request may have probed the same pair
+        puzzle_state = breach.meta["puzzle_state"]
+        gate = puzzle_state["gates"][gate_id]
+
+        # Re-check cache and budget after lock
+        if gate["probe_results"]&.key?(normalized)
+          prev = gate["probe_results"][normalized]
+          label = prev ? "CONNECTED \u2713" : "NO SIGNAL \u2717"
+          return CircuitProbeResult.new(
+            gate_id: gate_id, probe_pair: normalized, connected: prev,
+            probes_remaining: gate["probes_remaining"].to_i,
+            feedback: "Already probed: #{label}"
+          )
+        end
+        raise NoProbesRemaining, "No probes remaining for gate [#{gate_id}]. Submit your answer." if gate["probes_remaining"].to_i <= 0
+
+        solution_pairs = gate["solution"].split
+        connected = solution_pairs.include?(normalized)
+
+        gate["probe_results"] ||= {}
+        gate["probe_results"][normalized] = connected
+        gate["probes_remaining"] = gate["probes_remaining"].to_i - 1
+
+        breach.update!(meta: breach.meta.merge("puzzle_state" => puzzle_state))
+
+        log_action!(breach, "probe", gate_id, nil, {
+          gate_id: gate_id, probe_pair: normalized,
+          connected: connected, probes_remaining: gate["probes_remaining"]
+        })
+      end
+
+      label = connected ? "CONNECTED \u2713 \u2014 signal path confirmed" : "NO SIGNAL \u2717 \u2014 path rejected"
+      CircuitProbeResult.new(
+        gate_id: gate_id, probe_pair: normalized, connected: connected,
+        probes_remaining: gate["probes_remaining"],
+        feedback: label
       )
     end
 

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -82,16 +82,18 @@ module Grid
         output << "<span style='color: #a78bfa;'>  ▸ Fragment extracted: #{h(result.fragment)} (pending — granted on success)</span>"
       end
 
-      # Achievement/mission hooks
+      # Achievement/mission hooks (suppressed in sandbox mode)
       notifications = []
-      if result.protocol_destroyed
-        notifications += achievement_checker.check(:protocols_dismantled)
-        notifications += mission_progressor.record(:dismantle_protocols, protocol_type: breach.grid_breach_protocols.find_by(position: target_position)&.protocol_type)
-      end
+      unless breach.sandbox?
+        if result.protocol_destroyed
+          notifications += achievement_checker.check(:protocols_dismantled)
+          notifications += mission_progressor.record(:dismantle_protocols, protocol_type: breach.grid_breach_protocols.find_by(position: target_position)&.protocol_type)
+        end
 
-      if result.fragment
-        notifications += achievement_checker.check(:data_extracted)
-        notifications += mission_progressor.record(:extract_data, fragment_slug: result.fragment)
+        if result.fragment
+          notifications += achievement_checker.check(:data_extracted)
+          notifications += mission_progressor.record(:extract_data, fragment_slug: result.fragment)
+        end
       end
 
       if result.all_destroyed
@@ -99,17 +101,19 @@ module Grid
         resolve_result = Grid::BreachService.resolve_success!(hackr_breach: breach)
         output << resolve_result.display
 
-        template = breach.grid_breach_template
-        notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
-        notifications += achievement_checker.check(:breaches_completed_count)
-        notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
+        unless breach.sandbox?
+          template = breach.grid_breach_template
+          notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
+          notifications += achievement_checker.check(:breaches_completed_count)
+          notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
 
-        if resolve_result.xp_result[:leveled_up]
-          output << "<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE UP → #{resolve_result.xp_result[:new_clearance]}</span>"
+          if resolve_result.xp_result[:leveled_up]
+            output << "<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE UP → #{resolve_result.xp_result[:new_clearance]}</span>"
+          end
+
+          # Facility BREACH hooks (captured mode)
+          output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
         end
-
-        # Facility BREACH hooks (captured mode)
-        output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
       else
         # Check if round should end
         breach.reload
@@ -198,10 +202,12 @@ module Grid
       output = []
       output << result.effect_output
 
-      # Achievement/mission hooks for item usage
+      # Achievement/mission hooks for item usage (suppressed in sandbox mode)
       notifications = []
-      notifications += achievement_checker.check(:use_item, item_name: result.item_name)
-      notifications += mission_progressor.record(:use_item, item_name: result.item_name)
+      unless breach.sandbox?
+        notifications += achievement_checker.check(:use_item, item_name: result.item_name)
+        notifications += mission_progressor.record(:use_item, item_name: result.item_name)
+      end
 
       if result.emergency_jackout
         # Trigger clean jackout (bypasses PNR via emergency override)
@@ -228,6 +234,12 @@ module Grid
       end
 
       gate_id = args[0].upcase
+
+      # Circuit probe — free signal test, doesn't consume an action
+      if args[1]&.downcase == "probe"
+        return circuit_probe_command(gate_id, args[2..].join(" "))
+      end
+
       answer = args[1..].join(" ")
 
       result = Grid::BreachActionService.interface!(
@@ -241,9 +253,10 @@ module Grid
         output << "<span style='color: #34d399; font-weight: bold;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
       elsif result.gate_state == "failed"
         output << "<span style='color: #f87171; font-weight: bold;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
+        output << "<span style='color: #f59e0b;'>  DETECTION +#{Grid::BreachActionService::WRONG_ANSWER_DETECTION_BUMP}%</span>"
       else
         output << "<span style='color: #f87171;'>Gate [#{result.gate_id}]: #{h(result.feedback)}</span>"
-        output << "<span style='color: #9ca3af;'>  Review the gate with 'status'.</span>"
+        output << "<span style='color: #f59e0b;'>  DETECTION +#{Grid::BreachActionService::WRONG_ANSWER_DETECTION_BUMP}%</span>"
       end
 
       notifications = []
@@ -253,17 +266,19 @@ module Grid
         resolve_result = Grid::BreachService.resolve_success!(hackr_breach: breach)
         output << resolve_result.display
 
-        template = breach.grid_breach_template
-        notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
-        notifications += achievement_checker.check(:breaches_completed_count)
-        notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
+        unless breach.sandbox?
+          template = breach.grid_breach_template
+          notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
+          notifications += achievement_checker.check(:breaches_completed_count)
+          notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
 
-        if resolve_result.xp_result[:leveled_up]
-          output << "<span style='color: #fbbf24; font-weight: bold;'>\u25b2 CLEARANCE UP \u2192 #{resolve_result.xp_result[:new_clearance]}</span>"
+          if resolve_result.xp_result[:leveled_up]
+            output << "<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE UP → #{resolve_result.xp_result[:new_clearance]}</span>"
+          end
+
+          # Facility BREACH hooks (captured mode)
+          output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
         end
-
-        # Facility BREACH hooks (captured mode)
-        output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
       else
         # Check if round should end
         breach.reload
@@ -341,6 +356,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>jackout</span>                      <span style='color: #9ca3af;'>Abort the encounter</span>"
       output << ""
       output << "<span style='color: #6b7280;'>Free commands (no action cost):</span>"
+      output << "<span style='color: #fbbf24;'>if &lt;gate&gt; probe &lt;N1&gt;-&lt;N2&gt;</span>    <span style='color: #9ca3af;'>Test a circuit connection (limited budget)</span>"
       output << "<span style='color: #fbbf24;'>status</span>                       <span style='color: #9ca3af;'>Show encounter state</span>"
       output << "<span style='color: #fbbf24;'>deck</span>                         <span style='color: #9ca3af;'>Show loaded software + battery</span>"
       output << "<span style='color: #fbbf24;'>help</span>                         <span style='color: #9ca3af;'>This reference</span>"
@@ -386,6 +402,32 @@ module Grid
       else
         nil # Regular voluntary target — alert reduction already handled above
       end
+    end
+
+    def circuit_probe_command(gate_id, probe_pair)
+      if probe_pair.empty?
+        return "<span style='color: #fbbf24;'>Usage: interface #{h(gate_id)} probe NODE1-NODE2</span>"
+      end
+
+      result = Grid::BreachActionService.circuit_probe!(
+        hackr: hackr,
+        gate_id: gate_id,
+        probe_pair: probe_pair
+      )
+
+      color = result.connected ? "#34d399" : "#f87171"
+      output = []
+      output << "<span style='color: #{color}; font-weight: bold;'>PROBE [#{h(result.gate_id)}] #{h(result.probe_pair)}: #{result.feedback}</span>"
+      output << "<span style='color: #6b7280;'>Probes remaining: #{result.probes_remaining}</span>"
+      output.join("\n")
+    rescue Grid::BreachActionService::NotInBreach,
+      Grid::BreachActionService::GateNotFound,
+      Grid::BreachActionService::GateLocked,
+      Grid::BreachActionService::GateAlreadySolved,
+      Grid::BreachActionService::GateFailed,
+      Grid::BreachActionService::InvalidTarget,
+      Grid::BreachActionService::NoProbesRemaining => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 
     def maybe_end_round

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -127,15 +127,43 @@ module Grid
       "<span style='color: #f87171; font-weight: bold;'>\u26a0 SYSTEM ALERT: Intrusion signature locked. Jack-out route compromised.</span>"
     end
 
+    def render_sandbox_end(end_state, failure_mode: nil)
+      color = (end_state == "success") ? "#34d399" : "#f87171"
+      label = case end_state
+      when "success" then "S A N D B O X   C O M P L E T E"
+      when "failure" then "S A N D B O X   F A I L E D"
+      when "jacked_out" then "S A N D B O X   J A C K - O U T"
+      end
+      cause = case end_state
+      when "success" then "All protocols neutralized."
+      when "failure"
+        (failure_mode == :health_zero) ? "Neural link severed \u2014 vitals critical." : "Detection reached 100%."
+      when "jacked_out" then "Disconnected from encounter."
+      end
+
+      lines = []
+      lines << ""
+      lines << "<span style='color: #{color}; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
+      lines << "<span style='color: #{color}; font-weight: bold;'>\u2551  #{label}#{" " * [62 - label.length - 4, 0].max}\u2551</span>"
+      lines << "<span style='color: #{color}; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
+      lines << "<span style='color: #{color};'>\u2551</span>  <span style='color: #d0d0d0;'>#{cause}</span>"
+      lines << "<span style='color: #{color};'>\u2551</span>"
+      lines << "<span style='color: #{color};'>\u2551</span>  <span style='color: #fbbf24;'>SANDBOX MODE \u2014 no consequences applied.</span>"
+      lines << "<span style='color: #{color};'>\u2551</span>  <span style='color: #9ca3af;'>Vitals and DECK battery restored to pre-breach state.</span>"
+      lines << "<span style='color: #{color}; font-weight: bold;'>\u255a#{SEPARATOR}\u255d</span>"
+      lines.join("\n")
+    end
+
     private
 
     def header_block
       template = @breach.grid_breach_template
       tier_label = template.tier_label
       alive_count = @protocols.count(&:alive?)
+      sandbox_tag = @breach.sandbox? ? "  <span style='color: #fbbf24; font-weight: bold;'>[SANDBOX]</span>" : ""
       [
         "<span style='color: #{BORDER_COLOR};'>\u2554#{SEPARATOR}\u2557</span>",
-        "<span style='color: #{BORDER_COLOR};'>\u2551</span>  <span style='color: #22d3ee; font-weight: bold;'>B R E A C H</span>  <span style='color: #6b7280;'>::</span>  <span style='color: #d0d0d0;'>#{h(template.name)}</span>",
+        "<span style='color: #{BORDER_COLOR};'>\u2551</span>  <span style='color: #22d3ee; font-weight: bold;'>B R E A C H</span>  <span style='color: #6b7280;'>::</span>  <span style='color: #d0d0d0;'>#{h(template.name)}</span>#{sandbox_tag}",
         "<span style='color: #{BORDER_COLOR};'>\u2551</span>  <span style='color: #fbbf24;'>Tier:</span> <span style='color: #d0d0d0;'>#{tier_label}</span>    <span style='color: #fbbf24;'>Protocols:</span> <span style='color: #f87171;'>#{alive_count} active</span>",
         "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       ].join("\n")
@@ -245,6 +273,11 @@ module Grid
         end
 
         lines << "#{border}  <span style='color: #9ca3af;'>[#{gate_id}]</span> <span style='color: #d0d0d0;'>#{h(type_label)}</span>  <span style='color: #{state_color};'>#{icon} #{h(status_text)}</span>"
+
+        # Render puzzle display data for active gates (locked gates just show status)
+        if state == "active" && gate["display"]
+          lines.concat(render_gate_display(gate_id, gate))
+        end
       end
       lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       lines.join("\n")
@@ -258,6 +291,58 @@ module Grid
         "#{border}  <span style='color: #fbbf24;'>BREACH RANK:</span> <span style='color: #22d3ee;'>#{h(rank_label)}</span>",
         "<span style='color: #{BORDER_COLOR};'>\u255a#{SEPARATOR}\u255d</span>"
       ].join("\n")
+    end
+
+    def render_gate_display(gate_id, gate)
+      d = gate["display"]
+      return [] unless d
+      lines = []
+      lines << "#{border}    <span style='color: #6b7280;'>#{h(d["prompt"])}</span>" if d["prompt"]
+
+      case d["type"]
+      when "credential"
+        ciphers = d["ciphers"] || [d["encrypted"]].compact
+        if ciphers.size == 1
+          lines << "#{border}    <span style='color: #fbbf24;'>Encrypted:</span> <span style='color: #e0e0e0; font-weight: bold;'>#{h(ciphers[0])}</span>"
+        else
+          ciphers.each_with_index do |c, i|
+            lines << "#{border}    <span style='color: #fbbf24;'>Cipher #{i + 1}:</span>  <span style='color: #e0e0e0; font-weight: bold;'>#{h(c)}</span>"
+          end
+        end
+        hints = d["substitution_hints"] || (d["cipher_hint"].present? ? [d["cipher_hint"]] : [])
+        if hints.any?
+          lines << "#{border}    <span style='color: #fbbf24;'>Known substitutions:</span> #{hints.map { |s| "<span style='color: #34d399;'>#{h(s)}</span>" }.join("  ")}"
+        end
+      when "sequence"
+        nodes = d["nodes"]
+        lines << "#{border}    <span style='color: #fbbf24;'>Nodes:</span> #{nodes.map { |n| "<span style='color: #e0e0e0;'>#{h(n)}</span>" }.join("  ")}" if nodes
+      when "logic_gate"
+        lines << "#{border}    <span style='color: #e0e0e0;'>#{h(d["diagram"])}</span>" if d["diagram"]
+      when "circuit"
+        left = d["left_nodes"]
+        right = d["right_nodes"]
+        if left && right
+          lines << "#{border}    <span style='color: #fbbf24;'>Left:</span>  #{left.map { |n| "<span style='color: #e0e0e0;'>#{h(n)}</span>" }.join("  ")}"
+          lines << "#{border}    <span style='color: #fbbf24;'>Right:</span> #{right.map { |n| "<span style='color: #e0e0e0;'>#{h(n)}</span>" }.join("  ")}"
+        end
+        probes_remaining = gate["probes_remaining"].to_i
+        probe_results = gate["probe_results"] || {}
+        lines << "#{border}    <span style='color: #fbbf24;'>Probes:</span> <span style='color: #d0d0d0;'>#{probes_remaining} remaining</span>"
+        probe_results.each do |pair, connected|
+          color = connected ? "#34d399" : "#f87171"
+          icon = connected ? "\u2713 CONNECTED" : "\u2717 NO SIGNAL"
+          lines << "#{border}      <span style='color: #{color};'>#{icon}: #{h(pair)}</span>"
+        end
+      end
+
+      # Type-specific usage hints
+      if d["type"] == "circuit"
+        lines << "#{border}    <span style='color: #6b7280;'>Probe: interface #{gate_id} probe NODE1-NODE2</span>"
+        lines << "#{border}    <span style='color: #6b7280;'>Solve: interface #{gate_id} NODE1-NODE2 NODE3-NODE4 ...</span>"
+      else
+        lines << "#{border}    <span style='color: #6b7280;'>Use: interface #{gate_id} &lt;answer&gt;</span>"
+      end
+      lines
     end
 
     def bar(current, max, color, width: 16)

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -46,6 +46,10 @@ module Grid
       new(hackr).start_ambient!(template)
     end
 
+    def self.start_sandbox!(hackr:, template:)
+      new(hackr).start_sandbox!(template)
+    end
+
     def self.end_round!(hackr_breach:)
       new(hackr_breach.grid_hackr).end_round!(hackr_breach)
     end
@@ -249,6 +253,60 @@ module Grid
       raise AlreadyInBreach, "You are already in a BREACH encounter."
     end
 
+    # Start a sandbox (dry-run) breach. Bypasses all gates (clearance, mission,
+    # item prerequisites). No encounter record. Requires DECK equipped + not fried.
+    # Snapshots hackr vitals + DECK battery; restored on breach end.
+    def start_sandbox!(template)
+      raise AlreadyInBreach, "You are already in a BREACH encounter." if @hackr.in_breach?
+
+      deck = @hackr.equipped_deck
+      raise NoDeckEquipped, "No DECK equipped. Equip a DECK before initiating a BREACH." unless deck
+      raise DeckFried, "DECK is fried (level #{deck.deck_fried_level}/5). Repair it before initiating a BREACH." if deck.deck_fried?
+
+      breach = nil
+      protocols = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        raise AlreadyInBreach, "You are already in a BREACH encounter." if @hackr.in_breach?
+
+        breach = GridHackrBreach.create!(
+          grid_hackr: @hackr,
+          grid_breach_template: template,
+          grid_breach_encounter: nil,
+          origin_room_id: @hackr.current_room_id,
+          state: "active",
+          detection_level: 0,
+          pnr_threshold: template.pnr_threshold,
+          round_number: 1,
+          inspiration: 0,
+          actions_this_round: 1,
+          actions_remaining: 1,
+          reward_multiplier: 1.0,
+          started_at: Time.current,
+          meta: {
+            "sandbox" => true,
+            "sandbox_snapshot" => {
+              "deck_id" => deck.id,
+              "deck_battery" => deck.deck_battery,
+              "health" => @hackr.stat("health"),
+              "energy" => @hackr.stat("energy"),
+              "psyche" => @hackr.stat("psyche"),
+              "inspiration" => @hackr.stat("inspiration")
+            }
+          }
+        )
+
+        protocols = generate_protocols!(breach, template)
+        generate_puzzle_gates!(breach, template)
+      end
+
+      display = Grid::BreachRenderer.new(breach, protocols).render_full
+      StartResult.new(hackr_breach: breach, protocols: protocols, display: display)
+    rescue ActiveRecord::RecordNotUnique
+      raise AlreadyInBreach, "You are already in a BREACH encounter."
+    end
+
     def end_round!(hackr_breach)
       protocol_messages = []
       failure_display = nil
@@ -324,7 +382,8 @@ module Grid
       end
 
       # RestorePoint™ admission happens outside the breach transaction
-      if state == :health_zero
+      # Sandbox breaches skip RestorePoint — vitals are restored by restore_sandbox_state!
+      if state == :health_zero && !hackr_breach.sandbox?
         restore_result = Grid::RestorePointService.admit!(@hackr)
         restore_point_display = restore_result.display
       end
@@ -346,6 +405,8 @@ module Grid
     end
 
     def resolve_success!(hackr_breach)
+      return resolve_sandbox_end!(hackr_breach, "success") if hackr_breach.sandbox?
+
       template = hackr_breach.grid_breach_template
       xp_awarded = template.xp_reward
       cred_awarded = (template.cred_reward * hackr_breach.reward_multiplier).floor
@@ -401,6 +462,8 @@ module Grid
       unless hackr_breach.state == "active"
         return FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, fried_level: nil, software_wiped: false, captured: false, display: "")
       end
+
+      return resolve_sandbox_end!(hackr_breach, "failure", failure_mode: failure_mode) if hackr_breach.sandbox?
 
       template = hackr_breach.grid_breach_template
       vitals_hit = []
@@ -520,6 +583,8 @@ module Grid
       hackr_breach = @hackr.active_breach
       raise NotInBreach, "You are not in a BREACH encounter." unless hackr_breach
 
+      return resolve_sandbox_end!(hackr_breach, "jacked_out") if hackr_breach.sandbox?
+
       clean = emergency || !hackr_breach.pnr_crossed?
       vitals_hit = []
 
@@ -555,6 +620,54 @@ module Grid
     end
 
     private
+
+    # End a sandbox breach: mark terminal state, restore hackr snapshot.
+    # Works inside or outside an existing transaction (resolve_failure! is
+    # called from end_round!'s transaction; resolve_success!/jackout! are not).
+    def resolve_sandbox_end!(hackr_breach, end_state, failure_mode: nil)
+      wrap = !ActiveRecord::Base.connection.transaction_open?
+      run = proc do
+        hackr_breach.lock! if wrap
+        @hackr.lock! if wrap
+        hackr_breach.update!(state: end_state, ended_at: Time.current)
+        restore_sandbox_state!(hackr_breach)
+      end
+
+      if wrap
+        ActiveRecord::Base.transaction(&run)
+      else
+        run.call
+      end
+
+      display = Grid::BreachRenderer.new(hackr_breach).render_sandbox_end(end_state, failure_mode: failure_mode)
+
+      case end_state
+      when "success"
+        ResolveResult.new(hackr_breach: hackr_breach, xp_awarded: 0, cred_awarded: 0, xp_result: {leveled_up: false}, display: display)
+      when "failure"
+        FailureResult.new(hackr_breach: hackr_breach, vitals_hit: [], zone_lockout_minutes: nil, fried_level: nil, software_wiped: false, captured: false, display: display)
+      when "jacked_out"
+        JackoutResult.new(hackr_breach: hackr_breach, clean: true, vitals_hit: [], display: display)
+      end
+    end
+
+    # Restore hackr vitals and DECK battery from the sandbox snapshot.
+    def restore_sandbox_state!(hackr_breach)
+      snapshot = hackr_breach.meta&.dig("sandbox_snapshot")
+      return unless snapshot
+
+      new_stats = (@hackr.stats || {}).merge(
+        "health" => snapshot["health"],
+        "energy" => snapshot["energy"],
+        "psyche" => snapshot["psyche"],
+        "inspiration" => snapshot["inspiration"]
+      )
+      @hackr.update_column(:stats, new_stats)
+      @hackr.stats = new_stats
+
+      deck = GridItem.find_by(id: snapshot["deck_id"])
+      deck&.update!(properties: deck.properties.merge("battery_current" => snapshot["deck_battery"]))
+    end
 
     def generate_protocols!(breach, template)
       composition = template.protocols
@@ -633,7 +746,7 @@ module Grid
           "active"
         end
 
-        gates[spec["id"]] = {
+        gate_data = {
           "type" => spec["type"],
           "state" => initial_state,
           "attempts_remaining" => is_bypassed ? 0 : attempts,
@@ -642,6 +755,14 @@ module Grid
           "solution" => is_bypassed ? nil : generated[:solution],
           "display" => generated[:display_data]
         }
+
+        # Circuit gates get a probe budget for interactive signal testing
+        if spec["type"] == "circuit" && !is_bypassed
+          gate_data["probes_remaining"] = generated[:display_data]["probe_budget"]
+          gate_data["probe_results"] = {}
+        end
+
+        gates[spec["id"]] = gate_data
       end
 
       puzzle_state = {

--- a/app/services/grid/puzzle_generator_service.rb
+++ b/app/services/grid/puzzle_generator_service.rb
@@ -104,7 +104,9 @@ module Grid
         }
       end
 
-      # Circuit: connect node pairs to restore signal paths
+      # Circuit: connect node pairs to restore signal paths.
+      # Players get a limited probe budget to test individual connections
+      # before submitting the full answer.
       # Difficulty 1=2 pairs, 2=3, 3=4, 4=5, 5=6
       def generate_circuit(difficulty, rng)
         pair_count = 1 + difficulty
@@ -119,48 +121,111 @@ module Grid
         display_left = left.shuffle(random: rng)
         display_right = right.shuffle(random: rng)
 
+        # Probe budget: enough to solve with strategy, not enough to brute-force
+        probe_budget = case difficulty
+        when 1 then 1   # 2 pairs — probe 1, deduce other
+        when 2 then 2   # 3 pairs — probe 2, deduce other
+        when 3 then 3   # 4 pairs — probe 3, deduce other
+        when 4 then 3   # 5 pairs — must reason about 2 remaining
+        else 4           # 6 pairs — must reason about 2 remaining
+        end
+
         {
           display_data: {
             "type" => "circuit",
-            "prompt" => "Connect open circuit nodes to restore signal path.",
+            "prompt" => "Probe signal paths to map circuit connections.",
             "left_nodes" => display_left,
             "right_nodes" => display_right,
-            "pair_count" => pair_count
+            "pair_count" => pair_count,
+            "probe_budget" => probe_budget
           },
           solution: pairs.join(" ")
         }
       end
 
-      # Credential: decrypt an encrypted string using a partial cipher hint
-      # Difficulty 1=1 substitution, 2=2, 3=3, 4=4, 5=5
+      # Credential: decrypt an encrypted string using a partial substitution map.
+      #
+      # Four difficulty axes:
+      #   1. Substitution count — how many chars are replaced (1-5)
+      #   2. Hints revealed — fraction of real substitutions shown, no positions (all → few)
+      #   3. Red herrings — fake substitution hints mixed in (0-3)
+      #   4. Decoy ciphers — 1 cipher at easy, 3 at hard (only one is real)
+      #
+      # | Diff | Subs | Hints | Herrings | Ciphers |
+      # |------|------|-------|----------|---------|
+      # |  1   |  1   |  1/1  |    0     |    1    |
+      # |  2   |  2   |  1/2  |    1     |    1    |
+      # |  3   |  3   |  2/3  |    1     |    3    |
+      # |  4   |  4   |  2/4  |    2     |    3    |
+      # |  5   |  5   |  2/5  |    3     |    3    |
       def generate_credential(difficulty, rng)
         word = CREDENTIAL_WORDS[rng.rand(CREDENTIAL_WORDS.size)]
         suffix = CREDENTIAL_SUFFIXES[rng.rand(CREDENTIAL_SUFFIXES.size)]
         plaintext = word + suffix
 
-        encrypted = plaintext.dup
-        hint_parts = []
+        # 1. Apply substitutions
+        sub_count = difficulty.clamp(1, 5)
+        encrypted, applied_subs = encrypt_credential(plaintext, sub_count, rng)
 
-        # Apply substitutions at random positions (shift ensures no duplicates)
-        eligible = plaintext.chars.each_with_index.select { |ch, _| SUBSTITUTION_MAP.key?(ch) }
-        eligible.shuffle!(random: rng)
+        # 2. Partial hints (no positions) — reveal only some real substitutions
+        hints_shown = (difficulty <= 1) ? applied_subs.size : [2, applied_subs.size].min
+        real_hints = applied_subs.first(hints_shown).map { |s| "#{s[:to]}\u2192#{s[:from]}" }
 
-        [difficulty, eligible.size].min.times do
-          char, pos = eligible.shift
-          sub = SUBSTITUTION_MAP[char]
-          encrypted[pos] = sub
-          hint_parts << "pos #{pos + 1}: #{sub}\u2192#{char}"
+        # 3. Red herring substitutions (mappings not used in this encryption)
+        herring_count = case difficulty
+        when 1 then 0
+        when 2 then 1
+        when 3 then 1
+        when 4 then 2
+        else 3
+        end
+        used_chars = applied_subs.map { |s| s[:from] }
+        herring_hints = SUBSTITUTION_MAP.except(*used_chars).to_a
+          .sample(herring_count, random: rng)
+          .map { |from, to| "#{to}\u2192#{from}" }
+
+        all_hints = (real_hints + herring_hints).shuffle(random: rng)
+
+        # 4. Decoy ciphers (difficulty 3+)
+        ciphers = [encrypted]
+        if difficulty >= 3
+          decoy_words = (CREDENTIAL_WORDS - [word]).sample(2, random: rng)
+          decoy_words.each do |dw|
+            ds = CREDENTIAL_SUFFIXES[rng.rand(CREDENTIAL_SUFFIXES.size)]
+            decoy_enc, _ = encrypt_credential(dw + ds, sub_count, rng)
+            ciphers << decoy_enc
+          end
+          ciphers.shuffle!(random: rng)
         end
 
         {
           display_data: {
             "type" => "credential",
             "prompt" => "Decrypt the access credential.",
-            "encrypted" => encrypted,
-            "cipher_hint" => hint_parts.join(", ")
+            "ciphers" => ciphers,
+            "substitution_hints" => all_hints
           },
           solution: plaintext
         }
+      end
+
+      # Apply N random substitutions to a plaintext string.
+      # Returns [encrypted_string, applied_substitutions_array].
+      def encrypt_credential(plaintext, count, rng)
+        encrypted = plaintext.dup
+        applied = []
+
+        eligible = plaintext.chars.each_with_index.select { |ch, _| SUBSTITUTION_MAP.key?(ch) }
+        eligible.shuffle!(random: rng)
+
+        [count, eligible.size].min.times do
+          char, pos = eligible.shift
+          sub = SUBSTITUTION_MAP[char]
+          encrypted[pos] = sub
+          applied << {from: char, to: sub}
+        end
+
+        [encrypted, applied]
       end
     end
 

--- a/app/views/admin/grid_breach_sandbox/new.html.erb
+++ b/app/views/admin/grid_breach_sandbox/new.html.erb
@@ -1,0 +1,124 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/breach-sandbox :: BREACH SANDBOX</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 25px;">
+        <span class="yellow-255-text" style="font-weight: bold;">DEV TOOL</span>
+        <span style="color: #ccc;"> — Dry-run BREACH encounter. Bypasses all gates. No consequences on end (vitals + DECK battery restored). Exploits/consumables used during breach are NOT reverted.</span>
+      </div>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= link_to "All Hackrs", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%# Hackr info %>
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px; margin-bottom: 20px;">
+        <span style="color: #888;">Hackr:</span>
+        <span class="cyan-255-text" style="font-weight: bold;"><%= @hackr.hackr_alias %></span>
+        <span style="color: #888;"> (CL <%= @hackr.stat("clearance") %>)</span>
+        <% deck = @hackr.equipped_deck %>
+        <br>
+        <span style="color: #888;">DECK:</span>
+        <% if deck %>
+          <% if deck.deck_fried? %>
+            <span class="red-255-text"><%= deck.name %> [FRIED lvl <%= deck.deck_fried_level %>]</span>
+          <% else %>
+            <span class="green-255-text"><%= deck.name %></span>
+            <span style="color: #888;"> (battery: <%= deck.deck_battery %>/<%= deck.deck_battery_max %>, slots: <%= deck.deck_slots_used %>/<%= deck.deck_slot_count %>)</span>
+          <% end %>
+        <% else %>
+          <span class="red-255-text">None equipped</span>
+        <% end %>
+        <% if @hackr.in_breach? %>
+          <br>
+          <span class="red-255-text" style="font-weight: bold;">WARNING: Active BREACH in progress. Cannot start sandbox.</span>
+        <% end %>
+      </div>
+
+      <%# Template selector %>
+      <%= form_with url: admin_grid_breach_sandbox_index_path(hackr_id: @hackr.id), method: :post, local: true, id: "sandbox-form" do %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+          <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">BREACH TEMPLATE</label>
+
+          <input type="hidden" name="template_id" id="sandbox-template-id" value="">
+
+          <div class="admin-combobox">
+            <input type="text" id="sandbox-input" class="admin-combobox-input" autocomplete="off"
+              placeholder="Type to search... (name, tier, or slug)">
+            <div id="sandbox-dropdown" class="admin-combobox-dropdown"></div>
+          </div>
+
+          <p style="color: #666; margin-top: 6px; font-size: 0.85em;" id="sandbox-status">
+            <%= @templates.size %> templates — start typing to filter
+          </p>
+        </div>
+
+        <div style="margin-top: 20px;">
+          <%= submit_tag "START SANDBOX", class: "tui-button yellow-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Start sandbox BREACH on #{@hackr.hackr_alias}?" } %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    function ready(fn) {
+      if (document.readyState !== 'loading') fn();
+      else document.addEventListener('DOMContentLoaded', fn);
+    }
+    ready(function() {
+      var tierColors = {
+        ambient: '#6b7280',
+        standard: '#34d399',
+        advanced: '#fbbf24',
+        elite: '#f87171',
+        world_event: '#a78bfa'
+      };
+      AdminCombobox.init({
+        inputId: 'sandbox-input',
+        hiddenId: 'sandbox-template-id',
+        dropdownId: 'sandbox-dropdown',
+        statusId: 'sandbox-status',
+        formId: 'sandbox-form',
+        items: <%= raw json_escape(@templates.map { |t|
+          {
+            id: t.id,
+            name: t.name,
+            slug: t.slug,
+            tier: t.tier,
+            min_cl: t.min_clearance,
+            published: t.published?,
+            protocols: t.protocols.sum { |p| (p["count"] || 1).to_i },
+            gates: t.puzzle_gate_definitions.size
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) { return (r.name + ' ' + r.slug + ' ' + r.tier).toLowerCase(); },
+        getGroupKey: function(r) { return r.tier.toUpperCase(); },
+        renderOption: function(r, esc) {
+          var color = tierColors[r.tier] || '#9ca3af';
+          var pub = r.published ? '' : ' <span style="color: #f87171;">[DRAFT]</span>';
+          var info = 'CL' + r.min_cl + ' | ' + r.protocols + 'P';
+          if (r.gates > 0) info += ' ' + r.gates + 'G';
+          return '<span class="cb-name">' + esc(r.name) + '</span>' + pub +
+            ' <span class="cb-meta" style="color:' + color + ';">(' + info + ')</span>';
+        },
+        getLabel: function(r) { return r.tier.toUpperCase() + ' > ' + r.name + ' (CL' + r.min_cl + ')'; },
+        emptyText: 'No templates match',
+        selectedText: 'Selected — ready to start sandbox',
+        submitError: 'Select a breach template first'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/grid_breach_sandbox/show.html.erb
+++ b/app/views/admin/grid_breach_sandbox/show.html.erb
@@ -1,0 +1,186 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/breach-sandbox/<%= @breach.id %> :: SANDBOX TERMINAL</legend>
+
+    <div style="padding: 20px;">
+      <%# Banner %>
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 20px;">
+        <span class="yellow-255-text" style="font-weight: bold;">SANDBOX</span>
+        <span style="color: #ccc;"> — </span>
+        <span class="cyan-255-text"><%= @hackr.hackr_alias %></span>
+        <span style="color: #ccc;"> vs </span>
+        <span class="cyan-255-text"><%= @breach.grid_breach_template.name %></span>
+        <span style="color: #888;"> (<%= @breach.grid_breach_template.tier.upcase %>)</span>
+      </div>
+
+      <%# Nav %>
+      <div style="display: flex; gap: 10px; margin-bottom: 20px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= button_to "ABORT", abort_admin_grid_breach_sandbox_path(@breach), method: :delete, class: "tui-button red-168", style: "padding: 6px 14px; font-weight: bold;", data: { confirm: "Abort sandbox breach?" }, form: { id: "abort-form" } %>
+      </div>
+
+      <%# Terminal output — styled to match frontend GameOutput.tsx %>
+      <div id="breach-output" style="font-family: monospace; font-size: 0.75em; line-height: 1.2; white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word; height: 700px; min-height: 700px; max-height: 700px; overflow-y: auto; overflow-x: hidden; padding: 10px; background: #0d0d0d; color: #d0d0d0; border: 1px solid #4b5563; border-radius: 3px; margin-bottom: 8px;">
+<div><%= raw @initial_display %></div>
+      </div>
+
+      <%# Command input — styled to match frontend CommandInput.tsx %>
+      <div id="command-section">
+        <div style="display: flex; gap: 8px; margin-bottom: 6px;">
+          <input type="text" id="command-input" autocomplete="off" autofocus
+            placeholder="Enter command (type 'help' for commands)"
+            style="flex: 1; background: #262626; color: #e0e0e0; border: 1px solid #4b5563; padding: 6px 10px; font-family: monospace; font-size: 0.9em; border-radius: 3px;">
+          <button id="send-btn" style="background: #7c3aed; color: white; border: none; padding: 6px 16px; font-size: 0.85em; cursor: pointer; border-radius: 3px; font-weight: bold; flex-shrink: 0;">EXECUTE</button>
+        </div>
+        <div style="font-size: 0.75em; color: #9ca3af; line-height: 1.3;">
+          Commands: exec, analyze, reroute, interface, use, jackout, status, deck, help
+          <span style="margin-left: 10px; color: #666;">|</span>
+          <span style="margin-left: 10px;">&#x2191;/&#x2193; for history</span>
+        </div>
+      </div>
+
+      <%# Ended overlay (hidden by default) %>
+      <div id="breach-ended" style="display: none; margin-top: 15px; background: #1a1a1a; border: 2px solid #fbbf24; padding: 15px; text-align: center;">
+        <span class="yellow-255-text" style="font-weight: bold;">SANDBOX BREACH ENDED</span>
+        <span style="color: #ccc;"> — Vitals and DECK battery restored.</span>
+        <br><br>
+        <%= link_to "Back to Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 8px 16px;" %>
+        <%= link_to "New Sandbox", new_admin_grid_breach_sandbox_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 8px 16px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var commandUrl = '<%= command_admin_grid_breach_sandbox_path(@breach) %>';
+    var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    var outputEl = document.getElementById('breach-output');
+    var inputEl = document.getElementById('command-input');
+    var sendBtn = document.getElementById('send-btn');
+    var commandSection = document.getElementById('command-section');
+    var endedEl = document.getElementById('breach-ended');
+    var abortForm = document.getElementById('abort-form');
+    var sending = false;
+
+    // Command history (mirrors frontend useCommandHistory.ts)
+    var history = [];
+    var historyIndex = -1;
+    var currentDraft = '';
+
+    function addCommand(cmd) {
+      if (!cmd) return;
+      // Dedup consecutive
+      if (history.length > 0 && history[history.length - 1] === cmd) {
+        historyIndex = -1;
+        currentDraft = '';
+        return;
+      }
+      history.push(cmd);
+      if (history.length > 100) history = history.slice(-100);
+      historyIndex = -1;
+      currentDraft = '';
+    }
+
+    function navigateUp() {
+      if (history.length === 0) return;
+      if (historyIndex === -1) {
+        currentDraft = inputEl.value;
+        historyIndex = history.length - 1;
+      } else if (historyIndex > 0) {
+        historyIndex--;
+      }
+      inputEl.value = history[historyIndex];
+    }
+
+    function navigateDown() {
+      if (history.length === 0 || historyIndex === -1) return;
+      historyIndex++;
+      if (historyIndex >= history.length) {
+        historyIndex = -1;
+        inputEl.value = currentDraft;
+      } else {
+        inputEl.value = history[historyIndex];
+      }
+    }
+
+    function appendOutput(html) {
+      var div = document.createElement('div');
+      div.innerHTML = html;
+      outputEl.appendChild(div);
+      outputEl.scrollTop = outputEl.scrollHeight;
+    }
+
+    function endBreach() {
+      commandSection.style.display = 'none';
+      endedEl.style.display = 'block';
+      if (abortForm) abortForm.style.display = 'none';
+    }
+
+    function setDisabled(disabled) {
+      inputEl.disabled = disabled;
+      sendBtn.disabled = disabled;
+      sendBtn.style.opacity = disabled ? '0.5' : '1';
+      sendBtn.style.cursor = disabled ? 'not-allowed' : 'pointer';
+    }
+
+    function sendCommand() {
+      if (sending) return;
+      var input = inputEl.value.trim();
+      if (!input) return;
+
+      sending = true;
+      setDisabled(true);
+      addCommand(input);
+
+      appendOutput('<span style="color: #22d3ee;">&gt; ' + input.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</span>');
+      inputEl.value = '';
+
+      fetch(commandUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ input: input })
+      })
+      .then(function(response) { return response.json(); })
+      .then(function(data) {
+        if (data.output) {
+          appendOutput(data.output);
+        }
+        if (!data.breach_active) {
+          endBreach();
+        } else {
+          setDisabled(false);
+          inputEl.focus();
+        }
+        sending = false;
+      })
+      .catch(function(err) {
+        appendOutput('<span style="color: #f87171;">Error: ' + err.message + '</span>');
+        setDisabled(false);
+        sending = false;
+      });
+    }
+
+    inputEl.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        sendCommand();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        navigateUp();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        navigateDown();
+      }
+    });
+    sendBtn.addEventListener('click', sendCommand);
+
+    // Auto-scroll to bottom on load
+    outputEl.scrollTop = outputEl.scrollHeight;
+    inputEl.focus();
+  })();
+</script>

--- a/app/views/admin/grid_hackrs/show.html.erb
+++ b/app/views/admin/grid_hackrs/show.html.erb
@@ -22,6 +22,7 @@
         <% if dev_tools_enabled? %>
           <%= link_to "Edit Stats", edit_stats_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
           <%= link_to "Warp", warp_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
+          <%= link_to "Sandbox", new_admin_grid_breach_sandbox_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
         <% end %>
       </div>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -137,8 +137,30 @@
         77
       ],
       "note": "Safe: Open3.capture2 with array arguments bypasses the shell. default_branch and path are not shell-interpreted."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "c958789a93a0a6569a9512adbb513bca52c006cd26d0f9c428ac54623b99b0cc",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/grid_breach_sandbox/show.html.erb",
+      "line": 24,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Grid::BreachRenderer.new(GridHackrBreach.find(params[:id])).render_full",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "admin/grid_breach_sandbox/show"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Safe: BreachRenderer output is server-controlled HTML with inline styles. All dynamic text is escaped via ERB::Util.html_escape (the renderer's h() helper). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern used by the frontend terminal via dangerouslySetInnerHTML."
     }
   ],
-  "updated": "2026-03-14 04:30:00 +0000",
+  "updated": "2026-04-27 01:10:00 +0000",
   "brakeman_version": "8.0.4"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,14 @@ Rails.application.routes.draw do
     post "grid_hackrs/:hackr_id/items/grant", to: "grid_hackr_items#grant", as: :grant_grid_hackr_item
     delete "grid_hackrs/:hackr_id/items/:id", to: "grid_hackr_items#remove", as: :remove_grid_hackr_item
 
+    # BREACH sandbox (dev-only)
+    resources :grid_breach_sandbox, only: %i[new create show] do
+      member do
+        post :command
+        delete :abort
+      end
+    end
+
     # Grid achievements (runtime CRUD + manual award)
     resources :grid_achievements do
       member do

--- a/spec/services/grid/breach_phase2e_spec.rb
+++ b/spec/services/grid/breach_phase2e_spec.rb
@@ -275,8 +275,9 @@ RSpec.describe "BREACH Phase 2E: Failure + Puzzles" do
     it "generates a credential puzzle" do
       result = described_class.generate({"type" => "credential", "difficulty" => 3}, rng)
       expect(result[:display_data]["type"]).to eq("credential")
-      expect(result[:display_data]["encrypted"]).to be_a(String)
-      expect(result[:display_data]["cipher_hint"]).to be_a(String)
+      expect(result[:display_data]["ciphers"]).to be_an(Array)
+      expect(result[:display_data]["ciphers"].size).to eq(3)
+      expect(result[:display_data]["substitution_hints"]).to be_an(Array)
       expect(result[:solution]).to be_a(String)
     end
 


### PR DESCRIPTION
  BREACH dry-run sandbox for admin testing. Puzzle gate overhaul: credential difficulty redesign, circuit probe
  mechanic, detection penalty on wrong answers, inline gate display.

  Sandbox (DEV-ONLY gated)
  - Admin::GridBreachSandboxController with new/create/show/command/abort actions
  - BreachService.start_sandbox! bypasses all gates (clearance, mission, item prereqs); requires DECK equipped + not fried
  - Sandbox flag + vitals/battery snapshot in breach.meta["sandbox"]; restored on breach end via restore_sandbox_state!
  - Sandbox guards in resolve_success!, resolve_failure!, jackout!, end_round! (RestorePoint skip) — zero consequences on end
  - Achievement/mission hooks suppressed in exec_command, interface_command, use_command
  - [SANDBOX] indicator in BreachRenderer header; render_sandbox_end display panel
  - Admin breach terminal: frontend-matched styling (GameOutput/CommandInput parity), fetch-based command I/O, command history with up/down arrow navigation
  - IDOR guard: set_breach validates sandbox? flag
  - "Sandbox" button on hackr inspector (dev-tools-gated)

  Puzzle Gate Display
  - render_gate_display renders puzzle content inline for active gates: credential (ciphers + substitution map), sequence (node list), logic gate (diagram), circuit (node lists + probe state + usage hints)
  - Type-specific usage hints (probe vs solve for circuit, generic for others)

  Credential Puzzle Redesign
  - Four difficulty axes: substitution count (1-5), partial hints with no positions (map-only), red herring substitutions (0-3 fake mappings), decoy ciphers (1 or 3 candidates at difficulty 3+)
  - encrypt_credential extracted as reusable helper for real + decoy generation
  - Backward-compatible renderer handles both old (encrypted/cipher_hint) and new (ciphers/substitution_hints) display formats

  Circuit Probe Mechanic
  - BreachActionService.circuit_probe! — free signal test (no action cost), bounded by probe budget
  - Probe budget scales with difficulty: 1/2/3/3/4 probes for 2/3/4/5/6 pairs
  - CircuitProbeResult data type; cached results (re-probe = free); race-condition-safe (re-check after lock)
  - Node validation: rejects probes with unknown node names
  - Probe state (probes_remaining, probe_results) initialized in generate_puzzle_gates!
  - probe added to GridHackrBreachLog::ACTION_TYPES
  - circuit_probe_command in parser; listed in breach help under free commands

  Detection Penalty on Wrong Gate Answers
  - WRONG_ANSWER_DETECTION_BUMP = 5 — wrong interface answers raise detection by 5%
  - Applies to all breaches including PAC facility (unlimited attempts = gate never locks out, but detection still ticks)
  - Inline DETECTION +5% feedback on wrong answers