### PR TITLE
[TPG] Admin UX improvements, PAC facility room FKs

### DIFF
--- a/app/controllers/admin/grid_hackrs_controller.rb
+++ b/app/controllers/admin/grid_hackrs_controller.rb
@@ -9,9 +9,6 @@ class Admin::GridHackrsController < Admin::ApplicationController
   # GET /root/grid_hackrs
   def index
     @hackrs = GridHackr.includes(:current_room).order(:hackr_alias)
-    if params[:q].present?
-      @hackrs = @hackrs.where("LOWER(hackr_alias) LIKE ?", "%#{params[:q].downcase}%")
-    end
   end
 
   # GET /root/grid_hackrs/:id

--- a/app/controllers/admin/grid_regions_controller.rb
+++ b/app/controllers/admin/grid_regions_controller.rb
@@ -4,7 +4,7 @@ class Admin::GridRegionsController < Admin::ApplicationController
   versionable GridRegion
 
   before_action :set_region, only: %i[edit update destroy]
-  before_action :load_selects, only: %i[new edit create update]
+  before_action :load_selects, only: %i[edit update]
 
   def index
     @regions = GridRegion.includes(:grid_zones).order(:name)
@@ -12,6 +12,7 @@ class Admin::GridRegionsController < Admin::ApplicationController
 
   def new
     @region = GridRegion.new
+    load_selects
   end
 
   def create
@@ -20,6 +21,7 @@ class Admin::GridRegionsController < Admin::ApplicationController
       set_flash_success("Region '#{@region.name}' created.")
       redirect_to admin_grid_regions_path
     else
+      load_selects
       flash.now[:error] = @region.errors.full_messages.join(", ")
       render :new, status: :unprocessable_entity
     end
@@ -56,12 +58,16 @@ class Admin::GridRegionsController < Admin::ApplicationController
   end
 
   def load_selects
-    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+    if @region&.persisted?
+      @rooms = @region.grid_rooms.includes(grid_zone: :grid_region).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+    else
+      @rooms = GridRoom.none
+    end
   end
 
   def region_params
     params.require(:grid_region).permit(:name, :slug, :description,
-      :hospital_room_id, :containment_room_id,
+      :hospital_room_id, :containment_room_id, :cell_block_room_id, :sally_port_room_id,
       :facility_exit_room_id, :facility_bribe_exit_room_id)
   end
 end

--- a/app/controllers/admin/grid_regions_controller.rb
+++ b/app/controllers/admin/grid_regions_controller.rb
@@ -58,10 +58,10 @@ class Admin::GridRegionsController < Admin::ApplicationController
   end
 
   def load_selects
-    if @region&.persisted?
-      @rooms = @region.grid_rooms.includes(grid_zone: :grid_region).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+    @rooms = if @region&.persisted?
+      @region.grid_rooms.includes(grid_zone: :grid_region).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
     else
-      @rooms = GridRoom.none
+      GridRoom.none
     end
   end
 

--- a/app/controllers/admin/grid_rooms_controller.rb
+++ b/app/controllers/admin/grid_rooms_controller.rb
@@ -61,7 +61,7 @@ class Admin::GridRoomsController < Admin::ApplicationController
   end
 
   def load_selects
-    @zones = GridZone.order(:name)
+    @zones = GridZone.includes(:grid_region).order(:name)
     @playlists = ZonePlaylist.order(:name)
   end
 

--- a/app/controllers/admin/grid_world_export_controller.rb
+++ b/app/controllers/admin/grid_world_export_controller.rb
@@ -7,7 +7,7 @@ class Admin::GridWorldExportController < Admin::ApplicationController
     timestamp = Time.current.strftime("%Y%m%d-%H%M%S")
 
     send_data data,
-      filename: "world-export-#{timestamp}.tar.gz",
+      filename: "the-pulse-grid-world-export-#{timestamp}.tar.gz",
       type: "application/gzip",
       disposition: "attachment"
   end

