### PR TITLE
[TPG] Admin Tooling Phase B2: NPC Dialogue Tester

### DIFF
--- a/app/controllers/admin/grid_npc_dialogue_tester_controller.rb
+++ b/app/controllers/admin/grid_npc_dialogue_tester_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+class Admin::GridNpcDialogueTesterController < Admin::ApplicationController
+  before_action :require_dev_tools
+  before_action :preselect_from_params, only: %i[new]
+  before_action :load_session, only: %i[show command finish]
+
+  # GET /root/grid_npc_dialogue_tester/new?hackr_id=N&mob_id=N
+  def new
+    load_combobox_data
+  end
+
+  # POST /root/grid_npc_dialogue_tester
+  def create
+    @hackr = GridHackr.find_by(id: params[:hackr_id])
+    mob = GridMob.find_by(id: params[:mob_id])
+
+    unless @hackr && mob
+      flash.now[:error] = "Hackr and Mob are both required."
+      load_combobox_data
+      return render :new, status: :unprocessable_entity
+    end
+
+    service = Grid::NpcDialogueSessionService.new(@hackr)
+    service.start!(mob: mob)
+
+    session[:npc_tester] = {
+      "hackr_id" => @hackr.id,
+      "mob_id" => mob.id
+    }
+
+    redirect_to admin_grid_npc_dialogue_tester_path
+  rescue Grid::NpcDialogueSessionService::AlreadyInBreach => e
+    flash.now[:error] = e.message
+    load_combobox_data
+    render :new, status: :unprocessable_entity
+  end
+
+  # GET /root/grid_npc_dialogue_tester
+  def show
+    result = Grid::NpcDialogueCommandParser.new(@hackr, "look").execute
+    @initial_output = result.is_a?(Hash) ? result[:output] : result
+  end
+
+  # POST /root/grid_npc_dialogue_tester/command
+  def command
+    input = params[:input].to_s.strip
+    if input.empty?
+      return render json: {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", session_active: true}
+    end
+
+    result = Grid::NpcDialogueCommandParser.new(@hackr, input).execute
+    output = result.is_a?(Hash) ? result[:output] : result
+    event = result.is_a?(Hash) ? result[:event] : nil
+
+    render json: {output: output, session_active: true, event: event}
+  end
+
+  # DELETE /root/grid_npc_dialogue_tester
+  def finish
+    Grid::NpcDialogueSessionService.new(@hackr).restore!
+    session.delete(:npc_tester)
+
+    set_flash_success("NPC Dialogue Test ended. #{@hackr.hackr_alias} returned to original room.")
+    redirect_to admin_grid_hackr_path(@hackr)
+  end
+
+  private
+
+  def preselect_from_params
+    @hackr = GridHackr.find_by(id: params[:hackr_id]) if params[:hackr_id].present?
+    @mob = GridMob.find_by(id: params[:mob_id]) if params[:mob_id].present?
+  end
+
+  def load_session
+    tester = session[:npc_tester]
+    unless tester
+      set_flash_error("No active NPC Dialogue Tester session.")
+      return redirect_to admin_grid_hackrs_path
+    end
+
+    @hackr = GridHackr.find_by(id: tester["hackr_id"])
+    @mob = GridMob.find_by(id: tester["mob_id"])
+
+    unless @hackr && @mob
+      session.delete(:npc_tester)
+      set_flash_error("Session hackr or mob no longer exists.")
+      redirect_to admin_grid_hackrs_path
+    end
+  end
+
+  def load_combobox_data
+    @hackrs = GridHackr.order(:hackr_alias)
+    @mobs = GridMob
+      .joins(grid_room: {grid_zone: :grid_region})
+      .includes(grid_room: {grid_zone: :grid_region})
+      .order("grid_regions.name, grid_zones.name, grid_rooms.name, grid_mobs.name")
+  end
+end

--- a/app/services/grid/npc_dialogue/null_achievement_checker.rb
+++ b/app/services/grid/npc_dialogue/null_achievement_checker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Grid
+  module NpcDialogue
+    # Null-object replacement for Grid::AchievementChecker.
+    # Returns empty arrays so callers see no notifications without branching.
+    class NullAchievementChecker
+      def check(_trigger_type, _context = {})
+        []
+      end
+    end
+  end
+end

--- a/app/services/grid/npc_dialogue/null_mission_progressor.rb
+++ b/app/services/grid/npc_dialogue/null_mission_progressor.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Grid
+  module NpcDialogue
+    # Null-object replacement for Grid::MissionProgressor.
+    # Returns empty arrays so callers see no notifications without branching.
+    class NullMissionProgressor
+      def record(_trigger_type, _context = {})
+        []
+      end
+    end
+  end
+end

--- a/app/services/grid/npc_dialogue_command_parser.rb
+++ b/app/services/grid/npc_dialogue_command_parser.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Grid
+  # Subclass of CommandParser for the admin NPC Dialogue Tester.
+  # Inherits all routing and rendering from CommandParser while suppressing
+  # side effects via two layers:
+  #
+  # 1. Override side-effect helpers to no-op (increment_stat!, grant_faction_rep)
+  #    and replace achievement/mission services with null objects.
+  # 2. Wrap write-heavy commands (buy, sell, give, accept, turn_in) in an
+  #    always-rollback transaction — output is captured before revert.
+  #
+  # Read-only commands (talk, ask, examine, shop, look, etc.) pass through
+  # the inherited implementation unchanged — the null-object overrides
+  # silently discard their notification payloads.
+  class NpcDialogueCommandParser < CommandParser
+    TESTER_BANNER = "[TESTER]"
+
+    # Read-only commands that pass through with null-object side-effect suppression
+    READ_COMMANDS = %w[
+      look l examine ex x talk ask shop browse
+      missions quests mission quest
+      stat stats st rep reputation standing
+      inventory inv i loadout lo deck dk
+      who help ? clear cls cl
+    ].freeze
+
+    # Write commands wrapped in always-rollback transaction
+    WRITE_COMMANDS = %w[
+      buy purchase sell
+      accept acc ac turn_in turnin ti
+      abandon
+      give
+    ].freeze
+
+    ALLOWED_COMMANDS = (READ_COMMANDS + WRITE_COMMANDS).freeze
+
+    # Override execute to bypass breach/captured routing.
+    # The tester operates in normal command mode regardless of hackr state.
+    def execute
+      return {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", event: nil} if input.empty?
+
+      parts = input.split
+      command = parts.first&.downcase
+      args = parts[1..]
+
+      result = dispatch_command(command, args)
+      result.is_a?(Hash) ? result : {output: result, event: nil}
+    end
+
+    def dispatch_command(command, args)
+      unless ALLOWED_COMMANDS.include?(command)
+        return "<span style='color: #f87171;'>#{TESTER_BANNER} Command not available in NPC Dialogue Tester.</span>\n" \
+               "<span style='color: #9ca3af;'>Available: talk, ask, examine, shop, buy, sell, give, accept, turn_in, " \
+               "missions, mission, stat, rep, inventory, loadout, deck, look, who, help</span>"
+      end
+
+      if WRITE_COMMANDS.include?(command)
+        # Wrap write commands in an always-rollback transaction.
+        # Output string is captured before the rollback executes.
+        raw = nil
+        ActiveRecord::Base.transaction do
+          raw = super
+          raise ActiveRecord::Rollback
+        end
+        output = raw.is_a?(Hash) ? raw[:output] : raw
+        rollback_notice = "<span style='color: #fbbf24;'>#{TESTER_BANNER} Write reverted — no persistent changes.</span>"
+        "#{output}\n#{rollback_notice}"
+      else
+        super
+      end
+    end
+
+    # --- Side-effect suppressors ---
+
+    def increment_stat!(_key, _amount = 1)
+      nil
+    end
+
+    def grant_faction_rep(_faction, _delta, reason: nil, source: nil)
+      nil
+    end
+
+    def achievement_checker
+      @achievement_checker ||= Grid::NpcDialogue::NullAchievementChecker.new
+    end
+
+    def mission_progressor
+      @mission_progressor ||= Grid::NpcDialogue::NullMissionProgressor.new
+    end
+  end
+end

--- a/app/services/grid/npc_dialogue_session_service.rb
+++ b/app/services/grid/npc_dialogue_session_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Grid
+  # Manages the admin NPC Dialogue Tester session lifecycle:
+  # snapshot hackr's original room, warp to mob's room, restore on end.
+  #
+  # Mirrors how BreachService stores sandbox snapshots in breach.meta —
+  # here the snapshot lives in hackr.stats["npc_tester_snapshot"] since
+  # there is no breach record involved.
+  class NpcDialogueSessionService
+    SNAPSHOT_KEY = "npc_tester_snapshot"
+
+    class AlreadyInBreach < StandardError; end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Snapshot hackr's current room, then warp them to the mob's room.
+    # If a stale snapshot exists (crashed/abandoned session), restore first.
+    def start!(mob:)
+      # Clean up stale session first so the hackr is in a known state
+      restore! if active?
+
+      raise AlreadyInBreach, "#{@hackr.hackr_alias} is in an active BREACH." if @hackr.in_breach?
+
+      snapshot = {
+        "origin_room_id" => @hackr.current_room_id,
+        "origin_zone_entry_room_id" => @hackr.zone_entry_room_id,
+        "mob_id" => mob.id,
+        "started_at" => Time.current.iso8601
+      }
+
+      new_stats = (@hackr.stats || {}).merge(SNAPSHOT_KEY => snapshot)
+      @hackr.update!(
+        current_room_id: mob.grid_room_id,
+        zone_entry_room_id: mob.grid_room_id,
+        stats: new_stats
+      )
+    end
+
+    # Restore hackr to their original room and clear the snapshot.
+    def restore!
+      snapshot = @hackr.stats&.dig(SNAPSHOT_KEY)
+      return unless snapshot
+
+      origin_room_id = snapshot["origin_room_id"]
+      origin_zone_entry = snapshot["origin_zone_entry_room_id"]
+      new_stats = (@hackr.stats || {}).except(SNAPSHOT_KEY)
+
+      @hackr.update!(
+        current_room_id: origin_room_id,
+        zone_entry_room_id: origin_zone_entry,
+        stats: new_stats
+      )
+    end
+
+    # Is there an active tester snapshot on this hackr?
+    def active?
+      @hackr.stats&.dig(SNAPSHOT_KEY).present?
+    end
+  end
+end

--- a/app/views/admin/grid_hackrs/show.html.erb
+++ b/app/views/admin/grid_hackrs/show.html.erb
@@ -23,6 +23,7 @@
           <%= link_to "Edit Stats", edit_stats_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
           <%= link_to "Warp", warp_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
           <%= link_to "Sandbox", new_admin_grid_breach_sandbox_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
+          <%= link_to "NPC Tester", new_admin_grid_npc_dialogue_tester_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
         <% end %>
       </div>
 

--- a/app/views/admin/grid_mobs/index.html.erb
+++ b/app/views/admin/grid_mobs/index.html.erb
@@ -39,7 +39,10 @@
                   <td><%= mob.grid_room&.name || "—" %></td>
                   <td><%= mob.grid_faction&.name || "—" %></td>
                   <td style="text-align: right; white-space: nowrap;">
-                    <%= link_to "Edit", edit_admin_grid_mob_path(mob), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <% if dev_tools_enabled? %>
+                      <%= link_to "Test", new_admin_grid_npc_dialogue_tester_path(mob_id: mob.id), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <% end %>
+                    <%= link_to "Edit", edit_admin_grid_mob_path(mob), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= link_to "History", history_admin_grid_mob_path(mob), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= button_to "Delete", admin_grid_mob_path(mob), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{mob.name}'?" } %>
                   </td>

--- a/app/views/admin/grid_npc_dialogue_tester/new.html.erb
+++ b/app/views/admin/grid_npc_dialogue_tester/new.html.erb
@@ -1,0 +1,159 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/npc-dialogue-tester :: NPC DIALOGUE TESTER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 25px;">
+        <span class="yellow-255-text" style="font-weight: bold;">DEV TOOL</span>
+        <span style="color: #ccc;"> — Test NPC dialogue as a specific hackr. Side effects suppressed (no rep, stats, achievements, or mission progress). Write commands (buy, sell, accept, etc.) execute but auto-revert. Hackr is warped to mob's room for the session.</span>
+      </div>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <% if @hackr %>
+          <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <% end %>
+        <%= link_to "All Hackrs", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= link_to "All Mobs", admin_grid_mobs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%= form_with url: admin_grid_npc_dialogue_tester_path, method: :post, local: true, id: "tester-form" do %>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+          <%# Hackr selector %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+            <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">HACKR</label>
+
+            <input type="hidden" name="hackr_id" id="hackr-id" value="<%= @hackr&.id %>">
+
+            <div class="admin-combobox">
+              <input type="text" id="hackr-input" class="admin-combobox-input" autocomplete="off"
+                placeholder="Type to search hackrs..."
+                value="<%= @hackr ? "#{@hackr.hackr_alias} (CL #{@hackr.stat("clearance")})" : "" %>">
+              <div id="hackr-dropdown" class="admin-combobox-dropdown"></div>
+            </div>
+
+            <p style="color: #666; margin-top: 6px; font-size: 0.85em;" id="hackr-status">
+              <% if @hackr %>
+                <span style="color: #34d399;">Selected: <%= @hackr.hackr_alias %></span>
+              <% else %>
+                <%= @hackrs.size %> hackrs — start typing to filter
+              <% end %>
+            </p>
+          </div>
+
+          <%# Mob selector %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+            <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">NPC (MOB)</label>
+
+            <input type="hidden" name="mob_id" id="mob-id" value="<%= @mob&.id %>">
+
+            <div class="admin-combobox">
+              <input type="text" id="mob-input" class="admin-combobox-input" autocomplete="off"
+                placeholder="Type to search mobs..."
+                value="<%= @mob ? "#{@mob.grid_room.grid_zone.name} > #{@mob.grid_room.name} > #{@mob.name}" : "" %>">
+              <div id="mob-dropdown" class="admin-combobox-dropdown"></div>
+            </div>
+
+            <p style="color: #666; margin-top: 6px; font-size: 0.85em;" id="mob-status">
+              <% if @mob %>
+                <span style="color: #34d399;">Selected: <%= @mob.name %></span>
+              <% else %>
+                <%= @mobs.size %> mobs — start typing to filter
+              <% end %>
+            </p>
+          </div>
+        </div>
+
+        <div style="margin-top: 20px;">
+          <%= submit_tag "START DIALOGUE TEST", class: "tui-button yellow-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Start NPC Dialogue Test? Hackr will be warped to mob's room." } %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    function ready(fn) {
+      if (document.readyState !== 'loading') fn();
+      else document.addEventListener('DOMContentLoaded', fn);
+    }
+    ready(function() {
+      // --- Hackr combobox ---
+      AdminCombobox.init({
+        inputId: 'hackr-input',
+        hiddenId: 'hackr-id',
+        dropdownId: 'hackr-dropdown',
+        statusId: 'hackr-status',
+        formId: 'tester-form',
+        items: <%= raw json_escape(@hackrs.map { |h|
+          {
+            id: h.id,
+            alias: h.hackr_alias,
+            cl: h.stat("clearance"),
+            role: h.role || "hackr"
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) { return (r.alias + ' ' + r.role).toLowerCase(); },
+        getGroupKey: function(r) { return r.role.toUpperCase(); },
+        renderOption: function(r, esc) {
+          return '<span class="cb-name">' + esc(r.alias) + '</span>' +
+            ' <span class="cb-meta" style="color: #9ca3af;">(CL ' + r.cl + ')</span>';
+        },
+        getLabel: function(r) { return r.alias + ' (CL ' + r.cl + ')'; },
+        emptyText: 'No hackrs match',
+        selectedText: 'Selected',
+        submitError: 'Select a hackr first'
+      });
+
+      // --- Mob combobox ---
+      var mobTypeColors = {
+        quest_giver: '#fbbf24',
+        vendor: '#34d399',
+        lore: '#c084fc',
+        special: '#22d3ee'
+      };
+      AdminCombobox.init({
+        inputId: 'mob-input',
+        hiddenId: 'mob-id',
+        dropdownId: 'mob-dropdown',
+        statusId: 'mob-status',
+        formId: 'tester-form',
+        items: <%= raw json_escape(@mobs.map { |m|
+          {
+            id: m.id,
+            name: m.name,
+            mob_type: m.mob_type || "generic",
+            room_name: m.grid_room.name,
+            zone_name: m.grid_room.grid_zone.name,
+            region_name: m.grid_room.grid_zone.grid_region&.name || "Unknown",
+            has_dialogue: m.dialogue_tree.present?
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) {
+          return (r.name + ' ' + r.mob_type + ' ' + r.room_name + ' ' + r.zone_name + ' ' + r.region_name).toLowerCase();
+        },
+        getGroupKey: function(r) { return r.zone_name + ' > ' + r.room_name; },
+        renderOption: function(r, esc) {
+          var color = mobTypeColors[r.mob_type] || '#9ca3af';
+          var typeBadge = '<span style="color:' + color + ';">[' + esc(r.mob_type) + ']</span>';
+          var dlg = r.has_dialogue ? '' : ' <span style="color: #f87171;">(no dialogue)</span>';
+          return '<span class="cb-name">' + esc(r.name) + '</span> ' + typeBadge + dlg;
+        },
+        getLabel: function(r) { return r.zone_name + ' > ' + r.room_name + ' > ' + r.name; },
+        emptyText: 'No mobs match',
+        selectedText: 'Selected',
+        submitError: 'Select a mob first'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/grid_npc_dialogue_tester/show.html.erb
+++ b/app/views/admin/grid_npc_dialogue_tester/show.html.erb
@@ -1,0 +1,193 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/npc-dialogue-tester :: DIALOGUE TERMINAL</legend>
+
+    <div style="padding: 20px;">
+      <%# Banner %>
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 20px;">
+        <span class="yellow-255-text" style="font-weight: bold;">NPC DIALOGUE TESTER</span>
+        <span style="color: #ccc;"> — </span>
+        <span class="cyan-255-text"><%= @hackr.hackr_alias %></span>
+        <span style="color: #888;"> (CL <%= @hackr.stat("clearance") %>)</span>
+        <span style="color: #ccc;"> talking to </span>
+        <span class="cyan-255-text"><%= @mob.name %></span>
+        <% if @mob.mob_type %>
+          <span style="color: #888;"> (<%= @mob.mob_type.upcase %>)</span>
+        <% end %>
+        <span style="color: #888;"> in </span>
+        <span style="color: #888;"><%= @mob.grid_room.grid_zone&.name %> > <%= @mob.grid_room.name %></span>
+      </div>
+
+      <%# Nav %>
+      <div style="display: flex; gap: 10px; margin-bottom: 20px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= link_to "Mob", edit_admin_grid_mob_path(@mob), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= button_to "END SESSION", finish_admin_grid_npc_dialogue_tester_path, method: :delete, class: "tui-button red-168", style: "padding: 6px 14px; font-weight: bold;", data: { confirm: "End dialogue test? Hackr will be warped back to original room." }, form: { id: "end-form" } %>
+      </div>
+
+      <%# Terminal output — styled to match frontend GameOutput.tsx %>
+      <div id="dialogue-output" style="font-family: monospace; font-size: 0.75em; line-height: 1.2; white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word; height: 700px; min-height: 700px; max-height: 700px; overflow-y: auto; overflow-x: hidden; padding: 10px; background: #0d0d0d; color: #d0d0d0; border: 1px solid #4b5563; border-radius: 3px; margin-bottom: 8px;">
+<div><%= raw @initial_output %></div>
+      </div>
+
+      <%# Command input — styled to match frontend CommandInput.tsx %>
+      <div id="command-section">
+        <div style="display: flex; gap: 8px; margin-bottom: 6px;">
+          <input type="text" id="command-input" autocomplete="off" autofocus
+            placeholder="Enter command (type 'help' for commands)"
+            style="flex: 1; background: #262626; color: #e0e0e0; border: 1px solid #4b5563; padding: 6px 10px; font-family: monospace; font-size: 0.9em; border-radius: 3px;">
+          <button id="send-btn" style="background: #7c3aed; color: white; border: none; padding: 6px 16px; font-size: 0.85em; cursor: pointer; border-radius: 3px; font-weight: bold; flex-shrink: 0;">SEND</button>
+        </div>
+        <div style="font-size: 0.75em; color: #9ca3af; line-height: 1.3;">
+          Commands: talk, ask, examine, shop, buy, sell, give, accept, turn_in, missions, mission, stat, rep, inventory, look, who, help
+          <span style="margin-left: 10px; color: #666;">|</span>
+          <span style="margin-left: 10px;">&#x2191;/&#x2193; for history</span>
+        </div>
+      </div>
+
+      <%# Ended overlay (hidden by default) %>
+      <div id="session-ended" style="display: none; margin-top: 15px; background: #1a1a1a; border: 2px solid #fbbf24; padding: 15px; text-align: center;">
+        <span class="yellow-255-text" style="font-weight: bold;">NPC DIALOGUE TEST ENDED</span>
+        <span style="color: #ccc;"> — Hackr returned to original room.</span>
+        <br><br>
+        <%= link_to "Back to Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 8px 16px;" %>
+        <%= link_to "New Test", new_admin_grid_npc_dialogue_tester_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 8px 16px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var commandUrl = '<%= command_admin_grid_npc_dialogue_tester_path %>';
+    var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    var outputEl = document.getElementById('dialogue-output');
+    var inputEl = document.getElementById('command-input');
+    var sendBtn = document.getElementById('send-btn');
+    var commandSection = document.getElementById('command-section');
+    var endedEl = document.getElementById('session-ended');
+    var endForm = document.getElementById('end-form');
+    var sending = false;
+
+    // Command history (mirrors frontend useCommandHistory.ts)
+    var history = [];
+    var historyIndex = -1;
+    var currentDraft = '';
+
+    function addCommand(cmd) {
+      if (!cmd) return;
+      if (history.length > 0 && history[history.length - 1] === cmd) {
+        historyIndex = -1;
+        currentDraft = '';
+        return;
+      }
+      history.push(cmd);
+      if (history.length > 100) history = history.slice(-100);
+      historyIndex = -1;
+      currentDraft = '';
+    }
+
+    function navigateUp() {
+      if (history.length === 0) return;
+      if (historyIndex === -1) {
+        currentDraft = inputEl.value;
+        historyIndex = history.length - 1;
+      } else if (historyIndex > 0) {
+        historyIndex--;
+      }
+      inputEl.value = history[historyIndex];
+    }
+
+    function navigateDown() {
+      if (history.length === 0 || historyIndex === -1) return;
+      historyIndex++;
+      if (historyIndex >= history.length) {
+        historyIndex = -1;
+        inputEl.value = currentDraft;
+      } else {
+        inputEl.value = history[historyIndex];
+      }
+    }
+
+    function appendOutput(html) {
+      var div = document.createElement('div');
+      div.innerHTML = html;
+      outputEl.appendChild(div);
+      outputEl.scrollTop = outputEl.scrollHeight;
+    }
+
+    function endSession() {
+      commandSection.style.display = 'none';
+      endedEl.style.display = 'block';
+      if (endForm) endForm.style.display = 'none';
+    }
+
+    function setDisabled(disabled) {
+      inputEl.disabled = disabled;
+      sendBtn.disabled = disabled;
+      sendBtn.style.opacity = disabled ? '0.5' : '1';
+      sendBtn.style.cursor = disabled ? 'not-allowed' : 'pointer';
+    }
+
+    function sendCommand() {
+      if (sending) return;
+      var input = inputEl.value.trim();
+      if (!input) return;
+
+      sending = true;
+      setDisabled(true);
+      addCommand(input);
+
+      appendOutput('<span style="color: #22d3ee;">&gt; ' + input.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</span>');
+      inputEl.value = '';
+
+      fetch(commandUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ input: input })
+      })
+      .then(function(response) { return response.json(); })
+      .then(function(data) {
+        if (data.event && data.event.type === 'clear') {
+          outputEl.innerHTML = '';
+        } else if (data.output) {
+          appendOutput(data.output);
+        }
+        if (data.session_active === false) {
+          endSession();
+        } else {
+          setDisabled(false);
+          inputEl.focus();
+        }
+        sending = false;
+      })
+      .catch(function(err) {
+        appendOutput('<span style="color: #f87171;">Error: ' + err.message + '</span>');
+        setDisabled(false);
+        sending = false;
+      });
+    }
+
+    inputEl.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        sendCommand();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        navigateUp();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        navigateDown();
+      }
+    });
+    sendBtn.addEventListener('click', sendCommand);
+
+    // Auto-scroll to bottom on load
+    outputEl.scrollTop = outputEl.scrollHeight;
+    inputEl.focus();
+  })();
+</script>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -159,6 +159,50 @@
         79
       ],
       "note": "Safe: BreachRenderer output is server-controlled HTML with inline styles. All dynamic text is escaped via ERB::Util.html_escape (the renderer's h() helper). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern used by the frontend terminal via dangerouslySetInnerHTML."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "0c10703731f19cf7f2c32e709464b3c451dbebc9b859f8ca47cce091e5aa37ea",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/grid_npc_dialogue_tester/show.html.erb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Grid::NpcDialogueCommandParser.new(GridHackr.find_by(:id => session[:npc_tester][\"hackr_id\"]), \"look\").execute",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "admin/grid_npc_dialogue_tester/show"
+      },
+      "user_input": "GridHackr.find_by(:id => session[:npc_tester][\"hackr_id\"])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Safe: NpcDialogueCommandParser inherits CommandParser which escapes all dynamic text via h() (ERB::Util.html_escape). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern as the BREACH sandbox terminal."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "1f803af0a33db63095b8f415b39668734cbb768360de691a031f18819f7b5dc6",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/grid_npc_dialogue_tester/show.html.erb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Grid::NpcDialogueCommandParser.new(GridHackr.find_by(:id => session[:npc_tester][\"hackr_id\"]), \"look\").execute[:output]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "admin/grid_npc_dialogue_tester/show"
+      },
+      "user_input": "GridHackr.find_by(:id => session[:npc_tester][\"hackr_id\"])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Safe: NpcDialogueCommandParser inherits CommandParser which escapes all dynamic text via h() (ERB::Util.html_escape). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern as the BREACH sandbox terminal."
     }
   ],
   "updated": "2026-04-27 01:10:00 +0000",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -366,6 +366,12 @@ Rails.application.routes.draw do
       end
     end
 
+    # NPC Dialogue Tester (dev-only)
+    resource :grid_npc_dialogue_tester, only: %i[new create show], controller: "grid_npc_dialogue_tester" do
+      post :command
+      delete :finish
+    end
+
     # Grid achievements (runtime CRUD + manual award)
     resources :grid_achievements do
       member do

--- a/spec/services/grid/npc_dialogue_command_parser_spec.rb
+++ b/spec/services/grid/npc_dialogue_command_parser_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.describe Grid::NpcDialogueCommandParser do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+  let(:mob) do
+    create(:grid_mob,
+      grid_room: room,
+      name: "Test NPC",
+      dialogue_tree: {
+        "greeting" => "Hello, hackr!",
+        "topics" => {
+          "mission" => "We need your help.",
+          "lore" => "Let me tell you a story..."
+        }
+      })
+  end
+  let(:parser) { described_class.new(hackr, input) }
+
+  before { mob }
+
+  describe "allowed read commands" do
+    context "talk command" do
+      let(:input) { "talk Test NPC" }
+
+      it "returns the greeting" do
+        result = parser.execute
+        expect(result[:output]).to include("Hello, hackr!")
+      end
+
+      it "lists available topics" do
+        result = parser.execute
+        expect(result[:output]).to include("mission")
+        expect(result[:output]).to include("lore")
+      end
+    end
+
+    context "ask command" do
+      let(:input) { "ask Test NPC about mission" }
+
+      it "returns the topic response" do
+        result = parser.execute
+        expect(result[:output]).to include("We need your help.")
+      end
+    end
+
+    context "examine command" do
+      let(:input) { "examine Test NPC" }
+
+      it "returns mob description" do
+        result = parser.execute
+        expect(result[:output]).to include(mob.description)
+      end
+    end
+
+    context "look command" do
+      let(:input) { "look" }
+
+      it "returns room description with mob listed" do
+        result = parser.execute
+        expect(result[:output]).to include(room.name.upcase)
+        expect(result[:output]).to include("Test NPC")
+      end
+    end
+
+    context "stat command" do
+      let(:input) { "stat" }
+
+      it "returns hackr stats" do
+        result = parser.execute
+        expect(result[:output]).to include(hackr.hackr_alias)
+      end
+    end
+
+    context "help command" do
+      let(:input) { "help" }
+
+      it "returns help text" do
+        result = parser.execute
+        expect(result[:output]).to be_present
+      end
+    end
+  end
+
+  describe "side effect suppression" do
+    context "talk command" do
+      let(:input) { "talk Test NPC" }
+
+      it "does not increment npcs_talked stat" do
+        initial = hackr.stat("npcs_talked") || 0
+        parser.execute
+        hackr.reload
+        expect(hackr.stat("npcs_talked") || 0).to eq(initial)
+      end
+
+      it "returns greeting output despite suppressed side effects" do
+        result = parser.execute
+        expect(result[:output]).to include("Hello, hackr!")
+      end
+    end
+
+    context "talk to NPC with faction" do
+      let(:faction) { create(:grid_faction) }
+      let(:mob_with_faction) do
+        create(:grid_mob,
+          grid_room: room,
+          name: "Faction NPC",
+          grid_faction: faction,
+          dialogue_tree: {"greeting" => "Welcome, ally."})
+      end
+
+      before { mob_with_faction }
+
+      let(:input) { "talk Faction NPC" }
+
+      it "does not grant faction reputation" do
+        parser.execute
+        rep_record = GridHackrReputation.find_by(
+          grid_hackr_id: hackr.id,
+          subject_type: "GridFaction",
+          subject_id: faction.id
+        )
+        expect(rep_record).to be_nil
+      end
+    end
+  end
+
+  describe "blocked commands" do
+    context "disallowed command" do
+      let(:input) { "go north" }
+
+      it "returns not available message" do
+        result = parser.execute
+        expect(result[:output]).to include("[TESTER] Command not available")
+      end
+    end
+
+    %w[drop take salvage fabricate equip unequip breach rig den].each do |cmd|
+      context "#{cmd} command" do
+        let(:input) { cmd }
+
+        it "is blocked" do
+          result = parser.execute
+          expect(result[:output]).to include("[TESTER] Command not available")
+        end
+      end
+    end
+  end
+
+  describe "write commands with rollback" do
+    context "buy command with no vendor" do
+      let(:input) { "buy something" }
+
+      it "returns error from inherited command with rollback notice" do
+        result = parser.execute
+        expect(result[:output]).to include("no vendor here")
+        expect(result[:output]).to include("[TESTER] Write reverted")
+      end
+    end
+
+    context "accept command with nonexistent mission" do
+      let(:input) { "accept some-mission" }
+
+      it "returns error from inherited command with rollback notice" do
+        result = parser.execute
+        expect(result[:output]).to be_present
+        expect(result[:output]).to include("[TESTER] Write reverted")
+      end
+    end
+  end
+
+  describe "bypasses breach/captured routing" do
+    let(:input) { "look" }
+
+    it "executes normally even with breach active" do
+      # Create an active breach on the hackr (factory defaults to state: "active")
+      template = create(:grid_breach_template)
+      create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template)
+      hackr.reload
+
+      # Regular CommandParser would route to BreachCommandParser
+      # NpcDialogueCommandParser bypasses that
+      result = parser.execute
+      expect(result[:output]).to include(room.name.upcase)
+    end
+  end
+end

--- a/spec/services/grid/npc_dialogue_session_service_spec.rb
+++ b/spec/services/grid/npc_dialogue_session_service_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe Grid::NpcDialogueSessionService do
+  let(:zone) { create(:grid_zone) }
+  let(:original_room) { create(:grid_room, grid_zone: zone, name: "Original Room") }
+  let(:mob_room) { create(:grid_room, grid_zone: zone, name: "Mob Room") }
+  let(:hackr) { create(:grid_hackr, current_room: original_room, zone_entry_room: original_room) }
+  let(:mob) { create(:grid_mob, grid_room: mob_room, name: "Test NPC") }
+  let(:service) { described_class.new(hackr) }
+
+  describe "#start!" do
+    it "warps hackr to mob's room" do
+      service.start!(mob: mob)
+      hackr.reload
+      expect(hackr.current_room_id).to eq(mob_room.id)
+    end
+
+    it "updates zone_entry_room_id to mob's room" do
+      service.start!(mob: mob)
+      hackr.reload
+      expect(hackr.zone_entry_room_id).to eq(mob_room.id)
+    end
+
+    it "stores snapshot in hackr stats" do
+      service.start!(mob: mob)
+      hackr.reload
+      snapshot = hackr.stats["npc_tester_snapshot"]
+      expect(snapshot).to be_present
+      expect(snapshot["origin_room_id"]).to eq(original_room.id)
+      expect(snapshot["origin_zone_entry_room_id"]).to eq(original_room.id)
+      expect(snapshot["mob_id"]).to eq(mob.id)
+      expect(snapshot["started_at"]).to be_present
+    end
+
+    it "raises AlreadyInBreach if hackr is in breach" do
+      template = create(:grid_breach_template)
+      create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template)
+      hackr.reload
+
+      expect { service.start!(mob: mob) }
+        .to raise_error(Grid::NpcDialogueSessionService::AlreadyInBreach)
+    end
+
+    it "restores stale session before starting new one" do
+      # Start first session
+      service.start!(mob: mob)
+      hackr.reload
+      expect(hackr.current_room_id).to eq(mob_room.id)
+
+      # Start second session with different mob in a third room
+      third_room = create(:grid_room, grid_zone: zone, name: "Third Room")
+      other_mob = create(:grid_mob, grid_room: third_room, name: "Other NPC")
+
+      # Hackr is now at mob_room from first session
+      # Starting new session should restore to original_room first, then warp to third_room
+      service.start!(mob: other_mob)
+      hackr.reload
+
+      expect(hackr.current_room_id).to eq(third_room.id)
+      snapshot = hackr.stats["npc_tester_snapshot"]
+      # Stale session restored hackr to original_room before new snapshot was taken
+      expect(snapshot["origin_room_id"]).to eq(original_room.id)
+    end
+  end
+
+  describe "#restore!" do
+    before { service.start!(mob: mob) }
+
+    it "warps hackr back to original room" do
+      service.restore!
+      hackr.reload
+      expect(hackr.current_room_id).to eq(original_room.id)
+    end
+
+    it "restores zone_entry_room_id" do
+      service.restore!
+      hackr.reload
+      expect(hackr.zone_entry_room_id).to eq(original_room.id)
+    end
+
+    it "clears the snapshot from stats" do
+      service.restore!
+      hackr.reload
+      expect(hackr.stats["npc_tester_snapshot"]).to be_nil
+    end
+
+    it "is a no-op when no snapshot exists" do
+      service.restore!
+      hackr.reload
+      # Call again — should not raise or change anything
+      expect { service.restore! }.not_to raise_error
+      hackr.reload
+      expect(hackr.current_room_id).to eq(original_room.id)
+    end
+  end
+
+  describe "#active?" do
+    it "returns false before start" do
+      expect(service.active?).to be false
+    end
+
+    it "returns true after start" do
+      service.start!(mob: mob)
+      expect(service.active?).to be true
+    end
+
+    it "returns false after restore" do
+      service.start!(mob: mob)
+      service.restore!
+      # Need fresh service to re-read stats
+      hackr.reload
+      expect(described_class.new(hackr).active?).to be false
+    end
+  end
+end


### PR DESCRIPTION
  NPC dialogue impersonate-mode terminal for admin testing (DEV-ONLY).

  Select a hackr + mob via dual combobox, get warped to the mob's room,
  then interact through a terminal UI matching the BREACH sandbox pattern.

  Side-effect suppression (two-layer):
  - NpcDialogueCommandParser < CommandParser inherits all routing/rendering
  - Layer 1: null objects suppress incremental effects (stats, rep, achievements, missions) on read commands (talk, ask, shop, examine, etc.)
  - Layer 2: write commands (buy, sell, give, accept, turn_in, abandon) wrapped in always-rollback transactions — output captured before revert

  Session lifecycle:
  - NpcDialogueSessionService snapshots hackr room in stats["npc_tester_snapshot"], warps to mob room, restores on end
  - Stale sessions auto-cleaned on new start
  - Singular resource route — session cookie carries state, no DB record

  Entry points:
  - Hackr inspector: "NPC Tester" button (DEV-ONLY action bar)
  - Mob CRUD index: "Test" button per mob row (DEV-ONLY gated)