### PR TITLE
 [TPG] Visual Map Editor, world export system, production seed guards

### DIFF
--- a/app/controllers/admin/grid_map_editor_controller.rb
+++ b/app/controllers/admin/grid_map_editor_controller.rb
@@ -1,0 +1,588 @@
+# frozen_string_literal: true
+
+class Admin::GridMapEditorController < Admin::ApplicationController
+  OPPOSITE_DIRECTIONS = {
+    "north" => "south", "south" => "north",
+    "east" => "west", "west" => "east",
+    "northeast" => "southwest", "southwest" => "northeast",
+    "northwest" => "southeast", "southeast" => "northwest",
+    "up" => "down", "down" => "up"
+  }.freeze
+
+  # GET /root/grid_map_editor/:zone_id
+  def show
+    @zone = GridZone.find(params[:zone_id])
+    @region = @zone.grid_region
+  end
+
+  # GET /root/grid_map_editor/:zone_id/data?z=0
+  def data
+    zone = GridZone.find(params[:zone_id])
+    z_level = params[:z].to_i
+    all_zone_rooms = zone.grid_rooms.includes(:grid_zone).to_a
+    all_zone_room_ids = all_zone_rooms.map(&:id)
+
+    all_exits = GridExit.where(from_room_id: all_zone_room_ids)
+      .includes(to_room: {grid_zone: :grid_region}).to_a
+
+    # Compute BFS positions for rooms without stored coords (on z=0 plane)
+    bfs_positions = compute_bfs_positions(all_zone_rooms, all_exits)
+
+    # Discover z-levels present in this zone
+    z_levels = all_zone_rooms.map(&:map_z).uniq.sort
+    z_levels = [0] if z_levels.empty?
+
+    # Filter rooms for requested z-level
+    rooms = all_zone_rooms.select { |r| r.map_z == z_level }
+    room_ids = rooms.map(&:id)
+
+    # Find rooms on other z-levels connected via up/down (outbound + inbound)
+    z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
+    # Outbound: current-level rooms with up/down exits to other levels
+    outbound_vertical = all_exits.select { |e| room_ids.include?(e.from_room_id) && z_directions.key?(e.direction) }
+    # Inbound: other-level rooms with up/down exits pointing into current level
+    other_z_room_ids = all_zone_rooms.reject { |r| r.map_z == z_level }.map(&:id)
+    inbound_vertical = all_exits.select { |e| other_z_room_ids.include?(e.from_room_id) && room_ids.include?(e.to_room_id) && z_directions.key?(e.direction) }
+    # Collect all rooms on other z-levels that are connected vertically
+    vertical_room_ids = Set.new
+    outbound_vertical.each { |e| vertical_room_ids.add(e.to_room_id) }
+    inbound_vertical.each { |e| vertical_room_ids.add(e.from_room_id) }
+    vertical_rooms = all_zone_rooms.select { |r| vertical_room_ids.include?(r.id) && r.map_z != z_level }
+
+    exits = all_exits.select { |e| room_ids.include?(e.from_room_id) }
+
+    # Presence counts
+    hackr_counts = GridHackr.where(current_room_id: room_ids).group(:current_room_id).count
+    mob_data = GridMob.where(grid_room_id: room_ids).select(:id, :name, :mob_type, :grid_room_id).to_a
+    item_counts = GridItem.where(room_id: room_ids, container_id: nil, equipped_slot: nil)
+      .group(:room_id).count
+    encounter_data = GridBreachEncounter.where(grid_room_id: room_ids)
+      .includes(:grid_breach_template).to_a
+
+    # Ghost rooms: rooms in OTHER ZONES connected to this zone's rooms.
+    # Exclude same-zone rooms on different z-levels (those are vertical_rooms).
+    same_zone_ids = Set.new(all_zone_room_ids)
+    cross_exit_room_ids = exits
+      .reject { |e| room_ids.include?(e.to_room_id) || same_zone_ids.include?(e.to_room_id) }
+      .map(&:to_room_id).uniq
+    ghost_rooms = GridRoom.where(id: cross_exit_room_ids)
+      .includes(grid_zone: :grid_region).index_by(&:id)
+
+    # Reverse exits pointing into this zone (from ghost rooms) — load before ghost_data to avoid N+1
+    inbound_exits = GridExit.where(from_room_id: cross_exit_room_ids, to_room_id: room_ids)
+      .includes(from_room: {grid_zone: :grid_region}).to_a
+    inbound_index = inbound_exits.index_by { |e| [e.from_room_id, e.to_room_id] }
+
+    # Build ghost room data with connection info
+    ghost_data = ghost_rooms.values.map do |gr|
+      connections = exits.select { |e| e.to_room_id == gr.id }.map do |e|
+        reverse = inbound_index[[gr.id, e.from_room_id]]
+        {exit_id: e.id, local_room_id: e.from_room_id, direction: e.direction,
+         reverse_exit_id: reverse&.id, reverse_direction: reverse&.direction}
+      end
+      {id: gr.id, name: gr.name, room_type: gr.room_type,
+       zone_name: gr.grid_zone.name, zone_id: gr.grid_zone_id,
+       region_name: gr.grid_zone.grid_region.name,
+       connected_via: connections}
+    end
+
+    # All rooms grouped for combobox (cross-zone/region exit creation)
+    all_rooms_grouped = build_all_rooms_grouped
+
+    # Breach templates for placement
+    breach_templates = GridBreachTemplate.published.ordered.map do |t|
+      {id: t.id, name: t.name, slug: t.slug, tier: t.tier, min_clearance: t.min_clearance}
+    end
+
+    # Available zones for navigation (also used for zone color derivation)
+    all_zones = GridZone.includes(:grid_region).order("grid_regions.name, grid_zones.name").to_a
+    available_zones = all_zones.map { |z| {id: z.id, name: z.name, region_name: z.grid_region.name} }
+
+    # Zone color — match world map's per-zone color assignment
+    zone_index = all_zones.index { |z| z.id == zone.id } || 0
+    zone_color = Grid::WorldMapBuilder::ZONE_COLORS[zone_index % Grid::WorldMapBuilder::ZONE_COLORS.length]
+
+    render json: {
+      zone: {id: zone.id, name: zone.name, slug: zone.slug,
+             zone_type: zone.zone_type, danger_level: zone.danger_level,
+             region_id: zone.grid_region_id, region_name: zone.grid_region.name},
+      z_level: z_level,
+      z_levels: z_levels,
+      vertical_rooms: vertical_rooms.map { |r|
+        connections = []
+        # Outbound: local room --up/down--> this vertical room
+        outbound_vertical.select { |e| e.to_room_id == r.id }.each do |e|
+          connections << {exit_id: e.id, local_room_id: e.from_room_id, direction: e.direction}
+        end
+        # Inbound: this vertical room --up/down--> local room (reverse perspective)
+        inbound_vertical.select { |e| e.from_room_id == r.id }.each do |e|
+          reverse_dir = (e.direction == "up") ? "down" : "up"
+          connections << {exit_id: e.id, local_room_id: e.to_room_id, direction: reverse_dir}
+        end
+        {id: r.id, name: r.name, room_type: r.room_type, map_z: r.map_z,
+         connected_via: connections}
+      },
+      rooms: rooms.map { |r|
+        mobs = mob_data.select { |m| m.grid_room_id == r.id }
+        encounters = encounter_data.select { |e| e.grid_room_id == r.id }
+        room_exits = exits.select { |e| e.from_room_id == r.id }
+        # Include inbound exits from ghost rooms
+        inbound = inbound_exits.select { |e| e.to_room_id == r.id }
+        pos_source = r.map_x.nil? ? "computed" : "stored"
+        mx = r.map_x || bfs_positions.dig(r.id, 0) || 0
+        my = r.map_y || bfs_positions.dig(r.id, 1) || 0
+
+        {id: r.id, name: r.name, slug: r.slug, description: r.description,
+         room_type: r.room_type, min_clearance: r.min_clearance,
+         locked: r.locked?, grid_zone_id: r.grid_zone_id,
+         map_x: mx, map_y: my, map_z: r.map_z, position_source: pos_source,
+         hackr_count: hackr_counts[r.id].to_i,
+         mob_count: mobs.size, item_count: item_counts[r.id].to_i,
+         mobs: mobs.map { |m| {id: m.id, name: m.name, mob_type: m.mob_type} },
+         encounters: encounters.map { |e|
+           {id: e.id, template_name: e.grid_breach_template.name,
+            template_id: e.grid_breach_template_id, state: e.state,
+            tier: e.grid_breach_template.tier}
+         },
+         exits: room_exits.map { |e|
+           reverse = exits.find { |r_ex| r_ex.from_room_id == e.to_room_id && r_ex.to_room_id == e.from_room_id }
+           to_room = rooms.find { |rm| rm.id == e.to_room_id } || ghost_rooms[e.to_room_id]
+           to_zone = to_room&.grid_zone
+           {id: e.id, direction: e.direction, to_room_id: e.to_room_id,
+            to_room_name: to_room&.name || "unknown",
+            to_zone_name: to_zone&.name,
+            locked: e.locked?, reverse_exit_id: reverse&.id,
+            cross_zone: to_zone.present? && to_zone.id != zone.id}
+         },
+         inbound_exits: inbound.map { |e|
+           {id: e.id, direction: e.direction, from_room_id: e.from_room_id,
+            from_room_name: e.from_room&.name || "unknown",
+            from_zone_name: e.from_room&.grid_zone&.name}
+         }}
+      },
+      exits: exits.select { |e| room_ids.include?(e.to_room_id) }.map { |e|
+        reverse = exits.find { |r_ex| r_ex.from_room_id == e.to_room_id && r_ex.to_room_id == e.from_room_id }
+        {id: e.id, from_room_id: e.from_room_id, to_room_id: e.to_room_id,
+         direction: e.direction, locked: e.locked?,
+         reverse_exit_id: reverse&.id}
+      },
+      ghost_rooms: ghost_data,
+      breach_templates: breach_templates,
+      zone_color: zone_color,
+      available_zones: available_zones,
+      all_rooms_grouped: all_rooms_grouped
+    }
+  end
+
+  # POST /root/grid_map_editor/rooms
+  def create_room
+    zone = GridZone.find(params[:grid_zone_id])
+    room = GridRoom.new(
+      name: params[:name],
+      slug: params[:slug],
+      description: params[:description],
+      room_type: params[:room_type].presence,
+      min_clearance: params[:min_clearance].to_i,
+      grid_zone_id: zone.id,
+      map_x: params[:map_x].to_i,
+      map_y: params[:map_y].to_i,
+      map_z: params[:map_z].to_i
+    )
+
+    if room.save
+      render json: {success: true, room: {id: room.id, name: room.name, slug: room.slug}}
+    else
+      render json: {success: false, errors: room.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /root/grid_map_editor/rooms/:id
+  def update_room
+    room = GridRoom.find(params[:id])
+    attrs = {}
+    attrs[:name] = params[:name] if params.key?(:name)
+    attrs[:slug] = params[:slug] if params.key?(:slug)
+    attrs[:description] = params[:description] if params.key?(:description)
+    attrs[:room_type] = params[:room_type].presence if params.key?(:room_type)
+    attrs[:min_clearance] = params[:min_clearance].to_i if params.key?(:min_clearance)
+    attrs[:locked] = params[:locked] if params.key?(:locked)
+    attrs[:grid_zone_id] = params[:grid_zone_id].presence&.to_i if params.key?(:grid_zone_id)
+    attrs[:map_x] = params[:map_x].to_i if params.key?(:map_x)
+    attrs[:map_y] = params[:map_y].to_i if params.key?(:map_y)
+    attrs[:map_z] = params[:map_z].to_i if params.key?(:map_z)
+
+    if room.update(attrs)
+      render json: {success: true}
+    else
+      render json: {success: false, errors: room.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /root/grid_map_editor/rooms/:id
+  def destroy_room
+    room = GridRoom.find(params[:id])
+
+    ActiveRecord::Base.transaction do
+      blockers = deletion_blockers(room)
+      if blockers.any?
+        render json: {success: false, blockers: blockers}, status: :unprocessable_entity
+        raise ActiveRecord::Rollback
+      else
+        room.destroy!
+        render json: {success: true}
+      end
+    end
+  end
+
+  # POST /root/grid_map_editor/exits
+  def create_exit
+    from_room = GridRoom.find(params[:from_room_id])
+    to_room = GridRoom.find(params[:to_room_id])
+    direction = params[:direction].to_s.strip.downcase
+
+    exit_record = GridExit.new(
+      from_room: from_room, to_room: to_room,
+      direction: direction, locked: params[:locked] || false
+    )
+
+    result = nil
+    errors = nil
+    reverse = nil
+
+    ActiveRecord::Base.transaction do
+      unless exit_record.save
+        errors = exit_record.errors.full_messages
+        raise ActiveRecord::Rollback
+      end
+
+      if params[:bidirectional]
+        reverse_dir = params[:reverse_direction].presence || OPPOSITE_DIRECTIONS[direction] || direction
+        reverse = GridExit.new(
+          from_room: to_room, to_room: from_room,
+          direction: reverse_dir, locked: params[:locked] || false
+        )
+        unless reverse.save
+          errors = reverse.errors.full_messages
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      result = {
+        success: true,
+        exit: {id: exit_record.id, from_room_id: from_room.id, to_room_id: to_room.id, direction: direction},
+        reverse_exit: reverse ? {id: reverse.id, from_room_id: to_room.id, to_room_id: from_room.id, direction: reverse.direction} : nil
+      }
+    end
+
+    if result
+      render json: result
+    else
+      render json: {success: false, errors: errors || ["Transaction failed"]}, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /root/grid_map_editor/exits/:id
+  def update_exit
+    exit_record = GridExit.find(params[:id])
+    attrs = {}
+    attrs[:direction] = params[:direction].to_s.strip.downcase if params.key?(:direction)
+    attrs[:locked] = params[:locked] if params.key?(:locked)
+    attrs[:to_room_id] = params[:to_room_id].to_i if params.key?(:to_room_id)
+
+    if exit_record.update(attrs)
+      render json: {success: true}
+    else
+      render json: {success: false, errors: exit_record.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /root/grid_map_editor/exits/:id
+  def destroy_exit
+    exit_record = GridExit.find(params[:id])
+    reverse = nil
+
+    if ActiveModel::Type::Boolean.new.cast(params[:delete_reverse])
+      reverse_dir = OPPOSITE_DIRECTIONS[exit_record.direction]
+      if reverse_dir
+        reverse = GridExit.find_by(
+          from_room_id: exit_record.to_room_id,
+          to_room_id: exit_record.from_room_id,
+          direction: reverse_dir
+        )
+      end
+    end
+
+    ActiveRecord::Base.transaction do
+      reverse&.destroy!
+      exit_record.destroy!
+    end
+
+    render json: {success: true}
+  end
+
+  # POST /root/grid_map_editor/mobs
+  def create_mob
+    room = GridRoom.find(params[:grid_room_id])
+    mob = GridMob.new(
+      name: params[:name],
+      mob_type: params[:mob_type].presence,
+      description: params[:description],
+      grid_room: room,
+      dialogue_tree: {},
+      grid_faction_id: params[:grid_faction_id].presence&.to_i
+    )
+
+    if mob.save
+      render json: {success: true, mob: {id: mob.id, name: mob.name, mob_type: mob.mob_type}}
+    else
+      render json: {success: false, errors: mob.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /root/grid_map_editor/mobs/:id
+  def update_mob
+    mob = GridMob.find(params[:id])
+    attrs = {}
+    attrs[:name] = params[:name] if params.key?(:name)
+    attrs[:mob_type] = params[:mob_type].presence if params.key?(:mob_type)
+    attrs[:description] = params[:description] if params.key?(:description)
+    attrs[:grid_room_id] = params[:grid_room_id].to_i if params.key?(:grid_room_id)
+    attrs[:grid_faction_id] = params[:grid_faction_id].presence&.to_i if params.key?(:grid_faction_id)
+
+    if mob.update(attrs)
+      render json: {success: true}
+    else
+      render json: {success: false, errors: mob.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /root/grid_map_editor/mobs/:id
+  def remove_mob
+    mob = GridMob.find(params[:id])
+
+    blockers = []
+    blockers << "#{mob.grid_shop_listings.count} shop listing(s)" if mob.grid_shop_listings.any?
+    blockers << "#{mob.given_missions.count} mission(s) assigned as giver" if mob.given_missions.any?
+
+    if blockers.any?
+      render json: {success: false, blockers: blockers}, status: :unprocessable_entity
+      return
+    end
+
+    mob.destroy!
+    render json: {success: true}
+  end
+
+  # POST /root/grid_map_editor/encounters
+  def create_encounter
+    encounter = GridBreachEncounter.new(
+      grid_room_id: params[:grid_room_id],
+      grid_breach_template_id: params[:grid_breach_template_id],
+      state: "available"
+    )
+
+    if encounter.save
+      template = encounter.grid_breach_template
+      render json: {success: true, encounter: {
+        id: encounter.id, template_name: template.name,
+        template_id: template.id, state: encounter.state, tier: template.tier
+      }}
+    else
+      render json: {success: false, errors: encounter.errors.full_messages}, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /root/grid_map_editor/encounters/:id
+  def destroy_encounter
+    encounter = GridBreachEncounter.find(params[:id])
+
+    if encounter.grid_hackr_breaches.where(state: "active").exists?
+      render json: {success: false, errors: ["Active breaches reference this encounter"]}, status: :unprocessable_entity
+      return
+    end
+
+    encounter.destroy!
+    render json: {success: true}
+  end
+
+  # POST /root/grid_map_editor/:zone_id/auto_layout
+  def auto_layout
+    zone = GridZone.find(params[:zone_id])
+    rooms = zone.grid_rooms.includes(:grid_zone).to_a
+    room_ids = rooms.map(&:id)
+    exits = GridExit.where(from_room_id: room_ids)
+      .includes(to_room: {grid_zone: :grid_region}).to_a
+
+    positions = compute_bfs_positions(rooms, exits)
+    z_levels = compute_z_levels(rooms, exits)
+
+    room_index = rooms.index_by(&:id)
+    count = 0
+    ActiveRecord::Base.transaction do
+      positions.each do |room_id, (x, y)|
+        room = room_index[room_id]
+        next unless room
+        z = z_levels[room_id] || 0
+        room.update!(map_x: x, map_y: y, map_z: z)
+        count += 1
+      end
+    end
+
+    render json: {success: true, updated: count}
+  end
+
+  private
+
+  def compute_bfs_positions(rooms, exits)
+    return {} if rooms.empty?
+    bfs_positions(rooms, exits)
+  end
+
+  # Compute z-level for each room by walking up/down exits from z=0 seed.
+  def compute_z_levels(rooms, exits)
+    z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
+    room_ids = Set.new(rooms.map(&:id))
+    exits_by_from = exits.group_by(&:from_room_id)
+
+    # Seed: same priority as BFS
+    seed = rooms.find { |r| r.room_type == "hub" } ||
+      rooms.find { |r| r.room_type == "special" } ||
+      rooms.find { |r| r.room_type == "transit" } ||
+      rooms.min_by(&:id)
+    return {} unless seed
+
+    # BFS: walk horizontal exits to find all rooms reachable on z=0,
+    # then follow up/down exits to discover other z-levels
+    levels = {seed.id => 0}
+    queue = [seed.id]
+    visited = Set.new([seed.id])
+
+    while (rid = queue.shift)
+      current_z = levels[rid]
+      (exits_by_from[rid] || []).each do |ex|
+        next unless room_ids.include?(ex.to_room_id)
+        next if visited.include?(ex.to_room_id)
+
+        z_delta = z_directions[ex.direction]
+        visited.add(ex.to_room_id)
+        levels[ex.to_room_id] = current_z + (z_delta || 0)
+        queue << ex.to_room_id
+      end
+    end
+
+    # Any unvisited rooms default to z=0
+    rooms.each { |r| levels[r.id] ||= 0 }
+    levels
+  end
+
+  def bfs_positions(rooms, exits)
+    room_index = rooms.index_by(&:id)
+    room_ids = Set.new(rooms.map(&:id))
+    exits_by_from = exits.group_by(&:from_room_id)
+
+    direction_vectors = Grid::WorldMapBuilder::DIRECTION_VECTORS
+    z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
+
+    positions = {}
+    occupied = {}
+    remaining = Set.new(room_ids)
+
+    # Pick seed: hub > special > transit > min id
+    seed = rooms.find { |r| r.room_type == "hub" } ||
+      rooms.find { |r| r.room_type == "special" } ||
+      rooms.find { |r| r.room_type == "transit" } ||
+      rooms.min_by(&:id)
+    return {} unless seed
+
+    while remaining.any?
+      seed_id = remaining.include?(seed.id) ? seed.id : remaining.first
+      queue = [[seed_id, 0, positions.empty? ? 0 : (positions.values.map(&:last).max + 3)]]
+      visited = Set.new([seed_id])
+
+      while (item = queue.shift)
+        rid, lx, ly = item
+
+        if occupied[[lx, ly]] && occupied[[lx, ly]] != rid
+          # Find free cell
+          placed = false
+          (1..10).each do |radius|
+            break if placed
+            (-radius..radius).each do |dx|
+              break if placed
+              (-radius..radius).each do |dy|
+                next if dx == 0 && dy == 0
+                nx, ny = lx + dx, ly + dy
+                unless occupied.key?([nx, ny])
+                  lx, ly = nx, ny
+                  placed = true
+                end
+              end
+            end
+          end
+          lx, ly = lx + 11, ly unless placed
+        end
+
+        positions[rid] = [lx, ly]
+        occupied[[lx, ly]] = rid
+        remaining.delete(rid)
+
+        (exits_by_from[rid] || []).each do |ex|
+          next if z_directions.key?(ex.direction)
+          next unless room_ids.include?(ex.to_room_id)
+          next if visited.include?(ex.to_room_id)
+          vec = direction_vectors[ex.direction]
+          next unless vec
+          visited.add(ex.to_room_id)
+          queue << [ex.to_room_id, lx + vec[0], ly + vec[1]]
+        end
+      end
+
+      seed = room_index[remaining.first] if remaining.any?
+    end
+
+    # Normalize to start at (0, 0)
+    if positions.any?
+      min_x = positions.values.map(&:first).min
+      min_y = positions.values.map(&:last).min
+      positions.transform_values! { |pos| [pos[0] - min_x, pos[1] - min_y] }
+    end
+
+    positions
+  end
+
+  def deletion_blockers(room)
+    blockers = []
+    hackr_count = room.grid_hackrs.count
+    blockers << "#{hackr_count} hackr(s) currently in room" if hackr_count > 0
+
+    mob_count = room.grid_mobs.count
+    blockers << "#{mob_count} mob(s) assigned to room" if mob_count > 0
+
+    item_count = GridItem.where(room_id: room.id, container_id: nil, equipped_slot: nil).count
+    blockers << "#{item_count} item(s) on floor" if item_count > 0
+
+    encounter_count = room.grid_breach_encounters.count
+    blockers << "#{encounter_count} breach encounter(s) placed" if encounter_count > 0
+
+    # Region special room references
+    region_refs = []
+    region_refs << "hospital" if GridRegion.where(hospital_room_id: room.id).exists?
+    region_refs << "containment" if GridRegion.where(containment_room_id: room.id).exists?
+    region_refs << "facility exit" if GridRegion.where(facility_exit_room_id: room.id).exists?
+    region_refs << "facility bribe exit" if GridRegion.where(facility_bribe_exit_room_id: room.id).exists?
+    blockers << "Region #{region_refs.join(", ")} room reference" if region_refs.any?
+
+    blockers
+  end
+
+  def build_all_rooms_grouped
+    regions = GridRegion.includes(grid_zones: :grid_rooms).order(:name)
+    regions.map do |region|
+      {region: region.name, zones: region.grid_zones.sort_by(&:name).map { |z|
+        {zone: z.name, zone_id: z.id, rooms: z.grid_rooms.sort_by(&:name).map { |r|
+          {id: r.id, name: r.name}
+        }}
+      }}
+    end
+  end
+end

--- a/app/controllers/admin/grid_mobs_controller.rb
+++ b/app/controllers/admin/grid_mobs_controller.rb
@@ -34,7 +34,7 @@ class Admin::GridMobsController < Admin::ApplicationController
   def update
     if @mob.update(mob_params)
       set_flash_success("Mob '#{@mob.name}' updated.")
-      redirect_to admin_grid_mobs_path
+      redirect_to edit_admin_grid_mob_path(@mob)
     else
       load_selects
       load_listings if @mob.vendor?

--- a/app/controllers/admin/grid_world_export_controller.rb
+++ b/app/controllers/admin/grid_world_export_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Admin::GridWorldExportController < Admin::ApplicationController
+  # GET /root/grid_world_export — download world data as .tar.gz
+  def download
+    data = Grid::WorldExporter.new.to_tar_gz
+    timestamp = Time.current.strftime("%Y%m%d-%H%M%S")
+
+    send_data data,
+      filename: "world-export-#{timestamp}.tar.gz",
+      type: "application/gzip",
+      disposition: "attachment"
+  end
+end

--- a/app/javascript/components/pages/grid/GridGamePage.tsx
+++ b/app/javascript/components/pages/grid/GridGamePage.tsx
@@ -179,8 +179,8 @@ export const GridGamePage: React.FC = () => {
       return
     }
 
-    // Echo the command in cyan with breathing room
-    setOutput(prev => [...prev, '', `<span style="color: #22d3ee;">&gt; ${command}</span>`])
+    // Echo the command in cyan with separator + breathing room
+    setOutput(prev => [...prev, '<div style="height: 1px; background: #444; margin-top: 16px; margin-bottom: 12px; overflow: hidden;"></div>', `<span style="color: #22d3ee;">&gt; ${command}</span>`])
 
     setExecuting(true)
 

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -6,6 +6,9 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
+#  map_x               :integer
+#  map_y               :integer
+#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -62,7 +62,7 @@ module Grid
       lines = []
       lines << ""
       lines << "<span style='color: #34d399; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
-      lines << "<span style='color: #34d399; font-weight: bold;'>\u2551  B R E A C H   C O M P L E T E                              \u2551</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>\u2551  B R E A C H   C O M P L E T E                               \u2551</span>"
       lines << "<span style='color: #34d399; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
       lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #d0d0d0;'>#{h(template_name)}</span>"
       lines << "<span style='color: #34d399;'>\u2551</span>  <span style='color: #fbbf24;'>XP:</span> <span style='color: #34d399;'>+#{xp_awarded}</span>" if xp_awarded > 0
@@ -208,7 +208,7 @@ module Grid
         analyze = p.analyze_level
 
         if p.destroyed?
-          lines << "  <span style='color: #6b7280;'>[#{p.position + 1}] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \u2713 CLEARED</span>"
+          lines << "#{border}  <span style='color: #6b7280;'>[#{p.position + 1}] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 \u2713 CLEARED</span>"
           next
         end
 
@@ -239,7 +239,7 @@ module Grid
           ""
         end
 
-        lines << "  <span style='color: #9ca3af;'>[#{p.position + 1}]</span> #{health_bar}  #{type_hint}  <span style='color: #9ca3af;'>#{state_label}#{state_info}</span>  <span style='color: #6b7280;'>weak:</span> #{weakness_hint}"
+        lines << "#{border}  <span style='color: #9ca3af;'>[#{p.position + 1}]</span> #{health_bar}  #{type_hint}  <span style='color: #9ca3af;'>#{state_label}#{state_info}</span>  <span style='color: #6b7280;'>weak:</span> #{weakness_hint}"
       end
       lines << "<span style='color: #{BORDER_COLOR};'>\u2560#{SEPARATOR}\u2563</span>"
       lines.join("\n")
@@ -288,7 +288,7 @@ module Grid
       rank_label = rank_data ? rank_data[:rank] : "Unknown"
       [
         "#{border}  <span style='color: #9ca3af;'>Round #{@breach.round_number}</span>  <span style='color: #6b7280;'>\u2014</span>  <span style='color: #9ca3af;'>#{@breach.actions_remaining} actions remaining</span>",
-        "#{border}  <span style='color: #fbbf24;'>BREACH RANK:</span> <span style='color: #22d3ee;'>#{h(rank_label)}</span>",
+        "#{border}  <span style='color: #fbbf24;'>YOUR BREACH RANK:</span> <span style='color: #22d3ee;'>#{h(rank_label)}</span>",
         "<span style='color: #{BORDER_COLOR};'>\u255a#{SEPARATOR}\u255d</span>"
       ].join("\n")
     end

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -1,0 +1,352 @@
+# frozen_string_literal: true
+
+require "rubygems/package"
+
+module Grid
+  # Exports the full world state from the database to YAML files matching
+  # the seed format in data/world/. The exported YAML is the reverse of
+  # data:world — same keys, same slug cross-references — so the files
+  # are bidirectional: export from prod, seed into dev.
+  #
+  # Usage:
+  #   Grid::WorldExporter.new.export_all          # writes to data/world/
+  #   Grid::WorldExporter.new.export_all(dir: "/tmp/world")
+  #   Grid::WorldExporter.new.to_tar_gz           # returns binary string
+  class WorldExporter
+    YAML_LINE_WIDTH = 120
+
+    def initialize
+      @dir = nil
+    end
+
+    # Export all world YAML files to the given directory.
+    def export_all(dir: Rails.root.join("data", "world"))
+      @dir = dir
+      FileUtils.mkdir_p(@dir)
+
+      export_factions
+      export_regions
+      export_zones
+      export_rooms
+      export_exits
+      export_mobs
+      export_item_definitions
+      export_salvage_yields
+      export_items
+      export_achievements
+      export_shop_listings
+      export_missions
+      export_schematics
+      export_breach_templates
+      export_breach_encounters
+
+      @dir
+    end
+
+    # Generate a tar.gz archive of all exported YAML files.
+    def to_tar_gz
+      Dir.mktmpdir("world-export") do |tmpdir|
+        export_all(dir: tmpdir)
+
+        io = StringIO.new
+        Zlib::GzipWriter.wrap(io) do |gz|
+          Gem::Package::TarWriter.new(gz) do |tar|
+            Dir.glob(File.join(tmpdir, "*.yml")).sort.each do |path|
+              name = File.basename(path)
+              content = File.read(path)
+              tar.add_file_simple("world/#{name}", 0o644, content.bytesize) do |f|
+                f.write(content)
+              end
+            end
+          end
+        end
+        io.string
+      end
+    end
+
+    private
+
+    def write_yaml(filename, data)
+      File.write(File.join(@dir, filename), data.to_yaml(line_width: YAML_LINE_WIDTH))
+    end
+
+    # ── Factions ──────────────────────────────────────────────
+
+    def export_factions
+      factions = GridFaction.order(:position, :name).map do |f|
+        h = {"slug" => f.slug, "name" => f.name, "description" => f.description,
+             "color_scheme" => f.color_scheme, "kind" => f.kind, "position" => f.position}
+        h["artist_slug"] = f.artist&.slug if f.respond_to?(:artist) && f.artist_id.present?
+        h["parent_slug"] = f.parent&.slug if f.respond_to?(:parent) && f.parent_id.present?
+        h.compact
+      end
+
+      rep_links = GridFactionRepLink.includes(:source_faction, :target_faction).order(:id).map do |rl|
+        {"source_slug" => rl.source_faction.slug, "target_slug" => rl.target_faction.slug,
+         "weight" => rl.weight}
+      end
+
+      write_yaml("factions.yml", {"factions" => factions, "rep_links" => rep_links})
+    end
+
+    # ── Regions ───────────────────────────────────────────────
+
+    def export_regions
+      all_regions = GridRegion.order(:name).to_a
+      special_ids = all_regions.flat_map { |r|
+        [r.hospital_room_id, r.containment_room_id, r.facility_exit_room_id, r.facility_bribe_exit_room_id]
+      }.compact.uniq
+      slug_map = GridRoom.where(id: special_ids).pluck(:id, :slug).to_h
+
+      regions = all_regions.map do |r|
+        h = {"slug" => r.slug, "name" => r.name, "description" => r.description}
+        h["hospital_room_slug"] = slug_map[r.hospital_room_id] if r.hospital_room_id
+        h["containment_room_slug"] = slug_map[r.containment_room_id] if r.containment_room_id
+        h["facility_exit_room_slug"] = slug_map[r.facility_exit_room_id] if r.facility_exit_room_id
+        h["facility_bribe_exit_room_slug"] = slug_map[r.facility_bribe_exit_room_id] if r.facility_bribe_exit_room_id
+        h.compact
+      end
+      write_yaml("regions.yml", {"regions" => regions})
+    end
+
+    # ── Zones ─────────────────────────────────────────────────
+
+    def export_zones
+      zones = GridZone.includes(:grid_region, :grid_faction).order("grid_regions.name, grid_zones.name")
+        .references(:grid_region).map do |z|
+        h = {"slug" => z.slug, "name" => z.name, "description" => z.description,
+             "zone_type" => z.zone_type, "color_scheme" => z.color_scheme,
+             "danger_level" => z.danger_level,
+             "region_slug" => z.grid_region.slug}
+        h["faction_slug"] = z.grid_faction.slug if z.grid_faction
+        h["ambient_playlist_slug"] = z.ambient_playlist&.slug if z.ambient_playlist_id
+        h.compact
+      end
+      write_yaml("zones.yml", {"zones" => zones})
+    end
+
+    # ── Rooms ─────────────────────────────────────────────────
+
+    def export_rooms
+      rooms = GridRoom.includes(grid_zone: :grid_region)
+        .where.not(room_type: "den")
+        .order("grid_regions.name, grid_zones.name, grid_rooms.name")
+        .references(:grid_zone, :grid_region).map do |r|
+        h = {"slug" => r.slug, "name" => r.name, "description" => r.description,
+             "zone_slug" => r.grid_zone.slug, "room_type" => r.room_type,
+             "min_clearance" => r.min_clearance}
+        h["map_x"] = r.map_x unless r.map_x.nil?
+        h["map_y"] = r.map_y unless r.map_y.nil?
+        h["map_z"] = r.map_z if r.map_z != 0
+        h.compact
+      end
+      write_yaml("rooms.yml", {"rooms" => rooms})
+    end
+
+    # ── Exits ─────────────────────────────────────────────────
+
+    def export_exits
+      exits = GridExit.includes(:from_room, :to_room)
+        .order(:from_room_id, :direction).map do |e|
+        next unless e.from_room&.slug && e.to_room&.slug
+        h = {"from_room_slug" => e.from_room.slug, "to_room_slug" => e.to_room.slug,
+             "direction" => e.direction}
+        h["locked"] = true if e.locked?
+        h
+      end.compact
+      write_yaml("exits.yml", {"exits" => exits})
+    end
+
+    # ── Mobs ──────────────────────────────────────────────────
+
+    def export_mobs
+      mobs = GridMob.includes(:grid_room, :grid_faction).order(:name).map do |m|
+        next unless m.grid_room&.slug
+        h = {"name" => m.name, "room_slug" => m.grid_room.slug,
+             "description" => m.description, "mob_type" => m.mob_type}
+        h["faction_slug"] = m.grid_faction.slug if m.grid_faction
+        h["dialogue_tree"] = m.dialogue_tree if m.dialogue_tree.present?
+        h["vendor_config"] = m.vendor_config if m.vendor_config.present?
+        h.compact
+      end.compact
+      write_yaml("mobs.yml", {"mobs" => mobs})
+    end
+
+    # ── Item Definitions ──────────────────────────────────────
+
+    def export_item_definitions
+      defs = GridItemDefinition.order(:slug).map do |d|
+        h = {"slug" => d.slug, "name" => d.name, "description" => d.description,
+             "item_type" => d.item_type, "rarity" => d.rarity,
+             "value" => d.value}
+        h["max_stack"] = d.max_stack if d.max_stack
+        h["properties"] = d.properties if d.properties.present?
+        h.compact
+      end
+      write_yaml("item_definitions.yml", {"item_definitions" => defs})
+    end
+
+    # ── Salvage Yields ────────────────────────────────────────
+
+    def export_salvage_yields
+      yields = GridSalvageYield.includes(:source_definition, :output_definition)
+        .order(:source_definition_id, :position).map do |y|
+        {"source_slug" => y.source_definition.slug, "output_slug" => y.output_definition.slug,
+         "quantity" => y.quantity, "position" => y.position}
+      end
+      write_yaml("salvage_yields.yml", {"salvage_yields" => yields})
+    end
+
+    # ── Items (floor items only, no player inventory) ─────────
+
+    def export_items
+      items = GridItem.where.not(room_id: nil).where(grid_hackr_id: nil, container_id: nil, equipped_slot: nil)
+        .includes(:grid_item_definition, :room).order(:room_id).map do |i|
+        next unless i.grid_item_definition&.slug && i.room&.slug
+        h = {"definition_slug" => i.grid_item_definition.slug, "room_slug" => i.room.slug,
+             "quantity" => i.quantity}
+        h["value"] = i.value if i.value != i.grid_item_definition.value
+        h
+      end.compact
+      write_yaml("items.yml", {"items" => items})
+    end
+
+    # ── Achievements ──────────────────────────────────────────
+
+    def export_achievements
+      achievements = GridAchievement.order(:category, :slug).map do |a|
+        h = {"slug" => a.slug, "name" => a.name, "description" => a.description,
+             "badge_icon" => a.badge_icon, "trigger_type" => a.trigger_type,
+             "category" => a.category, "xp_reward" => a.xp_reward,
+             "cred_reward" => a.cred_reward}
+        h["trigger_data"] = a.trigger_data if a.trigger_data.present?
+        h["hidden"] = true if a.hidden?
+        h.compact
+      end
+      write_yaml("achievements.yml", {"achievements" => achievements})
+    end
+
+    # ── Shop Listings ─────────────────────────────────────────
+
+    def export_shop_listings
+      listings = GridShopListing.includes(:grid_mob, :grid_item_definition, grid_mob: :grid_room)
+        .order("grid_mobs.name, grid_item_definitions.slug").references(:grid_mob).map do |l|
+        next unless l.grid_mob&.grid_room&.slug
+        h = {"vendor_name" => l.grid_mob.name, "room_slug" => l.grid_mob.grid_room.slug,
+             "definition_slug" => l.grid_item_definition.slug,
+             "base_price" => l.base_price, "sell_price" => l.sell_price,
+             "max_stock" => l.max_stock, "restock_amount" => l.restock_amount,
+             "restock_interval_hours" => l.restock_interval_hours}
+        h["rotation_pool"] = true if l.rotation_pool?
+        h["min_clearance"] = l.min_clearance if l.min_clearance > 0
+        h["active"] = l.active unless l.rotation_pool? # rotation_pool items derive active state
+        h.compact
+      end.compact
+      write_yaml("shop_listings.yml", {"shop_listings" => listings})
+    end
+
+    # ── Missions ──────────────────────────────────────────────
+
+    def export_missions
+      arcs = GridMissionArc.order(:position, :name).map do |a|
+        {"slug" => a.slug, "name" => a.name, "description" => a.description,
+         "position" => a.position, "published" => a.published?}
+      end
+
+      missions = GridMission.includes(:giver_mob, :grid_mission_arc, :prereq_mission,
+        :min_rep_faction, :grid_mission_objectives, :grid_mission_rewards,
+        giver_mob: :grid_room).order(:position, :name).map do |m|
+        h = {"slug" => m.slug, "name" => m.name, "description" => m.description,
+             "min_clearance" => m.min_clearance, "repeatable" => m.repeatable?,
+             "position" => m.position, "published" => m.published?}
+        h["arc_slug"] = m.grid_mission_arc.slug if m.grid_mission_arc
+        h["giver_mob_name"] = m.giver_mob.name if m.giver_mob
+        h["giver_room_slug"] = m.giver_mob.grid_room.slug if m.giver_mob&.grid_room
+        h["prereq_mission_slug"] = m.prereq_mission.slug if m.prereq_mission
+        h["min_rep_faction_slug"] = m.min_rep_faction.slug if m.min_rep_faction
+        h["min_rep_value"] = m.min_rep_value if m.min_rep_value.to_i > 0
+        h["dialogue_path"] = m.dialogue_path if m.dialogue_path.present?
+
+        h["objectives"] = m.grid_mission_objectives.order(:position).map do |o|
+          oh = {"position" => o.position, "objective_type" => o.objective_type, "label" => o.label}
+          oh["target_slug"] = o.target_slug if o.target_slug.present?
+          oh["target_count"] = o.target_count if o.target_count > 1
+          oh.compact
+        end
+
+        h["rewards"] = m.grid_mission_rewards.order(:position).map do |r|
+          rh = {"position" => r.position, "reward_type" => r.reward_type}
+          rh["amount"] = r.amount if r.amount.to_i > 0
+          rh["target_slug"] = r.target_slug if r.target_slug.present?
+          rh["quantity"] = r.quantity if r.quantity > 1
+          rh.compact
+        end
+
+        h.compact
+      end
+
+      write_yaml("missions.yml", {"arcs" => arcs, "missions" => missions})
+    end
+
+    # ── Schematics ────────────────────────────────────────────
+
+    def export_schematics
+      schematics = GridSchematic.includes(:output_definition, ingredients: :input_definition)
+        .order(:position, :name).map do |s|
+        h = {"slug" => s.slug, "name" => s.name, "description" => s.description,
+             "output_slug" => s.output_definition.slug,
+             "output_quantity" => s.output_quantity,
+             "xp_reward" => s.xp_reward,
+             "required_clearance" => s.required_clearance,
+             "published" => s.published?, "position" => s.position}
+        h["required_mission_slug"] = s.required_mission_slug if s.required_mission_slug.present?
+        h["required_achievement_slug"] = s.required_achievement_slug if s.required_achievement_slug.present?
+        h["required_room_type"] = s.required_room_type if s.required_room_type.present?
+
+        h["ingredients"] = s.ingredients.order(:position).map do |i|
+          {"input_slug" => i.input_definition.slug, "quantity" => i.quantity, "position" => i.position}
+        end
+
+        h.compact
+      end
+      write_yaml("schematics.yml", {"schematics" => schematics})
+    end
+
+    # ── Breach Templates ──────────────────────────────────────
+
+    def export_breach_templates
+      templates = GridBreachTemplate.order(:position, :name).map do |t|
+        h = {"slug" => t.slug, "name" => t.name, "description" => t.description,
+             "tier" => t.tier, "min_clearance" => t.min_clearance,
+             "pnr_threshold" => t.pnr_threshold, "base_detection_rate" => t.base_detection_rate,
+             "cooldown_min" => t.cooldown_min, "cooldown_max" => t.cooldown_max,
+             "xp_reward" => t.xp_reward, "cred_reward" => t.cred_reward,
+             "published" => t.published?, "position" => t.position}
+        h["requires_mission_slug"] = t.requires_mission_slug if t.requires_mission_slug.present?
+        h["requires_item_slug"] = t.requires_item_slug if t.requires_item_slug.present?
+        h["danger_level_min"] = t.danger_level_min if t.danger_level_min.to_i > 0
+        h["zone_slugs"] = t.zone_slugs if t.zone_slugs.present?
+        h["protocol_composition"] = t.protocol_composition if t.protocol_composition.present?
+        h["puzzle_gates"] = t.puzzle_gates if t.puzzle_gates.present?
+        h["reward_table"] = t.reward_table if t.reward_table.present?
+        h["no_clearance_bypass"] = true if t.no_clearance_bypass?
+        h.compact
+      end
+      write_yaml("breach_templates.yml", {"breach_templates" => templates})
+    end
+
+    # ── Breach Encounters ─────────────────────────────────────
+
+    def export_breach_encounters
+      encounters = GridBreachEncounter.includes(:grid_breach_template, :grid_room)
+        .order(:grid_room_id).map do |e|
+        next unless e.grid_breach_template&.slug && e.grid_room&.slug
+        h = {"template_slug" => e.grid_breach_template.slug, "room_slug" => e.grid_room.slug}
+        h["state"] = e.state if e.state != "available"
+        h["instance_seed"] = e.instance_seed if e.instance_seed
+        h
+      end.compact
+      write_yaml("breach_encounters.yml", {"breach_encounters" => encounters})
+    end
+  end
+end

--- a/app/services/grid/world_map_builder.rb
+++ b/app/services/grid/world_map_builder.rb
@@ -36,6 +36,7 @@ module Grid
     STRIDE_X = 200    # horizontal center-to-center distance
     STRIDE_Y = 100    # vertical center-to-center distance
     PADDING = 40      # canvas edge padding
+    MIN_SVG_W = 1000  # minimum viewBox width to prevent oversized rooms
 
     ZONE_COLORS = %w[
       #00ffff #34d399 #f472b6 #fbbf24 #a78bfa
@@ -260,7 +261,7 @@ module Grid
 
       max_lx = positions.values.map(&:first).max
       max_ly = positions.values.map(&:last).max
-      svg_w = (max_lx + 1) * STRIDE_X + PADDING * 2
+      svg_w = [(max_lx + 1) * STRIDE_X + PADDING * 2, MIN_SVG_W].max
       svg_h = (max_ly + 1) * STRIDE_Y + PADDING * 2
 
       lines = []
@@ -346,7 +347,6 @@ module Grid
       x2 = to_lx * STRIDE_X + PADDING
       y2 = to_ly * STRIDE_Y + PADDING
 
-      # Shorten line to stop at box edges
       dx = x2 - x1
       dy = y2 - y1
       dist = Math.sqrt(dx * dx + dy * dy)
@@ -354,14 +354,27 @@ module Grid
 
       ux = dx / dist
       uy = dy / dist
-      inset = (dx.abs > dy.abs) ? BOX_W / 2.0 : BOX_H / 2.0
 
-      sx = x1 + ux * inset
-      sy = y1 + uy * inset
-      ex = x2 - ux * inset
-      ey = y2 - uy * inset
+      # Proper box-edge intersection: find where the direction ray exits the box
+      inset1 = box_edge_inset(ux, uy)
+      inset2 = box_edge_inset(-ux, -uy)
+
+      sx = x1 + ux * inset1
+      sy = y1 + uy * inset1
+      ex = x2 - ux * inset2
+      ey = y2 - uy * inset2
 
       %(<line x1="#{sx.round}" y1="#{sy.round}" x2="#{ex.round}" y2="#{ey.round}" stroke="#333" class="connector"/>)
+    end
+
+    # Distance from box center to its edge along direction (ux, uy).
+    # Handles all angles correctly, including diagonals.
+    def box_edge_inset(ux, uy)
+      hw = BOX_W / 2.0
+      hh = BOX_H / 2.0
+      return hh if ux.abs < 0.001
+      return hw if uy.abs < 0.001
+      [hw / ux.abs, hh / uy.abs].min
     end
 
     def h(text)

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -317,11 +317,27 @@
       var localRoom = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
       if (!localRoom) return;
       var vec = DIRECTION_VECTORS[conn.direction];
+      var gx, gy;
       if (vec) {
-        ghostPositions[gr.id] = [localRoom.map_x + vec[0], localRoom.map_y + vec[1]];
+        gx = localRoom.map_x + vec[0];
+        gy = localRoom.map_y + vec[1];
+      } else if (conn.direction === 'up') {
+        gx = localRoom.map_x;
+        gy = localRoom.map_y - 1;
+      } else if (conn.direction === 'down') {
+        gx = localRoom.map_x;
+        gy = localRoom.map_y + 1;
       } else {
-        ghostPositions[gr.id] = [localRoom.map_x + 1, localRoom.map_y];
+        gx = localRoom.map_x + 1;
+        gy = localRoom.map_y;
       }
+      // Nudge if position already occupied
+      for (var tries = 0; tries < 5; tries++) {
+        var collides = allPositions.some(function(p) { return p[0] === gx && p[1] === gy; });
+        if (!collides) break;
+        gy += (conn.direction === 'up' ? -1 : 1);
+      }
+      ghostPositions[gr.id] = [gx, gy];
       allPositions.push(ghostPositions[gr.id]);
     });
 
@@ -383,7 +399,8 @@
       gr.connected_via.forEach(function(conn) {
         var localRoom = roomById[conn.local_room_id];
         if (!localRoom) return;
-        drawConnector(localRoom.map_x, localRoom.map_y, gp[0], gp[1], {id: conn.exit_id, direction: conn.direction}, true);
+        var vertColor = conn.direction === 'up' ? '#a78bfa' : conn.direction === 'down' ? '#fb923c' : null;
+        drawConnector(localRoom.map_x, localRoom.map_y, gp[0], gp[1], {id: conn.exit_id, direction: conn.direction}, true, vertColor);
       });
     });
 
@@ -391,7 +408,8 @@
     state.ghost_rooms.forEach(function(gr) {
       var gp = ghostPositions[gr.id];
       if (!gp) return;
-      drawGhostRoom(gp[0], gp[1], gr);
+      var connDir = gr.connected_via.length > 0 ? gr.connected_via[0].direction : null;
+      drawGhostRoom(gp[0], gp[1], gr, connDir);
     });
 
     // Draw vertical rooms (other z-levels connected via up/down)
@@ -400,12 +418,14 @@
       var conn = vr.connected_via[0];
       var localRoom = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
       if (!localRoom) return;
-      // Offset slightly from the local room so they don't overlap
+      // Offset from local room, nudging until free cell found
       var offsetY = conn.direction === 'up' ? -1 : 1;
       var vx = localRoom.map_x, vy = localRoom.map_y + offsetY;
-      // Check collision with existing rooms
-      var occupied = state.rooms.some(function(r) { return r.map_x === vx && r.map_y === vy; });
-      if (occupied) vy += offsetY; // nudge further
+      for (var tries = 0; tries < 5; tries++) {
+        var collides = allPositions.some(function(p) { return p[0] === vx && p[1] === vy; });
+        if (!collides) break;
+        vy += offsetY;
+      }
       allPositions.push([vx, vy]);
       drawVerticalRoom(vx, vy, vr, conn.direction);
     });
