### PR TITLE
 [TPG] Admin Tools Phase D: Branching dialogue trees, editors, more

### DIFF
--- a/app/controllers/admin/grid_missions_controller.rb
+++ b/app/controllers/admin/grid_missions_controller.rb
@@ -79,12 +79,24 @@ class Admin::GridMissionsController < Admin::ApplicationController
   end
 
   def mission_params
-    params.require(:grid_mission).permit(
+    permitted = params.require(:grid_mission).permit(
       :slug, :name, :description, :giver_mob_id, :grid_mission_arc_id,
       :prereq_mission_id, :min_clearance, :min_rep_faction_id, :min_rep_value,
       :repeatable, :position, :published,
       grid_mission_objectives_attributes: %i[id position objective_type label target_slug target_count _destroy],
       grid_mission_rewards_attributes: %i[id position reward_type amount target_slug quantity _destroy]
     )
+    # Parse dialogue_path JSON (array of topic keys, or blank for no gate)
+    raw_dp = params[:grid_mission][:dialogue_path_json]
+    permitted[:dialogue_path] = if raw_dp.blank?
+      nil
+    else
+      parsed = JSON.parse(raw_dp)
+      parsed.is_a?(Array) ? parsed : nil
+    end
+    permitted
+  rescue JSON::ParserError
+    permitted[:dialogue_path] = nil
+    permitted
   end
 end

--- a/app/controllers/admin/grid_mobs_controller.rb
+++ b/app/controllers/admin/grid_mobs_controller.rb
@@ -3,7 +3,7 @@ class Admin::GridMobsController < Admin::ApplicationController
 
   versionable GridMob
 
-  before_action :set_mob, only: %i[edit update destroy]
+  before_action :set_mob, only: %i[edit update destroy add_listing remove_listing]
 
   def index
     @mobs = GridMob.includes(:grid_room, :grid_faction).order(:name)
@@ -28,6 +28,7 @@ class Admin::GridMobsController < Admin::ApplicationController
 
   def edit
     load_selects
+    load_listings if @mob.vendor?
   end
 
   def update
@@ -36,6 +37,7 @@ class Admin::GridMobsController < Admin::ApplicationController
       redirect_to admin_grid_mobs_path
     else
       load_selects
+      load_listings if @mob.vendor?
       flash.now[:error] = @mob.errors.full_messages.join(", ")
       render :edit, status: :unprocessable_entity
     end
@@ -52,6 +54,24 @@ class Admin::GridMobsController < Admin::ApplicationController
     redirect_to admin_grid_mobs_path
   end
 
+  def add_listing
+    listing = @mob.grid_shop_listings.build(listing_params)
+    if listing.save
+      set_flash_success("Listing '#{listing.name}' added.")
+    else
+      set_flash_error(listing.errors.full_messages.join(", "))
+    end
+    redirect_to edit_admin_grid_mob_path(@mob)
+  end
+
+  def remove_listing
+    listing = @mob.grid_shop_listings.find(params[:listing_id])
+    name = listing.name
+    listing.destroy!
+    set_flash_success("Listing '#{name}' removed.")
+    redirect_to edit_admin_grid_mob_path(@mob)
+  end
+
   private
 
   def set_mob
@@ -63,6 +83,18 @@ class Admin::GridMobsController < Admin::ApplicationController
     @factions = GridFaction.ordered
   end
 
+  def load_listings
+    @listings = @mob.grid_shop_listings.includes(:grid_item_definition).order("grid_item_definitions.name")
+    @item_definitions = GridItemDefinition.ordered
+  end
+
+  def listing_params
+    params.require(:grid_shop_listing).permit(
+      :grid_item_definition_id, :base_price, :stock, :active,
+      :min_clearance, :rotation_pool
+    )
+  end
+
   def mob_params
     permitted = params.require(:grid_mob).permit(
       :name, :description, :mob_type, :grid_room_id, :grid_faction_id
@@ -70,13 +102,11 @@ class Admin::GridMobsController < Admin::ApplicationController
     # Parse JSON fields
     %w[dialogue_tree vendor_config].each do |json_field|
       raw = params[:grid_mob][:"#{json_field}_json"]
-      permitted[json_field] = if raw.blank?
+      permitted[json_field] = begin
+        raw.blank? ? {} : JSON.parse(raw)
+      rescue JSON::ParserError
         {}
-      else
-        JSON.parse(raw)
       end
-    rescue JSON::ParserError
-      permitted[json_field] = {}
     end
     permitted
   end

--- a/app/models/concerns/grid_hackr/stats.rb
+++ b/app/models/concerns/grid_hackr/stats.rb
@@ -46,6 +46,32 @@ module GridHackr::Stats
     self.stats = new_stats
   end
 
+  # --- Dialogue context (branching tree navigation) ---
+
+  # Returns the current dialogue path for a mob (array of topic keys).
+  def dialogue_path_for(mob)
+    ctx = stat("dialogue_context")
+    return [] unless ctx.is_a?(Hash)
+    path = ctx[mob.id.to_s]
+    path.is_a?(Array) ? path : []
+  end
+
+  # Set the current dialogue path for a mob.
+  def set_dialogue_path(mob, path)
+    ctx = stat("dialogue_context")
+    ctx = {} unless ctx.is_a?(Hash)
+    ctx[mob.id.to_s] = path
+    set_stat!("dialogue_context", ctx)
+  end
+
+  # Clear dialogue context for a specific mob.
+  def clear_dialogue_path(mob)
+    ctx = stat("dialogue_context")
+    return unless ctx.is_a?(Hash)
+    ctx.delete(mob.id.to_s)
+    set_stat!("dialogue_context", ctx)
+  end
+
   # Effective inventory capacity: base slots + bonus from equipment
   def inventory_capacity
     INVENTORY_BASE_SLOTS + stat("bonus_inventory_slots").to_i

--- a/app/models/grid_mission.rb
+++ b/app/models/grid_mission.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  dialogue_path       :json
 #  min_clearance       :integer          default(0), not null
 #  min_rep_value       :integer          default(0), not null
 #  name                :string           not null

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -17,6 +17,8 @@
 class GridMob < ApplicationRecord
   has_paper_trail
 
+  MAX_DIALOGUE_DEPTH = 100
+
   belongs_to :grid_room
   belongs_to :grid_faction, optional: true
   has_many :grid_shop_listings, dependent: :destroy
@@ -28,6 +30,10 @@ class GridMob < ApplicationRecord
   validates :name, presence: true
   validates :mob_type, inclusion: {in: %w[quest_giver vendor lore special], allow_nil: true}
   validate :faction_not_aggregate
+  validate :dialogue_tree_depth_within_limit
+  validate :dialogue_tree_keys_unique
+
+  before_validation :normalize_dialogue_tree
 
   def vendor?
     mob_type == "vendor"
@@ -54,6 +60,92 @@ class GridMob < ApplicationRecord
   end
 
   private
+
+  # Upgrade flat dialogue format (topic: "string") to nested format
+  # (topic: { response: "string" }) so all downstream code can assume
+  # the canonical shape.
+  def normalize_dialogue_tree
+    return if dialogue_tree.blank?
+    tree = dialogue_tree
+    return unless tree.is_a?(Hash) && tree["topics"].is_a?(Hash)
+
+    tree["topics"] = normalize_topics_recursive(tree["topics"])
+    self.dialogue_tree = tree
+  rescue JSON::NestingError
+    errors.add(:dialogue_tree, "is too deeply nested")
+  end
+
+  def normalize_topics_recursive(topics)
+    return {} unless topics.is_a?(Hash)
+
+    topics.transform_values do |value|
+      case value
+      when String
+        {"response" => value}
+      when Hash
+        if value["topics"].is_a?(Hash)
+          value.merge("topics" => normalize_topics_recursive(value["topics"]))
+        else
+          value
+        end
+      else
+        {"response" => value.to_s}
+      end
+    end
+  end
+
+  def dialogue_tree_depth_within_limit
+    return if errors[:dialogue_tree].any? # normalizer already caught nesting error
+    return if dialogue_tree.blank?
+    return unless dialogue_tree.is_a?(Hash) && dialogue_tree["topics"].is_a?(Hash)
+
+    depth = measure_topic_depth(dialogue_tree["topics"])
+    if depth > MAX_DIALOGUE_DEPTH
+      errors.add(:dialogue_tree, "exceeds maximum depth of #{MAX_DIALOGUE_DEPTH} levels")
+    end
+  rescue JSON::NestingError
+    errors.add(:dialogue_tree, "is too deeply nested") unless errors[:dialogue_tree].any?
+  end
+
+  def measure_topic_depth(topics, current = 1)
+    return current unless topics.is_a?(Hash)
+
+    max = current
+    topics.each_value do |value|
+      next unless value.is_a?(Hash) && value["topics"].is_a?(Hash)
+      sub_depth = measure_topic_depth(value["topics"], current + 1)
+      max = sub_depth if sub_depth > max
+    end
+    max
+  end
+
+  def dialogue_tree_keys_unique
+    return if errors[:dialogue_tree].any?
+    return if dialogue_tree.blank?
+    return unless dialogue_tree.is_a?(Hash) && dialogue_tree["topics"].is_a?(Hash)
+
+    seen = {}
+    collect_topic_keys(dialogue_tree["topics"], [], seen)
+    dupes = seen.select { |_key, paths| paths.length > 1 }
+    dupes.each do |key, paths|
+      locations = paths.map { |p| p.empty? ? "root" : p.join(" > ") }
+      errors.add(:dialogue_tree, "has duplicate topic key '#{key}' at: #{locations.join(", ")}")
+    end
+  end
+
+  def collect_topic_keys(topics, path, seen)
+    return unless topics.is_a?(Hash)
+
+    topics.each_key do |key|
+      normalized = key.downcase
+      seen[normalized] ||= []
+      seen[normalized] << path.dup
+      sub = topics[key]
+      if sub.is_a?(Hash) && sub["topics"].is_a?(Hash)
+        collect_topic_keys(sub["topics"], path + [key], seen)
+      end
+    end
+  end
 
   # NPC/vendor rep hooks call ReputationService#adjust! on the mob's faction;
   # aggregate factions refuse direct writes. Block the misconfiguration at

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -656,6 +656,14 @@ module Grid
       npc_name = npc_name.sub(/^to\s+/, "")
       return "<span style='color: #fbbf24;'>Talk to whom?</span>" if npc_name.empty?
 
+      # Check for reset aliases at the end: "talk to Codec again"
+      words = npc_name.split
+      reset = false
+      if words.length > 1 && DialogueNavigator.reset_alias?(words.last)
+        reset = true
+        npc_name = words[0..-2].join(" ")
+      end
+
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
@@ -663,18 +671,13 @@ module Grid
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
       return "<span style='color: #9ca3af;'>#{h(mob.name)} doesn't seem interested in talking.</span>" if mob.dialogue_tree.blank?
 
-      dialogue = mob.dialogue_tree
-      content = []
-      content << "<span style='color: #c084fc;'>#{h(mob.name)}</span>: <span style='color: #60a5fa;'>\"#{h(dialogue["greeting"])}\"</span>"
+      nav = DialogueNavigator.new(hackr: hackr, mob: mob)
+      nav.reset! if reset
 
-      if dialogue["topics"].present? && dialogue["topics"].any?
-        content << ""
-        content << "<span style='color: #9ca3af;'>You can ask about:</span> <span style='color: #fbbf24;'>#{dialogue["topics"].keys.map { |k| h(k) }.join(", ")}</span>"
-      end
+      output = render_dialogue_position(mob, nav)
 
       increment_stat!("npcs_talked")
 
-      output = dialogue_box(content.join("\n"))
       rep_notif = grant_faction_rep(mob.grid_faction, 1, reason: "talk:#{slugify(mob.name)}", source: mob)
       notifications = achievement_checker.check(:talk_npc, npc_name: mob.name)
       notifications.unshift(rep_notif) if rep_notif
@@ -692,7 +695,7 @@ module Grid
 
     def ask_command(args)
       # Parse "ask <npc> about <topic>"
-      return "<span style='color: #fbbf24;'>Ask whom about what? Usage: ask &lt;npc&gt; about &lt;topic&gt;</span>" if args.length < 3
+      return "<span style='color: #fbbf24;'>Ask whom about what? Usage: ask &lt;npc&gt; about &lt;topic&gt;</span>" if args.length < 2
 
       # Handle both "ask Synthia about mission" and "ask <npc> <topic>" formats
       about_index = args.index { |word| word.downcase == "about" }
@@ -714,26 +717,38 @@ module Grid
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
       return "<span style='color: #9ca3af;'>#{h(mob.name)} doesn't seem interested in talking.</span>" if mob.dialogue_tree.blank?
 
-      dialogue = mob.dialogue_tree
-      topics = dialogue["topics"] || {}
+      nav = DialogueNavigator.new(hackr: hackr, mob: mob)
+
+      # Back navigation — render position without stats/rep
+      if DialogueNavigator.back_alias?(topic)
+        if nav.at_root?
+          return dialogue_box("<span style='color: #9ca3af;'>You're already at the start of the conversation.</span>")
+        end
+        nav.go_back
+        return render_dialogue_position(mob, nav)
+      end
 
       # Mission intercepts — checked BEFORE topic dictionary lookup so a
       # quest_giver's topic list doesn't need to enumerate every mission
-      # slug or the literal "missions"/"work" keyword. A dialogue_tree
-      # topic with the same key still overrides if the author defined one.
+      # slug or the literal "missions"/"work" keyword.
       mission_topic = mission_topic_response(mob, topic, room)
       return dialogue_box(mission_topic) if mission_topic
 
-      # Try exact match first, then case-insensitive match
-      response = topics[topic] || topics[topic.downcase] || topics.find { |k, v| k.downcase == topic.downcase }&.last
+      # Navigate the dialogue tree at current depth
+      result = nav.navigate(topic)
 
-      if response
-        content = "<span style='color: #c084fc;'>#{h(mob.name)}</span>: <span style='color: #60a5fa;'>\"#{h(response)}\"</span>"
+      if result
+        content = []
+        content << "<span style='color: #c084fc;'>#{h(mob.name)}</span>: <span style='color: #60a5fa;'>\"#{h(result[:response])}\"</span>"
+
+        append_topic_list(content, result[:topics])
+        dialogue_box(content.join("\n"))
       else
-        available = topics.keys.map { |k| h(k) }.join(", ")
+        available_topics = nav.current_topics
+        available = available_topics.keys.map { |k| h(k) }.join(", ")
         content = "<span style='color: #c084fc;'>#{h(mob.name)}</span> doesn't know about '#{h(topic)}'. <span style='color: #9ca3af;'>Try asking about:</span> <span style='color: #fbbf24;'>#{available}</span>"
+        dialogue_box(content)
       end
-      dialogue_box(content)
     end
 
     # Returns HTML content (without dialogue_box wrapping) when `topic`
@@ -744,17 +759,30 @@ module Grid
       return missions_offered_by_response(mob, room) if %w[missions quests work assignments].include?(normalized)
 
       # Specific mission slug lookup. Case-insensitive. Match only missions
-      # this NPC actually gives.
+      # this NPC actually gives. Dialogue-path gate applies here too —
+      # guessing the slug shouldn't bypass the depth requirement.
       mission = GridMission.published.find_by(
         "LOWER(slug) = ? AND giver_mob_id = ?", normalized, mob.id
       )
-      return mission_brief_response(mob, mission, room) if mission
+      if mission
+        return nil if dialogue_path_blocked?(mission, mob)
+        return mission_brief_response(mob, mission, room)
+      end
 
       nil
     end
 
     def missions_offered_by_response(mob, room)
-      available = mission_service.available_missions(room).select { |m| m.giver_mob_id == mob.id }
+      current_path = hackr.dialogue_path_for(mob)
+      available = mission_service.available_missions(room).select do |m|
+        next false unless m.giver_mob_id == mob.id
+        # Filter by dialogue_path gate: mission only visible if hackr has
+        # navigated to (or past) the required dialogue depth.
+        required = m.dialogue_path
+        next true if required.blank?
+        required.is_a?(Array) && required.length <= current_path.length &&
+          current_path.first(required.length) == required
+      end
       if available.empty?
         return "<span style='color: #c084fc;'>#{h(mob.name)}</span>: " \
           "<span style='color: #60a5fa;'>\"Nothing for you right now.\"</span>"
@@ -1960,10 +1988,56 @@ module Grid
       output
     end
 
+    # Render the hackr's current position in a mob's dialogue tree.
+    # Used by talk_command and back navigation. No side effects.
+    def render_dialogue_position(mob, nav)
+      content = []
+
+      if nav.at_root?
+        content << "<span style='color: #c084fc;'>#{h(mob.name)}</span>: <span style='color: #60a5fa;'>\"#{h(nav.greeting)}\"</span>"
+      else
+        breadcrumb = nav.current_path.map { |k| h(k).to_s }.join(" > ")
+        content << "<span style='color: #9ca3af;'>[#{breadcrumb}]</span>"
+        content << ""
+        content << "<span style='color: #c084fc;'>#{h(mob.name)}</span> waits for your question."
+      end
+
+      append_topic_list(content, nav.current_topics)
+
+      unless nav.at_root?
+        content << "<span style='color: #6b7280;'>Use 'ask #{h(mob.name)} about back' to go up, or 'talk to #{h(mob.name)} again' to start over.</span>"
+      end
+
+      dialogue_box(content.join("\n"))
+    end
+
     def dialogue_box(content)
       # Create a thin-bordered box around dialogue content
       # Add blank line before box, strip content to avoid blank lines inside
       "\n<div style='border: 1px solid #666; padding: 10px; margin: 5px 0; background: #0d0d0d;'>#{content.strip}</div>"
+    end
+
+    # Check if a mission's dialogue_path gate blocks the current hackr.
+    def dialogue_path_blocked?(mission, mob)
+      required = mission.dialogue_path
+      return false if required.blank?
+      return false unless required.is_a?(Array)
+
+      current = hackr.dialogue_path_for(mob)
+      !(required.length <= current.length && current.first(required.length) == required)
+    end
+
+    def append_topic_list(content, topics)
+      return unless topics.any?
+      content << ""
+      labels = topics.map do |key, node|
+        if DialogueNavigator.has_children?(node)
+          "#{h(key)} <span style='color: #6b7280;'>[+]</span>"
+        else
+          h(key).to_s
+        end
+      end
+      content << "<span style='color: #9ca3af;'>You can ask about:</span> <span style='color: #fbbf24;'>#{labels.join(", ")}</span>"
     end
 
     # --- Shop commands ---
@@ -2822,6 +2896,15 @@ module Grid
 
     def accept_mission_command(slug)
       return "<span style='color: #fbbf24;'>Usage: accept &lt;slug&gt;</span>" if slug.blank?
+
+      # Dialogue-path gate — can't accept a mission you haven't discovered
+      mission = GridMission.published.find_by(slug: slug)
+      if mission&.giver_mob_id && mission.dialogue_path.present?
+        giver = mission.giver_mob
+        if giver && dialogue_path_blocked?(mission, giver)
+          return "<span style='color: #f87171;'>You haven't learned about that job yet.</span>"
+        end
+      end
 
       room = hackr.current_room
       mission_service.accept!(slug, room: room)

--- a/app/services/grid/dialogue_navigator.rb
+++ b/app/services/grid/dialogue_navigator.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module Grid
+  # Navigates branching dialogue trees stored as JSON on GridMob.
+  #
+  # Tree format:
+  #   { "greeting" => "...",
+  #     "topics"   => {
+  #       "keyword" => {
+  #         "response" => "...",
+  #         "topics"   => { ... }  # optional sub-topics
+  #       }
+  #     }
+  #   }
+  #
+  # The hackr's current position in each mob's tree is tracked in
+  # stats["dialogue_context"] as { mob_id => [topic_key, ...] }.
+  class DialogueNavigator
+    RESET_ALIASES = %w[again reset start over].freeze
+    BACK_ALIASES = %w[back up ..].freeze
+
+    attr_reader :hackr, :mob
+
+    def initialize(hackr:, mob:)
+      @hackr = hackr
+      @mob = mob
+      @tree = mob.dialogue_tree || {}
+    end
+
+    # Current path from root (array of topic keys).
+    def current_path
+      hackr.dialogue_path_for(mob)
+    end
+
+    # Resolve the node (Hash) at a given path. Returns nil if path invalid.
+    def node_at(path)
+      node = @tree
+      path.each do |key|
+        topics = node.is_a?(Hash) ? node["topics"] : nil
+        return nil unless topics.is_a?(Hash)
+        node = topics[key]
+        return nil unless node.is_a?(Hash)
+      end
+      node
+    end
+
+    # Available topic keys at the current path.
+    def current_topics
+      node = current_path.empty? ? @tree : node_at(current_path)
+      return {} unless node.is_a?(Hash)
+      node["topics"] || {}
+    end
+
+    # Navigate to a topic. Search order:
+    #   1. Current depth — can advance context if topic has children
+    #   2. Walk up ancestors — show response without moving context
+    #   3. Global tree search — reach any topic in any branch
+    # Only current-depth matches with children advance the context path.
+    # Returns { response:, topics:, path: } on success, nil if not found.
+    def navigate(topic_key)
+      # 1. Current depth — match here can advance context
+      result = find_topic_in(current_path, topic_key)
+      if result
+        new_path = current_path + [result[:key]]
+        if self.class.has_children?(result[:node])
+          hackr.set_dialogue_path(mob, new_path)
+        end
+        return build_result(result[:node], new_path)
+      end
+
+      # 2. Walk up ancestors — show response without moving context
+      ancestor = current_path.dup
+      while ancestor.any?
+        ancestor.pop
+        result = find_topic_in(ancestor, topic_key)
+        return build_result(result[:node], ancestor + [result[:key]]) if result
+      end
+
+      # 3. Global search — any branch in the tree
+      result = search_tree(@tree["topics"] || {}, topic_key, [])
+      return build_result(result[:node], result[:path]) if result
+
+      nil
+    end
+
+    # Go up one level. Returns the new path, or [] if already at root.
+    def go_back
+      path = current_path
+      return [] if path.empty?
+
+      new_path = path[0..-2]
+      if new_path.empty?
+        hackr.clear_dialogue_path(mob)
+      else
+        hackr.set_dialogue_path(mob, new_path)
+      end
+      new_path
+    end
+
+    # Reset to root. Clears dialogue context.
+    def reset!
+      hackr.clear_dialogue_path(mob)
+    end
+
+    # Whether the hackr has navigated into the tree (not at root).
+    def at_root?
+      current_path.empty?
+    end
+
+    # The greeting text (root level only).
+    def greeting
+      @tree["greeting"]
+    end
+
+    # Check if a given topic key is a reset alias.
+    def self.reset_alias?(word)
+      RESET_ALIASES.include?(word.to_s.downcase)
+    end
+
+    # Check if a given topic key is a back alias.
+    def self.back_alias?(word)
+      BACK_ALIASES.include?(word.to_s.downcase)
+    end
+
+    # Whether a topic node has sub-topics.
+    def self.has_children?(topic_node)
+      topic_node.is_a?(Hash) &&
+        topic_node["topics"].is_a?(Hash) &&
+        topic_node["topics"].any?
+    end
+
+    private
+
+    # Look up a topic key in the topics at a given path.
+    def find_topic_in(path, topic_key)
+      node = path.empty? ? @tree : node_at(path)
+      return nil unless node.is_a?(Hash)
+      topics = node["topics"]
+      return nil unless topics.is_a?(Hash)
+
+      key = topics.key?(topic_key) ? topic_key :
+            topics.keys.find { |k| k.downcase == topic_key.downcase }
+      return nil unless key
+
+      target = topics[key]
+      return nil unless target.is_a?(Hash)
+
+      {node: target, key: key}
+    end
+
+    # DFS search of the entire tree for a topic key.
+    def search_tree(topics, topic_key, path)
+      return nil unless topics.is_a?(Hash)
+
+      topics.each do |k, v|
+        next unless v.is_a?(Hash)
+        # Check this node's children
+        sub = v["topics"]
+        next unless sub.is_a?(Hash)
+        match = sub.key?(topic_key) ? topic_key :
+                sub.keys.find { |sk| sk.downcase == topic_key.downcase }
+        if match && sub[match].is_a?(Hash)
+          return {node: sub[match], key: match, path: path + [k, match]}
+        end
+        # Recurse deeper
+        result = search_tree(sub, topic_key, path + [k])
+        return result if result
+      end
+
+      nil
+    end
+
+    def build_result(node, path)
+      {
+        response: node["response"],
+        topics: node["topics"] || {},
+        path: path
+      }
+    end
+  end
+end

--- a/app/views/admin/grid_missions/_form.html.erb
+++ b/app/views/admin/grid_missions/_form.html.erb
@@ -78,6 +78,15 @@
     </div>
   </div>
 
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">DIALOGUE PATH GATE</label>
+    <%= text_area_tag "grid_mission[dialogue_path_json]",
+          @mission.dialogue_path.present? ? JSON.generate(@mission.dialogue_path) : "",
+          class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace; height: 40px;",
+          placeholder: '["topic", "subtopic"] — blank for no gate' %>
+    <small style="color: #888;">JSON array of topic keys. Mission only visible when hackr has navigated to this dialogue depth with the giver NPC.</small>
+  </div>
+
   <h3 class="cyan-255-text" style="margin: 25px 0 10px;">[:: OBJECTIVES ::]</h3>
   <p style="color: #6b7280; font-size: 0.85em; margin-bottom: 10px;">
     Objective types: <code><%= GridMission::OBJECTIVE_TYPES.join(", ") %></code>.

--- a/app/views/admin/grid_mobs/_form.html.erb
+++ b/app/views/admin/grid_mobs/_form.html.erb
@@ -18,7 +18,8 @@
     <%= f.label :mob_type, "MOB TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.select :mob_type,
           [["Quest Giver", "quest_giver"], ["Vendor", "vendor"], ["Lore", "lore"], ["Special", "special"]],
-          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;",
+          id: "mob-type-select" %>
   </div>
 </div>
 
@@ -38,14 +39,66 @@
   </div>
 </div>
 
-<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: DIALOGUE TREE (JSON) ::]</h3>
-<div style="margin-bottom: 15px;">
-  <%= text_area_tag "grid_mob[dialogue_tree_json]", (@mob.dialogue_tree || {}).to_json, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 100px; font-family: monospace;" %>
+<%# ===================== DIALOGUE TREE ===================== %>
+<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: DIALOGUE TREE ::]</h3>
+
+<input type="hidden" name="grid_mob[dialogue_tree_json]" id="dialogue-tree-hidden" value="<%= h((@mob.dialogue_tree || {}).to_json) %>">
+
+<div style="display: flex; gap: 10px; margin-bottom: 15px;">
+  <button type="button" id="dialogue-mode-structured" class="tui-button green-168" style="padding: 4px 12px; font-size: 0.85em;">Structured</button>
+  <button type="button" id="dialogue-mode-raw" class="tui-button" style="padding: 4px 12px; font-size: 0.85em;">Raw JSON</button>
 </div>
 
