### PR TITLE
 [TPG] BREACH unwinnable auto-fail, PAC escape fixes, IC directions

### DIFF
--- a/app/models/grid_hackr_breach.rb
+++ b/app/models/grid_hackr_breach.rb
@@ -92,6 +92,48 @@ class GridHackrBreach < ApplicationRecord
     all_protocols_destroyed? || (has_gates && all_circumvention_gates_solved?)
   end
 
+  # True when neither win path (all protocols destroyed OR all gates solved)
+  # can succeed — e.g. gate-only BREACH where required gates have all failed.
+  def breach_unwinnable?
+    has_protocols = grid_breach_protocols.exists?
+    has_gates = puzzle_gates_exist?
+    return false unless has_gates
+    return false if has_protocols # protocol path always theoretically open
+
+    # Gate-only: can we still reach required_count?
+    ps = meta&.dig("puzzle_state")
+    return false unless ps
+
+    gates = ps["gates"] || {}
+    required = ps["required_count"].to_i
+    solved = ps["solved_count"].to_i
+
+    # A gate is potentially solvable if active, or locked with a solvable dependency.
+    # Fixed-point: seed with active/solved/bypassed, propagate through locked gates.
+    solvable_ids = Set.new
+    gates.each { |id, g| solvable_ids << id if %w[active solved bypassed].include?(g["state"]) }
+
+    changed = true
+    while changed
+      changed = false
+      gates.each do |id, g|
+        next if solvable_ids.include?(id)
+        next unless g["state"] == "locked"
+        if g["depends_on"] && solvable_ids.include?(g["depends_on"])
+          solvable_ids << id
+          changed = true
+        end
+      end
+    end
+
+    # Max possible solved = already solved + still-solvable active/locked gates.
+    # Bypassed gates are excluded from both solved_count AND this count, but they
+    # also reduce required_count at setup (required = total - bypass_count), so the
+    # comparison stays balanced.
+    max_possible = solved + solvable_ids.count { |id| %w[active locked].include?(gates[id]["state"]) }
+    max_possible < required
+  end
+
   def puzzle_gates_exist?
     meta&.dig("puzzle_state", "gates")&.any? || false
   end

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -7,7 +7,7 @@ module Grid
     AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action)
     RerouteResult = Data.define(:target_position, :protocol_type_label)
     UseItemResult = Data.define(:item_name, :effect_output, :emergency_jackout)
-    InterfaceResult = Data.define(:gate_id, :correct, :gate_state, :attempts_remaining, :all_solved, :feedback)
+    InterfaceResult = Data.define(:gate_id, :correct, :gate_state, :attempts_remaining, :all_solved, :all_failed, :feedback)
     CircuitProbeResult = Data.define(:gate_id, :probe_pair, :connected, :probes_remaining, :feedback)
 
     class NotInBreach < StandardError; end
@@ -385,6 +385,7 @@ module Grid
       gate_state = nil
       attempts_remaining = 0
       all_solved = false
+      all_failed = false
       feedback = nil
 
       ActiveRecord::Base.transaction do
@@ -436,6 +437,7 @@ module Grid
         )
 
         all_solved = breach.all_circumvention_gates_solved?
+        all_failed = !all_solved && breach.breach_unwinnable?
 
         log_action!(breach, "interface", gate_id, nil, {
           gate_id: gate_id,
@@ -451,6 +453,7 @@ module Grid
         gate_state: gate_state,
         attempts_remaining: attempts_remaining,
         all_solved: all_solved,
+        all_failed: all_failed,
         feedback: feedback
       )
     end

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -279,6 +279,11 @@ module Grid
           # Facility BREACH hooks (captured mode)
           output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
         end
+      elsif result.all_failed
+        # Gate-only BREACH with all gates exhausted — auto-resolve failure
+        output << "<span style='color: #f87171; font-weight: bold;'>ALL CIRCUMVENTION GATES FAILED — BREACH LOST</span>"
+        failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach, failure_mode: :gate_exhaustion)
+        output << failure_result.display
       else
         # Check if round should end
         breach.reload
@@ -439,6 +444,28 @@ module Grid
 
       if result.state == :failure
         # Failure display already included in result.display
+      elsif result.state == :success
+        # Win detected during end_round! — resolve properly
+        output = [result.display]
+        resolve_result = Grid::BreachService.resolve_success!(hackr_breach: breach)
+        output << resolve_result.display
+
+        unless breach.sandbox?
+          template = breach.grid_breach_template
+          notifications = []
+          notifications += achievement_checker.check(:breach_completed, template_slug: template.slug, tier: template.tier)
+          notifications += achievement_checker.check(:breaches_completed_count)
+          notifications += mission_progressor.record(:complete_breach, template_slug: template.slug, tier: template.tier)
+
+          if resolve_result.xp_result[:leveled_up]
+            output << "<span style='color: #fbbf24; font-weight: bold;'>▲ CLEARANCE UP → #{resolve_result.xp_result[:new_clearance]}</span>"
+          end
+
+          output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
+          append_notifications(output, notifications)
+        end
+
+        return output.compact.join("\n")
       end
 
       result.display