@@ -491,17 +511,21 @@
     svg.appendChild(g);
   }
 
-  function drawGhostRoom(gx, gy, ghostRoom) {
+  function drawGhostRoom(gx, gy, ghostRoom, connDirection) {
     var cx = gx * STRIDE_X, cy = gy * STRIDE_Y;
     var rx = cx - BOX_W / 2, ry = cy - BOX_H / 2;
+    var isVertical = connDirection === 'up' || connDirection === 'down';
+    var vertColor = connDirection === 'up' ? '#a78bfa' : '#fb923c';
+    var strokeColor = isVertical ? vertColor : '#555';
+    var arrow = connDirection === 'up' ? '↑ ' : connDirection === 'down' ? '↓ ' : '';
 
     var g = el('g', {'data-ghost-id': ghostRoom.id, class: 'me-ghost', style: 'cursor: pointer; opacity: ' + GHOST_OPACITY + ';'});
 
-    g.appendChild(el('rect', {x: rx, y: ry, width: BOX_W, height: BOX_H, fill: '#0d0d0d', stroke: '#555', 'stroke-width': 1, rx: 3, 'stroke-dasharray': '4,3'}));
+    g.appendChild(el('rect', {x: rx, y: ry, width: BOX_W, height: BOX_H, fill: '#0d0d0d', stroke: strokeColor, 'stroke-width': 1, rx: 3, 'stroke-dasharray': '4,3'}));
 
     var name = ghostRoom.name.length > 16 ? ghostRoom.name.substring(0, 15) + '…' : ghostRoom.name;
-    var nameEl = el('text', {x: cx, y: cy - 6, 'text-anchor': 'middle', fill: '#888', 'font-family': "'Courier New', monospace", 'font-size': '10px'});
-    nameEl.textContent = name;
+    var nameEl = el('text', {x: cx, y: cy - 6, 'text-anchor': 'middle', fill: isVertical ? vertColor : '#888', 'font-family': "'Courier New', monospace", 'font-size': '10px'});
+    nameEl.textContent = arrow + name;
     g.appendChild(nameEl);
 
     var zoneEl = el('text', {x: cx, y: cy + 10, 'text-anchor': 'middle', fill: '#555', 'font-family': "'Courier New', monospace", 'font-size': '8px'});
@@ -590,7 +614,7 @@
     svg.appendChild(g);
   }
 
-  function drawConnector(fromGX, fromGY, toGX, toGY, exitData, isGhost) {
+  function drawConnector(fromGX, fromGY, toGX, toGY, exitData, isGhost, colorOverride) {
     var x1 = fromGX * STRIDE_X, y1 = fromGY * STRIDE_Y;
     var x2 = toGX * STRIDE_X, y2 = toGY * STRIDE_Y;
 
@@ -606,8 +630,11 @@
     var sx = x1 + ux * inset1, sy = y1 + uy * inset1;
     var ex = x2 - ux * inset2, ey = y2 - uy * inset2;
 
-    var color = isGhost ? '#2a2a2a' : '#333';
-    var line = el('line', {x1: Math.round(sx), y1: Math.round(sy), x2: Math.round(ex), y2: Math.round(ey), stroke: color, 'stroke-width': isGhost ? 1 : 1.5, class: 'me-connector'});
+    var isVertical = colorOverride && exitData && (exitData.direction === 'up' || exitData.direction === 'down');
+    var color = colorOverride || (isGhost ? '#2a2a2a' : '#333');
+    var lineAttrs = {x1: Math.round(sx), y1: Math.round(sy), x2: Math.round(ex), y2: Math.round(ey), stroke: color, 'stroke-width': isGhost ? 1 : 1.5, class: 'me-connector'};
+    if (isVertical) lineAttrs['stroke-dasharray'] = '4,3';
+    var line = el('line', lineAttrs);
     if (exitData && exitData.id) {
       line.setAttribute('data-exit-id', exitData.id);
       line.style.cursor = 'pointer';
@@ -620,6 +647,17 @@
       });
     }
     svg.appendChild(line);
+
+    // Midpoint label for vertical connectors
+    if (isVertical) {
+      var mx = (sx + ex) / 2, my = (sy + ey) / 2;
+      var arrow = exitData.direction === 'up' ? '↑' : '↓';
+      var bg = el('circle', {cx: mx, cy: my, r: 7, fill: '#0d0d0d'});
+      svg.appendChild(bg);
+      var label = el('text', {x: mx, y: my + 4, 'text-anchor': 'middle', fill: color, 'font-family': "'Courier New', monospace", 'font-size': '10px', 'font-weight': 'bold'});
+      label.textContent = arrow;
+      svg.appendChild(label);
+    }
   }
 
   function boxEdgeInset(ux, uy) {

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -1,0 +1,1573 @@
+<% content_for(:title) { "/root :: Map Editor :: #{@zone.name}" } %>
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 100%; margin: 10px; padding: 10px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/map-editor/<%= @zone.slug %></legend>
+
+    <div style="padding: 10px;">
+      <%# Toolbar %>
+      <div id="me-toolbar" style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; align-items: center;">
+        <%= link_to "<- World Map", admin_grid_world_map_index_path, class: "tui-button", style: "padding: 4px 12px; font-size: 0.85em;" %>
+
+        <label style="color: #888; font-size: 0.85em;">Zone:</label>
+        <div style="min-width: 280px; max-width: 350px; position: relative;" class="admin-combobox">
+          <input type="text" id="me-zone-input" class="admin-combobox-input selected" style="padding: 4px 8px; font-size: 0.85em;" autocomplete="off" placeholder="Search zones..." value="<%= @zone.grid_region.name %> / <%= @zone.name %>" />
+          <input type="hidden" id="me-zone-hidden" value="<%= @zone.id %>" />
+          <div id="me-zone-dropdown" class="admin-combobox-dropdown"></div>
+          <div id="me-zone-status" style="display: none;"></div>
+        </div>
+
+        <button id="me-auto-layout" class="tui-button cyan-168" style="padding: 4px 12px; font-size: 0.85em;">Auto Layout</button>
+        <button id="me-zoom-in" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">+</button>
+        <button id="me-zoom-out" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">-</button>
+        <button id="me-zoom-reset" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">1:1</button>
+        <span style="color: #333; margin: 0 4px;">|</span>
+        <span id="me-z-buttons" style="display: inline-flex; gap: 4px; align-items: center;"></span>
+        <span id="me-status" style="color: #666; font-size: 0.85em; margin-left: auto;"></span>
+      </div>
+
+      <%# Main layout: map + side panel %>
+      <div style="display: flex; gap: 0; border: 1px solid #333; background: #0d0d0d;">
+        <%# SVG Canvas %>
+        <div id="me-canvas-wrap" style="flex: 1; overflow: auto; position: relative; min-height: 600px; cursor: crosshair;">
+          <svg id="me-svg" xmlns="http://www.w3.org/2000/svg" style="display: block;"></svg>
+        </div>
+
+        <%# Side Panel %>
+        <div id="me-panel" style="width: 340px; min-width: 340px; background: #111; border-left: 2px solid #333; overflow-y: auto; max-height: 80vh; display: none;">
+          <div id="me-panel-content" style="padding: 15px;"></div>
+        </div>
+      </div>
+
+      <%# Legend %>
+      <div style="margin-top: 8px; padding: 8px; border: 1px solid #222; background: #0a0a0a;">
+        <span style="color: #666; font-size: 0.85em;">
+          Click room to edit ·
+          Double-click empty space to create room ·
+          Drag room to move ·
+          Drag from <span style="color: #00ffff;">port dot</span> to draw exit ·
+          Click connector to edit/delete ·
+          <span style="color: #555; opacity: 0.6;">Ghost</span>=cross-zone room ·
+          Esc to deselect
+        </span>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<%# Exit creation dialog %>
+<div id="me-exit-dialog" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #1a1a1a; border: 2px solid #00ffff; padding: 20px; z-index: 10001; min-width: 320px;">
+  <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: CREATE EXIT ::]</h3>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">FROM:</label>
+    <span id="me-exit-from" style="color: #888;"></span>
+  </div>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">TO:</label>
+    <span id="me-exit-to" style="color: #888;"></span>
+  </div>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">DIRECTION:</label>
+    <input id="me-exit-direction" class="tui-input" style="width: 100%; padding: 6px;" />
+  </div>
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="font-size: 0.85em;">
+      <input type="checkbox" id="me-exit-bidi" checked /> Bidirectional
+    </label>
+    <span id="me-exit-reverse-dir-wrap" style="margin-left: 10px;">
+      <label style="color: #888; font-size: 0.85em;">Reverse:</label>
+      <input id="me-exit-reverse-dir" class="tui-input" style="width: 100px; padding: 4px; font-size: 0.85em;" />
+    </span>
+  </div>
+  <div style="display: flex; gap: 10px;">
+    <button id="me-exit-confirm" class="tui-button green-168" style="padding: 6px 16px;">Create</button>
+    <button id="me-exit-cancel" class="tui-button" style="padding: 6px 16px;">Cancel</button>
+  </div>
+</div>
+
+<%# Room creation dialog %>
+<div id="me-room-dialog" style="display: none; position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #1a1a1a; border: 2px solid #34d399; padding: 20px; z-index: 10001; min-width: 340px;">
+  <h3 class="green-255-text" style="margin-bottom: 15px;">[:: CREATE ROOM ::]</h3>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">NAME:</label>
+    <input id="me-room-name" class="tui-input" style="width: 100%; padding: 6px;" />
+  </div>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">SLUG:</label>
+    <input id="me-room-slug" class="tui-input" style="width: 100%; padding: 6px;" />
+  </div>
+  <div style="margin-bottom: 10px;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">TYPE:</label>
+    <select id="me-room-type" class="tui-input" style="width: 100%; padding: 6px;">
+      <option value="">(none)</option>
+      <option value="hub">Hub</option>
+      <option value="faction_base">Faction Base</option>
+      <option value="govcorp">GovCorp</option>
+      <option value="special">Special</option>
+      <option value="safe_zone">Safe Zone</option>
+      <option value="transit">Transit</option>
+      <option value="shop">Shop</option>
+      <option value="danger_zone">Danger Zone</option>
+      <option value="prism">Prism</option>
+      <option value="dream">Dream</option>
+      <option value="hospital">Hospital</option>
+      <option value="firmware_vendor">Firmware Vendor</option>
+      <option value="repair_service">Repair Service</option>
+      <option value="containment">Containment</option>
+      <option value="impound">Impound</option>
+      <option value="sally_port_anteroom">Sally Port Anteroom</option>
+      <option value="sally_port">Sally Port</option>
+    </select>
+  </div>
+  <div style="display: flex; gap: 10px;">
+    <button id="me-room-confirm" class="tui-button green-168" style="padding: 6px 16px;">Create</button>
+    <button id="me-room-cancel" class="tui-button" style="padding: 6px 16px;">Cancel</button>
+  </div>
+</div>
+
+<%# Overlay backdrop %>
+<div id="me-overlay" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); z-index: 10000;"></div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+(function() {
+  // ── Constants ──────────────────────────────────────────────
+  var BOX_W = 140, BOX_H = 52;
+  var STRIDE_X = 200, STRIDE_Y = 100;
+  var PADDING = 60;
+  var PORT_R = 5;
+  var MIN_VIEWBOX_W = 1000;
+  var GHOST_OPACITY = 0.35;
+  var NS = 'http://www.w3.org/2000/svg';
+
+  var DIRECTION_VECTORS = {
+    north: [0, -1], south: [0, 1], east: [1, 0], west: [-1, 0],
+    northeast: [1, -1], northwest: [-1, -1], southeast: [1, 1], southwest: [-1, 1]
+  };
+  var OPPOSITES = {
+    north: 'south', south: 'north', east: 'west', west: 'east',
+    northeast: 'southwest', southwest: 'northeast',
+    northwest: 'southeast', southeast: 'northwest',
+    up: 'down', down: 'up'
+  };
+  var PORT_POSITIONS = [
+    {dir: 'north', dx: 0, dy: -BOX_H/2},
+    {dir: 'south', dx: 0, dy: BOX_H/2},
+    {dir: 'east', dx: BOX_W/2, dy: 0},
+    {dir: 'west', dx: -BOX_W/2, dy: 0},
+    {dir: 'northeast', dx: BOX_W/2, dy: -BOX_H/2},
+    {dir: 'northwest', dx: -BOX_W/2, dy: -BOX_H/2},
+    {dir: 'southeast', dx: BOX_W/2, dy: BOX_H/2},
+    {dir: 'southwest', dx: -BOX_W/2, dy: BOX_H/2}
+  ];
+  var ROOM_TYPE_COLORS = {
+    hub: '#fbbf24', faction_base: '#a78bfa', govcorp: '#f87171',
+    special: '#e879f9', safe_zone: '#34d399', transit: '#60a5fa',
+    shop: '#fb923c', danger_zone: '#f87171', hospital: '#86efac',
+    containment: '#f87171', impound: '#f87171'
+  };
+
+  // ── State ──────────────────────────────────────────────────
+  var zoneId = <%= @zone.id %>;
+  var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  var state = {rooms: [], exits: [], ghostRooms: [], breachTemplates: [], allRoomsGrouped: [], zone: null, zoneColor: '#00ffff'};
+  var selectedRoomId = null;
+  var _panelZoneUid = null;
+  var zoomLevel = 0.75;
+  var currentZ = 0;
+  var dragState = null; // {type: 'room'|'port', roomId, startX, startY, origX, origY}
+  var drawLine = null;
+
+  // ── DOM refs ───────────────────────────────────────────────
+  var svg = document.getElementById('me-svg');
+  var canvasWrap = document.getElementById('me-canvas-wrap');
+  var panel = document.getElementById('me-panel');
+  var panelContent = document.getElementById('me-panel-content');
+  var statusEl = document.getElementById('me-status');
+  var zoneHidden = document.getElementById('me-zone-hidden');
+  var overlay = document.getElementById('me-overlay');
+
+  // ── API helpers ────────────────────────────────────────────
+  function api(method, path, body) {
+    var opts = {method: method, headers: {'X-CSRF-Token': csrfToken, 'Content-Type': 'application/json', 'Accept': 'application/json'}};
+    if (body) opts.body = JSON.stringify(body);
+    return fetch('/root/grid_map_editor/' + path, opts).then(function(r) {
+      if (!r.ok && r.headers.get('content-type')?.indexOf('json') === -1) {
+        throw new Error('HTTP ' + r.status);
+      }
+      return r.json();
+    }).catch(function(err) {
+      setStatus('Error: ' + err.message);
+      return {success: false, errors: [err.message]};
+    });
+  }
+
+  function setStatus(msg) { statusEl.textContent = msg; }
+
+  // ── Data loading ───────────────────────────────────────────
+  function loadData() {
+    setStatus('Loading...');
+    api('GET', zoneId + '/data?z=' + currentZ).then(function(d) {
+      state = d;
+      currentZ = d.z_level || 0;
+      populateZoneSelect();
+      syncZoneCombobox();
+      renderZButtons();
+      render();
+      // Re-open panel if a room was selected and still exists
+      if (selectedRoomId !== null) {
+        var still = state.rooms.find(function(r) { return r.id === selectedRoomId; });
+        if (still) showPanel(selectedRoomId);
+        else { selectedRoomId = null; closePanel(); }
+      }
+      var zLabel = currentZ === 0 ? 'z=0' : (currentZ > 0 ? 'z+' + currentZ : 'z' + currentZ);
+      setStatus(state.rooms.length + ' rooms · ' + state.exits.length + ' exits · ' + zLabel);
+    });
+  }
+
+  var _zoneComboboxInited = false;
+  function populateZoneSelect() {
+    if (_zoneComboboxInited) return; // only init once; items don't change
+    _zoneComboboxInited = true;
+    var zones = state.available_zones || [];
+    AdminCombobox.init({
+      inputId: 'me-zone-input',
+      hiddenId: 'me-zone-hidden',
+      dropdownId: 'me-zone-dropdown',
+      statusId: 'me-zone-status',
+      items: zones,
+      getSearchText: function(z) { return (z.name + ' ' + z.region_name).toLowerCase(); },
+      getGroupKey: function(z) { return z.region_name; },
+      renderOption: function(z, e) {
+        return '<span class="cb-name">' + e(z.name) + '</span> <span class="cb-meta">' + e(z.region_name) + '</span>';
+      },
+      getId: function(z) { return String(z.id); },
+      getLabel: function(z) { return z.region_name + ' / ' + z.name; },
+      emptyText: 'No zones match',
+      selectedText: 'Zone selected'
+    });
+  }
+
+  function syncZoneCombobox() {
+    var input = document.getElementById('me-zone-input');
+    var hidden = document.getElementById('me-zone-hidden');
+    var cur = (state.available_zones || []).find(function(z) { return z.id === zoneId; });
+    if (cur) {
+      input.value = cur.region_name + ' / ' + cur.name;
+      input.classList.add('selected');
+    }
+    // Set via property directly to avoid triggering the navigation hook
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(hidden, String(zoneId));
+  }
+
+  function renderZButtons() {
+    var wrap = document.getElementById('me-z-buttons');
+    wrap.innerHTML = '';
+    var levels = state.z_levels || [0];
+    if (levels.length <= 1) return;
+    levels.forEach(function(z) {
+      var btn = document.createElement('button');
+      btn.className = 'tui-button' + (z === currentZ ? ' green-168' : '');
+      btn.style.cssText = 'padding: 2px 8px; font-size: 0.8em;' + (z === currentZ ? ' cursor: default;' : '');
+      btn.textContent = z === 0 ? 'z=0' : (z > 0 ? '↑+' + z : '↓' + z);
+      if (z !== currentZ) {
+        btn.addEventListener('click', function() {
+          currentZ = z;
+          selectedRoomId = null;
+          closePanel();
+          loadData();
+        });
+      }
+      wrap.appendChild(btn);
+    });
+  }
+
+  // Intercept zone combobox selection by hooking the hidden input's value setter
+  (function() {
+    var desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+    Object.defineProperty(zoneHidden, 'value', {
+      set: function(v) {
+        desc.set.call(this, v);
+        var newId = parseInt(v);
+        if (newId && newId !== zoneId) {
+          zoneId = newId;
+          currentZ = 0;
+          selectedRoomId = null;
+          closePanel();
+          window.history.replaceState(null, '', '/root/grid_map_editor/' + zoneId);
+          loadData();
+        }
+      },
+      get: desc.get
+    });
+  })();
+
+  // ── SVG Rendering ──────────────────────────────────────────
+  function render() {
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    var allPositions = [];
+    state.rooms.forEach(function(r) { allPositions.push([r.map_x, r.map_y]); });
+
+    // Compute ghost room positions from connection directions
+    var ghostPositions = {};
+    state.ghost_rooms.forEach(function(gr) {
+      if (gr.connected_via.length === 0) return;
+      var conn = gr.connected_via[0];
+      var localRoom = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
+      if (!localRoom) return;
+      var vec = DIRECTION_VECTORS[conn.direction];
+      if (vec) {
+        ghostPositions[gr.id] = [localRoom.map_x + vec[0], localRoom.map_y + vec[1]];
+      } else {
+        ghostPositions[gr.id] = [localRoom.map_x + 1, localRoom.map_y];
+      }
+      allPositions.push(ghostPositions[gr.id]);
+    });
+
+    if (allPositions.length === 0) allPositions.push([0, 0]);
+
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    allPositions.forEach(function(p) {
+      if (p[0] < minX) minX = p[0];
+      if (p[1] < minY) minY = p[1];
+      if (p[0] > maxX) maxX = p[0];
+      if (p[1] > maxY) maxY = p[1];
+    });
+
+    // Add margin for ghost rooms and new room creation
+    minX -= 2; minY -= 2; maxX += 2; maxY += 2;
+
+    var vbW = (maxX - minX + 1) * STRIDE_X + PADDING * 2;
+    var vbH = (maxY - minY + 1) * STRIDE_Y + PADDING * 2;
+    if (vbW < MIN_VIEWBOX_W) vbW = MIN_VIEWBOX_W;
+    var vbX = minX * STRIDE_X - PADDING;
+    var vbY = minY * STRIDE_Y - PADDING;
+
+    svg.setAttribute('viewBox', vbX + ' ' + vbY + ' ' + vbW + ' ' + vbH);
+    svg.setAttribute('width', Math.round(vbW * zoomLevel));
+    svg.setAttribute('height', Math.round(vbH * zoomLevel));
+
+    // Background
+    var bg = el('rect', {x: vbX, y: vbY, width: vbW, height: vbH, fill: '#0d0d0d'});
+    svg.appendChild(bg);
+
+    // Grid dots
+    for (var gx = minX; gx <= maxX; gx++) {
+      for (var gy = minY; gy <= maxY; gy++) {
+        var dot = el('circle', {cx: gx * STRIDE_X, cy: gy * STRIDE_Y, r: 1.5, fill: '#1a1a1a'});
+        svg.appendChild(dot);
+      }
+    }
+
+    // Build room lookup
+    var roomById = {};
+    state.rooms.forEach(function(r) { roomById[r.id] = r; });
+
+    // Draw connectors
+    var drawnEdges = {};
+    state.exits.forEach(function(ex) {
+      var fromRoom = roomById[ex.from_room_id];
+      var toRoom = roomById[ex.to_room_id];
+      if (!fromRoom || !toRoom) return;
+      var key = [Math.min(ex.from_room_id, ex.to_room_id), Math.max(ex.from_room_id, ex.to_room_id)].join('-');
+      if (drawnEdges[key]) return;
+      drawnEdges[key] = true;
+      drawConnector(fromRoom.map_x, fromRoom.map_y, toRoom.map_x, toRoom.map_y, ex, false);
+    });
+
+    // Draw ghost-to-local connectors
+    state.ghost_rooms.forEach(function(gr) {
+      var gp = ghostPositions[gr.id];
+      if (!gp) return;
+      gr.connected_via.forEach(function(conn) {
+        var localRoom = roomById[conn.local_room_id];
+        if (!localRoom) return;
+        drawConnector(localRoom.map_x, localRoom.map_y, gp[0], gp[1], {id: conn.exit_id, direction: conn.direction}, true);
+      });
+    });
+
+    // Draw ghost rooms (cross-zone)
+    state.ghost_rooms.forEach(function(gr) {
+      var gp = ghostPositions[gr.id];
+      if (!gp) return;
+      drawGhostRoom(gp[0], gp[1], gr);
+    });
+
+    // Draw vertical rooms (other z-levels connected via up/down)
+    (state.vertical_rooms || []).forEach(function(vr) {
+      if (vr.connected_via.length === 0) return;
+      var conn = vr.connected_via[0];
+      var localRoom = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
+      if (!localRoom) return;
+      // Offset slightly from the local room so they don't overlap
+      var offsetY = conn.direction === 'up' ? -1 : 1;
+      var vx = localRoom.map_x, vy = localRoom.map_y + offsetY;
+      // Check collision with existing rooms
+      var occupied = state.rooms.some(function(r) { return r.map_x === vx && r.map_y === vy; });
+      if (occupied) vy += offsetY; // nudge further
+      allPositions.push([vx, vy]);
+      drawVerticalRoom(vx, vy, vr, conn.direction);
+    });
+
+    // Draw rooms
+    state.rooms.forEach(function(r) {
+      drawRoom(r);
+    });
+
+    // Draw line (for exit drawing in progress)
+    drawLine = el('line', {x1: 0, y1: 0, x2: 0, y2: 0, stroke: '#00ffff', 'stroke-width': 2, 'stroke-dasharray': '6,4', visibility: 'hidden'});
+    svg.appendChild(drawLine);
+  }
+
+  function el(tag, attrs) {
+    var e = document.createElementNS(NS, tag);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+
+  function drawRoom(room) {
+    var cx = room.map_x * STRIDE_X;
+    var cy = room.map_y * STRIDE_Y;
+    var rx = cx - BOX_W / 2, ry = cy - BOX_H / 2;
+    var isSelected = room.id === selectedRoomId;
+    var color = state.zone_color || '#00ffff';
+    var stroke = room.locked ? '#f87171' : (isSelected ? '#fff' : color);
+    var strokeW = isSelected ? 2.5 : (room.locked ? 2 : 1);
+    var fill = isSelected ? '#1a2a2a' : '#111';
+
+    var g = el('g', {'data-room-id': room.id, class: 'me-room', style: 'cursor: pointer;'});
+
+    // Hit area (invisible, larger for easier click)
+    g.appendChild(el('rect', {x: rx - 2, y: ry - 2, width: BOX_W + 4, height: BOX_H + 4, fill: 'transparent'}));
+
+    // Box
+    g.appendChild(el('rect', {x: rx, y: ry, width: BOX_W, height: BOX_H, fill: fill, stroke: stroke, 'stroke-width': strokeW, rx: 3}));
+
+    // Name
+    var name = room.name.length > 18 ? room.name.substring(0, 17) + '…' : room.name;
+    var nameEl = el('text', {x: cx, y: cy - 6, 'text-anchor': 'middle', fill: color, 'font-family': "'Courier New', monospace", 'font-size': '11px'});
+    nameEl.textContent = name;
+    g.appendChild(nameEl);
+
+    // Info line
+    var infoParts = [];
+    if (room.room_type) infoParts.push(room.room_type);
+    if (room.hackr_count > 0) infoParts.push(room.hackr_count + 'H');
+    if (room.mob_count > 0) infoParts.push(room.mob_count + 'M');
+    if (room.encounters && room.encounters.length > 0) infoParts.push(room.encounters.length + 'B');
+    var infoEl = el('text', {x: cx, y: cy + 10, 'text-anchor': 'middle', fill: '#666', 'font-family': "'Courier New', monospace", 'font-size': '9px'});
+    infoEl.textContent = infoParts.join(' · ');
+    g.appendChild(infoEl);
+
+    // Lock icon
+    if (room.locked) {
+      var lockEl = el('text', {x: rx + 4, y: ry + 11, 'font-size': '8', fill: '#f87171'});
+      lockEl.textContent = '🔒';
+      g.appendChild(lockEl);
+    }
+
+    // Port dots (for exit drawing) — only show on hover or when selected
+    PORT_POSITIONS.forEach(function(p) {
+      var port = el('circle', {cx: cx + p.dx, cy: cy + p.dy, r: PORT_R, fill: '#00ffff', opacity: 0, class: 'me-port', 'data-room-id': room.id, 'data-dir': p.dir, style: 'cursor: crosshair;'});
+      g.appendChild(port);
+    });
+
+    // Tooltip
+    var titleEl = el('title', {});
+    titleEl.textContent = room.name + ' [' + (room.room_type || 'none') + '] ' + room.hackr_count + 'H ' + room.mob_count + 'M';
+    g.appendChild(titleEl);
+
+    // Hover: show ports
+    g.addEventListener('mouseenter', function() {
+      g.querySelectorAll('.me-port').forEach(function(p) { p.setAttribute('opacity', '0.7'); });
+    });
+    g.addEventListener('mouseleave', function() {
+      if (!dragState || dragState.type !== 'port') {
+        g.querySelectorAll('.me-port').forEach(function(p) { p.setAttribute('opacity', '0'); });
+      }
+    });
+
+    svg.appendChild(g);
+  }
+
+  function drawGhostRoom(gx, gy, ghostRoom) {
+    var cx = gx * STRIDE_X, cy = gy * STRIDE_Y;
+    var rx = cx - BOX_W / 2, ry = cy - BOX_H / 2;
+
+    var g = el('g', {'data-ghost-id': ghostRoom.id, class: 'me-ghost', style: 'cursor: pointer; opacity: ' + GHOST_OPACITY + ';'});
+
+    g.appendChild(el('rect', {x: rx, y: ry, width: BOX_W, height: BOX_H, fill: '#0d0d0d', stroke: '#555', 'stroke-width': 1, rx: 3, 'stroke-dasharray': '4,3'}));
+
+    var name = ghostRoom.name.length > 16 ? ghostRoom.name.substring(0, 15) + '…' : ghostRoom.name;
+    var nameEl = el('text', {x: cx, y: cy - 6, 'text-anchor': 'middle', fill: '#888', 'font-family': "'Courier New', monospace", 'font-size': '10px'});
+    nameEl.textContent = name;
+    g.appendChild(nameEl);
+
+    var zoneEl = el('text', {x: cx, y: cy + 10, 'text-anchor': 'middle', fill: '#555', 'font-family': "'Courier New', monospace", 'font-size': '8px'});
+    zoneEl.textContent = ghostRoom.zone_name;
+    g.appendChild(zoneEl);
+
+    // Port dots for exit drawing to ghost rooms
+    PORT_POSITIONS.forEach(function(p) {
+      var port = el('circle', {cx: cx + p.dx, cy: cy + p.dy, r: PORT_R, fill: '#666', opacity: 0, class: 'me-port me-ghost-port', 'data-ghost-id': ghostRoom.id, 'data-dir': p.dir, style: 'cursor: crosshair;'});
+      g.appendChild(port);
+    });
+
+    g.addEventListener('mouseenter', function() {
+      g.style.opacity = '0.7';
+      g.querySelectorAll('.me-port').forEach(function(p) { p.setAttribute('opacity', '0.5'); });
+    });
+    g.addEventListener('mouseleave', function() {
+      g.style.opacity = GHOST_OPACITY;
+      g.querySelectorAll('.me-port').forEach(function(p) { p.setAttribute('opacity', '0'); });
+    });
+
+    // Click ghost: navigate to that zone
+    g.addEventListener('click', function(e) {
+      if (e.target.classList.contains('me-port') || e.target.classList.contains('me-ghost-port')) return;
+      if (confirm('Open zone "' + ghostRoom.zone_name + '" in editor?')) {
+        zoneId = ghostRoom.zone_id;
+        currentZ = 0;
+        selectedRoomId = null;
+        closePanel();
+        window.history.replaceState(null, '', '/root/grid_map_editor/' + zoneId);
+        loadData();
+      }
+    });
+
+    var titleEl = el('title', {});
+    titleEl.textContent = ghostRoom.name + ' [' + ghostRoom.zone_name + ' / ' + ghostRoom.region_name + ']';
+    g.appendChild(titleEl);
+
+    svg.appendChild(g);
+  }
+
+  function drawVerticalRoom(gx, gy, vRoom, direction) {
+    var cx = gx * STRIDE_X, cy = gy * STRIDE_Y;
+    var rx = cx - BOX_W / 2, ry = cy - BOX_H / 2;
+    var isUp = direction === 'up';
+    var color = isUp ? '#a78bfa' : '#fb923c';
+    var arrow = isUp ? '↑' : '↓';
+    var zLabel = 'z=' + vRoom.map_z;
+
+    var g = el('g', {'data-vertical-id': vRoom.id, class: 'me-vertical', style: 'cursor: pointer; opacity: 0.45;'});
+
+    g.appendChild(el('rect', {x: rx, y: ry, width: BOX_W, height: BOX_H, fill: '#0d0d0d', stroke: color, 'stroke-width': 1, rx: 3, 'stroke-dasharray': '6,3'}));
+
+    var name = vRoom.name.length > 14 ? vRoom.name.substring(0, 13) + '…' : vRoom.name;
+    var nameEl = el('text', {x: cx, y: cy - 6, 'text-anchor': 'middle', fill: color, 'font-family': "'Courier New', monospace", 'font-size': '10px'});
+    nameEl.textContent = arrow + ' ' + name;
+    g.appendChild(nameEl);
+
+    var zEl = el('text', {x: cx, y: cy + 10, 'text-anchor': 'middle', fill: '#555', 'font-family': "'Courier New', monospace", 'font-size': '8px'});
+    zEl.textContent = zLabel;
+    g.appendChild(zEl);
+
+    // Draw connector from the local room to this vertical stub
+    vRoom.connected_via.forEach(function(conn) {
+      var localRoom = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
+      if (localRoom) {
+        drawConnector(localRoom.map_x, localRoom.map_y, gx, gy, {id: conn.exit_id, direction: conn.direction}, true);
+      }
+    });
+
+    g.addEventListener('mouseenter', function() { g.style.opacity = '0.8'; });
+    g.addEventListener('mouseleave', function() { g.style.opacity = '0.45'; });
+
+    // Click: navigate to that z-level
+    g.addEventListener('click', function() {
+      currentZ = vRoom.map_z;
+      selectedRoomId = null;
+      closePanel();
+      loadData();
+    });
+
+    var titleEl = el('title', {});
+    titleEl.textContent = vRoom.name + ' [' + zLabel + '] — click to go to ' + zLabel;
+    g.appendChild(titleEl);
+
+    svg.appendChild(g);
+  }
+
+  function drawConnector(fromGX, fromGY, toGX, toGY, exitData, isGhost) {
+    var x1 = fromGX * STRIDE_X, y1 = fromGY * STRIDE_Y;
+    var x2 = toGX * STRIDE_X, y2 = toGY * STRIDE_Y;
+
+    var dx = x2 - x1, dy = y2 - y1;
+    var dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist === 0) return;
+
+    var ux = dx / dist, uy = dy / dist;
+    // Proper box-edge intersection
+    var inset1 = boxEdgeInset(ux, uy);
+    var inset2 = boxEdgeInset(-ux, -uy);
+
+    var sx = x1 + ux * inset1, sy = y1 + uy * inset1;
+    var ex = x2 - ux * inset2, ey = y2 - uy * inset2;
+
+    var color = isGhost ? '#2a2a2a' : '#333';
+    var line = el('line', {x1: Math.round(sx), y1: Math.round(sy), x2: Math.round(ex), y2: Math.round(ey), stroke: color, 'stroke-width': isGhost ? 1 : 1.5, class: 'me-connector'});
+    if (exitData && exitData.id) {
+      line.setAttribute('data-exit-id', exitData.id);
+      line.style.cursor = 'pointer';
+      // Wider invisible hit area
+      var hitLine = el('line', {x1: Math.round(sx), y1: Math.round(sy), x2: Math.round(ex), y2: Math.round(ey), stroke: 'transparent', 'stroke-width': 12, style: 'cursor: pointer;', 'data-exit-id': exitData.id});
+      svg.appendChild(hitLine);
+      hitLine.addEventListener('click', function(e) {
+        e.stopPropagation();
+        onConnectorClick(exitData.id);
+      });
+    }
+    svg.appendChild(line);
+  }
+
+  function boxEdgeInset(ux, uy) {
+    // Compute exact distance from center to box edge along direction (ux, uy)
+    var hw = BOX_W / 2, hh = BOX_H / 2;
+    if (Math.abs(ux) < 0.001) return hh;
+    if (Math.abs(uy) < 0.001) return hw;
+    var tx = hw / Math.abs(ux);
+    var ty = hh / Math.abs(uy);
+    return Math.min(tx, ty);
+  }
+
+  // ── Interaction: Room click/select ─────────────────────────
+  svg.addEventListener('click', function(e) {
+    var roomG = e.target.closest('.me-room');
+    if (roomG && !e.target.classList.contains('me-port')) {
+      var id = parseInt(roomG.getAttribute('data-room-id'));
+      selectRoom(id);
+      return;
+    }
+    // Click on empty space (not a room, not a connector, not ghost)
+    if (!e.target.closest('.me-ghost') && !e.target.closest('.me-connector') && !e.target.getAttribute('data-exit-id')) {
+      deselectRoom();
+    }
+  });
+
+  svg.addEventListener('dblclick', function(e) {
+    if (e.target.closest('.me-room') || e.target.closest('.me-ghost')) return;
+    // Double-click on empty space: create room
+    var pt = svgPoint(e);
+    var gx = Math.round(pt.x / STRIDE_X);
+    var gy = Math.round(pt.y / STRIDE_Y);
+    // Check if cell is occupied
+    var occupied = state.rooms.some(function(r) { return r.map_x === gx && r.map_y === gy; });
+    if (occupied) { setStatus('Cell occupied'); return; }
+    showRoomDialog(gx, gy);
+  });
+
+  function svgPoint(e) {
+    var pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    var ctm = svg.getScreenCTM();
+    if (!ctm) return pt;
+    return pt.matrixTransform(ctm.inverse());
+  }
+
+  // ── Interaction: Drag room to move ─────────────────────────
+  svg.addEventListener('mousedown', function(e) {
+    // Port drag (exit drawing)
+    if (e.target.classList.contains('me-port')) {
+      e.preventDefault();
+      var roomId = parseInt(e.target.getAttribute('data-room-id') || e.target.getAttribute('data-ghost-id'));
+      var isGhost = e.target.classList.contains('me-ghost-port');
+      var pt = svgPoint(e);
+      dragState = {type: 'port', roomId: roomId, isGhost: isGhost, startX: pt.x, startY: pt.y};
+      drawLine.setAttribute('x1', pt.x);
+      drawLine.setAttribute('y1', pt.y);
+      drawLine.setAttribute('x2', pt.x);
+      drawLine.setAttribute('y2', pt.y);
+      drawLine.setAttribute('visibility', 'visible');
+      return;
+    }
+
+    // Room drag (reposition)
+    var roomG = e.target.closest('.me-room');
+    if (roomG && !e.target.classList.contains('me-port')) {
+      e.preventDefault();
+      var id = parseInt(roomG.getAttribute('data-room-id'));
+      var room = state.rooms.find(function(r) { return r.id === id; });
+      if (!room) return;
+      var pt = svgPoint(e);
+      dragState = {type: 'room', roomId: id, startX: pt.x, startY: pt.y, origX: room.map_x, origY: room.map_y};
+    }
+  });
+
+  document.addEventListener('mousemove', function(e) {
+    if (!dragState) return;
+    var pt = svgPoint(e);
+
+    if (dragState.type === 'port') {
+      drawLine.setAttribute('x2', pt.x);
+      drawLine.setAttribute('y2', pt.y);
+      return;
+    }
+
+    if (dragState.type === 'room') {
+      var dx = pt.x - dragState.startX;
+      var dy = pt.y - dragState.startY;
+      var newGX = dragState.origX + Math.round(dx / STRIDE_X);
+      var newGY = dragState.origY + Math.round(dy / STRIDE_Y);
+      var room = state.rooms.find(function(r) { return r.id === dragState.roomId; });
+      if (room && (room.map_x !== newGX || room.map_y !== newGY)) {
+        var occupied = state.rooms.some(function(r) { return r.id !== room.id && r.map_x === newGX && r.map_y === newGY; });
+        if (!occupied) {
+          room.map_x = newGX;
+          room.map_y = newGY;
+          render();
+        }
+      }
+    }
+  });
+
+  document.addEventListener('mouseup', function(e) {
+    if (!dragState) return;
+
+    if (dragState.type === 'port') {
+      drawLine.setAttribute('visibility', 'hidden');
+      // Find target room under cursor
+      var pt = svgPoint(e);
+      var targetEl = document.elementFromPoint(e.clientX, e.clientY);
+      var targetG = targetEl ? (targetEl.closest('.me-room') || targetEl.closest('.me-ghost')) : null;
+      if (targetG) {
+        var targetId = parseInt(targetG.getAttribute('data-room-id') || targetG.getAttribute('data-ghost-id'));
+        if (targetId && targetId !== dragState.roomId) {
+          showExitDialog(dragState.roomId, targetId, dragState.isGhost, !!targetG.getAttribute('data-ghost-id'));
+        }
+      }
+      dragState = null;
+      return;
+    }
+
+    if (dragState.type === 'room') {
+      var room = state.rooms.find(function(r) { return r.id === dragState.roomId; });
+      var origX = dragState.origX, origY = dragState.origY;
+      dragState = null;
+      if (room && (room.map_x !== origX || room.map_y !== origY)) {
+        setStatus('Saving position...');
+        api('PATCH', 'rooms/' + room.id, {map_x: room.map_x, map_y: room.map_y}).then(function(d) {
+          if (d.success) {
+            room.position_source = 'stored';
+            setStatus('Position saved');
+          } else {
+            room.map_x = origX;
+            room.map_y = origY;
+            render();
+            setStatus('Error: ' + (d.errors || []).join(', '));
+          }
+        });
+      }
+    }
+  });
+
+  // ── Interaction: Connector click ───────────────────────────
+  function onConnectorClick(exitId) {
+    var exit = state.exits.find(function(e) { return e.id === exitId; });
+    if (!exit) return;
+    var fromRoom = state.rooms.find(function(r) { return r.id === exit.from_room_id; });
+    var toRoom = state.rooms.find(function(r) { return r.id === exit.to_room_id; });
+    var hasReverse = !!exit.reverse_exit_id;
+    var msg = (fromRoom ? fromRoom.name : '?') + ' → ' + exit.direction + ' → ' + (toRoom ? toRoom.name : '?');
+    if (hasReverse) msg += ' (bidirectional)';
+    msg += '\n\nDelete this exit?';
+    if (hasReverse) msg += '\n(Reverse exit will also be deleted)';
+
+    if (confirm(msg)) {
+      setStatus('Deleting exit...');
+      api('DELETE', 'exits/' + exitId + '?delete_reverse=' + hasReverse).then(function(d) {
+        if (d.success) {
+          setStatus('Exit deleted');
+          loadData();
+        } else {
+          setStatus('Error: ' + (d.errors || []).join(', '));
+        }
+      });
+    }
+  }
+
+  // ── Keyboard ───────────────────────────────────────────────
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      if (overlay.style.display !== 'none') {
+        hideDialogs();
+      } else {
+        deselectRoom();
+      }
+    }
+  });
+
+  // ── Room selection + side panel ────────────────────────────
+  function selectRoom(id) {
+    selectedRoomId = id;
+    render();
+    showPanel(id);
+  }
+
+  function deselectRoom() {
+    if (selectedRoomId === null) return;
+    selectedRoomId = null;
+    closePanel();
+    render();
+  }
+
+  function closePanel() {
+    panel.style.display = 'none';
+    panelContent.innerHTML = '';
+  }
+
+  function showPanel(roomId) {
+    var room = state.rooms.find(function(r) { return r.id === roomId; });
+    if (!room) return;
+    panel.style.display = 'block';
+
+    var html = '';
+    html += '<h3 class="cyan-255-text" style="margin-bottom: 12px; word-break: break-word;">[:: ' + esc(room.name) + ' ::]</h3>';
+
+    // Room properties form
+    html += '<div style="margin-bottom: 15px;">';
+    html += field('Name', 'me-p-name', room.name, 'text');
+    html += field('Slug', 'me-p-slug', room.slug || '', 'text');
+    html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em; margin-top: 8px;">Description:</label>';
+    html += '<textarea id="me-p-desc" class="tui-input" style="width: 100%; padding: 6px; min-height: 150px; font-size: 0.85em; box-sizing: border-box;">' + esc(room.description || '') + '</textarea>';
+    html += '<div style="display: flex; gap: 8px; margin-top: 8px;">';
+    html += '<div style="flex: 1;">';
+    html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Type:</label>';
+    html += '<select id="me-p-type" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;">';
+    html += '<option value="">(none)</option>';
+    var types = ['hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','prism','dream','hospital','firmware_vendor','repair_service','containment','impound','sally_port_anteroom','sally_port'];
+    types.forEach(function(t) {
+      html += '<option value="' + t + '"' + (room.room_type === t ? ' selected' : '') + '>' + t + '</option>';
+    });
+    html += '</select></div>';
+    html += '<div style="flex: 1;">';
+    html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">CL:</label>';
+    html += '<input id="me-p-cl" type="number" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;" value="' + room.min_clearance + '" min="0" />';
+    html += '</div>';
+    html += '<div style="flex: 1;">';
+    html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Z:</label>';
+    html += '<input id="me-p-z" type="number" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;" value="' + (room.map_z || 0) + '" />';
+    html += '</div></div>';
+    html += '<div style="margin-top: 8px;">';
+    html += '<label class="white-text" style="font-size: 0.85em;"><input type="checkbox" id="me-p-locked" ' + (room.locked ? 'checked' : '') + ' /> Locked</label>';
+    html += '</div>';
+
+    // Zone selector (combobox)
+    html += '<div style="margin-top: 8px;">';
+    html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Zone:</label>';
+    var panelZoneCb = zoneComboboxHtml('me-p-zone', room.grid_zone_id);
+    _panelZoneUid = panelZoneCb.uid;
+    html += panelZoneCb.html;
+    html += '</div>';
+
+    html += '<div style="margin-top: 12px; display: flex; gap: 8px;">';
+    html += '<button id="me-p-save" class="tui-button green-168" style="padding: 5px 14px; font-size: 0.85em;">Save</button>';
+    html += '<button id="me-p-delete" class="tui-button red-168" style="padding: 5px 14px; font-size: 0.85em;">Delete</button>';
+    html += '</div>';
+    html += '</div>';
+
+    // Exits section
+    var exitComboboxes = []; // {uid, excludeId} pairs to init after innerHTML
+    html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px;">';
+    html += '<h4 class="cyan-255-text" style="margin-bottom: 8px;">[:: EXITS ::]</h4>';
+    if (room.exits && room.exits.length > 0) {
+      room.exits.forEach(function(ex) {
+        var crossBadge = ex.cross_zone ? ' <span style="color: #fbbf24; font-size: 0.75em;">[cross]</span>' : '';
+        html += '<div class="me-exit-row" data-exit-id="' + ex.id + '" style="margin-bottom: 4px; padding: 4px 6px; background: #1a1a1a; border: 1px solid #222;">';
+        // Display row
+        html += '<div class="me-exit-display" style="display: flex; align-items: center; gap: 6px;">';
+        html += '<span style="color: #fbbf24; font-size: 0.85em; min-width: 70px;">' + esc(ex.direction) + '</span>';
+        html += '<span style="color: #888; font-size: 0.85em; flex: 1;">→ ' + esc(ex.to_room_name) + crossBadge + '</span>';
+        html += '<span style="color: ' + (ex.locked ? '#f87171' : '#333') + '; font-size: 0.75em;">' + (ex.locked ? '🔒' : '') + '</span>';
+        html += '<button class="me-edit-exit tui-button" style="padding: 1px 6px; font-size: 0.8em; color: #fbbf24;">✎</button>';
+        html += '<button class="me-del-exit tui-button" data-exit-id="' + ex.id + '" data-reverse-id="' + (ex.reverse_exit_id || '') + '" style="padding: 1px 6px; font-size: 0.8em; color: #f87171;">×</button>';
+        html += '</div>';
+        // Edit row (hidden by default)
+        html += '<div class="me-exit-edit" style="display: none; margin-top: 6px;">';
+        html += '<div style="display: flex; gap: 6px; margin-bottom: 4px;">';
+        html += '<div style="flex: 1;"><label style="color: #666; font-size: 0.75em;">Direction:</label>';
+        html += '<input class="me-exit-edit-dir tui-input" value="' + esc(ex.direction) + '" style="width: 100%; padding: 3px; font-size: 0.85em; box-sizing: border-box;" /></div>';
+        html += '<div><label style="color: #666; font-size: 0.75em;">Locked:</label><br/>';
+        html += '<input type="checkbox" class="me-exit-edit-locked" ' + (ex.locked ? 'checked' : '') + ' style="margin-top: 4px;" /></div>';
+        html += '</div>';
+        html += '<div style="margin-bottom: 4px;">';
+        html += '<div><label style="color: #666; font-size: 0.75em;">Target:</label>';
+        var editCb = roomComboboxHtml('me-exit-edit-' + ex.id, ex.to_room_id);
+        html += editCb.html;
+        exitComboboxes.push({uid: editCb.uid, excludeId: null});
+        html += '</div>';
+        html += '</div>';
+        html += '<div style="display: flex; gap: 6px;">';
+        html += '<button class="me-exit-save tui-button green-168" style="padding: 2px 10px; font-size: 0.8em;">Save</button>';
+        html += '<button class="me-exit-cancel tui-button" style="padding: 2px 10px; font-size: 0.8em;">Cancel</button>';
+        html += '</div>';
+        html += '</div>';
+        html += '</div>';
+      });
+    } else {
+      html += '<span style="color: #555; font-size: 0.85em;">No exits</span>';
+    }
+    // Inbound exits from ghost rooms
+    if (room.inbound_exits && room.inbound_exits.length > 0) {
+      html += '<div style="margin-top: 6px; color: #555; font-size: 0.8em;">Inbound from other zones:</div>';
+      room.inbound_exits.forEach(function(ex) {
+        html += '<div style="display: flex; align-items: center; gap: 6px; margin-bottom: 4px; padding: 3px 6px; background: #151515; border: 1px solid #1a1a1a;">';
+        html += '<span style="color: #666; font-size: 0.85em;">' + esc(ex.direction) + ' ← ' + esc(ex.from_room_name) + ' <span style="color: #555; font-size: 0.75em;">[' + esc(ex.from_zone_name || '') + ']</span></span>';
+        html += '</div>';
+      });
+    }
+    // Add exit via combobox
+    html += '<button id="me-add-exit-btn" class="tui-button cyan-168" style="margin-top: 6px; padding: 3px 10px; font-size: 0.85em;">+ Add Exit</button>';
+    html += '<div id="me-add-exit-form" style="display: none; margin-top: 8px; padding: 8px; background: #1a1a1a; border: 1px solid #333;">';
+    html += '<label style="color: #888; font-size: 0.8em;">Target Room:</label>';
+    var addCb = roomComboboxHtml('me-add-exit-target', null);
+    exitComboboxes.push({uid: addCb.uid, excludeId: roomId});
+    html += addCb.html;
+    html += '<label style="color: #888; font-size: 0.8em; margin-top: 6px; display: block;">Direction:</label>';
+    html += '<input id="me-exit-target-dir" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em; margin-bottom: 6px; box-sizing: border-box;" placeholder="north" />';
+    html += '<label style="color: #888; font-size: 0.8em;"><input type="checkbox" id="me-exit-target-bidi" checked /> Bidirectional</label>';
+    html += '<div style="margin-top: 6px;"><button id="me-exit-target-create" class="tui-button green-168" style="padding: 3px 10px; font-size: 0.85em;">Create</button></div>';
+    html += '</div>';
+    html += '</div>';
+
+    // Mobs section
+    html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px;">';
+    html += '<h4 class="cyan-255-text" style="margin-bottom: 8px;">[:: MOBS (' + (room.mobs ? room.mobs.length : 0) + ') ::]</h4>';
+    if (room.mobs && room.mobs.length > 0) {
+      room.mobs.forEach(function(m) {
+        var typeColor = ROOM_TYPE_COLORS[m.mob_type] || '#888';
+        html += '<div class="me-mob-row" data-mob-id="' + m.id + '" style="margin-bottom: 4px; padding: 4px 6px; background: #1a1a1a; border: 1px solid #222;">';
+        // Display row
+        html += '<div class="me-mob-display" style="display: flex; align-items: center; gap: 6px;">';
+        html += '<span style="color: ' + typeColor + ';">•</span> ';
+        html += '<span style="color: #ccc; font-size: 0.85em; flex: 1;">' + esc(m.name) + ' <span style="color: #555;">(' + esc(m.mob_type) + ')</span></span>';
+        html += '<a href="/root/grid_mobs/' + m.id + '/edit" style="color: #60a5fa; font-size: 0.8em; text-decoration: none;" title="Full editor">↗</a>';
+        html += '<button class="me-edit-mob tui-button" style="padding: 1px 6px; font-size: 0.8em; color: #fbbf24;">✎</button>';
+        html += '<button class="me-del-mob tui-button" style="padding: 1px 6px; font-size: 0.8em; color: #f87171;">×</button>';
+        html += '</div>';
+        // Edit row (hidden)
+        html += '<div class="me-mob-edit" style="display: none; margin-top: 6px;">';
+        html += '<div style="margin-bottom: 4px;"><label style="color: #666; font-size: 0.75em;">Name:</label>';
+        html += '<input class="me-mob-edit-name tui-input" value="' + esc(m.name) + '" style="width: 100%; padding: 3px; font-size: 0.85em; box-sizing: border-box;" /></div>';
+        html += '<div style="display: flex; gap: 6px; margin-bottom: 4px;">';
+        html += '<div style="flex: 1;"><label style="color: #666; font-size: 0.75em;">Type:</label>';
+        html += '<select class="me-mob-edit-type tui-input" style="width: 100%; padding: 3px; font-size: 0.85em;">';
+        ['quest_giver', 'vendor', 'lore', 'special'].forEach(function(t) {
+          html += '<option value="' + t + '"' + (m.mob_type === t ? ' selected' : '') + '>' + t + '</option>';
+        });
+        html += '</select></div></div>';
+        html += '<div style="display: flex; gap: 6px;">';
+        html += '<button class="me-mob-save tui-button green-168" style="padding: 2px 10px; font-size: 0.8em;">Save</button>';
+        html += '<button class="me-mob-cancel tui-button" style="padding: 2px 10px; font-size: 0.8em;">Cancel</button>';
+        html += '</div>';
+        html += '</div>';
+        html += '</div>';
+      });
+    } else {
+      html += '<span style="color: #555; font-size: 0.85em;">No mobs</span>';
+    }
+    // Add mob form
+    html += '<button id="me-add-mob-btn" class="tui-button cyan-168" style="margin-top: 6px; padding: 3px 10px; font-size: 0.85em;">+ Add Mob</button>';
+    html += '<div id="me-add-mob-form" style="display: none; margin-top: 8px; padding: 8px; background: #1a1a1a; border: 1px solid #333;">';
+    html += '<div style="margin-bottom: 6px;"><label style="color: #888; font-size: 0.8em;">Name:</label>';
+    html += '<input id="me-mob-name" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em; box-sizing: border-box;" placeholder="NPC name" /></div>';
+    html += '<div style="margin-bottom: 6px;"><label style="color: #888; font-size: 0.8em;">Type:</label>';
+    html += '<select id="me-mob-type" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;">';
+    html += '<option value="lore">lore</option><option value="quest_giver">quest_giver</option><option value="vendor">vendor</option><option value="special">special</option>';
+    html += '</select></div>';
+    html += '<div style="margin-bottom: 6px;"><label style="color: #888; font-size: 0.8em;">Description:</label>';
+    html += '<input id="me-mob-desc" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em; box-sizing: border-box;" placeholder="(optional)" /></div>';
+    html += '<div style="margin-top: 6px; display: flex; gap: 6px;"><button id="me-mob-create" class="tui-button green-168" style="padding: 3px 10px; font-size: 0.85em;">Create</button>';
+    html += '<button id="me-mob-cancel-add" class="tui-button" style="padding: 3px 10px; font-size: 0.85em;">Cancel</button></div>';
+    html += '</div>';
+    html += '</div>';
+
+    // Breach encounters section
+    html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px;">';
+    html += '<h4 class="cyan-255-text" style="margin-bottom: 8px;">[:: BREACHES ::]</h4>';
+    if (room.encounters && room.encounters.length > 0) {
+      room.encounters.forEach(function(enc) {
+        var stateColor = enc.state === 'available' ? '#34d399' : enc.state === 'active' ? '#fbbf24' : '#666';
+        html += '<div style="display: flex; align-items: center; gap: 6px; margin-bottom: 4px; padding: 3px 6px; background: #1a1a1a; border: 1px solid #222;">';
+        html += '<span style="color: #ccc; font-size: 0.85em; flex: 1;">' + esc(enc.template_name) + ' <span style="color: #555;">(' + esc(enc.tier) + ')</span></span>';
+        html += '<span style="color: ' + stateColor + '; font-size: 0.8em;">' + esc(enc.state) + '</span>';
+        html += '<button class="me-del-encounter tui-button" data-encounter-id="' + enc.id + '" style="padding: 1px 6px; font-size: 0.8em; color: #f87171;">×</button>';
+        html += '</div>';
+      });
+    } else {
+      html += '<span style="color: #555; font-size: 0.85em;">No encounters</span>';
+    }
+    html += '<div style="margin-top: 6px;">';
+    html += '<select id="me-place-template" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em; margin-bottom: 4px;">';
+    html += '<option value="">(select template)</option>';
+    (state.breach_templates || []).forEach(function(t) {
+      html += '<option value="' + t.id + '">' + esc(t.name) + ' [' + esc(t.tier) + ' CL' + esc(String(t.min_clearance)) + ']</option>';
+    });
+    html += '</select>';
+    html += '<button id="me-place-encounter" class="tui-button green-168" style="padding: 3px 10px; font-size: 0.85em;">+ Place Encounter</button>';
+    html += '</div>';
+    html += '</div>';
+
+    // Presence info
+    html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px;">';
+    html += '<h4 class="cyan-255-text" style="margin-bottom: 8px;">[:: PRESENCE ::]</h4>';
+    html += '<span style="color: #888; font-size: 0.85em;">';
+    html += room.hackr_count + ' hackr(s) · ' + room.mob_count + ' mob(s) · ' + room.item_count + ' item(s)';
+    html += '</span>';
+    html += '</div>';
+
+    // Position info
+    html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px; color: #555; font-size: 0.8em;">';
+    html += 'Position: (' + room.map_x + ', ' + room.map_y + ') · ' + room.position_source;
+    html += ' · <a href="/root/grid_rooms/' + room.id + '/edit" style="color: #60a5fa; text-decoration: none;">Full Edit →</a>';
+    html += '</div>';
+
+    panelContent.innerHTML = html;
+
+    // Init room comboboxes (must run after innerHTML is set)
+    exitComboboxes.forEach(function(cb) { initRoomCombobox(cb.uid, cb.excludeId); });
+    initZoneCombobox(panelZoneCb.uid);
+
+    // Wire up panel events
+    document.getElementById('me-p-save').addEventListener('click', function() { saveRoom(room.id); });
+    document.getElementById('me-p-delete').addEventListener('click', function() { deleteRoom(room.id); });
+
+    // Exit edit buttons
+    panelContent.querySelectorAll('.me-edit-exit').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-exit-row');
+        row.querySelector('.me-exit-display').style.display = 'none';
+        row.querySelector('.me-exit-edit').style.display = 'block';
+      });
+    });
+
+    // Exit save buttons
+    panelContent.querySelectorAll('.me-exit-save').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-exit-row');
+        var eid = parseInt(row.getAttribute('data-exit-id'));
+        var dir = row.querySelector('.me-exit-edit-dir').value.trim().toLowerCase();
+        var locked = row.querySelector('.me-exit-edit-locked').checked;
+        var hiddenInput = row.querySelector('.admin-combobox input[type="hidden"]');
+        var targetId = hiddenInput ? parseInt(hiddenInput.value) : 0;
+        if (!dir) { setStatus('Direction required'); return; }
+        if (!targetId) { setStatus('Target room required'); return; }
+        setStatus('Saving exit...');
+        api('PATCH', 'exits/' + eid, {direction: dir, locked: locked, to_room_id: targetId}).then(function(d) {
+          if (d.success) { setStatus('Exit saved'); loadData(); }
+          else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+        });
+      });
+    });
+
+    // Exit cancel buttons
+    panelContent.querySelectorAll('.me-exit-cancel').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-exit-row');
+        row.querySelector('.me-exit-display').style.display = 'flex';
+        row.querySelector('.me-exit-edit').style.display = 'none';
+      });
+    });
+
+    // Exit delete buttons
+    panelContent.querySelectorAll('.me-del-exit').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var eid = parseInt(btn.getAttribute('data-exit-id'));
+        var rid = btn.getAttribute('data-reverse-id');
+        var hasReverse = rid !== '' && rid !== null;
+        if (confirm('Delete this exit?' + (hasReverse ? ' (Reverse will also be deleted)' : ''))) {
+          api('DELETE', 'exits/' + eid + '?delete_reverse=' + hasReverse).then(function(d) {
+            if (d.success) { setStatus('Exit deleted'); loadData(); }
+            else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+          });
+        }
+      });
+    });
+
+    // Add exit form toggle
+    document.getElementById('me-add-exit-btn').addEventListener('click', function() {
+      var form = document.getElementById('me-add-exit-form');
+      form.style.display = form.style.display === 'none' ? 'block' : 'none';
+    });
+
+    // Add exit create button
+    document.getElementById('me-exit-target-create').addEventListener('click', function() {
+      var addForm = document.getElementById('me-add-exit-form');
+      var hiddenInput = addForm.querySelector('.admin-combobox input[type="hidden"]');
+      var targetId = hiddenInput ? parseInt(hiddenInput.value) : 0;
+      var dir = document.getElementById('me-exit-target-dir').value.trim().toLowerCase();
+      var bidi = document.getElementById('me-exit-target-bidi').checked;
+      if (!targetId || !dir) { setStatus('Target and direction required'); return; }
+      setStatus('Creating exit...');
+      api('POST', 'exits', {from_room_id: room.id, to_room_id: targetId, direction: dir, bidirectional: bidi}).then(function(d) {
+        if (d.success) { setStatus('Exit created'); loadData(); }
+        else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+      });
+    });
+
+    // Mob edit buttons
+    panelContent.querySelectorAll('.me-edit-mob').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-mob-row');
+        row.querySelector('.me-mob-display').style.display = 'none';
+        row.querySelector('.me-mob-edit').style.display = 'block';
+      });
+    });
+
+    // Mob save buttons
+    panelContent.querySelectorAll('.me-mob-save').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-mob-row');
+        var mid = parseInt(row.getAttribute('data-mob-id'));
+        var name = row.querySelector('.me-mob-edit-name').value.trim();
+        var mobType = row.querySelector('.me-mob-edit-type').value;
+        if (!name) { setStatus('Name required'); return; }
+        setStatus('Saving mob...');
+        api('PATCH', 'mobs/' + mid, {name: name, mob_type: mobType}).then(function(d) {
+          if (d.success) { setStatus('Mob saved'); loadData(); }
+          else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+        });
+      });
+    });
+
+    // Mob cancel buttons
+    panelContent.querySelectorAll('.me-mob-cancel').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-mob-row');
+        row.querySelector('.me-mob-display').style.display = 'flex';
+        row.querySelector('.me-mob-edit').style.display = 'none';
+      });
+    });
+
+    // Mob delete buttons
+    panelContent.querySelectorAll('.me-del-mob').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var row = btn.closest('.me-mob-row');
+        var mid = parseInt(row.getAttribute('data-mob-id'));
+        var name = row.querySelector('.me-mob-display').textContent.trim();
+        if (!confirm('Delete mob "' + name + '"?')) return;
+        setStatus('Deleting mob...');
+        api('DELETE', 'mobs/' + mid).then(function(d) {
+          if (d.success) { setStatus('Mob deleted'); loadData(); }
+          else {
+            var msg = (d.blockers || d.errors || []).join('\n• ');
+            alert('Cannot delete:\n• ' + msg);
+            setStatus('Delete blocked');
+          }
+        });
+      });
+    });
+
+    // Add mob form toggle
+    document.getElementById('me-add-mob-btn').addEventListener('click', function() {
+      var form = document.getElementById('me-add-mob-form');
+      form.style.display = form.style.display === 'none' ? 'block' : 'none';
+    });
+
+    document.getElementById('me-mob-cancel-add').addEventListener('click', function() {
+      document.getElementById('me-add-mob-form').style.display = 'none';
+    });
+
+    // Create mob button
+    document.getElementById('me-mob-create').addEventListener('click', function() {
+      var name = document.getElementById('me-mob-name').value.trim();
+      var mobType = document.getElementById('me-mob-type').value;
+      var desc = document.getElementById('me-mob-desc').value.trim();
+      if (!name) { setStatus('Name required'); return; }
+      setStatus('Creating mob...');
+      api('POST', 'mobs', {grid_room_id: room.id, name: name, mob_type: mobType, description: desc || null}).then(function(d) {
+        if (d.success) { setStatus('Mob created'); loadData(); }
+        else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+      });
+    });
+
+    // Encounter delete buttons
+    panelContent.querySelectorAll('.me-del-encounter').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var encId = parseInt(btn.getAttribute('data-encounter-id'));
+        if (confirm('Remove this encounter?')) {
+          api('DELETE', 'encounters/' + encId).then(function(d) {
+            if (d.success) { setStatus('Encounter removed'); loadData(); }
+            else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+          });
+        }
+      });
+    });
+
+    // Place encounter button
+    document.getElementById('me-place-encounter').addEventListener('click', function() {
+      var templateId = parseInt(document.getElementById('me-place-template').value);
+      if (!templateId) { setStatus('Select a template'); return; }
+      setStatus('Placing encounter...');
+      api('POST', 'encounters', {grid_room_id: room.id, grid_breach_template_id: templateId}).then(function(d) {
+        if (d.success) { setStatus('Encounter placed'); loadData(); }
+        else { setStatus('Error: ' + (d.errors || []).join(', ')); }
+      });
+    });
+  }
+
+  // ── Panel actions ──────────────────────────────────────────
+  function saveRoom(roomId) {
+    var attrs = {
+      name: document.getElementById('me-p-name').value,
+      slug: document.getElementById('me-p-slug').value,
+      description: document.getElementById('me-p-desc').value,
+      room_type: document.getElementById('me-p-type').value || null,
+      min_clearance: parseInt(document.getElementById('me-p-cl').value) || 0,
+      locked: document.getElementById('me-p-locked').checked,
+      grid_zone_id: parseInt(document.getElementById(_panelZoneUid + '-hidden').value),
+      map_z: parseInt(document.getElementById('me-p-z').value) || 0
+    };
+
+    setStatus('Saving...');
+    api('PATCH', 'rooms/' + roomId, attrs).then(function(d) {
+      if (d.success) {
+        setStatus('Saved');
+        loadData();
+      } else {
+        setStatus('Error: ' + (d.errors || []).join(', '));
+      }
+    });
+  }
+
+  function deleteRoom(roomId) {
+    var room = state.rooms.find(function(r) { return r.id === roomId; });
+    if (!room) return;
+
+    // Pre-check: show warnings
+    var warnings = [];
+    if (room.hackr_count > 0) warnings.push(room.hackr_count + ' hackr(s) in room');
+    if (room.mob_count > 0) warnings.push(room.mob_count + ' mob(s) assigned');
+    if (room.item_count > 0) warnings.push(room.item_count + ' item(s) on floor');
+    if (room.encounters && room.encounters.length > 0) warnings.push(room.encounters.length + ' encounter(s)');
+
+    var msg = 'Delete "' + room.name + '"?';
+    if (warnings.length > 0) msg += '\n\nWarning:\n• ' + warnings.join('\n• ');
+
+    if (!confirm(msg)) return;
+
+    setStatus('Deleting...');
+    api('DELETE', 'rooms/' + roomId).then(function(d) {
+      if (d.success) {
+        setStatus('Room deleted');
+        selectedRoomId = null;
+        closePanel();
+        loadData();
+      } else {
+        var errMsg = (d.blockers || d.errors || []).join('\n• ');
+        alert('Cannot delete:\n• ' + errMsg);
+        setStatus('Delete blocked');
+      }
+    });
+  }
+
+  // ── Exit dialog ────────────────────────────────────────────
+  function showExitDialog(fromId, toId, fromIsGhost, toIsGhost) {
+    var fromRoom = fromIsGhost
+      ? state.ghost_rooms.find(function(g) { return g.id === fromId; })
+      : state.rooms.find(function(r) { return r.id === fromId; });
+    var toRoom = toIsGhost
+      ? state.ghost_rooms.find(function(g) { return g.id === toId; })
+      : state.rooms.find(function(r) { return r.id === toId; });
+    if (!fromRoom || !toRoom) return;
+
+    // Infer direction from positions
+    var fromX, fromY, toX, toY;
+    if (fromIsGhost) {
+      // Ghost rooms - find position from connected_via
+      var conn = fromRoom.connected_via[0];
+      var localR = state.rooms.find(function(r) { return r.id === conn.local_room_id; });
+      var vec = DIRECTION_VECTORS[conn.direction];
+      fromX = (localR ? localR.map_x : 0) + (vec ? vec[0] : 0);
+      fromY = (localR ? localR.map_y : 0) + (vec ? vec[1] : 0);
+    } else {
+      fromX = fromRoom.map_x; fromY = fromRoom.map_y;
+    }
+    if (toIsGhost) {
+      var conn2 = toRoom.connected_via[0];
+      var localR2 = state.rooms.find(function(r) { return r.id === conn2.local_room_id; });
+      var vec2 = DIRECTION_VECTORS[conn2.direction];
+      toX = (localR2 ? localR2.map_x : 0) + (vec2 ? vec2[0] : 0);
+      toY = (localR2 ? localR2.map_y : 0) + (vec2 ? vec2[1] : 0);
+    } else {
+      toX = toRoom.map_x; toY = toRoom.map_y;
+    }
+
+    var dir = inferDirection(fromX, fromY, toX, toY);
+    var reverseDir = OPPOSITES[dir] || dir;
+
+    document.getElementById('me-exit-from').textContent = fromRoom.name;
+    document.getElementById('me-exit-to').textContent = toRoom.name;
+    document.getElementById('me-exit-direction').value = dir;
+    document.getElementById('me-exit-bidi').checked = true;
+    document.getElementById('me-exit-reverse-dir').value = reverseDir;
+
+    overlay.style.display = 'block';
+    document.getElementById('me-exit-dialog').style.display = 'block';
+
+    // Update reverse direction when direction changes
+    var dirInput = document.getElementById('me-exit-direction');
+    dirInput.onchange = function() {
+      var d = dirInput.value.trim().toLowerCase();
+      document.getElementById('me-exit-reverse-dir').value = OPPOSITES[d] || d;
+    };
+
+    document.getElementById('me-exit-confirm').onclick = function() {
+      var d = dirInput.value.trim().toLowerCase();
+      var bidi = document.getElementById('me-exit-bidi').checked;
+      var revDir = document.getElementById('me-exit-reverse-dir').value.trim().toLowerCase();
+      if (!d) { setStatus('Direction required'); return; }
+
+      setStatus('Creating exit...');
+      api('POST', 'exits', {
+        from_room_id: fromId, to_room_id: toId, direction: d,
+        bidirectional: bidi, reverse_direction: revDir
+      }).then(function(result) {
+        if (result.success) {
+          hideDialogs();
+          setStatus('Exit created');
+          loadData();
+        } else {
+          setStatus('Error: ' + (result.errors || []).join(', '));
+        }
+      });
+    };
+
+    document.getElementById('me-exit-cancel').onclick = hideDialogs;
+  }
+
+  function inferDirection(fromGX, fromGY, toGX, toGY) {
+    var dx = toGX - fromGX, dy = toGY - fromGY;
+    if (dx === 0 && dy === 0) return 'north';
+    var angle = Math.atan2(dy, dx) * 180 / Math.PI; // 0 = east, 90 = south (SVG y-down)
+    if (angle >= -22.5 && angle < 22.5) return 'east';
+    if (angle >= 22.5 && angle < 67.5) return 'southeast';
+    if (angle >= 67.5 && angle < 112.5) return 'south';
+    if (angle >= 112.5 && angle < 157.5) return 'southwest';
+    if (angle >= 157.5 || angle < -157.5) return 'west';
+    if (angle >= -157.5 && angle < -112.5) return 'northwest';
+    if (angle >= -112.5 && angle < -67.5) return 'north';
+    if (angle >= -67.5 && angle < -22.5) return 'northeast';
+    return 'north';
+  }
+
+  // ── Room creation dialog ───────────────────────────────────
+  var pendingRoomPos = null;
+
+  function showRoomDialog(gx, gy) {
+    pendingRoomPos = {x: gx, y: gy};
+    document.getElementById('me-room-name').value = '';
+    document.getElementById('me-room-slug').value = '';
+    document.getElementById('me-room-type').value = '';
+    overlay.style.display = 'block';
+    document.getElementById('me-room-dialog').style.display = 'block';
+    document.getElementById('me-room-name').focus();
+
+    // Auto-generate slug from name
+    document.getElementById('me-room-name').oninput = function() {
+      var name = this.value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+      document.getElementById('me-room-slug').value = name;
+    };
+  }
+
+  document.getElementById('me-room-confirm').addEventListener('click', function() {
+    if (!pendingRoomPos) return;
+    var name = document.getElementById('me-room-name').value.trim();
+    var slug = document.getElementById('me-room-slug').value.trim();
+    var roomType = document.getElementById('me-room-type').value;
+    if (!name) { setStatus('Name required'); return; }
+
+    setStatus('Creating room...');
+    api('POST', 'rooms', {
+      name: name, slug: slug, room_type: roomType || null,
+      grid_zone_id: zoneId, map_x: pendingRoomPos.x, map_y: pendingRoomPos.y, map_z: currentZ, min_clearance: 0
+    }).then(function(d) {
+      if (d.success) {
+        hideDialogs();
+        setStatus('Room created');
+        loadData();
+      } else {
+        setStatus('Error: ' + (d.errors || []).join(', '));
+      }
+    });
+  });
+
+  document.getElementById('me-room-cancel').addEventListener('click', hideDialogs);
+
+  function hideDialogs() {
+    overlay.style.display = 'none';
+    document.getElementById('me-exit-dialog').style.display = 'none';
+    document.getElementById('me-room-dialog').style.display = 'none';
+    pendingRoomPos = null;
+  }
+
+  overlay.addEventListener('click', hideDialogs);
+
+  // ── Toolbar buttons ────────────────────────────────────────
+  document.getElementById('me-auto-layout').addEventListener('click', function() {
+    if (!confirm('Recompute positions via BFS for all rooms in this zone?\nExisting positions will be overwritten.')) return;
+    setStatus('Computing layout...');
+    api('POST', zoneId + '/auto_layout').then(function(d) {
+      if (d.success) {
+        setStatus('Layout computed (' + d.updated + ' rooms)');
+        loadData();
+      } else {
+        setStatus('Error');
+      }
+    });
+  });
+
+  document.getElementById('me-zoom-in').addEventListener('click', function() {
+    zoomLevel = Math.min(zoomLevel + 0.25, 3.0);
+    applyZoom();
+  });
+
+  document.getElementById('me-zoom-out').addEventListener('click', function() {
+    zoomLevel = Math.max(zoomLevel - 0.25, 0.25);
+    applyZoom();
+  });
+
+  document.getElementById('me-zoom-reset').addEventListener('click', function() {
+    zoomLevel = 1.0;
+    applyZoom();
+  });
+
+  function applyZoom() {
+    var vb = svg.getAttribute('viewBox');
+    if (!vb) return;
+    var parts = vb.split(' ');
+    var vbW = parseFloat(parts[2]), vbH = parseFloat(parts[3]);
+    svg.setAttribute('width', Math.round(vbW * zoomLevel));
+    svg.setAttribute('height', Math.round(vbH * zoomLevel));
+    setStatus('Zoom: ' + Math.round(zoomLevel * 100) + '%');
+  }
+
+  // ── Helpers ────────────────────────────────────────────────
+  function esc(str) {
+    var div = document.createElement('div');
+    div.textContent = str || '';
+    return div.innerHTML;
+  }
+
+  function field(label, id, value, type) {
+    return '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em; margin-top: 8px;">' + label + ':</label>' +
+      '<input id="' + id + '" type="' + type + '" class="tui-input" style="width: 100%; padding: 6px; font-size: 0.85em; box-sizing: border-box;" value="' + esc(value) + '" />';
+  }
+
+  // Build sorted flat room list: current zone first, then same region, then rest
+  var _sortedRooms = null;
+  function getSortedRooms(excludeId) {
+    if (!_sortedRooms) {
+      var flat = [];
+      (state.all_rooms_grouped || []).forEach(function(rg) {
+        rg.zones.forEach(function(zg) {
+          zg.rooms.forEach(function(rm) {
+            flat.push({id: rm.id, name: rm.name, zone: zg.zone, zone_id: zg.zone_id, region: rg.region});
+          });
+        });
+      });
+      var curZoneId = state.zone ? state.zone.id : zoneId;
+      var curRegion = state.zone ? state.zone.region_name : '';
+      flat.sort(function(a, b) {
+        var aZone = a.zone_id === curZoneId ? 0 : 1;
+        var bZone = b.zone_id === curZoneId ? 0 : 1;
+        if (aZone !== bZone) return aZone - bZone;
+        var aReg = a.region === curRegion ? 0 : 1;
+        var bReg = b.region === curRegion ? 0 : 1;
+        if (aReg !== bReg) return aReg - bReg;
+        if (a.region !== b.region) return a.region < b.region ? -1 : 1;
+        if (a.zone !== b.zone) return a.zone < b.zone ? -1 : 1;
+        return a.name < b.name ? -1 : 1;
+      });
+      _sortedRooms = flat;
+    }
+    if (excludeId) return _sortedRooms.filter(function(r) { return r.id !== excludeId; });
+    return _sortedRooms;
+  }
+
+  // Invalidate sorted cache on data reload
+  var _origLoadData = loadData;
+  loadData = function() { _sortedRooms = null; _origLoadData(); };
+
+  // Render combobox HTML for room picker
+  var _cbCounter = 0;
+  function roomComboboxHtml(prefix, selectedId) {
+    var uid = prefix + '-' + (++_cbCounter);
+    var sel = getSortedRooms().find(function(r) { return r.id === selectedId; });
+    var label = sel ? sel.name : '';
+    var html = '<div class="admin-combobox" style="position: relative;">';
+    html += '<input type="text" id="' + uid + '-input" class="admin-combobox-input' + (sel ? ' selected' : '') + '" style="padding: 4px 6px; font-size: 0.85em;" autocomplete="off" placeholder="Search rooms..." value="' + esc(label) + '" />';
+    html += '<input type="hidden" id="' + uid + '-hidden" value="' + (selectedId || '') + '" />';
+    html += '<div id="' + uid + '-dropdown" class="admin-combobox-dropdown"></div>';
+    html += '<div id="' + uid + '-status" style="color: #666; font-size: 0.75em; margin-top: 2px;"></div>';
+    html += '</div>';
+    return {html: html, uid: uid};
+  }
+
+  function initRoomCombobox(uid, excludeId) {
+    var items = getSortedRooms(excludeId);
+    var curZoneId = state.zone ? state.zone.id : zoneId;
+    var curRegion = state.zone ? state.zone.region_name : '';
+    AdminCombobox.init({
+      inputId: uid + '-input',
+      hiddenId: uid + '-hidden',
+      dropdownId: uid + '-dropdown',
+      statusId: uid + '-status',
+      items: items,
+      getSearchText: function(r) { return (r.name + ' ' + r.zone + ' ' + r.region).toLowerCase(); },
+      getGroupKey: function(r) {
+        if (r.zone_id === curZoneId) return '★ ' + r.zone + ' (this zone)';
+        return r.region + ' / ' + r.zone;
+      },
+      renderOption: function(r, e) {
+        return '<span class="cb-name">' + e(r.name) + '</span> <span class="cb-meta">' + e(r.zone) + '</span>';
+      },
+      getId: function(r) { return String(r.id); },
+      getLabel: function(r) { return r.name; },
+      emptyText: 'No rooms match',
+      selectedText: 'Room selected'
+    });
+  }
+
+  // Zone combobox helpers
+  var _zoneCbCounter = 0;
+  function zoneComboboxHtml(prefix, selectedId) {
+    var uid = prefix + '-' + (++_zoneCbCounter);
+    var zones = state.available_zones || [];
+    var sel = zones.find(function(z) { return z.id === selectedId; });
+    var label = sel ? (sel.region_name + ' / ' + sel.name) : '';
+    var html = '<div class="admin-combobox" style="position: relative;">';
+    html += '<input type="text" id="' + uid + '-input" class="admin-combobox-input' + (sel ? ' selected' : '') + '" style="padding: 4px 6px; font-size: 0.85em;" autocomplete="off" placeholder="Search zones..." value="' + esc(label) + '" />';
+    html += '<input type="hidden" id="' + uid + '-hidden" value="' + (selectedId || '') + '" />';
+    html += '<div id="' + uid + '-dropdown" class="admin-combobox-dropdown"></div>';
+    html += '<div id="' + uid + '-status" style="color: #666; font-size: 0.75em; margin-top: 2px;"></div>';
+    html += '</div>';
+    return {html: html, uid: uid};
+  }
+
+  function initZoneCombobox(uid) {
+    var zones = state.available_zones || [];
+    AdminCombobox.init({
+      inputId: uid + '-input',
+      hiddenId: uid + '-hidden',
+      dropdownId: uid + '-dropdown',
+      statusId: uid + '-status',
+      items: zones,
+      getSearchText: function(z) { return (z.name + ' ' + z.region_name).toLowerCase(); },
+      getGroupKey: function(z) { return z.region_name; },
+      renderOption: function(z, e) {
+        return '<span class="cb-name">' + e(z.name) + '</span> <span class="cb-meta">' + e(z.region_name) + '</span>';
+      },
+      getId: function(z) { return String(z.id); },
+      getLabel: function(z) { return z.region_name + ' / ' + z.name; },
+      emptyText: 'No zones match',
+      selectedText: 'Zone selected'
+    });
+  }
+
+  // ── Init ───────────────────────────────────────────────────
+  loadData();
+})();
+</script>