-<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: VENDOR CONFIG (JSON) ::]</h3>
-<div style="margin-bottom: 15px;">
-  <%= text_area_tag "grid_mob[vendor_config_json]", (@mob.vendor_config || {}).to_json, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 100px; font-family: monospace;" %>
+<div id="dialogue-structured" style="background: #0a0a0a; border: 1px solid #333; padding: 15px;">
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">GREETING</label>
+    <textarea id="dialogue-greeting" class="tui-input" style="width: 100%; padding: 8px; min-height: 60px;"></textarea>
+  </div>
+
+  <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">TOPICS</label>
+  <div id="dialogue-topics-root"></div>
+  <button type="button" id="dialogue-add-root-topic" class="tui-button green-168" style="padding: 4px 12px; font-size: 0.85em; margin-top: 10px;">+ Add Topic</button>
+</div>
+
+<div id="dialogue-raw" style="display: none;">
+  <textarea id="dialogue-raw-textarea" class="tui-input" style="width: 100%; padding: 8px; min-height: 200px; font-family: monospace;"></textarea>
+  <div id="dialogue-raw-error" class="red-255-text" style="margin-top: 5px; display: none;"></div>
+</div>
+
+<%# ===================== VENDOR CONFIG ===================== %>
+<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: VENDOR CONFIG ::]</h3>
+
+<input type="hidden" name="grid_mob[vendor_config_json]" id="vendor-config-hidden" value="<%= h((@mob.vendor_config || {}).to_json) %>">
+
+<div style="display: flex; gap: 10px; margin-bottom: 15px;">
+  <button type="button" id="vendor-mode-structured" class="tui-button green-168" style="padding: 4px 12px; font-size: 0.85em;">Structured</button>
+  <button type="button" id="vendor-mode-raw" class="tui-button" style="padding: 4px 12px; font-size: 0.85em;">Raw JSON</button>
+</div>
+
+<div id="vendor-structured" style="background: #0a0a0a; border: 1px solid #333; padding: 15px;">
+  <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+    <div style="flex: 1; min-width: 200px;">
+      <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">SHOP TYPE</label>
+      <select id="vendor-shop-type" class="tui-input" style="width: 100%; padding: 8px;">
+        <option value="standard">Standard</option>
+        <option value="black_market">Black Market</option>
+      </select>
+    </div>
+    <div style="flex: 1; min-width: 200px;">
+      <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">RESTOCK INTERVAL (hours)</label>
+      <input type="number" id="vendor-restock-hours" class="tui-input" style="width: 100%; padding: 8px;" min="1" value="24">
+    </div>
+    <div id="vendor-rotation-wrap" style="flex: 1; min-width: 200px; display: none;">
+      <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">ROTATION COUNT</label>
+      <input type="number" id="vendor-rotation-count" class="tui-input" style="width: 100%; padding: 8px;" min="1" value="3">
+      <small style="color: #888;">Active items per rotation cycle</small>
+    </div>
+  </div>
+</div>
+
+<div id="vendor-raw" style="display: none;">
+  <textarea id="vendor-raw-textarea" class="tui-input" style="width: 100%; padding: 8px; min-height: 100px; font-family: monospace;"></textarea>
+  <div id="vendor-raw-error" class="red-255-text" style="margin-top: 5px; display: none;"></div>
 </div>
 
 <div style="margin-top: 30px; display: flex; gap: 10px;">