--- a/app/models/grid_region.rb
+++ b/app/models/grid_region.rb
@@ -9,25 +9,31 @@
 #  slug                        :string           not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  cell_block_room_id          :integer
 #  containment_room_id         :integer
 #  facility_bribe_exit_room_id :integer
 #  facility_exit_room_id       :integer
 #  hospital_room_id            :integer
+#  sally_port_room_id          :integer
 #
 # Indexes
 #
+#  index_grid_regions_on_cell_block_room_id           (cell_block_room_id)
 #  index_grid_regions_on_containment_room_id          (containment_room_id)
 #  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
 #  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
 #  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_sally_port_room_id           (sally_port_room_id)
 #  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
+#  cell_block_room_id           (cell_block_room_id => grid_rooms.id) ON DELETE => nullify
 #  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  sally_port_room_id           (sally_port_room_id => grid_rooms.id) ON DELETE => nullify
 #
 class GridRegion < ApplicationRecord
   has_paper_trail
@@ -36,10 +42,37 @@ class GridRegion < ApplicationRecord
   belongs_to :containment_room, class_name: "GridRoom", optional: true
   belongs_to :facility_exit_room, class_name: "GridRoom", optional: true
   belongs_to :facility_bribe_exit_room, class_name: "GridRoom", optional: true
+  belongs_to :cell_block_room, class_name: "GridRoom", optional: true
+  belongs_to :sally_port_room, class_name: "GridRoom", optional: true
 
   has_many :grid_zones, dependent: :restrict_with_error
   has_many :grid_rooms, through: :grid_zones
 
+  ROOM_FK_FIELDS = %i[
+    hospital_room_id containment_room_id cell_block_room_id
+    sally_port_room_id facility_exit_room_id facility_bribe_exit_room_id
+  ].freeze
+
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
+  validate :room_fks_belong_to_region
+
+  private
+
+  def room_fks_belong_to_region
+    return unless persisted?
+
+    region_room_ids = nil # lazy-loaded
+
+    ROOM_FK_FIELDS.each do |field|
+      room_id = send(field)
+      next if room_id.nil?
+
+      region_room_ids ||= grid_rooms.pluck(:id).to_set
+      unless region_room_ids.include?(room_id)
+        label = field.to_s.sub(/_id$/, "").humanize
+        errors.add(field, "must be a room within this region (#{label})")
+      end
+    end
+  end
 end

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -375,8 +375,8 @@ module Grid
     end
 
     # Post-BREACH-success actions when captured in a GovCorp facility.
-    # Handles cell escape (teleport to corridor), sally port progression,
-    # and alert reduction for voluntary targets.
+    # Handles cell escape, sally port progression, and alert reduction.
+    # Destination rooms are configured as FKs on GridRegion.
     def facility_breach_success_hook
       room = hackr.current_room
       return nil unless room
@@ -384,13 +384,14 @@ module Grid
       # Reduce facility alert for any successful BREACH in the facility
       Grid::ContainmentService.alert_reduce!(hackr: hackr)
 
+      region = room.grid_zone&.grid_region
+
       case room.room_type
       when "containment"
-        # Cell escape — teleport to the processing corridor (slug convention: *-processing-corridor)
-        corridor = room.grid_zone.grid_rooms.find_by("slug LIKE ?", "%-pac-processing-corridor")
-        corridor ||= room.grid_zone.grid_rooms.where.not(room_type: "containment").order(:id).first
-        if corridor
-          hackr.update!(current_room_id: corridor.id)
+        # Cell escape — teleport to the cell block corridor (region FK)
+        destination = region&.cell_block_room
+        if destination
+          hackr.update!(current_room_id: destination.id)
           "<span style='color: #34d399; font-weight: bold;'>Cell seal breached. You slip into the corridor.</span>"
         end
       when "sally_port"
@@ -398,10 +399,10 @@ module Grid
         escape_result = Grid::ContainmentService.escape_facility!(hackr: hackr, via: :sally_port)
         escape_result.display
       when "sally_port_anteroom"