--- a/app/views/admin/grid_world_map/index.html.erb
+++ b/app/views/admin/grid_world_map/index.html.erb
@@ -4,6 +4,11 @@
 
     <div style="padding: 20px;">
 
+      <div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-bottom: 20px;">
+        <%= link_to "Export World (.tar.gz)", admin_grid_world_export_path, class: "tui-button green-168", style: "padding: 6px 14px;" %>
+        <span style="color: #555; font-size: 0.8em;">tar xzf world-export-*.tar.gz -C data/ &nbsp;→&nbsp; git diff data/world/ &nbsp;→&nbsp; commit</span>
+      </div>
+
       <% if @connections.any? %>
         <div style="margin-bottom: 30px;">
           <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: INTER-REGION CONNECTIONS ::]</h3>

--- a/app/views/admin/grid_world_map/show.html.erb
+++ b/app/views/admin/grid_world_map/show.html.erb
@@ -6,6 +6,9 @@
       <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px;">
         <%= link_to "<- All Regions", admin_grid_world_map_index_path, class: "tui-button", style: "padding: 6px 14px;" %>
         <%= link_to "Edit Region", edit_admin_grid_region_path(@region), class: "tui-button cyan-168", style: "padding: 6px 14px;" %>
+        <% if @zones.any? %>
+          <%= link_to "Open Map Editor", admin_grid_map_editor_show_path(@zones.first.id), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+        <% end %>
       </div>
 
       <%# Zone legend %>

