### PR TITLE
[TPG] Zone and Room Type Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ bin/rails data:overlays             # Overlay scenes, elements, tickers
 - **grid_hackrs** - player accounts with bcrypt auth (role: operative/operator/admin), XP, clearance (0–99), vitals, CRED balance, mining stats, zone_entry_room_id, TOTP 2FA (encrypted OTP secret, backup codes), has_many :playlists
 - **grid_regions** - geographic hierarchy above zones (name, slug, description, hospital_room_id)
 - **grid_rooms** - locations with map coordinates (map_x, map_y, map_z), room_type, breach_template_slug
-- **grid_zones** - areas grouping rooms (zone_type, color_scheme, danger_level 0–10, belongs_to :grid_region)
+- **grid_zones** - areas grouping rooms (danger_level 0–10, belongs_to :grid_region, optional :grid_faction)
 - **grid_factions** - 7 factions (The Fracture Network, Hackrcore, Blackout, Frontwave, Offline, GovCorp, Dante Russo)
 - **grid_exits** - directional connections between rooms (including intercardinal)
 - **grid_items** - objects with rarity, stacking, equipped_slot, deck_id (software→DECK), container_id (fixture storage), grid_impound_record_id

--- a/app/controllers/admin/grid_map_editor_controller.rb
+++ b/app/controllers/admin/grid_map_editor_controller.rb
@@ -118,7 +118,7 @@ class Admin::GridMapEditorController < Admin::ApplicationController
 
     render json: {
       zone: {id: zone.id, name: zone.name, slug: zone.slug,
-             zone_type: zone.zone_type, danger_level: zone.danger_level,
+             danger_level: zone.danger_level,
              region_id: zone.grid_region_id, region_name: zone.grid_region.name},
       z_level: z_level,
       z_levels: z_levels,

--- a/app/controllers/admin/grid_zones_controller.rb
+++ b/app/controllers/admin/grid_zones_controller.rb
@@ -66,7 +66,7 @@ class Admin::GridZonesController < Admin::ApplicationController
 
   def zone_params
     params.require(:grid_zone).permit(
-      :name, :slug, :description, :zone_type, :color_scheme, :danger_level, :grid_region_id, :grid_faction_id, :ambient_playlist_id
+      :name, :slug, :description, :danger_level, :grid_region_id, :grid_faction_id, :ambient_playlist_id
     )
   end
 end

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -11,7 +11,7 @@
 #  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
-#  room_type           :string
+#  room_type           :string           default("standard"), not null
 #  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -51,8 +51,7 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[hub faction_base govcorp special safe_zone transit shop danger_zone prism dream den hospital firmware_vendor repair_service containment impound sally_port sally_port_anteroom],
-    allow_nil: true
+    in: %w[standard hub faction_base govcorp special safe_zone transit shop danger_zone den hospital firmware_vendor repair_service containment impound sally_port sally_port_anteroom]
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :owner_id, uniqueness: {allow_nil: true}
@@ -72,9 +71,6 @@ class GridRoom < ApplicationRecord
       end
     end
   end
-
-  # Delegate to zone for convenience
-  delegate :faction, :color_scheme, to: :grid_zone
 
   def clearance_gated?
     min_clearance > 0

--- a/app/models/grid_zone.rb
+++ b/app/models/grid_zone.rb
@@ -4,12 +4,10 @@
 # Database name: primary
 #
 #  id                  :integer          not null, primary key
-#  color_scheme        :string
 #  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string
-#  zone_type           :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer
@@ -37,9 +35,5 @@ class GridZone < ApplicationRecord
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
-  validates :zone_type, inclusion: {
-    in: %w[faction_base govcorp residential transit special danger_zone],
-    allow_nil: true
-  }
   validates :danger_level, numericality: {only_integer: true, in: 0..10}
 end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -174,7 +174,6 @@ module Grid
       output = []
       output << "\n<span style='color: #a78bfa;'>════════════════════════════════════════════════════════════════</span>"
       output << "<span style='color: #22d3ee; font-weight: bold;'>#{room.name.upcase}</span> <span style='color: #666;'>::</span> <span style='color: #fbbf24;'>#{room.grid_zone.name}</span> <span style='color: #666;'>::</span> <span style='color: #a78bfa;'>#{room.grid_zone.grid_region&.name || "Unknown Region"}</span>"
-      output << "<span style='color: #9ca3af;'>[#{room.color_scheme}]</span>" if room.color_scheme
       output << ""
       output << "<span style='color: #d0d0d0;'>#{codex_linkify(room.description)}</span>" if room.description
 

--- a/app/services/grid/den_service.rb
+++ b/app/services/grid/den_service.rb
@@ -19,8 +19,7 @@ module Grid
     # Raises DenAlreadyExists if hackr already has a den.
     # Pass consume_item: to atomically destroy the chip in the same transaction.
     def create_den!(consume_item: nil)
-      zone = GridZone.find_by!(zone_type: "residential")
-      corridor = zone.grid_rooms.find_by!(slug: RESIDENTIAL_CORRIDOR_SLUG)
+      corridor = GridRoom.find_by!(slug: RESIDENTIAL_CORRIDOR_SLUG)
 
       retries = 0
       begin
@@ -36,7 +35,7 @@ module Grid
             slug: den_slug,
             description: "A private node in the Residential District. Sparse but functional.",
             room_type: "den",
-            grid_zone: zone,
+            grid_zone: corridor.grid_zone,
             owner: @hackr,
             locked: false
           )

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -115,7 +115,6 @@ module Grid
       zones = GridZone.includes(:grid_region, :grid_faction).order("grid_regions.name, grid_zones.name")
         .references(:grid_region).map do |z|
         h = {"slug" => z.slug, "name" => z.name, "description" => z.description,
-             "zone_type" => z.zone_type, "color_scheme" => z.color_scheme,
              "danger_level" => z.danger_level,
              "region_slug" => z.grid_region.slug}
         h["faction_slug"] = z.grid_faction.slug if z.grid_faction

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -105,6 +105,7 @@
     <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">TYPE:</label>
     <select id="me-room-type" class="tui-input" style="width: 100%; padding: 6px;">
       <option value="">(none)</option>