-        # Outer door BREACH success = move to the sally_port room in the same zone.
-        sally_port = room.grid_zone.grid_rooms.find_by(room_type: "sally_port")
-        if sally_port
-          hackr.update!(current_room_id: sally_port.id)
+        # Outer door BREACH success — move to the sally port room (region FK)
+        destination = region&.sally_port_room
+        if destination
+          hackr.update!(current_room_id: destination.id)
           "<span style='color: #34d399; font-weight: bold;'>Outer door seal breached. You enter the sally port.</span>"
         end
       else

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -94,7 +94,8 @@ module Grid
     def export_regions
       all_regions = GridRegion.order(:name).to_a
       special_ids = all_regions.flat_map { |r|
-        [r.hospital_room_id, r.containment_room_id, r.facility_exit_room_id, r.facility_bribe_exit_room_id]
+        [r.hospital_room_id, r.containment_room_id, r.facility_exit_room_id, r.facility_bribe_exit_room_id,
+         r.cell_block_room_id, r.sally_port_room_id]
       }.compact.uniq
       slug_map = GridRoom.where(id: special_ids).pluck(:id, :slug).to_h
 
@@ -104,6 +105,8 @@ module Grid
         h["containment_room_slug"] = slug_map[r.containment_room_id] if r.containment_room_id
         h["facility_exit_room_slug"] = slug_map[r.facility_exit_room_id] if r.facility_exit_room_id
         h["facility_bribe_exit_room_slug"] = slug_map[r.facility_bribe_exit_room_id] if r.facility_bribe_exit_room_id
+        h["cell_block_room_slug"] = slug_map[r.cell_block_room_id] if r.cell_block_room_id
+        h["sally_port_room_slug"] = slug_map[r.sally_port_room_id] if r.sally_port_room_id
         h.compact
       end
       write_yaml("regions.yml", {"regions" => regions})

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -95,7 +95,7 @@ module Grid
       all_regions = GridRegion.order(:name).to_a
       special_ids = all_regions.flat_map { |r|
         [r.hospital_room_id, r.containment_room_id, r.facility_exit_room_id, r.facility_bribe_exit_room_id,
-         r.cell_block_room_id, r.sally_port_room_id]
+          r.cell_block_room_id, r.sally_port_room_id]
       }.compact.uniq
       slug_map = GridRoom.where(id: special_ids).pluck(:id, :slug).to_h
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -92,6 +92,7 @@
         <%= link_to "🗺️ Grid Zones", admin_grid_zones_path, class: "tui-button yellow-168", style: "padding: 10px 20px;" %>
         <%= link_to "🚪 Grid Rooms", admin_grid_rooms_path, class: "tui-button yellow-168", style: "padding: 10px 20px;" %>
         <%= link_to "🎮 GRID Admin", admin_grid_path, class: "tui-button green-168", style: "padding: 10px 20px;" %>
+        <%= link_to "📦 World Export", admin_grid_world_export_path, class: "tui-button green-168", style: "padding: 10px 20px;" %>
       </div>
 
       <!-- Recent Activity -->

--- a/app/views/admin/grid_hackrs/index.html.erb
+++ b/app/views/admin/grid_hackrs/index.html.erb
@@ -15,17 +15,17 @@
         </div>
       <% end %>
 
-      <%= form_with url: admin_grid_hackrs_path, method: :get, local: true, style: "display: inline-flex; gap: 8px; align-items: center; margin-bottom: 20px;" do %>
-        <label class="white-text" style="font-weight: bold;">SEARCH:</label>
-        <%= text_field_tag :q, params[:q], class: "tui-input", style: "padding: 6px 10px; width: 250px;", placeholder: "hackr alias..." %>
-        <%= submit_tag "Find", class: "tui-button green-168", style: "padding: 6px 14px;" %>
-        <% if params[:q].present? %>
-          <%= link_to "Clear", admin_grid_hackrs_path, class: "tui-button", style: "padding: 6px 14px;" %>
-        <% end %>
-      <% end %>
+      <div style="display: inline-flex; gap: 8px; align-items: center; margin-bottom: 20px;">
+        <label class="white-text" style="font-weight: bold;">FILTER:</label>
+        <input type="text" id="hackr-filter" class="tui-input" style="padding: 6px 10px; width: 250px;" placeholder="hackr alias..." autocomplete="off">
+        <span id="hackr-filter-status" style="color: #666; font-size: 0.85em;"><%= @hackrs.size %> hackrs</span>
+      </div>
 