--- a/app/views/admin/grid_world_map/zone_map.html.erb
+++ b/app/views/admin/grid_world_map/zone_map.html.erb
@@ -6,6 +6,7 @@
       <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px;">
         <%= link_to "<- #{@region.name}", admin_grid_world_map_path(@region), class: "tui-button", style: "padding: 6px 14px;" %>
         <%= link_to "Edit Zone", edit_admin_grid_zone_path(@zone), class: "tui-button cyan-168", style: "padding: 6px 14px;" %>
+        <%= link_to "Open Map Editor", admin_grid_map_editor_show_path(@zone.id), class: "tui-button green-168", style: "padding: 6px 14px;" %>
       </div>
 
       <div style="margin-bottom: 20px;">

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -100,6 +100,7 @@
           <%= link_to "Mobs", admin_grid_mobs_path, class: "green-168-text" %>
           <%= link_to "Exits", admin_grid_exits_path, class: "green-168-text" %>
           <%= link_to "World Map", admin_grid_world_map_index_path, class: "green-168-text" %>
+          <%= link_to "Map Editor", admin_grid_map_editor_show_path(GridZone.first&.id || 0), class: "green-168-text" %>
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
           <%= link_to "Impound", admin_grid_impound_records_path, class: "green-168-text" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,11 +304,32 @@ Rails.application.routes.draw do
     resources :radio_stations, only: %i[index show]
     resources :zone_playlists, only: %i[index show]
 