--- a/app/services/grid/breach_renderer.rb
+++ b/app/services/grid/breach_renderer.rb
@@ -85,8 +85,11 @@ module Grid
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2554#{SEPARATOR}\u2557</span>"
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2551  B R E A C H   F A I L E D                                   \u2551</span>"
       lines << "<span style='color: #f87171; font-weight: bold;'>\u2560#{SEPARATOR}\u2563</span>"
-      cause = if failure_mode == :health_zero
+      cause = case failure_mode
+      when :health_zero
         "Neural link severed \u2014 vitals critical."
+      when :gate_exhaustion
+        "All circumvention gates locked out \u2014 breach path collapsed."
       else
         "Detection reached 100% \u2014 system countermeasures engaged."
       end
@@ -137,7 +140,11 @@ module Grid
       cause = case end_state
       when "success" then "All protocols neutralized."
       when "failure"
-        (failure_mode == :health_zero) ? "Neural link severed \u2014 vitals critical." : "Detection reached 100%."
+        case failure_mode
+        when :health_zero then "Neural link severed \u2014 vitals critical."
+        when :gate_exhaustion then "All circumvention gates locked out."
+        else "Detection reached 100%."
+        end
       when "jacked_out" then "Disconnected from encounter."
       end
 

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -34,6 +34,10 @@ module Grid
     TRACE_DETECTION_BONUS = 4
     UNLIMITED_ATTEMPTS = -1 # Sentinel for infinite puzzle gate attempts (facility BREACHes)
 
+    # Failure modes that trigger DECK consequences and capture eligibility.
+    # :health_zero is excluded — dying in a breach skips DECK frying and capture.
+    DECK_CONSEQUENCE_MODES = %i[detection_overflow gate_exhaustion].freeze
+
     def self.breach_rank(clearance)
       BREACH_RANK_TABLE.find { |range, _| range.include?(clearance.to_i) }&.last
     end
@@ -378,6 +382,13 @@ module Grid
           if state == :ongoing && hackr_breach.breach_won?
             state = :success
           end
+
+          # 6. Check unwinnable (gate-only BREACH with all required gates failed)
+          if state == :ongoing && hackr_breach.breach_unwinnable?
+            failure_result = resolve_failure!(hackr_breach, failure_mode: :gate_exhaustion)
+            state = :failure
+            failure_display = failure_result.display
+          end
         end
       end
 
@@ -506,9 +517,9 @@ module Grid
             end
           end
 
-          # Tier 3+4: DECK consequences (detection-overflow only, not health-zero)
+          # Tier 3+4: DECK consequences (detection-overflow/gate-exhaustion, not health-zero)
           deck = @hackr.equipped_deck
-          if deck && failure_mode == :detection_overflow
+          if deck && DECK_CONSEQUENCE_MODES.include?(failure_mode)
             if %w[advanced elite world_event].include?(tier)
               # Tier 4: DECK fried — compute level + wipe software
               fried_level_set = compute_fried_level(tier)
@@ -896,7 +907,7 @@ module Grid
 
         # Tier 3+4: DECK consequences
         deck = @hackr.equipped_deck
-        if deck && failure_mode == :detection_overflow
+        if deck && DECK_CONSEQUENCE_MODES.include?(failure_mode)
           if %w[advanced elite world_event].include?(tier)
             fried_level_set = compute_fried_level(tier)
             deck.lock!
@@ -921,10 +932,10 @@ module Grid
     end
 
     # Determine whether this failure results in GovCorp capture.
-    # Capture only happens on detection-overflow, never health-zero.
+    # Capture only on detection-overflow/gate-exhaustion, never health-zero.
     # Probabilistic: standard 25%, advanced 50%, elite+ 100%.
     def should_capture?(tier, failure_mode)
-      return false unless failure_mode == :detection_overflow
+      return false unless DECK_CONSEQUENCE_MODES.include?(failure_mode)
       return false if Grid::ContainmentService.captured?(@hackr)
 
       case tier

--- a/app/services/grid/captured_command_parser.rb
+++ b/app/services/grid/captured_command_parser.rb
@@ -7,6 +7,7 @@ module Grid
   class CapturedCommandParser
     ALLOWED_COMMANDS = %w[
       look l go move north n south s east e west w up u down d out
+      northeast ne southeast se southwest sw northwest nw
       stat stats st inventory inv i help ?
       breach br bribe talk examine ex x who clear cls cl say
     ].freeze

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -56,6 +56,14 @@ module Grid
         go_command("east")
       when "west", "w"
         go_command("west")