+      <style>
+        .hackr-table td, .hackr-table th { padding: 6px 8px; }
+      </style>
       <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
-        <table class="tui-table" style="width: 100%;">
+        <table class="tui-table hackr-table" style="width: 100%; border-spacing: 0 2px; border-collapse: separate;">
           <thead>
             <tr>
               <th style="text-align: left;">Alias</th>
@@ -39,9 +39,9 @@
             </tr>
           </thead>
           <tbody>
-            <% @hackrs.each do |hackr| %>
-              <tr>
-                <td class="cyan-255-text"><%= hackr.hackr_alias %></td>
+            <% @hackrs.each_with_index do |hackr, i| %>
+              <tr style="<%= " background: #112;" if i.odd? %>">
+                <td class="cyan-255-text"><%= link_to hackr.hackr_alias, admin_grid_hackr_path(hackr), style: "color: inherit; text-decoration: none;" %></td>
                 <td style="color: #888;"><%= hackr.role %></td>
                 <td style="text-align: center;" class="cyan-255-text"><%= hackr.stat("clearance") %></td>
                 <td style="text-align: center; color: #888;"><%= hackr.stat("xp") %></td>
@@ -61,6 +61,13 @@
                 <td style="text-align: right; white-space: nowrap;">
                   <%= link_to "Inspect", admin_grid_hackr_path(hackr), class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
                   <%= link_to "Items", admin_grid_hackr_items_path(hackr), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                  <% if dev_tools_enabled? %>
+                    <%= link_to "Stats", edit_stats_admin_grid_hackr_path(hackr), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= link_to "Warp", warp_admin_grid_hackr_path(hackr), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= link_to "Sandbox", new_admin_grid_breach_sandbox_path(hackr_id: hackr.id), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= link_to "NPC", new_admin_grid_npc_dialogue_tester_path(hackr_id: hackr.id), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                    <%= link_to "PAC", new_admin_grid_pac_escape_tester_path(hackr_id: hackr.id), class: "tui-button yellow-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
+                  <% end %>
                 </td>
               </tr>
             <% end %>
@@ -68,7 +75,27 @@
         </table>
       </div>
 
-      <p style="color: #666; margin-top: 15px;"><%= @hackrs.size %> hackr<%= @hackrs.size == 1 ? "" : "s" %> found</p>
     </div>
   </fieldset>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var input = document.getElementById('hackr-filter');
+    var status = document.getElementById('hackr-filter-status');
+    var rows = document.querySelectorAll('.hackr-table tbody tr');
+    var total = rows.length;
+
+    input.addEventListener('input', function() {
+      var q = this.value.toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var alias = rows[i].cells[0].textContent.toLowerCase();
+        var show = !q || alias.indexOf(q) !== -1;
+        rows[i].style.display = show ? '' : 'none';
+        if (show) visible++;
+      }
+      status.textContent = visible + ' of ' + total + ' hackr' + (total === 1 ? '' : 's');
+    });
+  })();
+</script>

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -104,8 +104,7 @@
   <div style="margin-bottom: 10px;">
     <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">TYPE:</label>
     <select id="me-room-type" class="tui-input" style="width: 100%; padding: 6px;">
-      <option value="">(none)</option>
-      <option value="standard">Standard</option>
+      <option value="standard" selected>Standard</option>
       <option value="hub">Hub</option>
       <option value="faction_base">Faction Base</option>
       <option value="govcorp">GovCorp</option>