+    # World Export (download DB → YAML archive)
+    get "grid_world_export", to: "grid_world_export#download", as: :grid_world_export
+
     # World Map Viewer (read-only)
     resources :grid_world_map, only: %i[index show] do
       member do
         get :zone_map
       end
+    end
+
+    # Map Editor (zone-scoped visual editor)
+    scope "grid_map_editor", as: :grid_map_editor do
+      get ":zone_id", to: "grid_map_editor#show", as: :show
+      get ":zone_id/data", to: "grid_map_editor#data", as: :data
+      post "rooms", to: "grid_map_editor#create_room", as: :create_room
+      patch "rooms/:id", to: "grid_map_editor#update_room", as: :update_room
+      delete "rooms/:id", to: "grid_map_editor#destroy_room", as: :destroy_room
+      post "exits", to: "grid_map_editor#create_exit", as: :create_exit
+      patch "exits/:id", to: "grid_map_editor#update_exit", as: :update_exit
+      delete "exits/:id", to: "grid_map_editor#destroy_exit", as: :destroy_exit
+      post "mobs", to: "grid_map_editor#create_mob", as: :create_mob
+      patch "mobs/:id", to: "grid_map_editor#update_mob", as: :update_mob
+      delete "mobs/:id", to: "grid_map_editor#remove_mob", as: :remove_mob
+      post "encounters", to: "grid_map_editor#create_encounter", as: :create_encounter
+      delete "encounters/:id", to: "grid_map_editor#destroy_encounter", as: :destroy_encounter
+      post ":zone_id/auto_layout", to: "grid_map_editor#auto_layout", as: :auto_layout
     end
 
     # World resources (full CRUD)