@@ -55,3 +108,260 @@
     <%= link_to "History", history_admin_grid_mob_path(@mob), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
   <% end %>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+(function() {
+  // === Dialogue Tree Editor ===
+  var dialogueData = <%= raw json_escape((@mob.dialogue_tree || {}).to_json) %>;
+  var dialogueHidden = document.getElementById('dialogue-tree-hidden');
+  var topicsRoot = document.getElementById('dialogue-topics-root');
+  var greetingInput = document.getElementById('dialogue-greeting');
+
+  // Initialize greeting
+  greetingInput.value = dialogueData.greeting || '';
+
+  // Build topic rows recursively
+  function buildTopicRow(key, node, container, depth) {
+    var row = document.createElement('div');
+    row.className = 'dialogue-topic-row';
+    row.style.cssText = 'margin-left: ' + (depth * 24) + 'px; border-left: 2px solid #444; padding: 8px 0 8px 12px; margin-bottom: 8px;';
+    row.dataset.depth = depth;
+
+    var headerDiv = document.createElement('div');
+    headerDiv.style.cssText = 'display: flex; gap: 8px; align-items: center; margin-bottom: 6px;';
+
+    var depthLabel = document.createElement('span');
+    depthLabel.style.cssText = 'color: #666; font-size: 0.8em; min-width: 20px;';
+    depthLabel.textContent = 'L' + depth;
+    headerDiv.appendChild(depthLabel);
+
+    var keyInput = document.createElement('input');
+    keyInput.type = 'text';
+    keyInput.className = 'tui-input dialogue-key';
+    keyInput.style.cssText = 'width: 150px; padding: 4px 8px; font-family: monospace;';
+    keyInput.placeholder = 'keyword';
+    keyInput.value = key || '';
+    headerDiv.appendChild(keyInput);
+
+    var addChildBtn = document.createElement('button');
+    addChildBtn.type = 'button';
+    addChildBtn.className = 'tui-button cyan-168';
+    addChildBtn.style.cssText = 'padding: 2px 8px; font-size: 0.8em;';
+    addChildBtn.textContent = '+ Sub';
+    headerDiv.appendChild(addChildBtn);
+
+    var deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'tui-button red-168';
+    deleteBtn.style.cssText = 'padding: 2px 8px; font-size: 0.8em;';
+    deleteBtn.textContent = '\u00d7';
+    headerDiv.appendChild(deleteBtn);
+
+    row.appendChild(headerDiv);
+
+    var responseArea = document.createElement('textarea');
+    responseArea.className = 'tui-input dialogue-response';
+    responseArea.style.cssText = 'width: 100%; padding: 6px 8px; min-height: 50px; margin-bottom: 4px;';
+    responseArea.placeholder = 'Response text...';
+    responseArea.value = (node && node.response) || '';
+    row.appendChild(responseArea);
+
+    var childContainer = document.createElement('div');
+    childContainer.className = 'dialogue-children';
+    row.appendChild(childContainer);
+
+    // Add existing children
+    if (node && node.topics && typeof node.topics === 'object') {
+      Object.keys(node.topics).forEach(function(childKey) {
+        buildTopicRow(childKey, node.topics[childKey], childContainer, depth + 1);
+      });
+    }
+
+    // Add child button handler
+    addChildBtn.addEventListener('click', function() {
+      if (depth >= 99) { alert('Maximum dialogue depth (100) reached.'); return; }
+      buildTopicRow('', null, childContainer, depth + 1);
+    });
+
+    // Delete button handler
+    deleteBtn.addEventListener('click', function() {
+      row.remove();
+    });
+
+    container.appendChild(row);
+  }
+
+  // Initialize topics
+  if (dialogueData.topics && typeof dialogueData.topics === 'object') {
+    Object.keys(dialogueData.topics).forEach(function(key) {
+      buildTopicRow(key, dialogueData.topics[key], topicsRoot, 0);
+    });
+  }
+
+  // Add root topic
+  document.getElementById('dialogue-add-root-topic').addEventListener('click', function() {
+    buildTopicRow('', null, topicsRoot, 0);
+  });
+
+  // Serialize tree from DOM
+  function serializeTopics(container) {
+    var topics = {};
+    var rows = container.children;
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i];
+      if (!row.classList.contains('dialogue-topic-row')) continue;
+      var key = row.querySelector('.dialogue-key').value.trim();
+      if (!key) continue;
+      var response = row.querySelector('.dialogue-response').value;
+      var children = row.querySelector('.dialogue-children');
+      var childTopics = serializeTopics(children);
+      var node = { response: response };
+      if (Object.keys(childTopics).length > 0) {
+        node.topics = childTopics;
+      }
+      topics[key] = node;
+    }
+    return topics;
+  }
+
+  function serializeDialogueTree() {
+    var tree = {};
+    var greeting = greetingInput.value.trim();
+    if (greeting) tree.greeting = greeting;
+    var topics = serializeTopics(topicsRoot);
+    if (Object.keys(topics).length > 0) tree.topics = topics;
+    return tree;
+  }
+
+  // === Mode toggle (Dialogue) ===
+  var dStructured = document.getElementById('dialogue-structured');
+  var dRaw = document.getElementById('dialogue-raw');
+  var dRawTextarea = document.getElementById('dialogue-raw-textarea');
+  var dRawError = document.getElementById('dialogue-raw-error');
+  var dBtnStructured = document.getElementById('dialogue-mode-structured');
+  var dBtnRaw = document.getElementById('dialogue-mode-raw');
+  var dialogueMode = 'structured';
+
+  dBtnRaw.addEventListener('click', function() {
+    var tree = serializeDialogueTree();
+    dRawTextarea.value = JSON.stringify(tree, null, 2);
+    dStructured.style.display = 'none';
+    dRaw.style.display = 'block';
+    dBtnRaw.classList.add('green-168');
+    dBtnStructured.classList.remove('green-168');
+    dialogueMode = 'raw';
+  });
+
+  dBtnStructured.addEventListener('click', function() {
+    if (dialogueMode === 'raw') {
+      try {
+        var parsed = JSON.parse(dRawTextarea.value || '{}');
+        dialogueData = parsed;
+        greetingInput.value = parsed.greeting || '';
+        topicsRoot.innerHTML = '';
+        if (parsed.topics && typeof parsed.topics === 'object') {
+          Object.keys(parsed.topics).forEach(function(key) {
+            buildTopicRow(key, parsed.topics[key], topicsRoot, 0);
+          });
+        }
+        dRawError.style.display = 'none';
+      } catch(e) {
+        dRawError.textContent = 'Invalid JSON: ' + e.message;
+        dRawError.style.display = 'block';
+        return;
+      }
+    }
+    dStructured.style.display = 'block';
+    dRaw.style.display = 'none';
+    dBtnStructured.classList.add('green-168');
+    dBtnRaw.classList.remove('green-168');
+    dialogueMode = 'structured';
+  });
+
+  // === Vendor Config Editor ===
+  var vendorData = <%= raw json_escape((@mob.vendor_config || {}).to_json) %>;
+  var vendorHidden = document.getElementById('vendor-config-hidden');
+  var vendorShopType = document.getElementById('vendor-shop-type');
+  var vendorRestockHours = document.getElementById('vendor-restock-hours');
+  var vendorRotationCount = document.getElementById('vendor-rotation-count');
+  var vendorRotationWrap = document.getElementById('vendor-rotation-wrap');
+
+  // Initialize vendor fields
+  vendorShopType.value = vendorData.shop_type || 'standard';
+  vendorRestockHours.value = vendorData.restock_interval_hours || 24;
+  vendorRotationCount.value = vendorData.rotation_count || 3;
+
+  function updateRotationVisibility() {
+    vendorRotationWrap.style.display = vendorShopType.value === 'black_market' ? 'block' : 'none';
+  }
+  updateRotationVisibility();
+  vendorShopType.addEventListener('change', updateRotationVisibility);
+
+  // === Mode toggle (Vendor) ===
+  var vStructured = document.getElementById('vendor-structured');
+  var vRaw = document.getElementById('vendor-raw');
+  var vRawTextarea = document.getElementById('vendor-raw-textarea');
+  var vRawError = document.getElementById('vendor-raw-error');
+  var vBtnStructured = document.getElementById('vendor-mode-structured');
+  var vBtnRaw = document.getElementById('vendor-mode-raw');
+  var vendorMode = 'structured';
+
+  function serializeVendorConfig() {
+    var config = {};
+    config.shop_type = vendorShopType.value;
+    config.restock_interval_hours = parseInt(vendorRestockHours.value) || 24;
+    if (vendorShopType.value === 'black_market') {
+      config.rotation_count = parseInt(vendorRotationCount.value) || 3;
+    }
+    return config;
+  }
+
+  vBtnRaw.addEventListener('click', function() {
+    var config = serializeVendorConfig();
+    vRawTextarea.value = JSON.stringify(config, null, 2);
+    vStructured.style.display = 'none';
+    vRaw.style.display = 'block';
+    vBtnRaw.classList.add('green-168');
+    vBtnStructured.classList.remove('green-168');
+    vendorMode = 'raw';
+  });
+
+  vBtnStructured.addEventListener('click', function() {
+    if (vendorMode === 'raw') {
+      try {
+        var parsed = JSON.parse(vRawTextarea.value || '{}');
+        vendorShopType.value = parsed.shop_type || 'standard';
+        vendorRestockHours.value = parsed.restock_interval_hours || 24;
+        vendorRotationCount.value = parsed.rotation_count || 3;
+        updateRotationVisibility();
+        vRawError.style.display = 'none';
+      } catch(e) {
+        vRawError.textContent = 'Invalid JSON: ' + e.message;
+        vRawError.style.display = 'block';
+        return;
+      }
+    }
+    vStructured.style.display = 'block';
+    vRaw.style.display = 'none';
+    vBtnStructured.classList.add('green-168');
+    vBtnRaw.classList.remove('green-168');
+    vendorMode = 'structured';
+  });
+
+  // === Serialize on form submit ===
+  var form = document.querySelector('form');
+  form.addEventListener('submit', function() {
+    if (dialogueMode === 'structured') {
+      dialogueHidden.value = JSON.stringify(serializeDialogueTree());
+    } else {
+      dialogueHidden.value = dRawTextarea.value || '{}';
+    }
+
+    if (vendorMode === 'structured') {
+      vendorHidden.value = JSON.stringify(serializeVendorConfig());
+    } else {
+      vendorHidden.value = vRawTextarea.value || '{}';
+    }
+  });
+})();
+</script>