@@ -1338,7 +1337,6 @@
     html += '<div style="flex: 1;">';
     html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Type:</label>';
     html += '<select id="me-p-type" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;">';
-    html += '<option value="">(none)</option>';
     var types = ['standard','hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','hospital','firmware_vendor','repair_service','containment','impound','sally_port_anteroom','sally_port'];
     types.forEach(function(t) {
       html += '<option value="' + t + '"' + (room.room_type === t ? ' selected' : '') + '>' + t + '</option>';
@@ -1865,7 +1863,7 @@
     pendingRoomPos = {x: gx, y: gy};
     document.getElementById('me-room-name').value = '';
     document.getElementById('me-room-slug').value = '';
-    document.getElementById('me-room-type').value = '';
+    document.getElementById('me-room-type').value = 'standard';
     overlay.style.display = 'block';
     document.getElementById('me-room-dialog').style.display = 'block';
     document.getElementById('me-room-name').focus();

--- a/app/views/admin/grid_regions/_form.html.erb
+++ b/app/views/admin/grid_regions/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render "admin/shared/combobox" %>
+
 <% if @region.errors.any? %>
   <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
     <p class="red-255-text">ERRORS:</p>
@@ -25,27 +27,36 @@
   <%= f.text_area :description, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
 </div>
 
-<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
-  <div style="flex: 1; min-width: 250px;">
-    <%= f.label :hospital_room_id, "RESTOREPOINT ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.collection_select :hospital_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <%= f.label :containment_room_id, "CONTAINMENT CELL", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.collection_select :containment_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
-  </div>
-</div>
+<%
+  room_fields = [
+    { field: :hospital_room_id, label: "RESTOREPOINT ROOM" },
+    { field: :containment_room_id, label: "CONTAINMENT CELL" },
+    { field: :cell_block_room_id, label: "CELL BLOCK CORRIDOR" },
+    { field: :sally_port_room_id, label: "SALLY PORT ROOM" },
+    { field: :facility_exit_room_id, label: "FACILITY EXIT (SALLY PORT)" },
+    { field: :facility_bribe_exit_room_id, label: "FACILITY EXIT (BRIBE)" },
+  ]
+%>
 
-<div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
-  <div style="flex: 1; min-width: 250px;">
-    <%= f.label :facility_exit_room_id, "FACILITY EXIT (SALLY PORT)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.collection_select :facility_exit_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+<% room_fields.each_slice(2) do |pair| %>
+  <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+    <% pair.each do |rf| %>
+      <% cb_id = rf[:field].to_s.sub(/_id$/, "").dasherize %>
+      <% current_room = @region.send(rf[:field].to_s.sub(/_id$/, "")) %>
+      <div style="flex: 1; min-width: 250px;">
+        <%= f.label rf[:field], rf[:label], class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+        <input type="hidden" name="grid_region[<%= rf[:field] %>]" id="<%= cb_id %>-hidden" value="<%= @region.send(rf[:field]) %>">
+        <div class="admin-combobox">
+          <input type="text" id="<%= cb_id %>-input" class="admin-combobox-input<%= ' selected' if current_room %>" autocomplete="off"
+            placeholder="Type to search..."
+            value="<%= "#{current_room.grid_zone.grid_region.name} / #{current_room.grid_zone.name} / #{current_room.name}" if current_room %>">
+          <div id="<%= cb_id %>-dropdown" class="admin-combobox-dropdown"></div>
+        </div>
+        <p style="color: #666; margin-top: 4px; font-size: 0.85em;" id="<%= cb_id %>-status"></p>
+      </div>
+    <% end %>
   </div>
-  <div style="flex: 1; min-width: 250px;">
-    <%= f.label :facility_bribe_exit_room_id, "FACILITY EXIT (BRIBE)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.collection_select :facility_bribe_exit_room_id, @rooms, :id, ->(r) { "#{r.grid_zone.name} / #{r.name}" }, { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
-  </div>
-</div>
+<% end %>
 
 <div style="margin-top: 30px; display: flex; gap: 10px;">
   <%= f.submit @region.new_record? ? "Create Region" : "Update Region", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
@@ -54,3 +65,30 @@
     <%= link_to "History", history_admin_grid_region_path(@region), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
   <% end %>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var rooms = <%= raw @rooms.map { |r| { id: r.id, name: r.name, zone_name: r.grid_zone.name, region_name: r.grid_zone.grid_region.name } }.to_json %>;
+
+    var fields = <%= raw room_fields.map { |rf| rf[:field].to_s.sub(/_id$/, "").dasherize }.to_json %>;
+
+    fields.forEach(function(cbId) {
+      AdminCombobox.init({
+        inputId: cbId + '-input',
+        hiddenId: cbId + '-hidden',
+        dropdownId: cbId + '-dropdown',
+        statusId: cbId + '-status',
+        items: rooms,
+        getSearchText: function(r) { return (r.name + ' ' + r.zone_name + ' ' + r.region_name).toLowerCase(); },
+        getGroupKey: function(r) { return r.region_name + ' / ' + r.zone_name; },
+        renderOption: function(r, e) {
+          return '<span class="cb-name">' + e(r.name) + '</span> <span class="cb-meta">' + e(r.zone_name) + '</span>';
+        },
+        getId: function(r) { return String(r.id); },
+        getLabel: function(r) { return r.region_name + ' / ' + r.zone_name + ' / ' + r.name; },
+        emptyText: 'No rooms match',
+        selectedText: 'Room selected'
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/grid_rooms/_form.html.erb
+++ b/app/views/admin/grid_rooms/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render "admin/shared/combobox" %>
+
 <% if @room.errors.any? %>
   <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
     <p class="red-255-text">ERRORS:</p>
@@ -30,7 +32,7 @@
     <%= f.label :room_type, "ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.select :room_type,
           [["Standard", "standard"], ["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
-          { include_blank: "(none)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+          { selected: @room.room_type || "standard" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
@@ -41,7 +43,16 @@
 <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :grid_zone_id, "ZONE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.collection_select :grid_zone_id, @zones, :id, :name, { include_blank: "(select zone)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    <input type="hidden" name="grid_room[grid_zone_id]" id="zone-cb-hidden" value="<%= @room.grid_zone_id %>">
+    <div class="admin-combobox">
+      <input type="text" id="zone-cb-input" class="admin-combobox-input<%= ' selected' if @room.grid_zone_id.present? %>" autocomplete="off"
+        placeholder="Type to search..."
+        value="<%= @room.grid_zone&.grid_region&.name.to_s + ' / ' + @room.grid_zone&.name.to_s if @room.grid_zone_id.present? %>">
+      <div id="zone-cb-dropdown" class="admin-combobox-dropdown"></div>
+    </div>
+    <p style="color: #666; margin-top: 4px; font-size: 0.85em;" id="zone-cb-status">
+      <%= @zones.size %> zones
+    </p>
   </div>
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :ambient_playlist_id, "AMBIENT PLAYLIST", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
@@ -56,3 +67,44 @@
     <%= link_to "History", history_admin_grid_room_path(@room), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
   <% end %>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var nameField = document.getElementById('grid_room_name');
+    var slugField = document.getElementById('grid_room_slug');
+    var autoSlug = true;
+
+    function slugify(s) {
+      return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    }
+
+    if (slugField.value && slugField.value !== slugify(nameField.value)) {
+      autoSlug = false;
+    }
+
+    nameField.addEventListener('input', function() {
+      if (autoSlug) slugField.value = slugify(this.value);
+    });
+
+    slugField.addEventListener('input', function() {
+      autoSlug = false;
+    });
+  })();
+
+  AdminCombobox.init({
+    inputId: 'zone-cb-input',
+    hiddenId: 'zone-cb-hidden',
+    dropdownId: 'zone-cb-dropdown',
+    statusId: 'zone-cb-status',
+    items: <%= raw @zones.map { |z| { id: z.id, name: z.name, region_name: z.grid_region.name } }.to_json %>,
+    getSearchText: function(z) { return (z.name + ' ' + z.region_name).toLowerCase(); },
+    getGroupKey: function(z) { return z.region_name; },
+    renderOption: function(z, e) {
+      return '<span class="cb-name">' + e(z.name) + '</span> <span class="cb-meta">' + e(z.region_name) + '</span>';
+    },
+    getId: function(z) { return String(z.id); },
+    getLabel: function(z) { return z.region_name + ' / ' + z.name; },
+    emptyText: 'No zones match',
+    selectedText: 'Zone selected'
+  });
+</script>

--- a/db/migrate/20260502200000_add_facility_room_fks_to_grid_regions.rb
+++ b/db/migrate/20260502200000_add_facility_room_fks_to_grid_regions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFacilityRoomFksToGridRegions < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :grid_regions, :cell_block_room, foreign_key: {to_table: :grid_rooms, on_delete: :nullify}
+    add_reference :grid_regions, :sally_port_room, foreign_key: {to_table: :grid_rooms, on_delete: :nullify}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_02_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -571,6 +571,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_200000) do
   end
 
   create_table "grid_regions", force: :cascade do |t|
+    t.integer "cell_block_room_id"
     t.integer "containment_room_id"
     t.datetime "created_at", null: false
     t.text "description"
@@ -578,12 +579,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_200000) do
     t.integer "facility_exit_room_id"
     t.integer "hospital_room_id"
     t.string "name", null: false
+    t.integer "sally_port_room_id"
     t.string "slug", null: false
     t.datetime "updated_at", null: false
+    t.index ["cell_block_room_id"], name: "index_grid_regions_on_cell_block_room_id"
     t.index ["containment_room_id"], name: "index_grid_regions_on_containment_room_id"
     t.index ["facility_bribe_exit_room_id"], name: "index_grid_regions_on_facility_bribe_exit_room_id"
     t.index ["facility_exit_room_id"], name: "index_grid_regions_on_facility_exit_room_id"
     t.index ["hospital_room_id"], name: "index_grid_regions_on_hospital_room_id"
+    t.index ["sally_port_room_id"], name: "index_grid_regions_on_sally_port_room_id"
     t.index ["slug"], name: "index_grid_regions_on_slug", unique: true
   end
 
@@ -1271,10 +1275,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_200000) do
   add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "cell_block_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "containment_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "facility_bribe_exit_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "facility_exit_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "hospital_room_id", on_delete: :nullify
+  add_foreign_key "grid_regions", "grid_rooms", column: "sally_port_room_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
   add_foreign_key "grid_rooms", "grid_hackrs", column: "owner_id"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1264,11 +1264,15 @@ namespace :data do
       containment_room = GridRoom.find_by(slug: "#{region_slug}-pac-containment-cell")
       exit_room = GridRoom.find_by(slug: "#{region_slug}-pac-external-corridor")
       bribe_exit_room = GridRoom.find_by(slug: "#{region_slug}-pac-admin-discharge")
+      cell_block_room = GridRoom.find_by(slug: "#{region_slug}-pac-processing-corridor")
+      sally_port_room = GridRoom.find_by(slug: "#{region_slug}-pac-sally-port")
 
       updates = {}
       updates[:containment_room] = containment_room if containment_room && region.containment_room_id != containment_room.id
       updates[:facility_exit_room] = exit_room if exit_room && region.facility_exit_room_id != exit_room.id
       updates[:facility_bribe_exit_room] = bribe_exit_room if bribe_exit_room && region.facility_bribe_exit_room_id != bribe_exit_room.id
+      updates[:cell_block_room] = cell_block_room if cell_block_room && region.cell_block_room_id != cell_block_room.id
+      updates[:sally_port_room] = sally_port_room if sally_port_room && region.sally_port_room_id != sally_port_room.id
 
       if updates.any?
         region.update!(updates)

--- a/spec/factories/grid_regions.rb
+++ b/spec/factories/grid_regions.rb
@@ -9,25 +9,31 @@
 #  slug                        :string           not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  cell_block_room_id          :integer
 #  containment_room_id         :integer
 #  facility_bribe_exit_room_id :integer
 #  facility_exit_room_id       :integer
 #  hospital_room_id            :integer
+#  sally_port_room_id          :integer
 #
 # Indexes
 #
+#  index_grid_regions_on_cell_block_room_id           (cell_block_room_id)
 #  index_grid_regions_on_containment_room_id          (containment_room_id)
 #  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
 #  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
 #  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_sally_port_room_id           (sally_port_room_id)
 #  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
+#  cell_block_room_id           (cell_block_room_id => grid_rooms.id) ON DELETE => nullify
 #  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  sally_port_room_id           (sally_port_room_id => grid_rooms.id) ON DELETE => nullify
 #
 FactoryBot.define do
   factory :grid_region do

--- a/spec/models/grid_region_spec.rb
+++ b/spec/models/grid_region_spec.rb
@@ -9,25 +9,31 @@
 #  slug                        :string           not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
+#  cell_block_room_id          :integer
 #  containment_room_id         :integer
 #  facility_bribe_exit_room_id :integer
 #  facility_exit_room_id       :integer
 #  hospital_room_id            :integer
+#  sally_port_room_id          :integer
 #
 # Indexes
 #
+#  index_grid_regions_on_cell_block_room_id           (cell_block_room_id)
 #  index_grid_regions_on_containment_room_id          (containment_room_id)
 #  index_grid_regions_on_facility_bribe_exit_room_id  (facility_bribe_exit_room_id)
 #  index_grid_regions_on_facility_exit_room_id        (facility_exit_room_id)
 #  index_grid_regions_on_hospital_room_id             (hospital_room_id)
+#  index_grid_regions_on_sally_port_room_id           (sally_port_room_id)
 #  index_grid_regions_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #
+#  cell_block_room_id           (cell_block_room_id => grid_rooms.id) ON DELETE => nullify
 #  containment_room_id          (containment_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_bribe_exit_room_id  (facility_bribe_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  facility_exit_room_id        (facility_exit_room_id => grid_rooms.id) ON DELETE => nullify
 #  hospital_room_id             (hospital_room_id => grid_rooms.id) ON DELETE => nullify
+#  sally_port_room_id           (sally_port_room_id => grid_rooms.id) ON DELETE => nullify
 #
 require "rails_helper"
 


### PR DESCRIPTION
  Replace brittle slug-convention room lookups in facility BREACH
  success hook with explicit FK relations on GridRegion. Add admin
  tooling quality-of-life improvements across multiple views.

  PAC facility rooms:
  - Add cell_block_room_id and sally_port_room_id FKs to grid_regions
  - facility_breach_success_hook now uses region FKs instead of slug pattern matching (%-pac-processing-corridor) and room_type scans
  - Backfill all 16 regions, update PAC seed task and world exporter
  - Validate all 6 room FKs belong to a zone within the region
  - Region form room selects scoped to rooms within that region

  Admin room form:
  - Zone select → combobox with region grouping and fuzzy search
  - Auto-generate slug from name (stops on manual edit)
  - Remove (none) from room_type selects, default to Standard

  Admin hackr index:
  - Alias column links to inspect/show page
  - Dev-tools-gated action buttons: Stats, Warp, Sandbox, NPC, PAC
  - Striped rows + increased cell padding
  - Server-side search → client-side instant filter

  Admin region form:
  - All 6 room selects → comboboxes (region/zone/room grouped search)

  Other:
  - World Export button on admin dashboard quick actions
  - World export filename prefixed with "the-pulse-grid-"
  - Map editor Create Room defaults to Standard type