--- a/db/migrate/20260428200000_add_map_coordinates_to_grid_rooms.rb
+++ b/db/migrate/20260428200000_add_map_coordinates_to_grid_rooms.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddMapCoordinatesToGridRooms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_rooms, :map_x, :integer
+    add_column :grid_rooms, :map_y, :integer
+    add_column :grid_rooms, :map_z, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -622,6 +622,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_200000) do
     t.text "description"
     t.integer "grid_zone_id", null: false
     t.boolean "locked", default: false, null: false
+    t.integer "map_x"
+    t.integer "map_y"
+    t.integer "map_z", default: 0, null: false
     t.integer "min_clearance", default: 0, null: false
     t.string "name"
     t.integer "owner_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -2,6 +2,11 @@
 # YAML files provide initial seed data. The database is the source of truth.
 # Existing records are never overwritten — only new records are created.
 #
+# PRODUCTION GUARD: All world seed tasks are disabled in production because
+# the database is the authoritative source. Use the admin "Export World"
+# download or `rails data:world:export` to dump DB → YAML for version control.
+# Override with ALLOW_WORLD_SEED=true for disaster recovery.
+#
 # Import Order (respecting dependencies):
 # 1. catalog           (artists, releases, tracks from per-artist YAML files)
 # 2. hackrs            (no deps)
