### PR TITLE
[TPG] Admin Tooling Phase B3: PAC Escape Tester

### DIFF
--- a/app/controllers/admin/grid_pac_escape_tester_controller.rb
+++ b/app/controllers/admin/grid_pac_escape_tester_controller.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class Admin::GridPacEscapeTesterController < Admin::ApplicationController
+  before_action :require_dev_tools
+  before_action :preselect_from_params, only: %i[new]
+  before_action :load_session, only: %i[show command finish]
+
+  # GET /root/grid_pac_escape_tester/new?hackr_id=N
+  def new
+    load_hackrs
+  end
+
+  # POST /root/grid_pac_escape_tester
+  def create
+    @hackr = GridHackr.find_by(id: params[:hackr_id])
+    unless @hackr
+      flash.now[:error] = "Hackr is required."
+      load_hackrs
+      return render :new, status: :unprocessable_entity
+    end
+
+    impound = params[:impound] == "1"
+    service = Grid::PacEscapeTesterService.new(@hackr)
+    service.start!(impound: impound)
+
+    session[:pac_tester] = {"hackr_id" => @hackr.id}
+    redirect_to admin_grid_pac_escape_tester_path
+  rescue Grid::PacEscapeTesterService::AlreadyInBreach,
+    Grid::PacEscapeTesterService::AlreadyCaptured,
+    Grid::PacEscapeTesterService::NoContainmentRoom => e
+    flash.now[:error] = e.message
+    load_hackrs
+    render :new, status: :unprocessable_entity
+  end
+
+  # GET /root/grid_pac_escape_tester
+  def show
+    result = Grid::CommandParser.new(@hackr, "look").execute
+    @initial_output = result.is_a?(Hash) ? result[:output] : result
+  end
+
+  # POST /root/grid_pac_escape_tester/command
+  def command
+    input = params[:input].to_s.strip
+    if input.empty?
+      return render json: {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", session_active: true}
+    end
+
+    result = Grid::CommandParser.new(@hackr, input).execute
+    output = result.is_a?(Hash) ? result[:output] : result
+
+    @hackr.reload
+    escaped = !Grid::ContainmentService.captured?(@hackr)
+
+    render json: {output: output, session_active: true, escaped: escaped}
+  end
+
+  # DELETE /root/grid_pac_escape_tester
+  def finish
+    Grid::PacEscapeTesterService.new(@hackr).restore!
+    session.delete(:pac_tester)
+
+    set_flash_success("PAC Escape Test ended. #{@hackr.hackr_alias} restored to original state.")
+    redirect_to admin_grid_hackr_path(@hackr)
+  end
+
+  private
+
+  def preselect_from_params
+    @hackr = GridHackr.find_by(id: params[:hackr_id]) if params[:hackr_id].present?
+  end
+
+  def load_session
+    tester = session[:pac_tester]
+    unless tester
+      set_flash_error("No active PAC Escape Tester session.")
+      return redirect_to admin_grid_hackrs_path
+    end
+
+    @hackr = GridHackr.find_by(id: tester["hackr_id"])
+    unless @hackr
+      session.delete(:pac_tester)
+      set_flash_error("Session hackr no longer exists.")
+      redirect_to admin_grid_hackrs_path
+    end
+  end
+
+  def load_hackrs
+    @hackrs = GridHackr.order(:hackr_alias)
+    @breach_hackr_ids = GridHackrBreach.where(state: "active").distinct.pluck(:grid_hackr_id).to_set
+  end
+end

--- a/app/services/grid/pac_escape_tester_service.rb
+++ b/app/services/grid/pac_escape_tester_service.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Grid
+  # Manages the admin PAC Escape Tester session lifecycle:
+  # snapshot hackr state, force-capture into PAC, optional gear impound,
+  # full restore on end (room, captured state, remaining impound records).
+  #
+  # Follows NpcDialogueSessionService pattern — snapshot in hackr.stats,
+  # no separate DB record for the tester session itself.
+  class PacEscapeTesterService
+    SNAPSHOT_KEY = "pac_tester_snapshot"
+
+    class AlreadyInBreach < StandardError; end
+    class AlreadyCaptured < StandardError; end
+    class NoContainmentRoom < StandardError; end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Force-capture hackr into PAC containment cell.
+    # Optionally impounds all equipped gear.
+    def start!(impound: false)
+      # Clean up stale session first (crashed/abandoned)
+      restore! if active?
+
+      raise AlreadyInBreach, "#{@hackr.hackr_alias} is in an active BREACH." if @hackr.in_breach?
+      raise AlreadyCaptured, "#{@hackr.hackr_alias} is already captured." if ContainmentService.captured?(@hackr)
+
+      # Pre-check: region must have a containment facility
+      region = @hackr.current_room&.grid_zone&.grid_region
+      unless region&.containment_room
+        raise NoContainmentRoom, "No PAC facility in #{region&.name || "current region"}. Warp hackr to a region with a facility first."
+      end
+
+      # Snapshot current state before capture
+      snapshot = {
+        "origin_room_id" => @hackr.current_room_id,
+        "origin_zone_entry_room_id" => @hackr.zone_entry_room_id,
+        "started_at" => Time.current.iso8601
+      }
+
+      new_stats = (@hackr.stats || {}).merge(SNAPSHOT_KEY => snapshot)
+      @hackr.update!(stats: new_stats)
+
+      # Capture via real ContainmentService (sets captured state, moves to containment cell)
+      capture_result = ContainmentService.capture!(hackr: @hackr, breach: nil, impound: false)
+
+      # Optional gear impound (separate from capture).
+      # Rescue all errors — impound failure should not abort the session.
+      impound_result = nil
+      if impound
+        begin
+          impound_result = ImpoundService.impound_gear!(hackr: @hackr, breach: nil)
+        rescue ImpoundService::NoEquippedGear
+          # Nothing to impound — no gear equipped
+        rescue => e
+          Rails.logger.error("[PacEscapeTesterService] impound_gear! failed: #{e.message} — hackr #{@hackr.id} captured without impound")
+        end
+      end
+
+      {capture_result: capture_result, impound_result: impound_result}
+    end
+
+    # Restore hackr to pre-capture state:
+    # 1. Jackout active breach if any
+    # 2. Free-release remaining impound records
+    # 3. Clear captured state
+    # 4. Restore original room
+    # 5. Clear snapshot
+    def restore!
+      snapshot = @hackr.stats&.dig(SNAPSHOT_KEY)
+      return unless snapshot
+
+      # Jackout active breach first (containment cell, sally port, etc.)
+      if @hackr.in_breach?
+        begin
+          BreachService.jackout!(hackr: @hackr)
+        rescue => e
+          Rails.logger.error("[PacEscapeTesterService] jackout failed: #{e.message}")
+        ensure
+          @hackr.reload
+        end
+      end
+
+      # Free-release any remaining impound records (no payment required)
+      @hackr.grid_impound_records.impounded.each do |record|
+        ActiveRecord::Base.transaction do
+          record.lock!
+          next unless record.impounded?
+          record.impounded_items.update_all(grid_impound_record_id: nil)
+          record.update!(status: "recovered")
+        end
+      end
+
+      # Restore room and clear captured state + snapshot in one write
+      origin_room_id = snapshot["origin_room_id"]
+      origin_zone_entry = snapshot["origin_zone_entry_room_id"]
+
+      new_stats = (@hackr.stats || {}).except(SNAPSHOT_KEY)
+      new_stats.delete("captured")
+      new_stats.delete("captured_origin_room_id")
+      new_stats.delete("facility_alert_level")
+
+      @hackr.update!(
+        current_room_id: origin_room_id,
+        zone_entry_room_id: origin_zone_entry,
+        stats: new_stats
+      )
+
+      @hackr.reset_loadout_cache!
+    end
+
+    # Is there an active tester snapshot on this hackr?
+    def active?
+      @hackr.stats&.dig(SNAPSHOT_KEY).present?
+    end
+  end
+end

--- a/app/views/admin/grid_hackrs/show.html.erb
+++ b/app/views/admin/grid_hackrs/show.html.erb
@@ -24,6 +24,7 @@
           <%= link_to "Warp", warp_admin_grid_hackr_path(@hackr), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
           <%= link_to "Sandbox", new_admin_grid_breach_sandbox_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
           <%= link_to "NPC Tester", new_admin_grid_npc_dialogue_tester_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
+          <%= link_to "PAC Tester", new_admin_grid_pac_escape_tester_path(hackr_id: @hackr.id), class: "tui-button yellow-168", style: "padding: 6px 14px;" %>
         <% end %>
       </div>
 

--- a/app/views/admin/grid_pac_escape_tester/new.html.erb
+++ b/app/views/admin/grid_pac_escape_tester/new.html.erb
@@ -1,0 +1,133 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/pac-escape-tester :: PAC ESCAPE TESTER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="background: #332200; border: 2px solid #fbbf24; padding: 12px; margin-bottom: 25px;">
+        <span class="yellow-255-text" style="font-weight: bold;">DEV TOOL</span>
+        <span style="color: #ccc;"> — One-click capture into GovCorp Perception Alignment Center. Test escape flow (containment BREACH, facility navigation, bribe, impound recovery). Full state restore on end. CRED spent on bribes and items forfeited during test are NOT restored.</span>
+      </div>
+
+      <div style="display: flex; gap: 10px; margin-bottom: 25px;">
+        <% if @hackr %>
+          <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <% end %>
+        <%= link_to "All Hackrs", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+
+      <%= form_with url: admin_grid_pac_escape_tester_path, method: :post, local: true, id: "pac-tester-form" do %>
+        <%# Hackr selector %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px; margin-bottom: 20px;">
+          <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">HACKR</label>
+
+          <input type="hidden" name="hackr_id" id="hackr-id" value="<%= @hackr&.id %>">
+
+          <div class="admin-combobox">
+            <input type="text" id="hackr-input" class="admin-combobox-input" autocomplete="off"
+              placeholder="Type to search hackrs..."
+              value="<%= @hackr ? "#{@hackr.hackr_alias} (CL #{@hackr.stat("clearance")})" : "" %>">
+            <div id="hackr-dropdown" class="admin-combobox-dropdown"></div>
+          </div>
+
+          <p style="color: #666; margin-top: 6px; font-size: 0.85em;" id="hackr-status">
+            <% if @hackr %>
+              <span style="color: #34d399;">Selected: <%= @hackr.hackr_alias %></span>
+            <% else %>
+              <%= @hackrs.size %> hackrs — start typing to filter
+            <% end %>
+          </p>
+        </div>
+
+        <%# Hackr info (shown when pre-selected) %>
+        <% if @hackr %>
+          <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 15px; margin-bottom: 20px;">
+            <span style="color: #888;">Hackr:</span>
+            <span class="cyan-255-text" style="font-weight: bold;"><%= @hackr.hackr_alias %></span>
+            <span style="color: #888;"> (CL <%= @hackr.stat("clearance") %>)</span>
+            <br>
+            <span style="color: #888;">Location:</span>
+            <% room = @hackr.current_room %>
+            <% if room %>
+              <span class="white-text"><%= room.name %></span>
+              <span style="color: #888;"> — <%= room.grid_zone&.name %>, <%= room.grid_zone&.grid_region&.name %></span>
+            <% else %>
+              <span class="red-255-text">No room</span>
+            <% end %>
+            <% if @hackr.in_breach? %>
+              <br>
+              <span class="red-255-text" style="font-weight: bold;">WARNING: Active BREACH in progress. Cannot capture.</span>
+            <% end %>
+            <% if Grid::ContainmentService.captured?(@hackr) %>
+              <br>
+              <span class="red-255-text" style="font-weight: bold;">WARNING: Already captured in PAC.</span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%# Options %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px; margin-bottom: 20px;">
+          <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">OPTIONS</label>
+          <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+            <input type="checkbox" name="impound" value="1" style="width: 16px; height: 16px; accent-color: #f87171;">
+            <span style="color: #f87171;">Impound equipped gear</span>
+            <span style="color: #666; font-size: 0.85em;"> — confiscate loadout on capture (tests impound recovery / bribe forfeit)</span>
+          </label>
+        </div>
+
+        <div style="margin-top: 20px;">
+          <%= submit_tag "CAPTURE INTO PAC", class: "tui-button red-168", style: "padding: 10px 24px; font-weight: bold;", data: { confirm: "Force-capture hackr into PAC? (State will be restored on End Test)" } %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    function ready(fn) {
+      if (document.readyState !== 'loading') fn();
+      else document.addEventListener('DOMContentLoaded', fn);
+    }
+    ready(function() {
+      AdminCombobox.init({
+        inputId: 'hackr-input',
+        hiddenId: 'hackr-id',
+        dropdownId: 'hackr-dropdown',
+        statusId: 'hackr-status',
+        formId: 'pac-tester-form',
+        items: <%= raw json_escape(@hackrs.map { |h|
+          {
+            id: h.id,
+            alias: h.hackr_alias,
+            cl: h.stat("clearance"),
+            role: h.role || "hackr",
+            captured: Grid::ContainmentService.captured?(h),
+            in_breach: @breach_hackr_ids.include?(h.id)
+          }
+        }.to_json) %>,
+        getId: function(r) { return r.id; },
+        getSearchText: function(r) { return (r.alias + ' ' + r.role).toLowerCase(); },
+        getGroupKey: function(r) { return r.role.toUpperCase(); },
+        renderOption: function(r, esc) {
+          var flags = '';
+          if (r.captured) flags += ' <span style="color: #f87171;">[CAPTURED]</span>';
+          if (r.in_breach) flags += ' <span style="color: #fbbf24;">[IN BREACH]</span>';
+          return '<span class="cb-name">' + esc(r.alias) + '</span>' +
+            ' <span class="cb-meta" style="color: #9ca3af;">(CL ' + r.cl + ')</span>' + flags;
+        },
+        getLabel: function(r) { return r.alias + ' (CL ' + r.cl + ')'; },
+        emptyText: 'No hackrs match',
+        selectedText: 'Selected',
+        submitError: 'Select a hackr first'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/grid_pac_escape_tester/show.html.erb
+++ b/app/views/admin/grid_pac_escape_tester/show.html.erb
@@ -1,0 +1,170 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/pac-escape-tester :: PAC TERMINAL</legend>
+
+    <div style="padding: 20px;">
+      <%# Banner %>
+      <div style="background: #330011; border: 2px solid #f87171; padding: 12px; margin-bottom: 20px;">
+        <span class="red-255-text" style="font-weight: bold;">PAC ESCAPE TESTER</span>
+        <span style="color: #ccc;"> — </span>
+        <span class="cyan-255-text"><%= @hackr.hackr_alias %></span>
+        <span style="color: #888;"> (CL <%= @hackr.stat("clearance") %>)</span>
+        <span style="color: #ccc;"> in </span>
+        <span style="color: #888;"><%= @hackr.current_room&.grid_zone&.name %> > <%= @hackr.current_room&.name %></span>
+        <span id="escaped-badge" style="display: none; margin-left: 10px; padding: 2px 8px; background: #064e3b; border: 1px solid #34d399; color: #34d399; font-weight: bold;">ESCAPED</span>
+      </div>
+
+      <%# Nav %>
+      <div style="display: flex; gap: 10px; margin-bottom: 20px;">
+        <%= link_to "<- Inspector", admin_grid_hackr_path(@hackr), class: "tui-button", style: "padding: 6px 14px;" %>
+        <%= button_to "END TEST", finish_admin_grid_pac_escape_tester_path, method: :delete, class: "tui-button red-168", style: "padding: 6px 14px; font-weight: bold;", data: { confirm: "End PAC escape test? Hackr will be restored to original state." }, form: { id: "end-form" } %>
+      </div>
+
+      <%# Terminal output — styled to match frontend GameOutput.tsx %>
+      <div id="pac-output" style="font-family: monospace; font-size: 0.75em; line-height: 1.2; white-space: pre-wrap; word-break: break-word; overflow-wrap: break-word; height: 700px; min-height: 700px; max-height: 700px; overflow-y: auto; overflow-x: hidden; padding: 10px; background: #0d0d0d; color: #d0d0d0; border: 1px solid #4b5563; border-radius: 3px; margin-bottom: 8px;">
+<div><%= raw @initial_output %></div>
+      </div>
+
+      <%# Command input — styled to match frontend CommandInput.tsx %>
+      <div id="command-section">
+        <div style="display: flex; gap: 8px; margin-bottom: 6px;">
+          <input type="text" id="command-input" autocomplete="off" autofocus
+            placeholder="Enter command (type 'help' for commands)"
+            style="flex: 1; background: #262626; color: #e0e0e0; border: 1px solid #4b5563; padding: 6px 10px; font-family: monospace; font-size: 0.9em; border-radius: 3px;">
+          <button id="send-btn" style="background: #7c3aed; color: white; border: none; padding: 6px 16px; font-size: 0.85em; cursor: pointer; border-radius: 3px; font-weight: bold; flex-shrink: 0;">EXECUTE</button>
+        </div>
+        <div style="font-size: 0.75em; color: #9ca3af; line-height: 1.3;">
+          Captured: look, go, breach, bribe, talk, examine, stat, inventory, who, help
+          <span style="margin-left: 10px; color: #666;">|</span>
+          <span style="margin-left: 10px;">&#x2191;/&#x2193; for history</span>
+        </div>
+      </div>
+
+      <%# No auto-end overlay — terminal stays active post-escape so admin can look around. Use END TEST button to restore. %>
+    </div>
+  </fieldset>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var commandUrl = '<%= command_admin_grid_pac_escape_tester_path %>';
+    var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    var outputEl = document.getElementById('pac-output');
+    var inputEl = document.getElementById('command-input');
+    var sendBtn = document.getElementById('send-btn');
+    var escapedBadge = document.getElementById('escaped-badge');
+    var sending = false;
+
+    // Command history (mirrors frontend useCommandHistory.ts)
+    var history = [];
+    var historyIndex = -1;
+    var currentDraft = '';
+
+    function addCommand(cmd) {
+      if (!cmd) return;
+      if (history.length > 0 && history[history.length - 1] === cmd) {
+        historyIndex = -1;
+        currentDraft = '';
+        return;
+      }
+      history.push(cmd);
+      if (history.length > 100) history = history.slice(-100);
+      historyIndex = -1;
+      currentDraft = '';
+    }
+
+    function navigateUp() {
+      if (history.length === 0) return;
+      if (historyIndex === -1) {
+        currentDraft = inputEl.value;
+        historyIndex = history.length - 1;
+      } else if (historyIndex > 0) {
+        historyIndex--;
+      }
+      inputEl.value = history[historyIndex];
+    }
+
+    function navigateDown() {
+      if (history.length === 0 || historyIndex === -1) return;
+      historyIndex++;
+      if (historyIndex >= history.length) {
+        historyIndex = -1;
+        inputEl.value = currentDraft;
+      } else {
+        inputEl.value = history[historyIndex];
+      }
+    }
+
+    function appendOutput(html) {
+      var div = document.createElement('div');
+      div.innerHTML = html;
+      outputEl.appendChild(div);
+      outputEl.scrollTop = outputEl.scrollHeight;
+    }
+
+    function setDisabled(disabled) {
+      inputEl.disabled = disabled;
+      sendBtn.disabled = disabled;
+      sendBtn.style.opacity = disabled ? '0.5' : '1';
+      sendBtn.style.cursor = disabled ? 'not-allowed' : 'pointer';
+    }
+
+    function sendCommand() {
+      if (sending) return;
+      var input = inputEl.value.trim();
+      if (!input) return;
+
+      sending = true;
+      setDisabled(true);
+      addCommand(input);
+
+      appendOutput('<span style="color: #22d3ee;">&gt; ' + input.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</span>');
+      inputEl.value = '';
+
+      fetch(commandUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ input: input })
+      })
+      .then(function(response) { return response.json(); })
+      .then(function(data) {
+        if (data.output) {
+          appendOutput(data.output);
+        }
+        if (data.escaped) {
+          escapedBadge.style.display = 'inline';
+        }
+        setDisabled(false);
+        inputEl.focus();
+        sending = false;
+      })
+      .catch(function(err) {
+        appendOutput('<span style="color: #f87171;">Error: ' + err.message + '</span>');
+        setDisabled(false);
+        sending = false;
+      });
+    }
+
+    inputEl.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        sendCommand();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        navigateUp();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        navigateDown();
+      }
+    });
+    sendBtn.addEventListener('click', sendCommand);
+
+    // Auto-scroll to bottom on load
+    outputEl.scrollTop = outputEl.scrollHeight;
+    inputEl.focus();
+  })();
+</script>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -203,8 +203,52 @@
         79
       ],
       "note": "Safe: NpcDialogueCommandParser inherits CommandParser which escapes all dynamic text via h() (ERB::Util.html_escape). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern as the BREACH sandbox terminal."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "06e1954bd9044398d320b31ac202cfa8b3cc68da16879bf5f85725d621301997",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/grid_pac_escape_tester/show.html.erb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Grid::CommandParser.new(GridHackr.find_by(:id => session[:pac_tester][\"hackr_id\"]), \"look\").execute",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "admin/grid_pac_escape_tester/show"
+      },
+      "user_input": "GridHackr.find_by(:id => session[:pac_tester][\"hackr_id\"])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Safe: CommandParser escapes all dynamic text via h() (ERB::Util.html_escape). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern as the BREACH sandbox and NPC dialogue tester terminals."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "94c2316b2eae16960128324ff4651ef47f6751e7e1e41751cc8e463d276c6994",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/admin/grid_pac_escape_tester/show.html.erb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Grid::CommandParser.new(GridHackr.find_by(:id => session[:pac_tester][\"hackr_id\"]), \"look\").execute[:output]",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "admin/grid_pac_escape_tester/show"
+      },
+      "user_input": "GridHackr.find_by(:id => session[:pac_tester][\"hackr_id\"])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "Safe: CommandParser escapes all dynamic text via h() (ERB::Util.html_escape). Admin-only view behind require_admin + require_dev_tools. Same rendering pattern as the BREACH sandbox and NPC dialogue tester terminals."
     }
   ],
-  "updated": "2026-04-27 01:10:00 +0000",
+  "updated": "2026-04-27 03:15:00 +0000",
   "brakeman_version": "8.0.4"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,12 @@ Rails.application.routes.draw do
       delete :finish
     end
 
+    # PAC Escape Tester (dev-only)
+    resource :grid_pac_escape_tester, only: %i[new create show], controller: "grid_pac_escape_tester" do
+      post :command
+      delete :finish
+    end
+
     # Grid achievements (runtime CRUD + manual award)
     resources :grid_achievements do
       member do


### PR DESCRIPTION
  DEV-ONLY admin tool for testing GovCorp Perception Alignment Center escape
  flow.

  Admin::GridPacEscapeTesterController (singular resource, session-backed):
  hackr combobox with [CAPTURED]/[IN BREACH] flags (N+1-free via precomputed set),
  optional gear impound checkbox, terminal UI (frontend-matched styling,
  fetch-based command I/O, command history).

  Grid::PacEscapeTesterService:
  snapshots origin room in stats["pac_tester_snapshot"], force-captures via
  ContainmentService.capture!, optional ImpoundService.impound_gear! (all errors
  rescued - impound failure never orphans session). Terminal routes through real
  CommandParser - auto-delegates to CapturedCommandParser (facility commands) or
  BreachCommandParser (containment cell/sally port BREACHes) based on hackr state.
  escaped flag returned on each command; green ESCAPED badge in banner header.

  restore!: jackout active breach (reload in ensure), free-release remaining
  impound records (no payment), clear captured state + snapshot, restore origin
  room. Stale session auto-cleanup on new start!.

  Entry point: hackr inspector
  "PAC Tester" button (yellow-168, DEV-ONLY gated).