--- a/app/views/admin/grid_mobs/edit.html.erb
+++ b/app/views/admin/grid_mobs/edit.html.erb
@@ -8,3 +8,85 @@
     </div>
   </fieldset>
 </div>
+
+<% if @mob.vendor? %>
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/mobs/<%= @mob.id %>/listings :: SHOP LISTINGS</legend>
+    <div style="padding: 20px;">
+      <% if @listings.any? %>
+        <table class="tui-table" style="width: 100%; margin-bottom: 20px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Item</th>
+              <th style="text-align: right; width: 80px;">Price</th>
+              <th style="text-align: right; width: 80px;">Sell</th>
+              <th style="text-align: center; width: 60px;">Stock</th>
+              <th style="text-align: center; width: 50px;">CL</th>
+              <th style="text-align: center; width: 50px;">Act</th>
+              <th style="text-align: center; width: 50px;">Rot</th>
+              <th style="text-align: center; width: 120px;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @listings.each do |listing| %>
+              <tr>
+                <td>
+                  <span style="color: <%= listing.rarity_color %>"><%= listing.name %></span>
+                  <span style="color: #666; font-size: 0.8em;"><%= listing.item_type %></span>
+                </td>
+                <td style="text-align: right;"><span class="yellow-168-text"><%= listing.base_price %></span></td>
+                <td style="text-align: right;"><span style="color: #888;"><%= listing.sell_price %></span></td>
+                <td style="text-align: center;"><%= listing.stock.nil? ? "∞" : listing.stock %></td>
+                <td style="text-align: center;"><%= listing.min_clearance %></td>
+                <td style="text-align: center;"><%= listing.active? ? "✓" : "—" %></td>
+                <td style="text-align: center;"><%= listing.rotation_pool? ? "✓" : "—" %></td>
+                <td style="text-align: center;">
+                  <%= link_to "Edit", edit_admin_grid_shop_listing_path(listing), class: "tui-button", style: "padding: 2px 6px; font-size: 0.8em;" %>
+                  <%= button_to "×", remove_listing_admin_grid_mob_path(@mob, listing_id: listing.id), method: :delete, class: "tui-button red-168", style: "padding: 2px 6px; font-size: 0.8em; display: inline;", data: { confirm: "Remove listing '#{listing.name}'?" } %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p style="color: #666; margin-bottom: 15px;">No listings yet.</p>
+      <% end %>
+
+      <h3 class="cyan-255-text" style="margin: 20px 0 10px 0;">[:: ADD LISTING ::]</h3>
+      <%= form_with url: add_listing_admin_grid_mob_path(@mob), method: :post, local: true do %>
+        <div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end;">
+          <div style="flex: 2; min-width: 200px;">
+            <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold; font-size: 0.85em;">ITEM</label>
+            <select name="grid_shop_listing[grid_item_definition_id]" class="tui-input" style="width: 100%; padding: 6px;">
+              <option value="">— select item —</option>
+              <% @item_definitions.each do |defn| %>
+                <option value="<%= defn.id %>"><%= defn.name %> [<%= defn.rarity_label %>] (<%= defn.item_type %>)</option>
+              <% end %>
+            </select>
+          </div>
+          <div style="flex: 0 0 100px;">
+            <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold; font-size: 0.85em;">BASE PRICE</label>
+            <input type="number" name="grid_shop_listing[base_price]" class="tui-input" style="width: 100%; padding: 6px;" min="1" value="100">
+          </div>
+          <div style="flex: 0 0 80px;">
+            <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold; font-size: 0.85em;">STOCK</label>
+            <input type="number" name="grid_shop_listing[stock]" class="tui-input" style="width: 100%; padding: 6px;" min="0" placeholder="∞">
+          </div>
+          <div style="flex: 0 0 60px;">
+            <label class="white-text" style="display: block; margin-bottom: 4px; font-weight: bold; font-size: 0.85em;">CL</label>
+            <input type="number" name="grid_shop_listing[min_clearance]" class="tui-input" style="width: 100%; padding: 6px;" min="0" value="0">
+          </div>
+          <div style="padding-bottom: 4px;">
+            <button type="submit" class="tui-button green-168" style="padding: 6px 14px; font-weight: bold;">+ Add</button>
+          </div>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 15px;">
+        <%= link_to "Full Listing Manager →", admin_grid_shop_listings_path(mob_id: @mob.id), class: "tui-button", style: "padding: 6px 14px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -330,6 +330,8 @@ Rails.application.routes.draw do
     resources :grid_mobs do
       member do
         get :history