@@ -32,6 +37,16 @@
 # 28. breach_encounters (depends on breach_templates, rooms)
 
 namespace :data do
+  # Guard: prevent accidental world seeding in production.
+  # The database is the authoritative source in production.
+  # Override with ALLOW_WORLD_SEED=true for disaster recovery.
+  def self.guard_world_seed!
+    if Rails.env.production? && ENV["ALLOW_WORLD_SEED"] != "true"
+      abort "World seed tasks are disabled in production (DB is master). " \
+            "Set ALLOW_WORLD_SEED=true to override for disaster recovery."
+    end
+  end
+
   # === Master Tasks ===
   desc "Seed data from YAML (creates missing records only). Set S3_BUCKET to also load audio from S3."
   task load: :environment do
@@ -189,7 +204,12 @@ namespace :data do
   task system: [:hackrs, :channels, :radio_stations, :zone_playlists, :redirects]
 
   desc "Load world data (factions, regions, zones, rooms, etc.)"
-  task world: [:factions, :regions, :zones, :rooms, :exits, :mobs, :item_definitions, :salvage_yields, :items, :achievements, :shop_listings, :missions, :schematics, :breach_templates, :breach_encounters, :pac_facilities]
+  task world: :environment do
+    guard_world_seed!
+    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities].each do |t|
+      Rake::Task["data:#{t}"].invoke
+    end
+  end
 
   desc "Load playlists (key playlists with radio station links)"
   task playlists: [:catalog, :hackrs, :radio_stations, :key_playlists]
@@ -431,6 +451,7 @@ namespace :data do
 
   desc "Load factions from YAML"
   task factions: :environment do
+    guard_world_seed!
     puts "\n--- Loading Factions ---"
     yaml_file = Rails.root.join("data", "world", "factions.yml")
 
@@ -505,6 +526,7 @@ namespace :data do
 
   desc "Load regions from YAML"
   task regions: :environment do
+    guard_world_seed!
     puts "\n--- Loading Regions ---"
     yaml_file = Rails.root.join("data", "world", "regions.yml")
 
@@ -535,6 +557,7 @@ namespace :data do
 
   desc "Load zones from YAML"
   task zones: [:environment, :regions] do
+    guard_world_seed!
     puts "\n--- Loading Zones ---"
     yaml_file = Rails.root.join("data", "world", "zones.yml")
 
@@ -580,6 +603,7 @@ namespace :data do
 
   desc "Load rooms from YAML"
   task rooms: :environment do
+    guard_world_seed!
     puts "\n--- Loading Rooms ---"
     yaml_file = Rails.root.join("data", "world", "rooms.yml")
 
@@ -607,7 +631,10 @@ namespace :data do
         description: attrs["description"],
         grid_zone: zone,
         room_type: attrs["room_type"],
-        min_clearance: attrs["min_clearance"] || 0
+        min_clearance: attrs["min_clearance"] || 0,
+        map_x: attrs["map_x"],
+        map_y: attrs["map_y"],
+        map_z: attrs["map_z"] || 0
       )
       room.save!
       created += 1
@@ -631,6 +658,7 @@ namespace :data do
 
   desc "Load exits from YAML"
   task exits: :environment do
+    guard_world_seed!
     puts "\n--- Loading Exits ---"
     yaml_file = Rails.root.join("data", "world", "exits.yml")
 
@@ -670,6 +698,7 @@ namespace :data do
 
   desc "Load mobs from YAML"
   task mobs: :environment do
+    guard_world_seed!
     puts "\n--- Loading Mobs ---"
     yaml_file = Rails.root.join("data", "world", "mobs.yml")
 
@@ -711,6 +740,7 @@ namespace :data do
 
   desc "Load item definitions from YAML"
   task item_definitions: :environment do
+    guard_world_seed!
     puts "\n--- Loading Item Definitions ---"
     yaml_file = Rails.root.join("data", "world", "item_definitions.yml")
 
@@ -746,6 +776,7 @@ namespace :data do
 
   desc "Load salvage yield definitions from YAML"
   task salvage_yields: :environment do
+    guard_world_seed!
     puts "\n--- Loading Salvage Yields ---"
     yaml_file = Rails.root.join("data", "world", "salvage_yields.yml")
 
@@ -791,6 +822,7 @@ namespace :data do
 
   desc "Load items from YAML"
   task items: :environment do
+    guard_world_seed!
     puts "\n--- Loading Items ---"
     yaml_file = Rails.root.join("data", "world", "items.yml")
 
@@ -836,6 +868,7 @@ namespace :data do
 
   desc "Load BREACH templates from YAML"
   task breach_templates: :environment do
+    guard_world_seed!
     puts "\n--- Loading BREACH Templates ---"
     yaml_file = Rails.root.join("data", "world", "breach_templates.yml")
 
@@ -884,6 +917,7 @@ namespace :data do
 
   desc "Load BREACH encounters from YAML"
   task breach_encounters: :environment do
+    guard_world_seed!
     puts "\n--- Loading BREACH Encounters ---"
     yaml_file = Rails.root.join("data", "world", "breach_encounters.yml")
 
@@ -929,6 +963,7 @@ namespace :data do
 
   desc "Stamp GovCorp Perception Alignment Facilities per region from template"
   task pac_facilities: :environment do
+    guard_world_seed!
     puts "\n--- Loading PAC Facilities ---"
     yaml_file = Rails.root.join("data", "world", "pac_facilities.yml")
 
@@ -1082,6 +1117,7 @@ namespace :data do
 
   desc "Load achievements from YAML"
   task achievements: :environment do
+    guard_world_seed!
     puts "\n--- Loading Achievements ---"
     yaml_file = Rails.root.join("data", "world", "achievements.yml")
 
@@ -1119,6 +1155,7 @@ namespace :data do
 
   desc "Load shop listings from YAML"
   task shop_listings: :environment do
+    guard_world_seed!
     puts "\n--- Loading Shop Listings ---"
     yaml_file = Rails.root.join("data", "world", "shop_listings.yml")
 
@@ -2116,6 +2153,7 @@ namespace :data do
 
   desc "Load missions and arcs from YAML"
   task missions: :environment do
+    guard_world_seed!
     puts "\n--- Loading Mission Arcs & Missions ---"
     yaml_file = Rails.root.join("data", "world", "missions.yml")
 
@@ -2231,6 +2269,7 @@ namespace :data do
 
   desc "Load fabrication schematics from YAML"
   task schematics: :environment do
+    guard_world_seed!
     puts "\n--- Loading Fabrication Schematics ---"
     yaml_file = Rails.root.join("data", "world", "schematics.yml")
 
@@ -2286,6 +2325,21 @@ namespace :data do
     end
 
     puts "Schematics: #{created} created, #{GridSchematic.count} total"
+  end
+
+  # === World Export ===
+
+  namespace :world do
+    desc "Export world data from DB to YAML files in data/world/ (reverse of data:world)"
+    task export: :environment do
+      puts "\n" + "=" * 80
+      puts "EXPORTING WORLD DATA (DB → YAML)"
+      puts "=" * 80 + "\n"
+
+      dir = Grid::WorldExporter.new.export_all
+      puts "\n✓ Exported to #{dir}"
+      puts "  Run `git diff data/world/` to review changes."
+    end
   end
 end
 