+      <option value="standard">Standard</option>
       <option value="hub">Hub</option>
       <option value="faction_base">Faction Base</option>
       <option value="govcorp">GovCorp</option>
@@ -113,8 +114,6 @@
       <option value="transit">Transit</option>
       <option value="shop">Shop</option>
       <option value="danger_zone">Danger Zone</option>
-      <option value="prism">Prism</option>
-      <option value="dream">Dream</option>
       <option value="hospital">Hospital</option>
       <option value="firmware_vendor">Firmware Vendor</option>
       <option value="repair_service">Repair Service</option>
@@ -1340,7 +1339,7 @@
     html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Type:</label>';
     html += '<select id="me-p-type" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;">';
     html += '<option value="">(none)</option>';
-    var types = ['hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','prism','dream','hospital','firmware_vendor','repair_service','containment','impound','sally_port_anteroom','sally_port'];
+    var types = ['standard','hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','hospital','firmware_vendor','repair_service','containment','impound','sally_port_anteroom','sally_port'];
     types.forEach(function(t) {
       html += '<option value="' + t + '"' + (room.room_type === t ? ' selected' : '') + '>' + t + '</option>';
     });

--- a/app/views/admin/grid_rooms/_form.html.erb
+++ b/app/views/admin/grid_rooms/_form.html.erb
@@ -29,7 +29,7 @@
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :room_type, "ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.select :room_type,
-          [["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Prism", "prism"], ["Dream", "dream"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
+          [["Standard", "standard"], ["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
           { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>
   <div style="flex: 1; min-width: 200px;">

--- a/app/views/admin/grid_zones/_form.html.erb
+++ b/app/views/admin/grid_zones/_form.html.erb
@@ -27,16 +27,6 @@
 
 <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
   <div style="flex: 1; min-width: 200px;">
-    <%= f.label :zone_type, "ZONE TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.select :zone_type,
-          [["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Residential", "residential"], ["Transit", "transit"], ["Special", "special"], ["Danger Zone", "danger_zone"]],
-          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
-  </div>
-  <div style="flex: 1; min-width: 200px;">
-    <%= f.label :color_scheme, "COLOR SCHEME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.text_field :color_scheme, class: "tui-input", style: "width: 100%; padding: 8px;" %>
-  </div>
-  <div style="flex: 1; min-width: 200px;">
     <%= f.label :danger_level, "DANGER LEVEL", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.number_field :danger_level, class: "tui-input", style: "width: 100%; padding: 8px;", min: 0, max: 10 %>
     <small style="color: #888;">0 = safe, 10 = max ambient encounters</small>

--- a/app/views/admin/grid_zones/index.html.erb
+++ b/app/views/admin/grid_zones/index.html.erb
@@ -28,7 +28,6 @@
                 <th style="text-align: left;">Name</th>
                 <th style="text-align: left;">Slug</th>
                 <th style="text-align: left;">Region</th>
-                <th style="text-align: left;">Type</th>
                 <th style="text-align: left;">Faction</th>
                 <th style="text-align: left;">Ambient Playlist</th>
                 <th style="text-align: center;">Danger</th>
@@ -42,7 +41,6 @@
                   <td class="cyan-255-text"><strong><%= zone.name %></strong></td>
                   <td style="font-family: monospace; color: #666;">/<%= zone.slug %></td>
                   <td><%= zone.grid_region&.name || "—" %></td>
-                  <td><%= zone.zone_type || "—" %></td>
                   <td><%= zone.grid_faction&.name || "—" %></td>
                   <td>
                     <% if zone.ambient_playlist %>

--- a/data/content/codex.yml
+++ b/data/content/codex.yml
@@ -2275,7 +2275,6 @@ codex_entries:
     published: true
     metadata:
       type: Faction headquarters
-      zone_type: faction_base
       control: "XERAEN / The Fracture Network"
       security: Maximum
     content: |

--- a/data/world/pac_facilities.yml
+++ b/data/world/pac_facilities.yml
@@ -6,8 +6,6 @@
 zone:
   name: "GovCorp Perception Alignment Center"
   description: "A sanitized GovCorp containment facility. Neutral walls, filtered air, and the quiet hum of compliance infrastructure. Somewhere behind these walls is a processing corridor that leads to daylight — if you can reach it."
-  zone_type: govcorp
-  color_scheme: white/red
   faction_slug: govcorp
   danger_level: 5
 

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -224,7 +224,7 @@ rooms:
     slug: riverlands-den-corridor
     description: "A residential hallway carved into the bluff rock. Numbered doors line both sides. The stone walls keep the temperature constant year-round."
     zone_slug: riverlands-blufftop
-    room_type: hub
+    room_type: standard
     map_x: 1
     map_y: 1
 
@@ -687,7 +687,7 @@ rooms:
     slug: canyon-upper-dwelling
     description: "A residential unit carved into the upper canyon wall. The entrance is a reinforced door set into sandstone. Inside, the rock keeps everything cool and quiet."
     zone_slug: canyon-dwellings
-    room_type: hub
+    room_type: standard
     map_x: 0
     map_y: 0
     map_z: -1

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -3,8 +3,6 @@ zones:
   - name: hackr.tv Central
     slug: hackr-tv-central
     description: "The central hub of Fracture Network broadcasting operations."
-    zone_type: faction_base
-    color_scheme: purple
     region_slug: the-lakeshore
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
@@ -13,8 +11,6 @@ zones:
   - name: Sector X
     slug: sector-x
     description: "XERAEN's homebase. A fortress of temporal technology and Fracture Network operations."
-    zone_type: faction_base
-    color_scheme: purple
     region_slug: the-lakeshore
     faction_slug: xeraen
     ambient_playlist_slug: fracture-network-ambience
@@ -23,8 +19,6 @@ zones:
   - name: Transit Network
     slug: transit-network
     description: "Neutral corridors connecting the major zones of THE PULSE GRID."
-    zone_type: transit
-    color_scheme: gray/neon green
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: transit-network-ambience
@@ -33,8 +27,6 @@ zones:
   - name: GovCorp Surveillance District
     slug: govcorp-surveillance
     description: "Enemy territory under total GovCorp control."
-    zone_type: govcorp
-    color_scheme: red
     region_slug: the-lakeshore
     faction_slug: govcorp
     ambient_playlist_slug: govcorp-surveillance-ambience
@@ -43,8 +35,6 @@ zones:
   - name: The Underbelly
     slug: the-underbelly
     description: "A network of unregistered passages beneath the Transit Network. Surveillance dead zone. If you know, you know."
-    zone_type: danger_zone
-    color_scheme: red/black
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
@@ -53,8 +43,6 @@ zones:
   - name: Residential District
     slug: residential-district
     description: "A quieter section of THE PULSE GRID. Rows of private nodes line the data-corridors. Hackrs with enough standing have claimed their own spaces here."
-    zone_type: residential
-    color_scheme: blue/gray
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
@@ -63,8 +51,6 @@ zones:
   - name: The Hackr Hangar
     slug: hackr-hangar
     description: "Ryker M. Pulse's headquarters and primary broadcast facility. Where the raw signal is created before transmission to Sector X."
-    zone_type: faction_base
-    color_scheme: purple/cyan
     region_slug: the-riverlands
     faction_slug: thecyberpulse
     ambient_playlist_slug: fracture-network-ambience
@@ -73,8 +59,6 @@ zones:
   - name: "GovCorp RestorePoint\u2122 — Lakeshore"
     slug: restorepoint-lakeshore
     description: "A sterile GovCorp medical facility. Soft lighting, ambient wellness muzak, and the faint smell of antiseptic. A scrolling display reads: 'RestorePoint\u2122 — Because Your Wellbeing Is Our Priority.' The exit is clearly marked. Your CRED balance is clearly lower."
-    zone_type: govcorp
-    color_scheme: white/cyan
     region_slug: the-lakeshore
     faction_slug: null
     ambient_playlist_slug: null
@@ -84,8 +68,6 @@ zones:
   - name: Lakeshore Market District
     slug: lakeshore-market
     description: "Open-air stalls and reinforced shop fronts crowd a pedestrian throughway. Neon vendor signs compete for attention. The smell of solder, street food, and desperation."
-    zone_type: null
-    color_scheme: green/yellow
     region_slug: the-lakeshore
     faction_slug: null
     danger_level: 2
@@ -93,8 +75,6 @@ zones:
   - name: Industrial Sprawl
     slug: lakeshore-industrial
     description: "Abandoned manufacturing blocks repurposed by squatters and salvage crews. Rusted cranes loom overhead. GovCorp patrols are infrequent — the margins aren't worth protecting."
-    zone_type: danger_zone
-    color_scheme: orange/black
     region_slug: the-lakeshore
     faction_slug: null
     danger_level: 6
@@ -103,8 +83,6 @@ zones:
   - name: Riverlands Transit Depot
     slug: riverlands-transit
     description: "A weathered transit station where river barges dock alongside data-cable junction boxes. The architecture is old — pre-GovCorp — and the signal quality shows it."
-    zone_type: transit
-    color_scheme: gray/green
     region_slug: the-riverlands
     faction_slug: null
     danger_level: 1
@@ -112,8 +90,6 @@ zones:
   - name: The Delta
     slug: riverlands-delta
     description: "Where the river splits into a maze of channels before reaching the sea. Smuggler routes thread between sandbars. RIDE coverage is unreliable — the water interferes."
-    zone_type: danger_zone
-    color_scheme: dark green/brown
     region_slug: the-riverlands
     faction_slug: null
     danger_level: 7
@@ -121,8 +97,6 @@ zones:
   - name: Blufftop Commons
     slug: riverlands-blufftop
     description: "Residential platforms carved into the river bluffs. The view is stunning. The rent is manageable. GovCorp considers this a low-value residential zone — which is exactly why people live here."
-    zone_type: residential
-    color_scheme: blue/warm white
     region_slug: the-riverlands
     faction_slug: null
     danger_level: 0
@@ -130,8 +104,6 @@ zones:
   - name: The Amp District
     slug: riverlands-amp
     description: "Converted warehouse blocks that pulse with sound. Every surface vibrates. Live music venues, recording studios, and instrument workshops occupy every available space. The Fracture Network's cultural heart."
-    zone_type: special
-    color_scheme: purple/magenta
     region_slug: the-riverlands
     faction_slug: thecyberpulse
     danger_level: 1
@@ -140,8 +112,6 @@ zones:
   - name: Narrows Central Terminal
     slug: narrows-terminal
     description: "A massive vertical transit hub built into the side of a cliff. Elevators, walkways, and cable cars connect dozens of levels. The density is suffocating. The throughput is impressive."
-    zone_type: transit
-    color_scheme: gray/cyan
     region_slug: the-narrows
     faction_slug: null
     danger_level: 2
@@ -149,8 +119,6 @@ zones:
   - name: The Stack
     slug: narrows-stack
     description: "A residential tower built so high the upper floors lose reliable RIDE signal. Lower floors are affordable. Upper floors are free — but you're on your own."
-    zone_type: residential
-    color_scheme: blue/dark
     region_slug: the-narrows
     faction_slug: null
     danger_level: 0
@@ -158,8 +126,6 @@ zones:
   - name: Harbor Market
     slug: narrows-harbor
     description: "Waterfront commercial district. Salt air, fish stalls, and firmware vendors share the same boardwalk. The harbor cranes move cargo containers that officially contain consumer goods."
-    zone_type: null
-    color_scheme: teal/yellow
     region_slug: the-narrows
     faction_slug: null
     danger_level: 3
@@ -167,8 +133,6 @@ zones:
   - name: GovCorp Financial Core
     slug: narrows-financial
     description: "Glass-and-steel towers housing GovCorp's eastern financial operations. Every surface is monitored. Every transaction is logged. The RIDE overlay here is flawless — which is how they want it."
-    zone_type: govcorp
-    color_scheme: white/gold
     region_slug: the-narrows
     faction_slug: govcorp
     danger_level: 5
@@ -176,8 +140,6 @@ zones:
   - name: Deep Harbor
     slug: narrows-deep
     description: "Flooded sub-levels beneath the harbor district. Sealed bulkheads, emergency lighting, and the constant sound of water. What GovCorp sank down here, they meant to forget."
-    zone_type: danger_zone
-    color_scheme: dark blue/black
     region_slug: the-narrows
     faction_slug: null
     danger_level: 8
@@ -186,8 +148,6 @@ zones:
   - name: Gate Transit Station
     slug: gate-transit
     description: "A sleek, over-engineered transit hub. Everything is chrome and holographic wayfinding. GovCorp built this as a showcase — proof that infrastructure can be beautiful when you control the budget."
-    zone_type: transit
-    color_scheme: chrome/blue
     region_slug: the-gate
     faction_slug: null
     danger_level: 1
@@ -195,8 +155,6 @@ zones:
   - name: Innovation Quarter
     slug: gate-innovation
     description: "Research labs and startup incubators clustered around a central plaza. The ideas here are brilliant. The surveillance is total. GovCorp funds the innovation and owns the patents."
-    zone_type: special
-    color_scheme: white/green
     region_slug: the-gate
     faction_slug: null
     danger_level: 2
@@ -204,8 +162,6 @@ zones:
   - name: GovCorp R&D Campus
     slug: gate-govcorp-rd
     description: "A fortified research campus where RIDE infrastructure is developed. Clearance-gated at every door. The work done here shapes what everyone else experiences as reality."
-    zone_type: govcorp
-    color_scheme: white/red
     region_slug: the-gate
     faction_slug: govcorp
     danger_level: 6
@@ -213,8 +169,6 @@ zones:
   - name: Pier District
     slug: gate-pier
     description: "Former fishing wharves converted to residential lofts. Fog rolls in from the strait every evening. The locals have learned to navigate by sound when visibility drops to zero."
-    zone_type: residential
-    color_scheme: gray/warm white
     region_slug: the-gate
     faction_slug: null
     danger_level: 0
@@ -222,8 +176,6 @@ zones:
   - name: The Fog
     slug: gate-fog
     description: "Below the pier pilings, where fog and seawater create a permanent twilight. Unregistered data drops and dead-letter caches hide in the moisture. Signal attenuation is severe and deliberate."
-    zone_type: danger_zone
-    color_scheme: gray/black
     region_slug: the-gate
     faction_slug: null
     danger_level: 8
@@ -232,8 +184,6 @@ zones:
   - name: Bend Transit Wharf
     slug: bend-transit
     description: "A transit hub built on pylons above the waterline. Everything floods eventually. The locals have stopped repairing the lower level and just moved operations up."
-    zone_type: transit
-    color_scheme: brown/cyan
     region_slug: the-bend
     faction_slug: null
     danger_level: 2
@@ -241,8 +191,6 @@ zones:
   - name: The Quarter
     slug: bend-quarter
     description: "Narrow streets packed with music halls, bars, and street performers. GovCorp's Cultural Zone programming here is a thin veneer over something genuinely alive. The music is real even if the economy isn't."
-    zone_type: special
-    color_scheme: purple/gold
     region_slug: the-bend
     faction_slug: null
     danger_level: 1
@@ -250,8 +198,6 @@ zones:
   - name: Levee District
     slug: bend-levee
     description: "Residential blocks behind the levee wall. The constant awareness of water pressure on the other side creates a particular kind of community — one that helps each other without being asked."
-    zone_type: residential
-    color_scheme: blue/gray
     region_slug: the-bend
     faction_slug: null
     danger_level: 0
@@ -259,8 +205,6 @@ zones:
   - name: Canal Networks
     slug: bend-canals
     description: "Flooded service tunnels beneath the city. Some are mapped. Most aren't. The water is chest-deep in places and the rats are the size of small dogs. GovCorp pretends this doesn't exist."
-    zone_type: danger_zone
-    color_scheme: dark green/black
     region_slug: the-bend
     faction_slug: null
     danger_level: 9
@@ -268,8 +212,6 @@ zones:
   - name: GovCorp Cultural Bureau
     slug: bend-govcorp
     description: "A gleaming office complex where GovCorp curates the region's cultural output. What gets performed, recorded, and broadcast is decided here. The irony is not lost on the locals."
-    zone_type: govcorp
-    color_scheme: white/purple
     region_slug: the-bend
     faction_slug: govcorp
     danger_level: 4
@@ -278,8 +220,6 @@ zones:
   - name: Canyon Rim Station
     slug: canyon-rim
     description: "A transit platform on the canyon rim. Wind howls across the gap. Cable cars descend into the depths on fraying lines. The view is breathtaking if you don't look down at the infrastructure."
-    zone_type: transit
-    color_scheme: red/orange
     region_slug: the-canyon
     faction_slug: null
     danger_level: 2
@@ -287,8 +227,6 @@ zones:
   - name: Cliff Dwellings
     slug: canyon-dwellings
     description: "Residential units carved directly into the canyon wall. Ancient construction techniques layered with modern tech. The walls are three hundred million years of geological history. The wifi is spotty."
-    zone_type: residential
-    color_scheme: sandstone/warm white
     region_slug: the-canyon
     faction_slug: null
     danger_level: 0
@@ -296,8 +234,6 @@ zones:
   - name: The Ledge Market
     slug: canyon-ledge
     description: "A commercial strip built on a natural rock shelf halfway down the canyon. Vendors sell salvaged tech and desert survival gear. The drop on the outer edge is two hundred meters straight down."
-    zone_type: null
-    color_scheme: tan/green
     region_slug: the-canyon
     faction_slug: null
     danger_level: 3
@@ -305,8 +241,6 @@ zones:
   - name: River Bottom
     slug: canyon-river
     description: "The canyon floor where the ancient river still runs. Dark, cool, and echoing. The signal from the rim barely reaches here. What lives down here has adapted to the silence."
-    zone_type: danger_zone
-    color_scheme: dark blue/black
     region_slug: the-canyon
     faction_slug: null
     danger_level: 8
@@ -314,8 +248,6 @@ zones:
   - name: GovCorp Canyon Relay
     slug: canyon-govcorp
     description: "A signal relay station bolted to the canyon wall. GovCorp's attempt to extend RIDE coverage into the depths. The staff rotate out every two weeks. Nobody asks for a third rotation."
-    zone_type: govcorp
-    color_scheme: white/red
     region_slug: the-canyon
     faction_slug: govcorp
     danger_level: 5

--- a/db/migrate/20260501200000_cleanup_zone_and_room_types.rb
+++ b/db/migrate/20260501200000_cleanup_zone_and_room_types.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class CleanupZoneAndRoomTypes < ActiveRecord::Migration[8.0]
+  def up
+    # Drop unused zone columns
+    remove_column :grid_zones, :zone_type, :string
+    remove_column :grid_zones, :color_scheme, :string
+
+    # Backfill mistyped hub rooms to standard
+    execute <<~SQL
+      UPDATE grid_rooms SET room_type = 'standard'
+      WHERE slug IN ('riverlands-den-corridor', 'canyon-upper-dwelling')
+        AND room_type = 'hub'
+    SQL
+
+    # Backfill any nil room_types, then enforce not-null with default
+    execute <<~SQL
+      UPDATE grid_rooms SET room_type = 'standard' WHERE room_type IS NULL
+    SQL
+    change_column_default :grid_rooms, :room_type, "standard"
+    change_column_null :grid_rooms, :room_type, false
+  end
+
+  def down
+    change_column_null :grid_rooms, :room_type, true
+    change_column_default :grid_rooms, :room_type, nil
+
+    add_column :grid_zones, :zone_type, :string
+    add_column :grid_zones, :color_scheme, :string
+
+    execute <<~SQL
+      UPDATE grid_rooms SET room_type = 'hub'
+      WHERE slug IN ('riverlands-den-corridor', 'canyon-upper-dwelling')
+        AND room_type = 'standard'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_28_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -628,7 +628,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_200000) do
     t.integer "min_clearance", default: 0, null: false
     t.string "name"
     t.integer "owner_id"
-    t.string "room_type"
+    t.string "room_type", default: "standard", null: false
     t.string "slug"
     t.datetime "updated_at", null: false
     t.index ["ambient_playlist_id"], name: "index_grid_rooms_on_ambient_playlist_id"
@@ -758,7 +758,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_200000) do
 
   create_table "grid_zones", force: :cascade do |t|
     t.integer "ambient_playlist_id"
-    t.string "color_scheme"
     t.datetime "created_at", null: false
     t.integer "danger_level", default: 0, null: false
     t.text "description"
@@ -767,7 +766,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_28_200000) do
     t.string "name"
     t.string "slug"
     t.datetime "updated_at", null: false
-    t.string "zone_type"
     t.index ["ambient_playlist_id"], name: "index_grid_zones_on_ambient_playlist_id"
     t.index ["grid_region_id"], name: "index_grid_zones_on_grid_region_id"
   end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -773,8 +773,6 @@ namespace :data do
       zone.assign_attributes(
         name: attrs["name"],
         description: attrs["description"],
-        zone_type: attrs["zone_type"],
-        color_scheme: attrs["color_scheme"],
         danger_level: attrs["danger_level"] || 0,
         grid_region: region,
         grid_faction: faction,
@@ -1182,8 +1180,6 @@ namespace :data do
         zone.assign_attributes(
           name: zone_tmpl["name"],
           description: zone_tmpl["description"],
-          zone_type: zone_tmpl["zone_type"],
-          color_scheme: zone_tmpl["color_scheme"],
           grid_region: region,
           grid_faction: govcorp_faction,
           danger_level: zone_tmpl["danger_level"] || 0

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -11,7 +11,7 @@
 #  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
-#  room_type           :string
+#  room_type           :string           default("standard"), not null
 #  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -62,12 +62,8 @@ FactoryBot.define do
       room_type { "danger_zone" }
     end
 
-    trait :prism do
-      room_type { "prism" }
-    end
-
-    trait :dream do
-      room_type { "dream" }
+    trait :standard do
+      room_type { "standard" }
     end
 
     trait :den do

--- a/spec/factories/grid_zones.rb
+++ b/spec/factories/grid_zones.rb
@@ -4,12 +4,10 @@
 # Database name: primary
 #
 #  id                  :integer          not null, primary key
-#  color_scheme        :string
 #  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string
-#  zone_type           :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer
@@ -31,30 +29,11 @@ FactoryBot.define do
     sequence(:name) { |n| "Zone #{n}" }
     sequence(:slug) { |n| "zone_#{n}" }
     description { "A test zone in THE PULSE GRID" }
-    zone_type { "transit" }
-    color_scheme { "gray/neon green" }
     association :grid_region
     grid_faction { nil }
 
     trait :faction_base do
-      zone_type { "faction_base" }
-      color_scheme { "purple" }
       association :grid_faction
-    end
-
-    trait :govcorp do
-      zone_type { "govcorp" }
-      color_scheme { "red" }
-    end
-
-    trait :residential do
-      zone_type { "residential" }
-      color_scheme { "blue" }
-    end
-
-    trait :special do
-      zone_type { "special" }
-      color_scheme { "cyan" }
     end
   end
 end

--- a/spec/models/grid_den_invite_spec.rb
+++ b/spec/models/grid_den_invite_spec.rb
@@ -32,7 +32,7 @@ require "rails_helper"
 RSpec.describe GridDenInvite do
   let(:owner) { create(:grid_hackr) }
   let(:guest) { create(:grid_hackr) }
-  let(:zone) { create(:grid_zone, :residential) }
+  let(:zone) { create(:grid_zone) }
   let(:den) { create(:grid_room, :den, grid_zone: zone, owner: owner) }
 
   describe "associations" do

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -11,7 +11,7 @@
 #  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
-#  room_type           :string
+#  room_type           :string           default("standard"), not null
 #  slug                :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/models/grid_zone_spec.rb
+++ b/spec/models/grid_zone_spec.rb
@@ -4,12 +4,10 @@
 # Database name: primary
 #
 #  id                  :integer          not null, primary key
-#  color_scheme        :string
 #  danger_level        :integer          default(0), not null
 #  description         :text
 #  name                :string
 #  slug                :string
-#  zone_type           :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  ambient_playlist_id :integer

--- a/spec/services/grid/den_service_spec.rb
+++ b/spec/services/grid/den_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Grid::DenService do
-  let(:zone) { create(:grid_zone, :residential, slug: "residential-district") }
+  let(:zone) { create(:grid_zone, slug: "residential-district") }
   let(:corridor) { create(:grid_room, :hub, grid_zone: zone, slug: "residential-corridor", name: "Residential Corridor") }
   let(:hackr) { create(:grid_hackr) }
   let(:service) { described_class.new(hackr) }

--- a/spec/services/grid/fixture_commands_spec.rb
+++ b/spec/services/grid/fixture_commands_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Fixture Commands", type: :service do
-  let(:zone) { create(:grid_zone, :residential, slug: "residential-district") }
+  let(:zone) { create(:grid_zone, slug: "residential-district") }
   let(:corridor) { create(:grid_room, :hub, grid_zone: zone, slug: "residential-corridor", name: "Residential Corridor") }
   let(:hackr) { create(:grid_hackr, current_room: den) }
   let(:den) { Grid::DenService.new(hackr_for_den).create_den! }


### PR DESCRIPTION
  - Remove zone_type column from grid_zones - only 1 of 6 values (residential) had a code path, and that's replaced with a direct slug lookup in DenService
  - Remove color_scheme column from grid_zones - freeform flavor text never parsed or branched on; faction color_scheme stays (different model)
  - Remove color_scheme from look command output, room delegate, world exporter, map editor, admin form/index, seeder, and all YAML seeds
  - Add standard room type for generic rooms that have no special mechanical behavior - prevents hub from being the default junk drawer
  - Drop prism and dream room types (unused placeholders with no behavior)
  - Remove dead delegate :faction on GridRoom (delegated to nonexistent method, zero callers)
  - Make room_type NOT NULL with default "standard" - nil no longer meaningful now that standard exists
  - Backfill 2 mistyped hub rooms to standard (riverlands-den-corridor, canyon-upper-dwelling)