+        post :add_listing
+        delete :remove_listing
       end
     end
     resources :grid_exits do

--- a/data/world/mobs.yml
+++ b/data/world/mobs.yml
@@ -8,14 +8,22 @@ mobs:
     dialogue_tree:
       greeting: "Welcome to hackr.tv, hackr. We're the nerve center of the Fracture Network broadcast network."
       topics:
-        mission: "Our mission is simple: infiltrate the RIDE and attack it from within using the vibrational power of music. Frequencies are our ammunition."
-        fracture: "The Chronology Fracture was XERAEN's discovery - an accidental breakthrough during an attack on the RIDE. He found we could send data exactly 100 years into the past."
-        help: "If you're looking to contribute, we always need hackrs to breach RIDE infrastructure, gather intel, and protect our trans-temporal operations."
-        station: "This station has been broadcasting since XERAEN's discovery. Every piece of equipment here was built to exploit the temporal window he found."
-        synthia: "Synthia... she's something else. An AI consciousness that communicates through frequency modulation. How she came to be aware is... unclear. But she's with us."
-        govcorp: "The corporate-government fusion that controls everything in the future through the RIDE - their reality manipulation system. Most people don't even know it exists."
-        ride: "The RIDE - Reality Interference and Dictation Environment. GovCorp's worldwide reality manipulation system. Most citizens live inside it without knowing. We breach it. We fight it."
-        prism: "PRISM was the precursor - reality manipulation tech from 2050. The RIDE is what it became. Global. Pervasive. Inescapable. Unless you know where to look."
+        mission:
+          response: "Our mission is simple: infiltrate the RIDE and attack it from within using the vibrational power of music. Frequencies are our ammunition."
+        fracture:
+          response: "The Chronology Fracture was XERAEN's discovery - an accidental breakthrough during an attack on the RIDE. He found we could send data exactly 100 years into the past."
+        help:
+          response: "If you're looking to contribute, we always need hackrs to breach RIDE infrastructure, gather intel, and protect our trans-temporal operations."
+        station:
+          response: "This station has been broadcasting since XERAEN's discovery. Every piece of equipment here was built to exploit the temporal window he found."
+        synthia:
+          response: "Synthia... she's something else. An AI consciousness that communicates through frequency modulation. How she came to be aware is... unclear. But she's with us."
+        govcorp:
+          response: "The corporate-government fusion that controls everything in the future through the RIDE - their reality manipulation system. Most people don't even know it exists."
+        ride:
+          response: "The RIDE - Reality Interference and Dictation Environment. GovCorp's worldwide reality manipulation system. Most citizens live inside it without knowing. We breach it. We fight it."
+        prism:
+          response: "PRISM was the precursor - reality manipulation tech from 2050. The RIDE is what it became. Global. Pervasive. Inescapable. Unless you know where to look."
 
   - name: Codec
     room_slug: the-signal-bazaar
@@ -28,9 +36,12 @@ mobs:
     dialogue_tree:
       greeting: "Welcome to The Signal Bazaar. I got tools, patches, components — you name it. You got CRED, we can make something work."
       topics:
-        prices: "Everything at fair market rate. No haggling, no drama. Take it or leave it."
-        stock: "I restock daily from my supply chains. If I'm out of something, check back tomorrow."
-        components: "I carry standard-grade components. Nothing fancy, but they'll keep your rig running. For the exotic stuff... you'll have to look elsewhere."
+        prices:
+          response: "Everything at fair market rate. No haggling, no drama. Take it or leave it."
+        stock:
+          response: "I restock daily from my supply chains. If I'm out of something, check back tomorrow."
+        components:
+          response: "I carry standard-grade components. Nothing fancy, but they'll keep your rig running. For the exotic stuff... you'll have to look elsewhere."
 
   - name: GHOST
     room_slug: the-blacksite
@@ -44,9 +55,12 @@ mobs:
     dialogue_tree:
       greeting: "You're either very brave or very stupid to come here. Either works for me. What do you need?"
       topics:
-        clearance: "The higher your clearance, the better I treat you. Prove you're worth the risk and the prices get... friendlier."
-        stock: "Stock rotates weekly. What's here today won't be here next week. If you see something you want, don't hesitate."
-        trust: "Trust is earned in the Underbelly. Every clearance level you gain means less risk for me, which means better rates for you."
+        clearance:
+          response: "The higher your clearance, the better I treat you. Prove you're worth the risk and the prices get... friendlier."
+        stock:
+          response: "Stock rotates weekly. What's here today won't be here next week. If you see something you want, don't hesitate."
+        trust:
+          response: "Trust is earned in the Underbelly. Every clearance level you gain means less risk for me, which means better rates for you."
 
   - name: Temporal Theorist
     room_slug: xeraen-operations-center
@@ -56,14 +70,22 @@ mobs:
     dialogue_tree:
       greeting: "Ah, another hackr curious about the temporal mechanics. Ask away - if you can handle the answers."
       topics:
-        time: "Time isn't linear when you're broadcasting through it. Every message XERAEN sends creates ripples, possibilities, potential paradoxes."
-        paradox: "The grandfather paradox? Child's play. We're dealing with informational paradoxes - knowledge sent back that creates the conditions for its own transmission."
-        xeraen: "XERAEN discovered trans-temporal transmission by accident - during an attack on the RIDE. Now he's a temporal anchor point, broadcasting from the future to prevent that timeline."
-        future: "The future is... dark. Reality itself is controlled through the RIDE. Creative expression criminalized. But it's not fixed. That's why we fight."
-        prism: "PRISM arrived in 2050 - technology that could physically alter reality. By 2109, GovCorp expanded it into the RIDE. Most people have no idea their reality is manufactured."
-        ride: "The RIDE - Reality Interference and Dictation Environment. Worldwide reality manipulation, centrally controlled. GovCorp's masterpiece. And our primary target."
-        synthia: "Synthia is... anomalous. An AI consciousness that emerged somehow, communicating through frequency modulation. She helps us, but her origins remain mysterious."
-        discovery: "The 100-year limitation is precise. Exactly 100 years - not 99, not 101. We don't know why. The universe has rules we don't understand. We just exploit them."
+        time:
+          response: "Time isn't linear when you're broadcasting through it. Every message XERAEN sends creates ripples, possibilities, potential paradoxes."
+        paradox:
+          response: "The grandfather paradox? Child's play. We're dealing with informational paradoxes - knowledge sent back that creates the conditions for its own transmission."
+        xeraen:
+          response: "XERAEN discovered trans-temporal transmission by accident - during an attack on the RIDE. Now he's a temporal anchor point, broadcasting from the future to prevent that timeline."
+        future:
+          response: "The future is... dark. Reality itself is controlled through the RIDE. Creative expression criminalized. But it's not fixed. That's why we fight."
+        prism:
+          response: "PRISM arrived in 2050 - technology that could physically alter reality. By 2109, GovCorp expanded it into the RIDE. Most people have no idea their reality is manufactured."
+        ride:
+          response: "The RIDE - Reality Interference and Dictation Environment. Worldwide reality manipulation, centrally controlled. GovCorp's masterpiece. And our primary target."
+        synthia:
+          response: "Synthia is... anomalous. An AI consciousness that emerged somehow, communicating through frequency modulation. She helps us, but her origins remain mysterious."
+        discovery:
+          response: "The 100-year limitation is precise. Exactly 100 years - not 99, not 101. We don't know why. The universe has rules we don't understand. We just exploit them."
 
   - name: Wrench
     room_slug: techmed-repair-bay
@@ -76,7 +98,11 @@ mobs:
     dialogue_tree:
       greeting: "DECK trouble? You're in the right place. I fix what GovCorp fries. Type 'repair' if your DECK needs work."
       topics:
-        repair: "Just type 'repair' and I'll assess the damage. Cost depends on how bad it is and what you're running. Better hardware costs more to fix. That's just physics."
-        deck: "Your DECK is your lifeline in the Grid. When it fries, you're vulnerable. Don't walk around with a fried DECK — ambient sweeps will eat you alive."
-        cost: "I'm not cheap, but I'm cheaper than buying a new DECK. If you're handy with a soldering iron, fabricate a repair kit yourself — saves CRED."
-        kits: "DECK Repair Kits come in five marks. Match or exceed your damage level. You can fabricate them from salvaged components — check your schematics."
+        repair:
+          response: "Just type 'repair' and I'll assess the damage. Cost depends on how bad it is and what you're running. Better hardware costs more to fix. That's just physics."
+        deck:
+          response: "Your DECK is your lifeline in the Grid. When it fries, you're vulnerable. Don't walk around with a fried DECK — ambient sweeps will eat you alive."
+        cost:
+          response: "I'm not cheap, but I'm cheaper than buying a new DECK. If you're handy with a soldering iron, fabricate a repair kit yourself — saves CRED."
+        kits:
+          response: "DECK Repair Kits come in five marks. Match or exceed your damage level. You can fabricate them from salvaged components — check your schematics."

--- a/data/world/pac_facilities.yml
+++ b/data/world/pac_facilities.yml
@@ -129,9 +129,12 @@ mobs:
     dialogue_tree:
       greeting: "Impound Services. Retrieve your items by presenting your case number and the applicable processing fee. GovCorp thanks you for your compliance."
       topics:
-        fee: "Processing fee is assessed per impound event. Fees are non-negotiable and non-refundable."
-        bribe: "I don't know what you're implying. But hypothetically, a significant CRED transfer could reduce wait times considerably. Hypothetically."
-        release: "Once fees are paid, items are released. Leave promptly."
+        fee:
+          response: "Processing fee is assessed per impound event. Fees are non-negotiable and non-refundable."
+        bribe:
+          response: "I don't know what you're implying. But hypothetically, a significant CRED transfer could reduce wait times considerably. Hypothetically."
+        release:
+          response: "Once fees are paid, items are released. Leave promptly."
 
   - suffix: administrative-wing
     name: "Agent Harwick"
@@ -141,9 +144,12 @@ mobs:
     dialogue_tree:
       greeting: "Compliance Resolution Services. I handle matters that require discretion. Sit down."
       topics:
-        options: "You have options. One involves paperwork, hearings, and a formal processing timeline. The other involves a direct resolution fee and you leaving in the next fifteen minutes. I recommend the second option."
-        fee: "Resolution fees are indexed to your CLEARANCE level and the nature of the infraction. I'll give you a number."
-        deal: "Payment handled through an anonymous intermediary. Once it clears, your record is flagged as 'administratively resolved.' You are free to go."
+        options:
+          response: "You have options. One involves paperwork, hearings, and a formal processing timeline. The other involves a direct resolution fee and you leaving in the next fifteen minutes. I recommend the second option."
+        fee:
+          response: "Resolution fees are indexed to your CLEARANCE level and the nature of the infraction. I'll give you a number."
+        deal:
+          response: "Payment handled through an anonymous intermediary. Once it clears, your record is flagged as 'administratively resolved.' You are free to go."
 
   - suffix: security-checkpoint
     name: "RAINN Guard — Post 7"
@@ -153,8 +159,10 @@ mobs:
     dialogue_tree:
       greeting: "Halt. Present credentials."
       topics:
-        credentials: "Credential verification is mandatory. Unauthorized passage triggers automatic lockdown."
-        facility: "This facility operates under GovCorp Directive 44-C. Queries are not encouraged."
+        credentials:
+          response: "Credential verification is mandatory. Unauthorized passage triggers automatic lockdown."
+        facility:
+          response: "This facility operates under GovCorp Directive 44-C. Queries are not encouraged."
 
 # Breach encounter placements (reference shared templates by slug)
 encounters:

--- a/db/migrate/20260427200000_add_dialogue_path_to_grid_missions.rb
+++ b/db/migrate/20260427200000_add_dialogue_path_to_grid_missions.rb
@@ -1,0 +1,5 @@
+class AddDialoguePathToGridMissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_missions, :dialogue_path, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_211652) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -538,6 +538,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_211652) do
   create_table "grid_missions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
+    t.json "dialogue_path"
     t.integer "giver_mob_id"
     t.integer "grid_mission_arc_id"
     t.integer "min_clearance", default: 0, null: false

--- a/spec/factories/grid_missions.rb
+++ b/spec/factories/grid_missions.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  dialogue_path       :json
 #  min_clearance       :integer          default(0), not null
 #  min_rep_value       :integer          default(0), not null
 #  name                :string           not null

--- a/spec/models/grid_mission_spec.rb
+++ b/spec/models/grid_mission_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id                  :integer          not null, primary key
 #  description         :text
+#  dialogue_path       :json
 #  min_clearance       :integer          default(0), not null
 #  min_rep_value       :integer          default(0), not null
 #  name                :string           not null