--- a/spec/controllers/admin/grid_map_editor_controller_spec.rb
+++ b/spec/controllers/admin/grid_map_editor_controller_spec.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::GridMapEditorController, type: :controller do
+  let(:admin_hackr) { create(:grid_hackr, :admin) }
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", room_type: "hub", map_x: 0, map_y: 0) }
+  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", room_type: "transit", map_x: 1, map_y: 0) }
+
+  before { session[:grid_hackr_id] = admin_hackr.id }
+
+  describe "GET #show" do
+    it "returns success" do
+      get :show, params: {zone_id: zone.id}
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "assigns zone and region" do
+      get :show, params: {zone_id: zone.id}
+      expect(assigns(:zone)).to eq(zone)
+      expect(assigns(:region)).to eq(region)
+    end
+  end
+
+  describe "GET #data" do
+    before { room1; room2 }
+
+    it "returns JSON with rooms" do
+      get :data, params: {zone_id: zone.id}, format: :json
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["rooms"].length).to eq(2)
+    end
+
+    it "includes zone info" do
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      expect(json["zone"]["id"]).to eq(zone.id)
+      expect(json["zone"]["name"]).to eq(zone.name)
+    end
+
+    it "includes room positions" do
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      hub = json["rooms"].find { |r| r["name"] == "Hub Alpha" }
+      expect(hub["map_x"]).to eq(0)
+      expect(hub["map_y"]).to eq(0)
+      expect(hub["position_source"]).to eq("stored")
+    end
+
+    it "computes BFS positions for rooms without stored coords" do
+      room_no_coords = create(:grid_room, grid_zone: zone, name: "Unplaced Room")
+      create(:grid_exit, from_room: room1, to_room: room_no_coords, direction: "east")
+
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      unplaced = json["rooms"].find { |r| r["name"] == "Unplaced Room" }
+      expect(unplaced["position_source"]).to eq("computed")
+    end
+
+    it "includes exits" do
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      expect(json["exits"].length).to eq(1)
+      expect(json["exits"][0]["direction"]).to eq("east")
+    end
+
+    it "includes ghost rooms for cross-zone connections" do
+      other_zone = create(:grid_zone, grid_region: region)
+      other_room = create(:grid_room, grid_zone: other_zone, name: "Other Zone Room")
+      create(:grid_exit, from_room: room1, to_room: other_room, direction: "north")
+
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      expect(json["ghost_rooms"].length).to eq(1)
+      expect(json["ghost_rooms"][0]["name"]).to eq("Other Zone Room")
+    end
+
+    it "includes breach templates" do
+      create(:grid_breach_template, published: true)
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      expect(json["breach_templates"]).not_to be_empty
+    end
+
+    it "includes presence counts" do
+      hackr = create(:grid_hackr, :online, current_room: room1)
+      get :data, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      hub = json["rooms"].find { |r| r["id"] == room1.id }
+      expect(hub["hackr_count"]).to eq(1)
+    end
+  end
+
+  describe "POST #create_room" do
+    it "creates a room at specified position" do
+      expect {
+        post :create_room, params: {
+          name: "New Room", slug: "new-room", room_type: "transit",
+          grid_zone_id: zone.id, map_x: 3, map_y: 2, min_clearance: 0
+        }, format: :json
+      }.to change(GridRoom, :count).by(1)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      room = GridRoom.last
+      expect(room.map_x).to eq(3)
+      expect(room.map_y).to eq(2)
+    end
+
+    it "returns errors for invalid room" do
+      post :create_room, params: {
+        name: "", slug: "", grid_zone_id: zone.id, map_x: 0, map_y: 0, min_clearance: 0
+      }, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["errors"]).not_to be_empty
+    end
+  end
+
+  describe "PATCH #update_room" do
+    it "updates room properties" do
+      patch :update_room, params: {id: room1.id, name: "Renamed Hub", min_clearance: 5}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(room1.reload.name).to eq("Renamed Hub")
+      expect(room1.min_clearance).to eq(5)
+    end
+
+    it "updates position" do
+      patch :update_room, params: {id: room1.id, map_x: 10, map_y: 5}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(room1.reload.map_x).to eq(10)
+      expect(room1.reload.map_y).to eq(5)
+    end
+
+    it "returns errors for invalid updates" do
+      patch :update_room, params: {id: room1.id, room_type: "nonexistent"}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+  end
+
+  describe "DELETE #destroy_room" do
+    it "deletes a room with no dependencies" do
+      room = create(:grid_room, grid_zone: zone)
+      expect {
+        delete :destroy_room, params: {id: room.id}, format: :json
+      }.to change(GridRoom, :count).by(-1)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+    end
+
+    it "blocks deletion when hackrs present" do
+      create(:grid_hackr, :online, current_room: room1)
+      delete :destroy_room, params: {id: room1.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["blockers"]).to include(match(/hackr/))
+    end
+
+    it "blocks deletion when mobs assigned" do
+      create(:grid_mob, grid_room: room1)
+      delete :destroy_room, params: {id: room1.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["blockers"]).to include(match(/mob/))
+    end
+
+    it "blocks deletion when items on floor" do
+      definition = create(:grid_item_definition)
+      create(:grid_item, grid_item_definition: definition, room: room1)
+      delete :destroy_room, params: {id: room1.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["blockers"]).to include(match(/item/))
+    end
+
+    it "blocks deletion for region special room references" do
+      region.update!(hospital_room_id: room1.id)
+      delete :destroy_room, params: {id: room1.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["blockers"]).to include(match(/hospital/))
+    end
+  end
+
+  describe "POST #create_exit" do
+    it "creates a one-way exit" do
+      expect {
+        post :create_exit, params: {
+          from_room_id: room1.id, to_room_id: room2.id, direction: "east"
+        }, format: :json
+      }.to change(GridExit, :count).by(1)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["exit"]["direction"]).to eq("east")
+    end
+
+    it "creates bidirectional exits" do
+      expect {
+        post :create_exit, params: {
+          from_room_id: room1.id, to_room_id: room2.id,
+          direction: "east", bidirectional: true
+        }, format: :json
+      }.to change(GridExit, :count).by(2)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["reverse_exit"]).not_to be_nil
+      expect(json["reverse_exit"]["direction"]).to eq("west")
+    end
+
+    it "allows custom reverse direction" do
+      post :create_exit, params: {
+        from_room_id: room1.id, to_room_id: room2.id,
+        direction: "corridor-a", bidirectional: true,
+        reverse_direction: "corridor-b"
+      }, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["reverse_exit"]["direction"]).to eq("corridor-b")
+    end
+
+    it "returns errors for duplicate direction" do
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      post :create_exit, params: {
+        from_room_id: room1.id, to_room_id: room2.id, direction: "east"
+      }, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+
+    it "rolls back both exits if reverse fails" do
+      create(:grid_exit, from_room: room2, to_room: room1, direction: "west")
+      expect {
+        post :create_exit, params: {
+          from_room_id: room1.id, to_room_id: room2.id,
+          direction: "east", bidirectional: true
+        }, format: :json
+      }.not_to change(GridExit, :count)
+    end
+  end
+
+  describe "PATCH #update_exit" do
+    it "updates exit direction" do
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      patch :update_exit, params: {id: exit_record.id, direction: "northeast"}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(exit_record.reload.direction).to eq("northeast")
+    end
+
+    it "updates exit locked state" do
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east", locked: false)
+      patch :update_exit, params: {id: exit_record.id, locked: true}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(exit_record.reload.locked).to be true
+    end
+
+    it "updates exit target room" do
+      room3 = create(:grid_room, grid_zone: zone, name: "Room Three")
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      patch :update_exit, params: {id: exit_record.id, to_room_id: room3.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(exit_record.reload.to_room_id).to eq(room3.id)
+    end
+
+    it "returns errors for duplicate direction" do
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "north")
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      patch :update_exit, params: {id: exit_record.id, direction: "north"}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+  end
+
+  describe "DELETE #destroy_exit" do
+    it "deletes a single exit" do
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      expect {
+        delete :destroy_exit, params: {id: exit_record.id}, format: :json
+      }.to change(GridExit, :count).by(-1)
+    end
+
+    it "deletes reverse exit when requested" do
+      exit1 = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      create(:grid_exit, from_room: room2, to_room: room1, direction: "west")
+      expect {
+        delete :destroy_exit, params: {id: exit1.id, delete_reverse: true}, format: :json
+      }.to change(GridExit, :count).by(-2)
+    end
+  end
+
+  describe "POST #create_mob" do
+    it "creates a mob in the room" do
+      expect {
+        post :create_mob, params: {
+          grid_room_id: room1.id, name: "Test NPC", mob_type: "lore"
+        }, format: :json
+      }.to change(GridMob, :count).by(1)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["mob"]["name"]).to eq("Test NPC")
+    end
+
+    it "returns errors for missing name" do
+      post :create_mob, params: {grid_room_id: room1.id, name: "", mob_type: "lore"}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+  end
+
+  describe "PATCH #update_mob" do
+    it "updates mob name and type" do
+      mob = create(:grid_mob, grid_room: room1, name: "Old Name", mob_type: "lore")
+      patch :update_mob, params: {id: mob.id, name: "New Name", mob_type: "quest_giver"}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(mob.reload.name).to eq("New Name")
+      expect(mob.mob_type).to eq("quest_giver")
+    end
+  end
+
+  describe "DELETE #remove_mob" do
+    it "deletes a mob with no dependencies" do
+      mob = create(:grid_mob, grid_room: room1)
+      expect {
+        delete :remove_mob, params: {id: mob.id}, format: :json
+      }.to change(GridMob, :count).by(-1)
+    end
+
+    it "blocks deletion when shop listings exist" do
+      mob = create(:grid_mob, grid_room: room1, mob_type: "vendor")
+      definition = create(:grid_item_definition)
+      create(:grid_shop_listing, grid_mob: mob, grid_item_definition: definition)
+      delete :remove_mob, params: {id: mob.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+      expect(json["blockers"]).to include(match(/shop listing/))
+    end
+  end
+
+  describe "POST #create_encounter" do
+    it "places a breach encounter in a room" do
+      template = create(:grid_breach_template, published: true)
+      expect {
+        post :create_encounter, params: {
+          grid_room_id: room1.id, grid_breach_template_id: template.id
+        }, format: :json
+      }.to change(GridBreachEncounter, :count).by(1)
+
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["encounter"]["template_name"]).to eq(template.name)
+    end
+
+    it "rejects duplicate template in same room" do
+      template = create(:grid_breach_template, published: true)
+      create(:grid_breach_encounter, grid_room: room1, grid_breach_template: template)
+      post :create_encounter, params: {
+        grid_room_id: room1.id, grid_breach_template_id: template.id
+      }, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+  end
+
+  describe "DELETE #destroy_encounter" do
+    it "removes an encounter" do
+      template = create(:grid_breach_template, published: true)
+      encounter = create(:grid_breach_encounter, grid_room: room1, grid_breach_template: template)
+      expect {
+        delete :destroy_encounter, params: {id: encounter.id}, format: :json
+      }.to change(GridBreachEncounter, :count).by(-1)
+    end
+
+    it "blocks removal when active breaches exist" do
+      template = create(:grid_breach_template, published: true)
+      encounter = create(:grid_breach_encounter, grid_room: room1, grid_breach_template: template)
+      hackr = create(:grid_hackr, :online, current_room: room1)
+      create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template,
+             grid_breach_encounter: encounter, state: "active")
+
+      delete :destroy_encounter, params: {id: encounter.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be false
+    end
+  end
+
+  describe "POST #auto_layout" do
+    it "computes and saves BFS positions" do
+      room_a = create(:grid_room, grid_zone: zone, name: "A", map_x: nil, map_y: nil, room_type: "hub")
+      room_b = create(:grid_room, grid_zone: zone, name: "B", map_x: nil, map_y: nil)
+      create(:grid_exit, from_room: room_a, to_room: room_b, direction: "east")
+
+      post :auto_layout, params: {zone_id: zone.id}, format: :json
+      json = response.parsed_body
+      expect(json["success"]).to be true
+      expect(json["updated"]).to eq(2)
+
+      room_a.reload
+      room_b.reload
+      expect(room_a.map_x).not_to be_nil
+      expect(room_b.map_x).not_to be_nil
+      expect(room_b.map_x).to eq(room_a.map_x + 1) # east = +1 x
+    end
+  end
+
+  describe "authentication" do
+    it "requires admin" do
+      session[:grid_hackr_id] = nil
+      get :show, params: {zone_id: zone.id}
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "rejects non-admin users" do
+      regular = create(:grid_hackr, role: "operative")
+      session[:grid_hackr_id] = regular.id
+      get :show, params: {zone_id: zone.id}
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/controllers/admin/grid_map_editor_controller_spec.rb
+++ b/spec/controllers/admin/grid_map_editor_controller_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
   end
 
   describe "GET #data" do
-    before { room1; room2 }
+    before do
+      room1
+      room2
+    end
 
     it "returns JSON with rooms" do
       get :data, params: {zone_id: zone.id}, format: :json
@@ -87,7 +90,7 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
     end
 
     it "includes presence counts" do
-      hackr = create(:grid_hackr, :online, current_room: room1)
+      create(:grid_hackr, :online, current_room: room1)
       get :data, params: {zone_id: zone.id}, format: :json
       json = response.parsed_body
       hub = json["rooms"].find { |r| r["id"] == room1.id }
@@ -389,7 +392,7 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
       encounter = create(:grid_breach_encounter, grid_room: room1, grid_breach_template: template)
       hackr = create(:grid_hackr, :online, current_room: room1)
       create(:grid_hackr_breach, grid_hackr: hackr, grid_breach_template: template,
-             grid_breach_encounter: encounter, state: "active")
+        grid_breach_encounter: encounter, state: "active")
 
       delete :destroy_encounter, params: {id: encounter.id}, format: :json
       json = response.parsed_body

--- a/spec/controllers/admin/grid_world_export_controller_spec.rb
+++ b/spec/controllers/admin/grid_world_export_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::GridWorldExportController, type: :controller do
+  let(:admin_hackr) { create(:grid_hackr, :admin) }
+
+  before { session[:grid_hackr_id] = admin_hackr.id }
+
+  describe "GET #download" do
+    it "returns a gzipped tar file" do
+      get :download
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Type"]).to eq("application/gzip")
+      expect(response.headers["Content-Disposition"]).to include("world-export-")
+      expect(response.headers["Content-Disposition"]).to include(".tar.gz")
+    end
+
+    it "contains valid gzip data" do
+      get :download
+      bytes = response.body.bytes
+      expect(bytes[0..1]).to eq([0x1f, 0x8b])
+    end
+
+    it "requires admin" do
+      session[:grid_hackr_id] = nil
+      get :download
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -6,6 +6,9 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
+#  map_x               :integer
+#  map_y               :integer
+#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -6,6 +6,9 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
+#  map_x               :integer
+#  map_y               :integer
+#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string

--- a/spec/services/grid/world_exporter_spec.rb
+++ b/spec/services/grid/world_exporter_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::WorldExporter do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", slug: "hub-alpha", room_type: "hub", map_x: 0, map_y: 0) }
+  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", slug: "transit-beta", room_type: "transit", map_x: 1, map_y: 0) }
+
+  describe "#export_all" do
+    it "writes YAML files to the target directory" do
+      room1; room2
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+
+        %w[regions.yml zones.yml rooms.yml exits.yml mobs.yml
+           item_definitions.yml salvage_yields.yml items.yml
+           achievements.yml shop_listings.yml missions.yml
+           schematics.yml breach_templates.yml breach_encounters.yml
+           factions.yml].each do |file|
+          expect(File.exist?(File.join(dir, file))).to be(true), "Missing #{file}"
+        end
+      end
+    end
+
+    it "exports rooms with slug cross-references" do
+      room1
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "rooms.yml"))
+        exported = data["rooms"].find { |r| r["slug"] == room1.slug }
+        expect(exported["name"]).to eq("Hub Alpha")
+        expect(exported["zone_slug"]).to eq(zone.slug)
+      end
+    end
+
+    it "exports map_x and map_y for rooms with stored coordinates" do
+      room1
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "rooms.yml"))
+        exported = data["rooms"].find { |r| r["slug"] == room1.slug }
+        expect(exported["map_x"]).to eq(0)
+        expect(exported["map_y"]).to eq(0)
+      end
+    end
+
+    it "omits map_x/map_y for rooms without stored coordinates" do
+      room = create(:grid_room, grid_zone: zone, map_x: nil, map_y: nil)
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "rooms.yml"))
+        exported = data["rooms"].find { |r| r["slug"] == room.slug }
+        expect(exported).not_to have_key("map_x")
+        expect(exported).not_to have_key("map_y")
+      end
+    end
+
+    it "exports exits with room slug references" do
+      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "exits.yml"))
+        exported = data["exits"].find { |e| e["from_room_slug"] == room1.slug }
+        expect(exported["to_room_slug"]).to eq(room2.slug)
+        expect(exported["direction"]).to eq("east")
+      end
+    end
+
+    it "exports mobs with room slug references" do
+      mob = create(:grid_mob, grid_room: room1, name: "Guard", mob_type: "lore")
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "mobs.yml"))
+        exported = data["mobs"].find { |m| m["name"] == "Guard" }
+        expect(exported["room_slug"]).to eq(room1.slug)
+      end
+    end
+
+    it "exports breach encounters with template and room slugs" do
+      template = create(:grid_breach_template, published: true)
+      create(:grid_breach_encounter, grid_breach_template: template, grid_room: room1)
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "breach_encounters.yml"))
+        expect(data["breach_encounters"].size).to eq(1)
+        expect(data["breach_encounters"][0]["template_slug"]).to eq(template.slug)
+        expect(data["breach_encounters"][0]["room_slug"]).to eq(room1.slug)
+      end
+    end
+
+    it "excludes den rooms from export" do
+      den = create(:grid_room, :den, grid_zone: zone)
+      Dir.mktmpdir do |dir|
+        described_class.new.export_all(dir: dir)
+        data = YAML.load_file(File.join(dir, "rooms.yml"))
+        slugs = data["rooms"].map { |r| r["slug"] }
+        expect(slugs).not_to include(den.slug)
+      end
+    end
+  end
+
+  describe "#to_tar_gz" do
+    it "returns a valid gzipped tar archive" do
+      room1
+      data = described_class.new.to_tar_gz
+      expect(data).to be_a(String)
+      expect(data.bytes[0..1]).to eq([0x1f, 0x8b]) # gzip magic bytes
+
+      # Verify it contains world/*.yml files
+      io = StringIO.new(data)
+      filenames = []
+      Zlib::GzipReader.wrap(io) do |gz|
+        Gem::Package::TarReader.new(gz) do |tar|
+          tar.each { |entry| filenames << entry.full_name }
+        end
+      end
+      expect(filenames).to include("world/rooms.yml")
+      expect(filenames).to include("world/exits.yml")
+    end
+  end
+end

--- a/spec/services/grid/world_exporter_spec.rb
+++ b/spec/services/grid/world_exporter_spec.rb
@@ -10,17 +10,20 @@ RSpec.describe Grid::WorldExporter do
 
   describe "#export_all" do
     it "writes YAML files to the target directory" do
-      room1; room2
+      room1
+      room2
       create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
 
       Dir.mktmpdir do |dir|
         described_class.new.export_all(dir: dir)
 
-        %w[regions.yml zones.yml rooms.yml exits.yml mobs.yml
-           item_definitions.yml salvage_yields.yml items.yml
-           achievements.yml shop_listings.yml missions.yml
-           schematics.yml breach_templates.yml breach_encounters.yml
-           factions.yml].each do |file|
+        %w[
+          regions.yml zones.yml rooms.yml exits.yml mobs.yml
+          item_definitions.yml salvage_yields.yml items.yml
+          achievements.yml shop_listings.yml missions.yml
+          schematics.yml breach_templates.yml breach_encounters.yml
+          factions.yml
+        ].each do |file|
           expect(File.exist?(File.join(dir, file))).to be(true), "Missing #{file}"
         end
       end
@@ -60,7 +63,7 @@ RSpec.describe Grid::WorldExporter do
     end
 
     it "exports exits with room slug references" do
-      exit_record = create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
       Dir.mktmpdir do |dir|
         described_class.new.export_all(dir: dir)
         data = YAML.load_file(File.join(dir, "exits.yml"))
@@ -71,7 +74,7 @@ RSpec.describe Grid::WorldExporter do
     end
 
     it "exports mobs with room slug references" do
-      mob = create(:grid_mob, grid_room: room1, name: "Guard", mob_type: "lore")
+      create(:grid_mob, grid_room: room1, name: "Guard", mob_type: "lore")
       Dir.mktmpdir do |dir|
         described_class.new.export_all(dir: dir)
         data = YAML.load_file(File.join(dir, "mobs.yml"))


### PR DESCRIPTION
  Interactive SVG map editor for the admin panel with room CRUD, exit drawing
  between rooms, mob management, BREACH encounter placement, drag-to-reposition,
  ghost rooms for cross-zone context, z-level navigation, and stored coordinates
  (map_x, map_y, map_z). Side panel provides inline editing with combobox search
  for rooms and zones.

  World export system (DB→YAML) produces files matching the exact seed format for
  bidirectional flow. Admin can download as .tar.gz. Production seed tasks now
  guarded behind ALLOW_WORLD_SEED env var.

  Also: fix WorldMapBuilder diagonal connector insets and viewBox min-width cap,
  add separator lines between Grid terminal command outputs, redirect mob edit
  back to form instead of index.