+      when "northeast", "ne"
+        go_command("northeast")
+      when "southeast", "se"
+        go_command("southeast")
+      when "southwest", "sw"
+        go_command("southwest")
+      when "northwest", "nw"
+        go_command("northwest")
       when "up", "u"
         go_command("up")
       when "down", "d"
@@ -150,6 +158,8 @@ module Grid
         who_command
       when "clear", "cls", "cl"
         clear_command
+      when "bribe"
+        "<span style='color: #9ca3af;'>Bribe is only available inside a GovCorp facility while in custody.</span>"
       else
         "<span style='color: #f87171;'>Unknown command: #{h(command)}. Type 'help' for a list of commands.</span>"
       end
@@ -157,7 +167,7 @@ module Grid
 
     private
 
-    def look_command
+    def look_command(include_alert_bar: true)
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere. This shouldn't happen!</span>" unless room
 
@@ -280,8 +290,9 @@ module Grid
         output << "<span style='color: #fbbf24;'>Hackrs:</span> #{hackr_entries.join(", ")}"
       end
 
-      # Facility alert HUD (captured mode)
-      if Grid::ContainmentService.captured?(hackr)
+      # Facility alert HUD (captured mode) — suppressed when go_command handles
+      # alert_increment! separately (avoids double-rendering stale + current bar).
+      if include_alert_bar && Grid::ContainmentService.captured?(hackr)
         output << ""
         output << Grid::ContainmentService.render_alert_bar(hackr.stat("facility_alert_level").to_i)
       end
@@ -290,7 +301,7 @@ module Grid
     end
 
     def go_command(direction)
-      return "<span style='color: #fbbf24;'>Go where? Specify a direction (e.g. north, south, east, west, up, down)</span>" unless direction
+      return "<span style='color: #fbbf24;'>Go where? Specify a direction (e.g. north, south, east, west, ne, se, sw, nw, up, down)</span>" unless direction
 
       old_room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless old_room
@@ -382,7 +393,7 @@ module Grid
         hackr.grant_xp!(5) # Bonus XP for new room discovery
       end
 
-      look_output = look_command
+      look_output = look_command(include_alert_bar: !Grid::ContainmentService.captured?(hackr))
       notifications = achievement_checker.check(:room_visit, room_slug: new_room.slug)
       notifications += achievement_checker.check(:rooms_visited)
       notifications += mission_progressor.record(:visit_room, room_slug: new_room.slug)
@@ -887,6 +898,7 @@ module Grid
           <span style='color: #34d399;'>go &lt;direction&gt;</span>             - Move in a direction
           <span style='color: #34d399;'>north, n / south, s</span>        - Move north/south
           <span style='color: #34d399;'>east, e / west, w</span>          - Move east/west
+          <span style='color: #34d399;'>ne / se / sw / nw</span>          - Move diagonally
           <span style='color: #34d399;'>up, u / down, d</span>            - Move up/down
 
         <span style='color: #fbbf24;'>Items:</span>


### PR DESCRIPTION
  Add intercardinal direction shortcuts (ne/se/sw/nw) to command parser,
  fix gate-only BREACH encounters getting stuck when all gates fail, and
  fix several PAC facility escape bugs.

  Intercardinal directions:
  - ne, se, sw, nw interpreted as go northeast, etc.
  - Help text and "Go where?" hint updated
  - Added to CapturedCommandParser ALLOWED_COMMANDS

  BREACH gate exhaustion auto-fail (correctness fix):
  - GridHackrBreach#breach_unwinnable? — fixed-point reachability check detects when no win path remains in gate-only BREACHes (handles dependency chains where a parent gate failure blocks locked children)
  - InterfaceResult gains all_failed field; interface_command auto-resolves failure on gate exhaustion
  - end_round! step 6 checks breach_unwinnable? as safety net
  - New :gate_exhaustion failure mode with DECK_CONSEQUENCE_MODES constant — same consequences as :detection_overflow for now, distinguishable for future tuning. Distinct renderer cause text.

  PAC escape fixes:
  - Double facility alert bar: go_command was rendering stale alert bar from look_command then appending the incremented bar from alert_increment!. look_command now accepts include_alert_bar: param, suppressed when go_command handles alert separately.
  - maybe_end_round success path (correctness fix): end_round! could detect breach_won? and return state: :success, but maybe_end_round only handled :failure — resolve_success! and the facility escape hook were never called. Breach stayed active indefinitely. Now properly resolves with achievements/missions/hook.
  - bribe in main parser: returns helpful message instead of "Unknown command" when not captured (reachable if capture state clears but hackr remains in PAC due to missing exit room config).