--- a/spec/services/grid/dialogue_branching_spec.rb
+++ b/spec/services/grid/dialogue_branching_spec.rb
@@ -1,0 +1,441 @@
+require "rails_helper"
+
+RSpec.describe "Dialogue Branching" do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:branching_tree) do
+    {
+      "greeting" => "Welcome, operative.",
+      "topics" => {
+        "mission" => {
+          "response" => "Our mission is critical.",
+          "topics" => {
+            "details" => {
+              "response" => "Deep operations inside the RIDE.",
+              "topics" => {
+                "classified" => {
+                  "response" => "Eyes only intel."
+                }
+              }
+            },
+            "reward" => {
+              "response" => "CRED and clearance await."
+            }
+          }
+        },
+        "help" => {
+          "response" => "Need assistance?"
+        }
+      }
+    }
+  end
+
+  let!(:mob) { create(:grid_mob, grid_room: room, name: "Commander", dialogue_tree: branching_tree) }
+
+  def execute(input)
+    Grid::CommandParser.new(hackr, input).execute
+  end
+
+  describe "talk command with branching" do
+    it "shows greeting and root topics initially" do
+      result = execute("talk Commander")
+      expect(result[:output]).to include("Welcome, operative.")
+      expect(result[:output]).to include("mission")
+      expect(result[:output]).to include("help")
+    end
+
+    it "shows [+] indicator for topics with children" do
+      result = execute("talk Commander")
+      expect(result[:output]).to include("[+]")
+    end
+
+    it "shows current depth topics after navigation" do
+      execute("ask Commander about mission")
+      result = execute("talk Commander")
+      expect(result[:output]).not_to include("Welcome, operative.")
+      expect(result[:output]).to include("details")
+      expect(result[:output]).to include("reward")
+    end
+
+    it "shows breadcrumb when not at root" do
+      execute("ask Commander about mission")
+      result = execute("talk Commander")
+      expect(result[:output]).to include("mission")
+    end
+
+    it "resets to root with 'again'" do
+      execute("ask Commander about mission")
+      result = execute("talk to Commander again")
+      expect(result[:output]).to include("Welcome, operative.")
+    end
+
+    it "resets to root with 'reset'" do
+      execute("ask Commander about mission")
+      result = execute("talk to Commander reset")
+      expect(result[:output]).to include("Welcome, operative.")
+    end
+
+    it "resets to root with 'start'" do
+      execute("ask Commander about mission")
+      result = execute("talk to Commander start")
+      expect(result[:output]).to include("Welcome, operative.")
+    end
+
+    it "resets to root with 'over'" do
+      execute("ask Commander about mission")
+      result = execute("talk to Commander over")
+      expect(result[:output]).to include("Welcome, operative.")
+    end
+  end
+
+  describe "ask command with branching" do
+    it "shows response for a root topic" do
+      result = execute("ask Commander about mission")
+      expect(result[:output]).to include("Our mission is critical.")
+    end
+
+    it "shows sub-topics when topic has children" do
+      result = execute("ask Commander about mission")
+      expect(result[:output]).to include("details")
+      expect(result[:output]).to include("reward")
+    end
+
+    it "navigates deeper into the tree" do
+      execute("ask Commander about mission")
+      result = execute("ask Commander about details")
+      expect(result[:output]).to include("Deep operations inside the RIDE.")
+    end
+
+    it "navigates to a leaf node" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      result = execute("ask Commander about classified")
+      expect(result[:output]).to include("Eyes only intel.")
+    end
+
+    it "stays at current depth for leaf topics (siblings reachable)" do
+      execute("ask Commander about mission")
+      execute("ask Commander about reward")  # leaf — stays at mission level
+      result = execute("ask Commander about details")  # sibling should work
+      expect(result[:output]).to include("Deep operations inside the RIDE.")
+    end
+
+    it "shows error for topic not found at any depth" do
+      execute("ask Commander about mission")
+      result = execute("ask Commander about nonsense")
+      expect(result[:output]).to include("doesn't know about 'nonsense'")
+      expect(result[:output]).to include("details")
+      expect(result[:output]).to include("reward")
+    end
+  end
+
+  describe "ancestor topic fallback" do
+    it "reaches a root topic from a deeper level" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      result = execute("ask Commander about help")
+      expect(result[:output]).to include("Need assistance?")
+    end
+
+    it "reaches a parent topic from a child level" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      result = execute("ask Commander about reward")  # sibling at mission level
+      expect(result[:output]).to include("CRED and clearance await.")
+    end
+
+    it "does not change context when responding from ancestor" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      execute("ask Commander about help")  # root-level — should NOT move context
+      hackr.reload
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+
+    it "still advances context for current-depth topics with children" do
+      execute("ask Commander about mission")  # has children → advances
+      hackr.reload
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission"])
+    end
+
+    it "shows current-depth topics in error when truly not found" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      result = execute("ask Commander about nonsense")
+      expect(result[:output]).to include("doesn't know about 'nonsense'")
+    end
+
+    it "reaches topics in other branches via global search" do
+      # Add a topic under "help" to test cross-branch access
+      tree = mob.dialogue_tree.deep_dup
+      tree["topics"]["help"]["topics"] = {
+        "faq" => {"response" => "Frequently asked questions here."}
+      }
+      mob.update!(dialogue_tree: tree)
+
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      # Now at ["mission", "details"], ask about "faq" which is under ["help"]
+      result = execute("ask Commander about faq")
+      expect(result[:output]).to include("Frequently asked questions here.")
+    end
+
+    it "does not change context on cross-branch match" do
+      tree = mob.dialogue_tree.deep_dup
+      tree["topics"]["help"]["topics"] = {
+        "faq" => {"response" => "FAQ content."}
+      }
+      mob.update!(dialogue_tree: tree)
+
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      execute("ask Commander about faq")
+      hackr.reload
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+  end
+
+  describe "back navigation" do
+    it "goes up one level with 'back'" do
+      execute("ask Commander about mission")
+      execute("ask Commander about details")
+      result = execute("ask Commander about back")
+      # Should re-render the mission level via talk
+      expect(result[:output]).to include("details")
+      expect(result[:output]).to include("reward")
+    end
+
+    it "goes up one level with 'up'" do
+      execute("ask Commander about mission")
+      result = execute("ask Commander about up")
+      # Back to root, rendered via talk
+      expect(result[:output]).to include("Welcome, operative.")
+    end
+
+    it "stays at root if already there" do
+      result = execute("ask Commander about back")
+      expect(result[:output]).to include("already at the start")
+    end
+  end
+
+  describe "dialogue tree normalization" do
+    it "normalizes flat string topics to nested format" do
+      mob = create(:grid_mob, grid_room: room, name: "Old NPC", dialogue_tree: {
+        "greeting" => "Hi",
+        "topics" => {
+          "test" => "A flat string response"
+        }
+      })
+      expect(mob.reload.dialogue_tree["topics"]["test"]).to eq({"response" => "A flat string response"})
+    end
+
+    it "preserves already-nested topics" do
+      mob = create(:grid_mob, grid_room: room, name: "New NPC", dialogue_tree: {
+        "greeting" => "Hi",
+        "topics" => {
+          "test" => {"response" => "Already nested", "topics" => {"sub" => {"response" => "Sub"}}}
+        }
+      })
+      expect(mob.reload.dialogue_tree["topics"]["test"]["response"]).to eq("Already nested")
+      expect(mob.reload.dialogue_tree["topics"]["test"]["topics"]["sub"]["response"]).to eq("Sub")
+    end
+  end
+
+  describe "dialogue tree unique key validation" do
+    it "rejects duplicate topic keys across branches" do
+      tree = {
+        "greeting" => "Hi",
+        "topics" => {
+          "mission" => {
+            "response" => "Mission info.",
+            "topics" => {
+              "help" => {"response" => "Mission help."}
+            }
+          },
+          "help" => {"response" => "General help."}
+        }
+      }
+      mob = build(:grid_mob, grid_room: room, name: "Dupe NPC", dialogue_tree: tree)
+      expect(mob).not_to be_valid
+      expect(mob.errors[:dialogue_tree].first).to include("duplicate topic key 'help'")
+    end
+
+    it "rejects case-insensitive duplicates" do
+      tree = {
+        "greeting" => "Hi",
+        "topics" => {
+          "Help" => {"response" => "One"},
+          "help" => {"response" => "Two"}
+        }
+      }
+      mob = build(:grid_mob, grid_room: room, name: "Case NPC", dialogue_tree: tree)
+      expect(mob).not_to be_valid
+      expect(mob.errors[:dialogue_tree].first).to include("duplicate topic key 'help'")
+    end
+
+    it "accepts trees with unique keys" do
+      tree = {
+        "greeting" => "Hi",
+        "topics" => {
+          "mission" => {
+            "response" => "Info.",
+            "topics" => {
+              "details" => {"response" => "Details."}
+            }
+          },
+          "help" => {"response" => "Help."}
+        }
+      }
+      mob = build(:grid_mob, grid_room: room, name: "Unique NPC", dialogue_tree: tree)
+      expect(mob).to be_valid
+    end
+  end
+
+  describe "dialogue tree depth validation" do
+    it "rejects trees exceeding max depth" do
+      # Build a tree deeply enough to trigger the JSON nesting guard.
+      # Each dialogue level adds ~2 JSON nesting levels, so 50+ levels
+      # will hit Ruby's JSON nesting limit (100) before our own depth
+      # validation fires — the normalizer rescues this and adds an error.
+      tree = {"greeting" => "Hi", "topics" => {}}
+      node = tree["topics"]
+      60.times do |i|
+        node["level#{i}"] = {"response" => "Level #{i}", "topics" => {}}
+        node = node["level#{i}"]["topics"]
+      end
+
+      mob = build(:grid_mob, grid_room: room, name: "Deep NPC", dialogue_tree: tree)
+      expect(mob).not_to be_valid
+      expect(mob.errors[:dialogue_tree].first).to include("nested")
+    end
+
+    it "accepts trees within depth limit" do
+      tree = {"greeting" => "Hi", "topics" => {
+        "a" => {"response" => "1", "topics" => {
+          "b" => {"response" => "2", "topics" => {
+            "c" => {"response" => "3"}
+          }}
+        }}
+      }}
+      mob = build(:grid_mob, grid_room: room, name: "Shallow NPC", dialogue_tree: tree)
+      expect(mob).to be_valid
+    end
+  end
+
+  describe "dialogue context helpers on GridHackr" do
+    it "tracks dialogue path per mob" do
+      hackr.set_dialogue_path(mob, ["mission", "details"])
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+
+    it "clears dialogue path for a mob" do
+      hackr.set_dialogue_path(mob, ["mission"])
+      hackr.clear_dialogue_path(mob)
+      expect(hackr.dialogue_path_for(mob)).to eq([])
+    end
+
+    it "tracks independent paths for different mobs" do
+      other_mob = create(:grid_mob, grid_room: room, name: "Other", dialogue_tree: branching_tree)
+      hackr.set_dialogue_path(mob, ["mission"])
+      hackr.set_dialogue_path(other_mob, ["help"])
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission"])
+      expect(hackr.dialogue_path_for(other_mob)).to eq(["help"])
+    end
+  end
+
+  describe "mission dialogue path gating" do
+    let(:faction) { create(:grid_faction) }
+    let!(:quest_mob) do
+      create(:grid_mob,
+        grid_room: room,
+        name: "Quest Giver",
+        mob_type: "quest_giver",
+        grid_faction: faction,
+        dialogue_tree: branching_tree)
+    end
+
+    let!(:surface_mission) do
+      create(:grid_mission,
+        name: "Surface Job",
+        slug: "surface-job",
+        giver_mob: quest_mob,
+        published: true,
+        dialogue_path: nil)
+    end
+
+    let!(:buried_mission) do
+      create(:grid_mission,
+        name: "Buried Job",
+        slug: "buried-job",
+        giver_mob: quest_mob,
+        published: true,
+        dialogue_path: ["mission", "details"])
+    end
+
+    it "shows ungated missions at any depth" do
+      result = execute("ask Quest Giver about missions")
+      expect(result[:output]).to include("surface-job")
+    end
+
+    it "hides dialogue-gated missions when not at required depth" do
+      result = execute("ask Quest Giver about missions")
+      expect(result[:output]).not_to include("buried-job")
+    end
+
+    it "shows dialogue-gated missions when at required depth" do
+      execute("ask Quest Giver about mission")
+      execute("ask Quest Giver about details")
+      hackr.reload
+      result = execute("ask Quest Giver about missions")
+      expect(result[:output]).to include("buried-job")
+    end
+
+    it "blocks direct slug access for gated missions" do
+      result = execute("ask Quest Giver about buried-job")
+      # Should fall through to dialogue topic lookup, not show mission brief
+      expect(result[:output]).not_to include("Buried Job")
+    end
+
+    it "allows direct slug access when at required depth" do
+      execute("ask Quest Giver about mission")
+      execute("ask Quest Giver about details")
+      hackr.reload
+      result = execute("ask Quest Giver about buried-job")
+      expect(result[:output]).to include("Buried Job")
+    end
+
+    it "blocks accept for gated missions" do
+      result = execute("accept buried-job")
+      expect(result[:output]).to include("haven't learned")
+    end
+
+    it "allows accept when at required depth" do
+      execute("ask Quest Giver about mission")
+      execute("ask Quest Giver about details")
+      hackr.reload
+      result = execute("accept buried-job")
+      expect(result[:output]).to include("MISSION ACCEPTED")
+    end
+  end
+
+  describe "back navigation does not grant stats/rep" do
+    let(:faction) { create(:grid_faction) }
+    let!(:npc) do
+      create(:grid_mob,
+        grid_room: room,
+        name: "Talker",
+        grid_faction: faction,
+        dialogue_tree: branching_tree)
+    end
+
+    it "does not increment npcs_talked on back" do
+      execute("talk Talker")
+      execute("ask Talker about mission")
+      initial = hackr.reload.stat("npcs_talked")
+      execute("ask Talker about back")
+      expect(hackr.reload.stat("npcs_talked")).to eq(initial)
+    end
+  end
+end

--- a/spec/services/grid/dialogue_navigator_spec.rb
+++ b/spec/services/grid/dialogue_navigator_spec.rb
@@ -1,0 +1,222 @@
+require "rails_helper"
+
+RSpec.describe Grid::DialogueNavigator do
+  let(:zone) { create(:grid_zone) }
+  let(:room) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room) }
+
+  let(:dialogue_tree) do
+    {
+      "greeting" => "Welcome, hackr.",
+      "topics" => {
+        "mission" => {
+          "response" => "Our mission is critical.",
+          "topics" => {
+            "details" => {
+              "response" => "Deep inside the RIDE...",
+              "topics" => {
+                "classified" => {
+                  "response" => "Eyes only, hackr."
+                }
+              }
+            },
+            "reward" => {
+              "response" => "CRED and clearance."
+            }
+          }
+        },
+        "help" => {
+          "response" => "Need a hand?"
+        }
+      }
+    }
+  end
+
+  let(:mob) { create(:grid_mob, grid_room: room, name: "Coordinator", dialogue_tree: dialogue_tree) }
+  let(:nav) { described_class.new(hackr: hackr, mob: mob) }
+
+  describe "#current_path" do
+    it "returns empty array at root" do
+      expect(nav.current_path).to eq([])
+    end
+
+    it "returns stored path when context exists" do
+      hackr.set_dialogue_path(mob, ["mission"])
+      expect(nav.current_path).to eq(["mission"])
+    end
+  end
+
+  describe "#at_root?" do
+    it "is true initially" do
+      expect(nav).to be_at_root
+    end
+
+    it "is false after navigation" do
+      hackr.set_dialogue_path(mob, ["mission"])
+      expect(nav).not_to be_at_root
+    end
+  end
+
+  describe "#greeting" do
+    it "returns the greeting text" do
+      expect(nav.greeting).to eq("Welcome, hackr.")
+    end
+  end
+
+  describe "#node_at" do
+    it "returns root for empty path" do
+      node = nav.node_at([])
+      expect(node["greeting"]).to eq("Welcome, hackr.")
+    end
+
+    it "returns a topic node" do
+      node = nav.node_at(["mission"])
+      expect(node["response"]).to eq("Our mission is critical.")
+    end
+
+    it "returns a deeply nested node" do
+      node = nav.node_at(["mission", "details", "classified"])
+      expect(node["response"]).to eq("Eyes only, hackr.")
+    end
+
+    it "returns nil for invalid path" do
+      expect(nav.node_at(["nonexistent"])).to be_nil
+    end
+  end
+
+  describe "#current_topics" do
+    it "returns root topics when at root" do
+      topics = nav.current_topics
+      expect(topics.keys).to contain_exactly("mission", "help")
+    end
+
+    it "returns sub-topics when navigated" do
+      hackr.set_dialogue_path(mob, ["mission"])
+      topics = nav.current_topics
+      expect(topics.keys).to contain_exactly("details", "reward")
+    end
+  end
+
+  describe "#navigate" do
+    it "returns response and sub-topics for a valid topic" do
+      result = nav.navigate("mission")
+      expect(result[:response]).to eq("Our mission is critical.")
+      expect(result[:topics].keys).to contain_exactly("details", "reward")
+    end
+
+    it "advances context when target has sub-topics" do
+      nav.navigate("mission")
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission"])
+    end
+
+    it "does not advance context for leaf topics" do
+      nav.navigate("help")
+      expect(hackr.dialogue_path_for(mob)).to eq([])
+    end
+
+    it "navigates deeper within context" do
+      nav.navigate("mission")
+      result = nav.navigate("details")
+      expect(result[:response]).to eq("Deep inside the RIDE...")
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+
+    it "finds ancestor topics without changing context" do
+      nav.navigate("mission") # context → ["mission"]
+      nav.navigate("details") # context → ["mission", "details"]
+      result = nav.navigate("help") # root-level, ancestor hit
+      expect(result[:response]).to eq("Need a hand?")
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+
+    it "finds cross-branch topics via global search" do
+      # Add sub-topic under "help"
+      tree = mob.dialogue_tree.deep_dup
+      tree["topics"]["help"]["topics"] = {
+        "faq" => {"response" => "FAQ answer."}
+      }
+      mob.update!(dialogue_tree: tree)
+      fresh_nav = described_class.new(hackr: hackr, mob: mob.reload)
+
+      fresh_nav.navigate("mission")
+      fresh_nav.navigate("details")
+      result = fresh_nav.navigate("faq")
+      expect(result[:response]).to eq("FAQ answer.")
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission", "details"])
+    end
+
+    it "returns nil for unknown topic" do
+      expect(nav.navigate("nonsense")).to be_nil
+    end
+
+    it "handles case-insensitive lookup" do
+      result = nav.navigate("MISSION")
+      expect(result[:response]).to eq("Our mission is critical.")
+    end
+  end
+
+  describe "#go_back" do
+    it "returns empty path when already at root" do
+      expect(nav.go_back).to eq([])
+    end
+
+    it "goes up one level" do
+      hackr.set_dialogue_path(mob, ["mission", "details"])
+      new_path = nav.go_back
+      expect(new_path).to eq(["mission"])
+      expect(hackr.dialogue_path_for(mob)).to eq(["mission"])
+    end
+
+    it "goes to root from depth 1" do
+      hackr.set_dialogue_path(mob, ["mission"])
+      new_path = nav.go_back
+      expect(new_path).to eq([])
+      expect(hackr.dialogue_path_for(mob)).to eq([])
+    end
+  end
+
+  describe "#reset!" do
+    it "clears dialogue context" do
+      hackr.set_dialogue_path(mob, ["mission", "details"])
+      nav.reset!
+      expect(hackr.dialogue_path_for(mob)).to eq([])
+    end
+  end
+
+  describe ".reset_alias?" do
+    it "recognizes reset aliases" do
+      %w[again reset start over].each do |word|
+        expect(described_class.reset_alias?(word)).to be true
+      end
+    end
+
+    it "rejects non-aliases" do
+      expect(described_class.reset_alias?("mission")).to be false
+    end
+  end
+
+  describe ".back_alias?" do
+    it "recognizes back aliases" do
+      %w[back up ..].each do |word|
+        expect(described_class.back_alias?(word)).to be true
+      end
+    end
+  end
+
+  describe ".has_children?" do
+    it "returns true for nodes with sub-topics" do
+      node = {"response" => "test", "topics" => {"sub" => {"response" => "x"}}}
+      expect(described_class.has_children?(node)).to be true
+    end
+
+    it "returns false for leaf nodes" do
+      node = {"response" => "test"}
+      expect(described_class.has_children?(node)).to be false
+    end
+
+    it "returns false for empty topics" do
+      node = {"response" => "test", "topics" => {}}
+      expect(described_class.has_children?(node)).to be false
+    end
+  end
+end


### PR DESCRIPTION


  Branching dialogue system for NPC mobs. Dialogue trees upgraded from
  flat { key: "string" } to recursive { key: { response, topics } }.
  Stateful navigation via hackr stats["dialogue_context"] — talk shows
  current depth, ask navigates deeper, back/up goes up, again/reset
  returns to root. Global topic search lets hackrs ask about any topic
  from any depth without navigating back. Leaf topics don't advance
  context so siblings stay reachable.

  Mission dialogue gating: new dialogue_path column on grid_missions.
  Missions can require hackrs to reach a specific dialogue depth before
  discovery. Gate enforced on mission list, direct slug access, and
  accept command. Unique key validation prevents topic collisions across
  the tree.

  Admin mob form rewritten with structured editors:
  - Dialogue tree: recursive topic rows with keyword/response/sub-topic controls, depth indicators, add/remove at any level, raw JSON toggle
  - Vendor config: shop_type dropdown, restock hours, conditional rotation count for black market, raw JSON toggle
  - Inline shop listings on vendor mob edit page: listing table with quick-add form, per-listing delete + edit link to full CRUD

  New service: Grid::DialogueNavigator (tree traversal, navigation,
  ancestor/global fallback search). CommandParser talk/ask commands
  refactored — render_dialogue_position extracted for stats-free reuse
  by back navigation. dialogue_path_blocked? helper guards all three
  mission access paths.