### PR TITLE
[TPG] Region Map Editor: purely calculated positioning, perf fixes

### DIFF
--- a/app/controllers/admin/grid_map_editor_controller.rb
+++ b/app/controllers/admin/grid_map_editor_controller.rb
@@ -13,43 +13,174 @@ class Admin::GridMapEditorController < Admin::ApplicationController
   def show
     @zone = GridZone.find(params[:zone_id])
     @region = @zone.grid_region
+    @scope = "zone"
+  end
+
+  # GET /root/grid_map_editor/region/:region_id
+  def region_show
+    @region = GridRegion.find(params[:region_id])
+    @scope = "region"
+    render :show
+  end
+
+  # GET /root/grid_map_editor/region/:region_id/data
+  def region_data
+    region = GridRegion.find(params[:region_id])
+    zones = region.grid_zones.to_a
+    all_rooms = region.grid_rooms.includes(:grid_zone).to_a
+    all_room_ids = all_rooms.map(&:id)
+    region_room_id_set = Set.new(all_room_ids)
+
+    all_exits = GridExit.where(from_room_id: all_room_ids)
+      .includes(to_room: {grid_zone: :grid_region}).to_a
+
+    # Compute per-zone room BFS positions and z-levels
+    rooms_by_zone = all_rooms.group_by(&:grid_zone_id)
+    zone_room_bfs = {}
+    zone_room_z = {}
+    zone_bboxes = {}
+
+    zones.each do |z|
+      z_rooms = rooms_by_zone[z.id] || []
+      z_room_ids = Set.new(z_rooms.map(&:id))
+      z_exits = all_exits.select { |e| z_room_ids.include?(e.from_room_id) }
+      bfs = bfs_positions(z_rooms, z_exits)
+      z_levels = compute_z_levels(z_rooms, z_exits)
+      zone_room_bfs[z.id] = bfs
+      zone_room_z[z.id] = z_levels
+
+      positions = z_rooms.map { |r| bfs[r.id] || [0, 0] }
+      if positions.any?
+        xs = positions.map(&:first)
+        ys = positions.map(&:last)
+        zone_bboxes[z.id] = {width: xs.max - xs.min, height: ys.max - ys.min}
+      else
+        zone_bboxes[z.id] = {width: 0, height: 0}
+      end
+    end
+
+    # Compute zone positions via BFS
+    zone_positions = compute_zone_bfs_positions(zones, all_rooms, all_exits, zone_bboxes)
+
+    # Zone colors
+    zone_color_map = build_zone_color_map
+    all_zones_sorted = GridZone.includes(:grid_region).order("grid_regions.name, grid_zones.name").to_a
+
+    # Z-levels present across entire region
+    z_level_map = zone_room_z.values.reduce({}, :merge)
+    z_levels = z_level_map.values.uniq.sort
+    z_levels = [0] if z_levels.empty?
+
+    # Build indexes for O(1) lookups
+    exits_by_from = all_exits.group_by(&:from_room_id)
+    reverse_exit_index = all_exits.index_by { |e| [e.to_room_id, e.from_room_id] }
+    room_by_id = all_rooms.index_by(&:id)
+    presence = load_presence_data(all_room_ids)
+
+    # Ghost rooms + inbound exits
+    ghost_rooms, inbound_exits, inbound_index = load_ghost_data(all_exits, region_room_id_set, all_room_ids)
+    inbound_by_to = inbound_exits.group_by(&:to_room_id)
+    exits_by_to = all_exits.group_by(&:to_room_id)
+
+    ghost_data = build_ghost_json(ghost_rooms, exits_by_to, inbound_index)
+
+    # Build rooms with world coordinates (zone offset + room local)
+    rooms_json = all_rooms.map do |r|
+      zp = zone_positions[r.grid_zone_id] || [0, 0]
+      local = zone_room_bfs.dig(r.grid_zone_id, r.id) || [0, 0]
+      local_x, local_y = local
+      room_z = z_level_map[r.id] || 0
+      room_exits = exits_by_from[r.id] || []
+
+      build_room_json(r, zp[0] + local_x, zp[1] + local_y, room_z, presence, room_exits,
+        reverse_exit_index, room_by_id, ghost_rooms, inbound_by_to[r.id] || []) do |exit_hash, e, to_room|
+        to_zone = to_room&.grid_zone
+        exit_hash[:cross_zone] = to_zone.present? && to_zone.id != r.grid_zone_id
+        exit_hash[:cross_region] = to_zone.present? && to_zone.grid_region_id != region.id
+      end.merge(
+        local_x: local_x, local_y: local_y,
+        zone_color: zone_color_map[r.grid_zone_id] || "#00ffff"
+      )
+    end
+
+    # Exits (only intra-region for connector rendering)
+    exits_json = all_exits.select { |e| region_room_id_set.include?(e.to_room_id) }.map do |e|
+      {id: e.id, from_room_id: e.from_room_id, to_room_id: e.to_room_id,
+       direction: e.direction, locked: e.locked?,
+       reverse_exit_id: reverse_exit_index[[e.from_room_id, e.to_room_id]]&.id}
+    end
+
+    # Zones with positions
+    room_counts_by_zone = rooms_by_zone.transform_values(&:size)
+    zones_json = zones.map do |z|
+      zp = zone_positions[z.id] || [0, 0]
+      {id: z.id, name: z.name, slug: z.slug, danger_level: z.danger_level,
+       map_x: zp[0], map_y: zp[1],
+       color: zone_color_map[z.id] || "#00ffff",
+       room_count: room_counts_by_zone[z.id] || 0}
+    end
+
+    available_zones = all_zones_sorted.map { |z| {id: z.id, name: z.name, region_name: z.grid_region.name} }
+    available_regions = GridRegion.order(:name).map { |r| {id: r.id, name: r.name, slug: r.slug} }
+
+    render json: {
+      region: {id: region.id, name: region.name, slug: region.slug},
+      zones: zones_json,
+      z_level: 0,
+      z_levels: z_levels,
+      rooms: rooms_json,
+      exits: exits_json,
+      ghost_rooms: ghost_data,
+      vertical_rooms: [],
+      breach_templates: GridBreachTemplate.published.ordered.map { |t|
+        {id: t.id, name: t.name, slug: t.slug, tier: t.tier, min_clearance: t.min_clearance}
+      },
+      available_zones: available_zones,
+      available_regions: available_regions,
+      all_rooms_grouped: build_all_rooms_grouped
+    }
   end
 
   # GET /root/grid_map_editor/:zone_id/data?z=0&all_z=true
   def data
     zone = GridZone.find(params[:zone_id])
-    z_level = params[:z].to_i
-    all_z = ActiveModel::Type::Boolean.new.cast(params[:all_z])
     all_zone_rooms = zone.grid_rooms.includes(:grid_zone).to_a
     all_zone_room_ids = all_zone_rooms.map(&:id)
 
     all_exits = GridExit.where(from_room_id: all_zone_room_ids)
       .includes(to_room: {grid_zone: :grid_region}).to_a
 
-    # Compute BFS positions for rooms without stored coords (on z=0 plane)
-    bfs_positions = compute_bfs_positions(all_zone_rooms, all_exits)
+    # Always compute positions and z-levels from exit topology
+    positions = bfs_positions(all_zone_rooms, all_exits)
+    z_levels_map = compute_z_levels(all_zone_rooms, all_exits)
 
     # Discover z-levels present in this zone
-    z_levels = all_zone_rooms.map(&:map_z).uniq.sort
+    z_levels = z_levels_map.values.uniq.sort
     z_levels = [0] if z_levels.empty?
+
+    z_level = params[:z].to_i
+    all_z = ActiveModel::Type::Boolean.new.cast(params[:all_z])
 
     # Snap to first available z-level if requested level has no rooms
     z_level = z_levels.first unless z_levels.include?(z_level)
 
     # In all_z mode, include every room; otherwise filter to requested z-level
-    rooms = all_z ? all_zone_rooms : all_zone_rooms.select { |r| r.map_z == z_level }
+    rooms = if all_z
+      all_zone_rooms
+    else
+      all_zone_rooms.select { |r| (z_levels_map[r.id] || 0) == z_level }
+    end
     room_ids = rooms.map(&:id)
+    room_id_set = Set.new(room_ids)
 
     z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
-    outbound_vertical = all_exits.select { |e| room_ids.include?(e.from_room_id) && z_directions.key?(e.direction) }
+    outbound_vertical = all_exits.select { |e| room_id_set.include?(e.from_room_id) && z_directions.key?(e.direction) }
 
     same_zone_ids = Set.new(all_zone_room_ids)
 
     if all_z
-      # In all_z mode, vertical rooms are CROSS-ZONE rooms connected via up/down
       cross_zone_vertical_ids = Set.new
       outbound_vertical.each { |e| cross_zone_vertical_ids.add(e.to_room_id) unless same_zone_ids.include?(e.to_room_id) }
-      # Also check inbound: other-zone rooms with up/down exits pointing into this zone
       inbound_vertical_exits = GridExit.where(to_room_id: room_ids, direction: %w[up down])
         .where.not(from_room_id: room_ids).to_a
       cross_zone_vertical_ids.merge(inbound_vertical_exits.map(&:from_room_id))
@@ -57,62 +188,41 @@ class Admin::GridMapEditorController < Admin::ApplicationController
         .includes(grid_zone: :grid_region).to_a
       inbound_vertical = inbound_vertical_exits
     else
-      other_z_room_ids = all_zone_rooms.reject { |r| r.map_z == z_level }.map(&:id)
-      inbound_vertical = all_exits.select { |e| other_z_room_ids.include?(e.from_room_id) && room_ids.include?(e.to_room_id) && z_directions.key?(e.direction) }
+      other_z_room_ids = all_zone_rooms.reject { |r| (z_levels_map[r.id] || 0) == z_level }.map(&:id)
+      other_z_set = Set.new(other_z_room_ids)
+      inbound_vertical = all_exits.select { |e| other_z_set.include?(e.from_room_id) && room_id_set.include?(e.to_room_id) && z_directions.key?(e.direction) }
       vertical_room_ids = Set.new
       outbound_vertical.each { |e| vertical_room_ids.add(e.to_room_id) }
       inbound_vertical.each { |e| vertical_room_ids.add(e.from_room_id) }
-      vertical_rooms = all_zone_rooms.select { |r| vertical_room_ids.include?(r.id) && r.map_z != z_level }
+      vertical_rooms = all_zone_rooms.select { |r| vertical_room_ids.include?(r.id) && (z_levels_map[r.id] || 0) != z_level }
     end
 
-    exits = all_exits.select { |e| room_ids.include?(e.from_room_id) }
+    exits = all_exits.select { |e| room_id_set.include?(e.from_room_id) }
 
-    # Presence counts
-    hackr_counts = GridHackr.where(current_room_id: room_ids).group(:current_room_id).count
-    mob_data = GridMob.where(grid_room_id: room_ids).select(:id, :name, :mob_type, :description, :grid_room_id).to_a
-    item_counts = GridItem.where(room_id: room_ids, container_id: nil, equipped_slot: nil)
-      .group(:room_id).count
-    encounter_data = GridBreachEncounter.where(grid_room_id: room_ids)
-      .includes(:grid_breach_template).to_a
+    # Build indexes for O(1) lookups
+    exits_by_from = exits.group_by(&:from_room_id)
+    reverse_exit_index = exits.index_by { |e| [e.to_room_id, e.from_room_id] }
+    room_by_id = rooms.index_by(&:id)
+    presence = load_presence_data(room_ids)
 
-    # Ghost rooms: rooms in OTHER ZONES connected to this zone's rooms.
+    # Ghost rooms + inbound exits
     cross_exit_room_ids = exits
-      .reject { |e| room_ids.include?(e.to_room_id) || same_zone_ids.include?(e.to_room_id) }
+      .reject { |e| room_id_set.include?(e.to_room_id) || same_zone_ids.include?(e.to_room_id) }
       .map(&:to_room_id).uniq
     ghost_rooms = GridRoom.where(id: cross_exit_room_ids)
       .includes(grid_zone: :grid_region).index_by(&:id)
 
-    # Reverse exits pointing into this zone (from ghost rooms) — load before ghost_data to avoid N+1
     inbound_exits = GridExit.where(from_room_id: cross_exit_room_ids, to_room_id: room_ids)
       .includes(from_room: {grid_zone: :grid_region}).to_a
     inbound_index = inbound_exits.index_by { |e| [e.from_room_id, e.to_room_id] }
+    inbound_by_to = inbound_exits.group_by(&:to_room_id)
+    exits_by_to = exits.group_by(&:to_room_id)
 
-    # Build ghost room data with connection info
-    ghost_data = ghost_rooms.values.map do |gr|
-      connections = exits.select { |e| e.to_room_id == gr.id }.map do |e|
-        reverse = inbound_index[[gr.id, e.from_room_id]]
-        {exit_id: e.id, local_room_id: e.from_room_id, direction: e.direction,
-         reverse_exit_id: reverse&.id, reverse_direction: reverse&.direction}
-      end
-      {id: gr.id, name: gr.name, room_type: gr.room_type,
-       zone_name: gr.grid_zone.name, zone_id: gr.grid_zone_id,
-       region_name: gr.grid_zone.grid_region.name,
-       connected_via: connections}
-    end
+    ghost_data = build_ghost_json(ghost_rooms, exits_by_to, inbound_index)
 
-    # All rooms grouped for combobox (cross-zone/region exit creation)
-    all_rooms_grouped = build_all_rooms_grouped
-
-    # Breach templates for placement
-    breach_templates = GridBreachTemplate.published.ordered.map do |t|
-      {id: t.id, name: t.name, slug: t.slug, tier: t.tier, min_clearance: t.min_clearance}
-    end
-
-    # Available zones for navigation (also used for zone color derivation)
     all_zones = GridZone.includes(:grid_region).order("grid_regions.name, grid_zones.name").to_a
     available_zones = all_zones.map { |z| {id: z.id, name: z.name, region_name: z.grid_region.name} }
 
-    # Zone color — match world map's per-zone color assignment
     zone_index = all_zones.index { |z| z.id == zone.id } || 0
     zone_color = Grid::WorldMapBuilder::ZONE_COLORS[zone_index % Grid::WorldMapBuilder::ZONE_COLORS.length]
 
@@ -124,69 +234,40 @@ class Admin::GridMapEditorController < Admin::ApplicationController
       z_levels: z_levels,
       vertical_rooms: vertical_rooms.map { |r|
         connections = []
-        # Outbound: local room --up/down--> this vertical room
         outbound_vertical.select { |e| e.to_room_id == r.id }.each do |e|
           connections << {exit_id: e.id, local_room_id: e.from_room_id, direction: e.direction}
         end
-        # Inbound: this vertical room --up/down--> local room (reverse perspective)
         inbound_vertical.select { |e| e.from_room_id == r.id }.each do |e|
           reverse_dir = (e.direction == "up") ? "down" : "up"
           connections << {exit_id: e.id, local_room_id: e.to_room_id, direction: reverse_dir}
         end
-        {id: r.id, name: r.name, room_type: r.room_type, map_z: r.map_z,
+        {id: r.id, name: r.name, room_type: r.room_type, map_z: z_levels_map[r.id] || 0,
          zone_name: r.grid_zone&.name, zone_id: r.grid_zone_id,
          region_name: r.grid_zone&.grid_region&.name,
          connected_via: connections}
       },
       rooms: rooms.map { |r|
-        mobs = mob_data.select { |m| m.grid_room_id == r.id }
-        encounters = encounter_data.select { |e| e.grid_room_id == r.id }
-        room_exits = exits.select { |e| e.from_room_id == r.id }
-        # Include inbound exits from ghost rooms
-        inbound = inbound_exits.select { |e| e.to_room_id == r.id }
-        pos_source = r.map_x.nil? ? "computed" : "stored"
-        mx = r.map_x || bfs_positions.dig(r.id, 0) || 0
-        my = r.map_y || bfs_positions.dig(r.id, 1) || 0
+        pos = positions[r.id] || [0, 0]
+        room_exits = exits_by_from[r.id] || []
 
-        {id: r.id, name: r.name, slug: r.slug, description: r.description,
-         room_type: r.room_type, min_clearance: r.min_clearance,
-         locked: r.locked?, grid_zone_id: r.grid_zone_id,
-         map_x: mx, map_y: my, map_z: r.map_z, position_source: pos_source,
-         hackr_count: hackr_counts[r.id].to_i,
-         mob_count: mobs.size, item_count: item_counts[r.id].to_i,
-         mobs: mobs.map { |m| {id: m.id, name: m.name, mob_type: m.mob_type, description: m.description} },
-         encounters: encounters.map { |e|
-           {id: e.id, template_name: e.grid_breach_template.name,
-            template_id: e.grid_breach_template_id, state: e.state,
-            tier: e.grid_breach_template.tier}
-         },
-         exits: room_exits.map { |e|
-           reverse = exits.find { |r_ex| r_ex.from_room_id == e.to_room_id && r_ex.to_room_id == e.from_room_id }
-           to_room = rooms.find { |rm| rm.id == e.to_room_id } || ghost_rooms[e.to_room_id]
-           to_zone = to_room&.grid_zone
-           {id: e.id, direction: e.direction, to_room_id: e.to_room_id,
-            to_room_name: to_room&.name || "unknown",
-            to_zone_name: to_zone&.name,
-            locked: e.locked?, reverse_exit_id: reverse&.id,
-            cross_zone: to_zone.present? && to_zone.id != zone.id}
-         },
-         inbound_exits: inbound.map { |e|
-           {id: e.id, direction: e.direction, from_room_id: e.from_room_id,
-            from_room_name: e.from_room&.name || "unknown",
-            from_zone_name: e.from_room&.grid_zone&.name}
-         }}
+        build_room_json(r, pos[0], pos[1], z_levels_map[r.id] || 0, presence, room_exits,
+          reverse_exit_index, room_by_id, ghost_rooms, inbound_by_to[r.id] || []) do |exit_hash, _e, to_room|
+          to_zone = to_room&.grid_zone
+          exit_hash[:cross_zone] = to_zone.present? && to_zone.id != zone.id
+        end
       },
-      exits: exits.select { |e| room_ids.include?(e.to_room_id) }.map { |e|
-        reverse = exits.find { |r_ex| r_ex.from_room_id == e.to_room_id && r_ex.to_room_id == e.from_room_id }
+      exits: exits.select { |e| room_id_set.include?(e.to_room_id) }.map { |e|
         {id: e.id, from_room_id: e.from_room_id, to_room_id: e.to_room_id,
          direction: e.direction, locked: e.locked?,
-         reverse_exit_id: reverse&.id}
+         reverse_exit_id: reverse_exit_index[[e.from_room_id, e.to_room_id]]&.id}
       },
       ghost_rooms: ghost_data,
-      breach_templates: breach_templates,
+      breach_templates: GridBreachTemplate.published.ordered.map { |t|
+        {id: t.id, name: t.name, slug: t.slug, tier: t.tier, min_clearance: t.min_clearance}
+      },
       zone_color: zone_color,
       available_zones: available_zones,
-      all_rooms_grouped: all_rooms_grouped
+      all_rooms_grouped: build_all_rooms_grouped
     }
   end
 
@@ -199,10 +280,7 @@ class Admin::GridMapEditorController < Admin::ApplicationController
       description: params[:description],
       room_type: params[:room_type].presence,
       min_clearance: params[:min_clearance].to_i,
-      grid_zone_id: zone.id,
-      map_x: params[:map_x].to_i,
-      map_y: params[:map_y].to_i,
-      map_z: params[:map_z].to_i
+      grid_zone_id: zone.id
     )
 
     if room.save
@@ -223,9 +301,6 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     attrs[:min_clearance] = params[:min_clearance].to_i if params.key?(:min_clearance)
     attrs[:locked] = params[:locked] if params.key?(:locked)
     attrs[:grid_zone_id] = params[:grid_zone_id].presence&.to_i if params.key?(:grid_zone_id)
-    attrs[:map_x] = params[:map_x].to_i if params.key?(:map_x)
-    attrs[:map_y] = params[:map_y].to_i if params.key?(:map_y)
-    attrs[:map_z] = params[:map_z].to_i if params.key?(:map_z)
 
     if room.update(attrs)
       render json: {success: true}
@@ -421,38 +496,98 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     render json: {success: true}
   end
 
-  # POST /root/grid_map_editor/:zone_id/auto_layout
-  def auto_layout
-    zone = GridZone.find(params[:zone_id])
-    rooms = zone.grid_rooms.includes(:grid_zone).to_a
-    room_ids = rooms.map(&:id)
-    exits = GridExit.where(from_room_id: room_ids)
-      .includes(to_room: {grid_zone: :grid_region}).to_a
-
-    positions = compute_bfs_positions(rooms, exits)
-    z_levels = compute_z_levels(rooms, exits)
-
-    room_index = rooms.index_by(&:id)
-    count = 0
-    ActiveRecord::Base.transaction do
-      positions.each do |room_id, (x, y)|
-        room = room_index[room_id]
-        next unless room
-        z = z_levels[room_id] || 0
-        room.update!(map_x: x, map_y: y, map_z: z)
-        count += 1
-      end
-    end
-
-    render json: {success: true, updated: count}
-  end
-
   private
 
-  def compute_bfs_positions(rooms, exits)
-    return {} if rooms.empty?
-    bfs_positions(rooms, exits)
+  # ── Shared JSON builders ────────────────────────────────────
+
+  # Load presence counts for a set of room IDs, returns a struct-like hash.
+  def load_presence_data(room_ids)
+    {
+      hackr_counts: GridHackr.where(current_room_id: room_ids).group(:current_room_id).count,
+      mob_data: GridMob.where(grid_room_id: room_ids).select(:id, :name, :mob_type, :description, :grid_room_id).to_a
+        .group_by(&:grid_room_id),
+      item_counts: GridItem.where(room_id: room_ids, container_id: nil, equipped_slot: nil).group(:room_id).count,
+      encounter_data: GridBreachEncounter.where(grid_room_id: room_ids).includes(:grid_breach_template).to_a
+        .group_by(&:grid_room_id)
+    }
   end
+
+  # Load ghost rooms and inbound exits for cross-scope connections.
+  # Returns [ghost_rooms_hash, inbound_exits_array, inbound_index].
+  def load_ghost_data(exits, scope_room_id_set, scope_room_ids)
+    cross_exit_room_ids = exits
+      .reject { |e| scope_room_id_set.include?(e.to_room_id) }
+      .map(&:to_room_id).uniq
+    ghost_rooms = GridRoom.where(id: cross_exit_room_ids)
+      .includes(grid_zone: :grid_region).index_by(&:id)
+
+    inbound_exits = GridExit.where(from_room_id: cross_exit_room_ids, to_room_id: scope_room_ids)
+      .includes(from_room: {grid_zone: :grid_region}).to_a
+    inbound_index = inbound_exits.index_by { |e| [e.from_room_id, e.to_room_id] }
+
+    [ghost_rooms, inbound_exits, inbound_index]
+  end
+
+  # Build ghost room JSON from pre-indexed data.
+  def build_ghost_json(ghost_rooms, exits_by_to, inbound_index)
+    ghost_rooms.values.map do |gr|
+      connections = (exits_by_to[gr.id] || []).map do |e|
+        reverse = inbound_index[[gr.id, e.from_room_id]]
+        {exit_id: e.id, local_room_id: e.from_room_id, direction: e.direction,
+         reverse_exit_id: reverse&.id, reverse_direction: reverse&.direction}
+      end
+      {id: gr.id, name: gr.name, room_type: gr.room_type,
+       zone_name: gr.grid_zone.name, zone_id: gr.grid_zone_id,
+       region_name: gr.grid_zone.grid_region.name,
+       region_id: gr.grid_zone.grid_region_id,
+       connected_via: connections}
+    end
+  end
+
+  # Build room JSON hash with all nested data (exits, mobs, encounters).
+  # Accepts a block to add scope-specific exit fields (cross_zone, cross_region).
+  def build_room_json(room, map_x, map_y, map_z, presence, room_exits,
+    reverse_exit_index, room_by_id, ghost_rooms, inbound_for_room)
+    mobs = presence[:mob_data][room.id] || []
+    encounters = presence[:encounter_data][room.id] || []
+
+    {id: room.id, name: room.name, slug: room.slug, description: room.description,
+     room_type: room.room_type, min_clearance: room.min_clearance,
+     locked: room.locked?, grid_zone_id: room.grid_zone_id,
+     map_x: map_x, map_y: map_y, map_z: map_z,
+     hackr_count: presence[:hackr_counts][room.id].to_i,
+     mob_count: mobs.size, item_count: presence[:item_counts][room.id].to_i,
+     mobs: mobs.map { |m| {id: m.id, name: m.name, mob_type: m.mob_type, description: m.description} },
+     encounters: encounters.map { |e|
+       {id: e.id, template_name: e.grid_breach_template.name,
+        template_id: e.grid_breach_template_id, state: e.state,
+        tier: e.grid_breach_template.tier}
+     },
+     exits: room_exits.map { |e|
+       reverse = reverse_exit_index[[e.from_room_id, e.to_room_id]]
+       to_room = room_by_id[e.to_room_id] || ghost_rooms[e.to_room_id]
+       to_zone = to_room&.grid_zone
+       exit_hash = {id: e.id, direction: e.direction, to_room_id: e.to_room_id,
+        to_room_name: to_room&.name || "unknown",
+        to_zone_name: to_zone&.name,
+        locked: e.locked?, reverse_exit_id: reverse&.id}
+       yield(exit_hash, e, to_room) if block_given?
+       exit_hash
+     },
+     inbound_exits: inbound_for_room.map { |e|
+       {id: e.id, direction: e.direction, from_room_id: e.from_room_id,
+        from_room_name: e.from_room&.name || "unknown",
+        from_zone_name: e.from_room&.grid_zone&.name}
+     }}
+  end
+
+  # Build zone color map from global zone ordering (consistent with world map).
+  def build_zone_color_map
+    all_zones = GridZone.includes(:grid_region).order("grid_regions.name, grid_zones.name").to_a
+    all_zones.each_with_index.to_h { |z, i| [z.id, Grid::WorldMapBuilder::ZONE_COLORS[i % Grid::WorldMapBuilder::ZONE_COLORS.length]] }
+  end
+
+  # ── BFS algorithms ──────────────────────────────────────────
 
   # Compute z-level for each room by walking up/down exits from z=0 seed.
   def compute_z_levels(rooms, exits)
@@ -460,15 +595,12 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     room_ids = Set.new(rooms.map(&:id))
     exits_by_from = exits.group_by(&:from_room_id)
 
-    # Seed: same priority as BFS
     seed = rooms.find { |r| r.room_type == "hub" } ||
       rooms.find { |r| r.room_type == "special" } ||
       rooms.find { |r| r.room_type == "transit" } ||
       rooms.min_by(&:id)
     return {} unless seed
 
-    # BFS: walk horizontal exits to find all rooms reachable on z=0,
-    # then follow up/down exits to discover other z-levels
     levels = {seed.id => 0}
     queue = [seed.id]
     visited = Set.new([seed.id])
@@ -486,12 +618,13 @@ class Admin::GridMapEditorController < Admin::ApplicationController
       end
     end
 
-    # Any unvisited rooms default to z=0
     rooms.each { |r| levels[r.id] ||= 0 }
     levels
   end
 
   def bfs_positions(rooms, exits)
+    return {} if rooms.empty?
+
     room_index = rooms.index_by(&:id)
     room_ids = Set.new(rooms.map(&:id))
     exits_by_from = exits.group_by(&:from_room_id)
@@ -503,7 +636,6 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     occupied = {}
     remaining = Set.new(room_ids)
 
-    # Pick seed: hub > special > transit > min id
     seed = rooms.find { |r| r.room_type == "hub" } ||
       rooms.find { |r| r.room_type == "special" } ||
       rooms.find { |r| r.room_type == "transit" } ||
@@ -519,7 +651,6 @@ class Admin::GridMapEditorController < Admin::ApplicationController
         rid, lx, ly = item
 
         if occupied[[lx, ly]] && occupied[[lx, ly]] != rid
-          # Find free cell
           placed = false
           (1..10).each do |radius|
             break if placed
@@ -566,6 +697,8 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     positions
   end
 
+  # ── Misc helpers ────────────────────────────────────────────
+
   def deletion_blockers(room)
     blockers = []
     hackr_count = room.grid_hackrs.count
@@ -580,7 +713,6 @@ class Admin::GridMapEditorController < Admin::ApplicationController
     encounter_count = room.grid_breach_encounters.count
     blockers << "#{encounter_count} breach encounter(s) placed" if encounter_count > 0
 
-    # Region special room references
     region_refs = []
     region_refs << "hospital" if GridRegion.where(hospital_room_id: room.id).exists?
     region_refs << "containment" if GridRegion.where(containment_room_id: room.id).exists?
@@ -600,5 +732,97 @@ class Admin::GridMapEditorController < Admin::ApplicationController
         }}
       }}
     end
+  end
+
+  # BFS over zones using cross-zone exits as edges to compute zone positions.
+  # Uses zone bounding boxes for tight spacing instead of fixed stride.
+  # Handles disconnected clusters: each connected component gets BFS-positioned
+  # internally, then clusters stack below each other.
+  def compute_zone_bfs_positions(zones, rooms, exits, zone_bboxes = {})
+    zone_gap = 3
+
+    zone_of = rooms.index_by(&:id).transform_values(&:grid_zone_id)
+    zone_ids = Set.new(zones.map(&:id))
+
+    zone_connections = Hash.new { |h, k| h[k] = [] }
+    exits.each do |ex|
+      from_zone = zone_of[ex.from_room_id]
+      to_zone = zone_of[ex.to_room_id]
+      next unless from_zone && to_zone && from_zone != to_zone
+      next unless zone_ids.include?(to_zone)
+      direction_vec = Grid::WorldMapBuilder::DIRECTION_VECTORS[ex.direction]
+      next unless direction_vec
+      zone_connections[from_zone] << {to: to_zone, vec: direction_vec}
+    end
+
+    positions = {}
+    remaining = Set.new(zones.map(&:id))
+    zone_room_counts = rooms.group_by(&:grid_zone_id).transform_values(&:count)
+    cluster_offset_y = 0
+
+    # Process each connected component
+    while remaining.any?
+      # Pick seed: largest unplaced zone
+      seed_id = remaining.max_by { |zid| zone_room_counts[zid] || 0 }
+
+      # BFS this cluster
+      cluster_positions = {}
+      cluster_positions[seed_id] = [0, 0]
+      cluster_occupied = Set.new([[0, 0]])
+      queue = [seed_id]
+      remaining.delete(seed_id)
+
+      while (zid = queue.shift)
+        zx, zy = cluster_positions[zid]
+        src_bb = zone_bboxes[zid] || {width: 4, height: 4}
+
+        zone_connections[zid].each do |conn|
+          next unless remaining.include?(conn[:to])
+          remaining.delete(conn[:to])
+
+          tgt_bb = zone_bboxes[conn[:to]] || {width: 4, height: 4}
+          dx, dy = conn[:vec]
+
+          offset_x = if dx > 0 then src_bb[:width] + zone_gap + 1
+                     elsif dx < 0 then -(tgt_bb[:width] + zone_gap + 1)
+                     else 0
+                     end
+          offset_y = if dy > 0 then src_bb[:height] + zone_gap + 1
+                     elsif dy < 0 then -(tgt_bb[:height] + zone_gap + 1)
+                     else 0
+                     end
+
+          new_zx = zx + offset_x
+          new_zy = zy + offset_y
+
+          nudge_step = [tgt_bb[:height] + zone_gap + 1, zone_gap + 1].max
+          safety = 0
+          while cluster_occupied.include?([new_zx, new_zy]) && safety < 50
+            new_zy += nudge_step
+            safety += 1
+          end
+
+          cluster_positions[conn[:to]] = [new_zx, new_zy]
+          cluster_occupied.add([new_zx, new_zy])
+          queue << conn[:to]
+        end
+      end
+
+      # Normalize cluster to (0, 0) origin, then offset below previous clusters
+      if cluster_positions.any?
+        min_x = cluster_positions.values.map(&:first).min
+        min_y = cluster_positions.values.map(&:last).min
+        cluster_positions.transform_values! { |pos| [pos[0] - min_x, pos[1] - min_y + cluster_offset_y] }
+
+        cluster_bottom = cluster_positions.map { |zid, pos|
+          pos[1] + (zone_bboxes[zid] || {height: 0})[:height]
+        }.max
+
+        positions.merge!(cluster_positions)
+        cluster_offset_y = cluster_bottom + zone_gap + 1
+      end
+    end
+
+    positions
   end
 end

--- a/app/controllers/admin/grid_map_editor_controller.rb
+++ b/app/controllers/admin/grid_map_editor_controller.rb
@@ -567,10 +567,12 @@ class Admin::GridMapEditorController < Admin::ApplicationController
        reverse = reverse_exit_index[[e.from_room_id, e.to_room_id]]
        to_room = room_by_id[e.to_room_id] || ghost_rooms[e.to_room_id]
        to_zone = to_room&.grid_zone
-       exit_hash = {id: e.id, direction: e.direction, to_room_id: e.to_room_id,
-        to_room_name: to_room&.name || "unknown",
-        to_zone_name: to_zone&.name,
-        locked: e.locked?, reverse_exit_id: reverse&.id}
+       exit_hash = {
+         id: e.id, direction: e.direction, to_room_id: e.to_room_id,
+         to_room_name: to_room&.name || "unknown",
+         to_zone_name: to_zone&.name,
+         locked: e.locked?, reverse_exit_id: reverse&.id
+       }
        yield(exit_hash, e, to_room) if block_given?
        exit_hash
      },
@@ -783,14 +785,20 @@ class Admin::GridMapEditorController < Admin::ApplicationController
           tgt_bb = zone_bboxes[conn[:to]] || {width: 4, height: 4}
           dx, dy = conn[:vec]
 
-          offset_x = if dx > 0 then src_bb[:width] + zone_gap + 1
-                     elsif dx < 0 then -(tgt_bb[:width] + zone_gap + 1)
-                     else 0
-                     end
-          offset_y = if dy > 0 then src_bb[:height] + zone_gap + 1
-                     elsif dy < 0 then -(tgt_bb[:height] + zone_gap + 1)
-                     else 0
-                     end
+          offset_x = if dx > 0
+            src_bb[:width] + zone_gap + 1
+          elsif dx < 0
+            -(tgt_bb[:width] + zone_gap + 1)
+          else
+            0
+          end
+          offset_y = if dy > 0
+            src_bb[:height] + zone_gap + 1
+          elsif dy < 0
+            -(tgt_bb[:height] + zone_gap + 1)
+          else
+            0
+          end
 
           new_zx = zx + offset_x
           new_zy = zy + offset_y

--- a/app/controllers/admin/grid_mobs_controller.rb
+++ b/app/controllers/admin/grid_mobs_controller.rb
@@ -79,7 +79,7 @@ class Admin::GridMobsController < Admin::ApplicationController
   end
 
   def load_selects
-    @rooms = GridRoom.includes(:grid_zone).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
+    @rooms = GridRoom.includes(grid_zone: :grid_region).joins(:grid_zone).order("grid_zones.name, grid_rooms.name")
     @factions = GridFaction.ordered
   end
 

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -6,9 +6,6 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
-#  map_x               :integer
-#  map_y               :integer
-#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string           default("standard"), not null

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -134,13 +134,9 @@ module Grid
         .where.not(room_type: "den")
         .order("grid_regions.name, grid_zones.name, grid_rooms.name")
         .references(:grid_zone, :grid_region).map do |r|
-        h = {"slug" => r.slug, "name" => r.name, "description" => r.description,
-             "zone_slug" => r.grid_zone.slug, "room_type" => r.room_type,
-             "min_clearance" => r.min_clearance}
-        h["map_x"] = r.map_x unless r.map_x.nil?
-        h["map_y"] = r.map_y unless r.map_y.nil?
-        h["map_z"] = r.map_z if r.map_z != 0
-        h.compact
+        {"slug" => r.slug, "name" => r.name, "description" => r.description,
+         "zone_slug" => r.grid_zone.slug, "room_type" => r.room_type,
+         "min_clearance" => r.min_clearance}.compact
       end
       write_yaml("rooms.yml", {"rooms" => rooms})
     end

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -1,38 +1,50 @@
-<% content_for(:title) { "/root :: Map Editor :: #{@zone.name}" } %>
+<% content_for(:title) { "/root :: Map Editor :: #{@scope == 'region' ? @region.name : @zone.name}" } %>
 <%= render "admin/shared/combobox" %>
 
-<div class="tui-window white-text admin-panel" style="display: block; max-width: 100%; margin: 10px; padding: 10px;">
-  <fieldset class="admin-panel-border">
-    <legend class="center">/root/grid/map-editor/<%= @zone.slug %></legend>
+<div class="tui-window white-text admin-panel" style="display: flex; flex-direction: column; max-width: 100%; margin: 10px; padding: 10px; height: calc(100vh - 85px); overflow: hidden;">
+  <fieldset class="admin-panel-border" style="display: flex; flex-direction: column; flex: 1; min-height: 0;">
+    <legend class="center">/root/grid/map-editor/<%= @scope == 'region' ? "region/#{@region.slug}" : @zone.slug %></legend>
 
-    <div style="padding: 10px;">
+    <div style="padding: 10px; display: flex; flex-direction: column; flex: 1; min-height: 0;">
       <%# Toolbar %>
       <div id="me-toolbar" style="display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; align-items: center;">
-        <%= link_to "<- Zones", admin_grid_zones_path, class: "tui-button", style: "padding: 4px 12px; font-size: 0.85em;" %>
+        <%= link_to "<- Regions", admin_grid_regions_path, class: "tui-button", style: "padding: 4px 12px; font-size: 0.85em;" %>
 
-        <label style="color: #888; font-size: 0.85em;">Zone:</label>
-        <div style="min-width: 280px; max-width: 350px; position: relative;" class="admin-combobox">
-          <input type="text" id="me-zone-input" class="admin-combobox-input selected" style="padding: 4px 8px; font-size: 0.85em;" autocomplete="off" placeholder="Search zones..." value="<%= @zone.grid_region.name %> / <%= @zone.name %>" />
-          <input type="hidden" id="me-zone-hidden" value="<%= @zone.id %>" />
+        <button id="me-scope-region" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">Region</button>
+        <button id="me-scope-zone" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">Zone</button>
+        <span style="color: #333; margin: 0 2px;">|</span>
+
+        <%# Region picker (shown in region scope) %>
+        <div id="me-region-picker" style="min-width: 200px; max-width: 280px; position: relative;" class="admin-combobox">
+          <input type="text" id="me-region-input" class="admin-combobox-input" style="padding: 4px 8px; font-size: 0.85em;" autocomplete="off" placeholder="Search regions..." value="<%= @region.name %>" />
+          <input type="hidden" id="me-region-hidden" value="<%= @region.id %>" />
+          <div id="me-region-dropdown" class="admin-combobox-dropdown"></div>
+          <div id="me-region-status" style="display: none;"></div>
+        </div>
+
+        <label id="me-zone-label" style="color: #888; font-size: 0.85em;">Zone:</label>
+        <div id="me-zone-picker" style="min-width: 280px; max-width: 350px; position: relative;" class="admin-combobox">
+          <input type="text" id="me-zone-input" class="admin-combobox-input selected" style="padding: 4px 8px; font-size: 0.85em;" autocomplete="off" placeholder="Search zones..." value="<%= @scope == 'zone' ? "#{@zone.grid_region.name} / #{@zone.name}" : '' %>" />
+          <input type="hidden" id="me-zone-hidden" value="<%= @scope == 'zone' ? @zone.id : '' %>" />
           <div id="me-zone-dropdown" class="admin-combobox-dropdown"></div>
           <div id="me-zone-status" style="display: none;"></div>
         </div>
 
-        <button id="me-auto-layout" class="tui-button cyan-168" style="padding: 4px 12px; font-size: 0.85em;">Auto Layout</button>
+        <button id="me-reset-layout" class="tui-button cyan-168" style="padding: 4px 12px; font-size: 0.85em;">Reset Layout</button>
         <button id="me-zoom-in" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">+</button>
         <button id="me-zoom-out" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">-</button>
         <button id="me-zoom-reset" class="tui-button" style="padding: 4px 10px; font-size: 0.85em;">1:1</button>
         <span style="color: #333; margin: 0 4px;">|</span>
         <span id="me-z-buttons" style="display: inline-flex; gap: 4px; align-items: center;"></span>
         <span style="color: #333; margin: 0 4px;">|</span>
-        <button id="me-25d-toggle" class="tui-button" style="padding: 4px 12px; font-size: 0.85em;">2.5D</button>
+        <button id="me-25d-toggle" class="tui-button cyan-168" style="padding: 4px 12px; font-size: 0.85em;">2D</button>
         <span style="color: #333; margin: 0 4px;">|</span>
         <%= link_to "Export World", admin_grid_world_export_path, class: "tui-button green-168", style: "padding: 4px 12px; font-size: 0.85em;" %>
         <span id="me-status" style="color: #666; font-size: 0.85em; margin-left: auto;"></span>
       </div>
 
       <%# Main layout: map + side panel %>
-      <div id="me-layout" style="display: flex; gap: 0; border: 1px solid #333; background: #0d0d0d; height: 80vh;">
+      <div id="me-layout" style="display: flex; gap: 0; border: 1px solid #333; background: #0d0d0d; flex: 1; min-height: 0;">
         <%# SVG Canvas %>
         <div id="me-canvas-wrap" style="flex: 1; overflow: auto; position: relative; height: 100%; cursor: crosshair;">
           <svg id="me-svg" xmlns="http://www.w3.org/2000/svg" style="display: block;"></svg>
@@ -50,9 +62,11 @@
           Click room to edit ·
           Double-click empty space to create room ·
           Drag room to move ·
+          Drag background to pan ·
           Drag from <span style="color: #00ffff;">port dot</span> to draw exit ·
           Click connector to edit/delete ·
-          <span style="color: #555; opacity: 0.6;">Ghost</span>=cross-zone room ·
+          <span id="me-legend-ghost" style="color: #555; opacity: 0.6;">Ghost</span>=<span id="me-legend-ghost-desc">cross-zone room</span> ·
+          <span id="me-legend-zone-drag" style="display: none;">Drag zone label to reposition cluster ·</span>
           Esc to deselect
         </span>
       </div>
@@ -122,6 +136,10 @@
       <option value="sally_port">Sally Port</option>
     </select>
   </div>
+  <div id="me-room-zone-wrap" style="margin-bottom: 10px; display: none;">
+    <label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">ZONE:</label>
+    <select id="me-room-zone-select" class="tui-input" style="width: 100%; padding: 6px;"></select>
+  </div>
   <div style="display: flex; gap: 10px;">
     <button id="me-room-confirm" class="tui-button green-168" style="padding: 6px 16px;">Create</button>
     <button id="me-room-cancel" class="tui-button" style="padding: 6px 16px;">Cancel</button>
@@ -144,7 +162,7 @@
 
   // ── 2.5D Isometric constants ──────────────────────────────
   var ISO_TILE_W = 160, ISO_TILE_H = 80;
-  var ISO_WALL_H = 22;
+  var ISO_WALL_H = 32;
   var ISO_Z_SPACING = 120;
   var ISO_FADED_OPACITY = 0.3;
 
@@ -176,16 +194,22 @@
   };
 
   // ── State ──────────────────────────────────────────────────
-  var zoneId = <%= @zone.id %>;
+  var scope = '<%= @scope %>';
+  var zoneId = <%= @scope == 'zone' ? @zone.id : 'null' %>;
+  var regionId = <%= @region.id %>;
   var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-  var state = {rooms: [], exits: [], ghostRooms: [], breachTemplates: [], allRoomsGrouped: [], zone: null, zoneColor: '#00ffff'};
+  var state = {rooms: [], exits: [], ghostRooms: [], zones: [], region: null, breachTemplates: [], allRoomsGrouped: [], zone: null, zoneColor: '#00ffff'};
   var selectedRoomId = null;
   var _panelZoneUid = null;
-  var zoomLevel = 1.0;
+  var zoomLevel = 1.25;
   var currentZ = 0;
-  var mode25D = false;
-  var dragState = null; // {type: 'room'|'port', roomId, startX, startY, origX, origY}
+  var mode25D = true;
+  var dragState = null; // {type: 'room'|'port'|'zone'|'pan', roomId, startX, startY, origX, origY}
   var drawLine = null;
+  var PAN_THRESHOLD = 5;
+  var isoPanX = 0, isoPanY = 0; // viewBox pan offset for 2.5D mode
+  var _isoContentCX = 0, _isoContentCY = 0; // content center from last render (for pan)
+  var _pendingCenterZoneId = null; // set before loadData to center on a zone after render
 
   // ── DOM refs ───────────────────────────────────────────────
   var svg = document.getElementById('me-svg');
@@ -214,30 +238,100 @@
   function setStatus(msg) { statusEl.textContent = msg; }
 
   function navigateToZone(newZoneId) {
+    scope = 'zone';
     zoneId = newZoneId;
     currentZ = 0;
+    isoPanX = 0; isoPanY = 0;
+    _pendingCenterZoneId = null;
     selectedRoomId = null;
     closePanel();
     window.history.replaceState(null, '', '/root/grid_map_editor/' + zoneId);
+    updateScopeUI();
     loadData();
+  }
+
+  function navigateToRegion(newRegionId, centerZoneId) {
+    scope = 'region';
+    regionId = newRegionId;
+    zoneId = null;
+    currentZ = 0;
+    isoPanX = 0; isoPanY = 0;
+    _pendingCenterZoneId = centerZoneId || null;
+    selectedRoomId = null;
+    closePanel();
+    window.history.replaceState(null, '', '/root/grid_map_editor/region/' + regionId);
+    updateScopeUI();
+    loadData();
+  }
+
+  // Center the viewport on a specific zone's rooms
+  function centerOnZone(targetZoneId) {
+    var zoneRooms = state.rooms.filter(function(r) { return r.grid_zone_id === targetZoneId; });
+    if (zoneRooms.length === 0) return;
+
+    if (mode25D) {
+      // Compute screen-space center of target zone's rooms
+      var sumX = 0, sumY = 0;
+      zoneRooms.forEach(function(r) {
+        var p = iso(r.map_x, r.map_y, r.map_z || 0);
+        sumX += p[0]; sumY += p[1];
+      });
+      var zoneCX = sumX / zoneRooms.length;
+      var zoneCY = sumY / zoneRooms.length;
+      isoPanX = zoneCX - _isoContentCX;
+      isoPanY = zoneCY - _isoContentCY;
+      // Re-apply viewBox with new pan offset
+      var vb = svg.getAttribute('viewBox');
+      if (vb) {
+        var parts = vb.split(' ');
+        var vbW = parseFloat(parts[2]), vbH = parseFloat(parts[3]);
+        svg.setAttribute('viewBox', (_isoContentCX - vbW / 2 + isoPanX) + ' ' + (_isoContentCY - vbH / 2 + isoPanY) + ' ' + vbW + ' ' + vbH);
+      }
+    } else {
+      // Flat mode: scroll to center of target zone's rooms
+      var sumGX = 0, sumGY = 0;
+      zoneRooms.forEach(function(r) { sumGX += r.map_x; sumGY += r.map_y; });
+      var cx = (sumGX / zoneRooms.length) * STRIDE_X;
+      var cy = (sumGY / zoneRooms.length) * STRIDE_Y;
+      canvasWrap.scrollLeft = cx + PADDING - canvasWrap.clientWidth / 2;
+      canvasWrap.scrollTop = cy + PADDING - canvasWrap.clientHeight / 2;
+    }
   }
 
   // ── Data loading ───────────────────────────────────────────
   function loadData() {
     setStatus('Loading...');
-    var dataUrl = zoneId + '/data?z=' + currentZ + (mode25D ? '&all_z=true' : '');
+    var dataUrl;
+    if (scope === 'region') {
+      dataUrl = 'region/' + regionId + '/data';
+    } else {
+      dataUrl = zoneId + '/data?z=' + currentZ + (mode25D ? '&all_z=true' : '');
+    }
     api('GET', dataUrl).then(function(d) {
       state = d;
-      currentZ = d.z_level || 0;
+      if (scope === 'region') {
+        currentZ = 0;
+        // Derive regionId from response
+        if (d.region) regionId = d.region.id;
+      } else {
+        currentZ = d.z_level || 0;
+      }
       // If no rooms exist at currentZ, snap to first available z-level
       var zLevels = state.z_levels || [0];
       if (zLevels.indexOf(currentZ) === -1 && zLevels.length > 0) {
         currentZ = zLevels[0];
       }
+      populateRegionSelect();
       populateZoneSelect();
+      syncRegionCombobox();
       syncZoneCombobox();
       renderZButtons();
       if (mode25D) render25D(); else render();
+      // Center on a specific zone if requested
+      if (_pendingCenterZoneId && scope === 'region') {
+        centerOnZone(_pendingCenterZoneId);
+        _pendingCenterZoneId = null;
+      }
       // Re-open panel if a room was selected and still exists
       if (selectedRoomId !== null) {
         var still = state.rooms.find(function(r) { return r.id === selectedRoomId; });
@@ -245,7 +339,9 @@
         else { selectedRoomId = null; closePanel(); }
       }
       var zLabel = currentZ === 0 ? 'z=0' : (currentZ > 0 ? 'z+' + currentZ : 'z' + currentZ);
-      setStatus(state.rooms.length + ' rooms · ' + state.exits.length + ' exits · ' + zLabel);
+      var scopeLabel = scope === 'region' ? ('Region: ' + (state.region ? state.region.name : '')) : '';
+      var zoneCount = scope === 'region' ? ((state.zones || []).length + ' zones · ') : '';
+      setStatus(zoneCount + state.rooms.length + ' rooms · ' + state.exits.length + ' exits' + (scopeLabel ? ' · ' + scopeLabel : ' · ' + zLabel));
     });
   }
 
@@ -275,13 +371,48 @@
   function syncZoneCombobox() {
     var input = document.getElementById('me-zone-input');
     var hidden = document.getElementById('me-zone-hidden');
-    var cur = (state.available_zones || []).find(function(z) { return z.id === zoneId; });
+    if (scope === 'zone' && zoneId) {
+      var cur = (state.available_zones || []).find(function(z) { return z.id === zoneId; });
+      if (cur) {
+        input.value = cur.region_name + ' / ' + cur.name;
+        input.classList.add('selected');
+      }
+      // Set via property directly to avoid triggering the navigation hook
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(hidden, String(zoneId));
+    }
+  }
+
+  var _regionComboboxInited = false;
+  function populateRegionSelect() {
+    if (_regionComboboxInited) return;
+    var regions = state.available_regions || [];
+    if (regions.length === 0) return;
+    _regionComboboxInited = true;
+    AdminCombobox.init({
+      inputId: 'me-region-input',
+      hiddenId: 'me-region-hidden',
+      dropdownId: 'me-region-dropdown',
+      statusId: 'me-region-status',
+      items: regions,
+      getSearchText: function(r) { return (r.name + ' ' + r.slug).toLowerCase(); },
+      getGroupKey: function() { return 'Regions'; },
+      renderOption: function(r, e) { return '<span class="cb-name">' + e(r.name) + '</span>'; },
+      getId: function(r) { return String(r.id); },
+      getLabel: function(r) { return r.name; },
+      emptyText: 'No regions match',
+      selectedText: 'Region selected'
+    });
+  }
+
+  function syncRegionCombobox() {
+    var input = document.getElementById('me-region-input');
+    var hidden = document.getElementById('me-region-hidden');
+    var cur = (state.available_regions || []).find(function(r) { return r.id === regionId; });
     if (cur) {
-      input.value = cur.region_name + ' / ' + cur.name;
+      input.value = cur.name;
       input.classList.add('selected');
     }
-    // Set via property directly to avoid triggering the navigation hook
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(hidden, String(zoneId));
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(hidden, String(regionId));
   }
 
   function renderZButtons() {
@@ -319,12 +450,71 @@
         desc.set.call(this, v);
         var newId = parseInt(v);
         if (newId && newId !== zoneId) {
-          navigateToZone(newId);
+          if (scope === 'zone') {
+            navigateToZone(newId);
+          } else {
+            // In region scope, zone picker tracks "active zone for room creation"
+            zoneId = newId;
+          }
         }
       },
       get: desc.get
     });
   })();
+
+  // Intercept region combobox selection
+  (function() {
+    var regionHidden = document.getElementById('me-region-hidden');
+    var desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+    Object.defineProperty(regionHidden, 'value', {
+      set: function(v) {
+        desc.set.call(this, v);
+        var newId = parseInt(v);
+        if (newId && newId !== regionId) {
+          navigateToRegion(newId);
+        }
+      },
+      get: desc.get
+    });
+  })();
+
+  // ── Zone background rendering (region scope) ───────────────
+  function renderZoneBackgrounds() {
+    var zones = state.zones || [];
+    zones.forEach(function(zone) {
+      var zoneRooms = state.rooms.filter(function(r) { return r.grid_zone_id === zone.id; });
+      if (zoneRooms.length === 0) return;
+      var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      zoneRooms.forEach(function(r) {
+        if (r.map_x < minX) minX = r.map_x;
+        if (r.map_y < minY) minY = r.map_y;
+        if (r.map_x > maxX) maxX = r.map_x;
+        if (r.map_y > maxY) maxY = r.map_y;
+      });
+      var ZONE_PAD = 35;
+      var svgX = minX * STRIDE_X - BOX_W/2 - ZONE_PAD;
+      var svgY = minY * STRIDE_Y - BOX_H/2 - ZONE_PAD;
+      var svgW = (maxX - minX) * STRIDE_X + BOX_W + ZONE_PAD * 2;
+      var svgH = (maxY - minY) * STRIDE_Y + BOX_H + ZONE_PAD * 2;
+      var color = zone.color || '#333';
+
+      var bg = el('rect', {x: svgX, y: svgY, width: svgW, height: svgH,
+        fill: 'transparent', stroke: color, 'stroke-width': 1,
+        opacity: 0.2, rx: 6, 'stroke-dasharray': '8,4',
+        class: 'me-zone-bg', 'data-zone-id': zone.id});
+      svg.appendChild(bg);
+
+      // Zone label — draggable for repositioning
+      var labelEl = el('text', {x: svgX + 8, y: svgY - 6,
+        fill: color, opacity: 0.6,
+        'font-family': "'Courier New', monospace",
+        'font-size': '11px', 'font-weight': 'bold',
+        class: 'me-zone-label', 'data-zone-id': zone.id,
+        style: 'cursor: move; user-select: none;'});
+      labelEl.textContent = zone.name + ' (' + zoneRooms.length + ')';
+      svg.appendChild(labelEl);
+    });
+  }
 
   // ── SVG Rendering ──────────────────────────────────────────
   function render() {
@@ -399,6 +589,9 @@
         svg.appendChild(dot);
       }
     }
+
+    // Zone backgrounds (region scope)
+    if (scope === 'region') renderZoneBackgrounds();
 
     // Build room lookup
     var roomById = {};
@@ -475,7 +668,7 @@
     var cy = room.map_y * STRIDE_Y;
     var rx = cx - BOX_W / 2, ry = cy - BOX_H / 2;
     var isSelected = room.id === selectedRoomId;
-    var color = state.zone_color || '#00ffff';
+    var color = (scope === 'region') ? (room.zone_color || '#00ffff') : (state.zone_color || '#00ffff');
     var stroke = room.locked ? '#f87171' : (isSelected ? '#fff' : color);
     var strokeW = isSelected ? 2.5 : (room.locked ? 2 : 1);
     var fill = isSelected ? '#1a2a2a' : '#111';
@@ -571,11 +764,17 @@
       g.querySelectorAll('.me-port').forEach(function(p) { p.setAttribute('opacity', '0'); });
     });
 
-    // Click ghost: navigate to that zone
+    // Click ghost: navigate to that zone (zone scope) or region (region scope)
     g.addEventListener('click', function(e) {
       if (e.target.classList.contains('me-port') || e.target.classList.contains('me-ghost-port')) return;
-      if (confirm('Open zone "' + ghostRoom.zone_name + '" in editor?')) {
-        navigateToZone(ghostRoom.zone_id);
+      if (scope === 'region' && ghostRoom.region_id) {
+        if (confirm('Open region "' + ghostRoom.region_name + '" in editor?')) {
+          navigateToRegion(ghostRoom.region_id);
+        }
+      } else {
+        if (confirm('Open zone "' + ghostRoom.zone_name + '" in editor?')) {
+          navigateToZone(ghostRoom.zone_id);
+        }
       }
     });
 
@@ -714,13 +913,13 @@
     var hw = ISO_TILE_W / 2, hh = ISO_TILE_H / 2;
 
     var top = [cx, cy - hh], right = [cx + hw, cy], bottom = [cx, cy + hh], left = [cx - hw, cy];
-    var color = ROOM_TYPE_COLORS[room.room_type] || (state.zone_color || '#00ffff');
+    var color = ROOM_TYPE_COLORS[room.room_type] || ((scope === 'region') ? (room.zone_color || '#00ffff') : (state.zone_color || '#00ffff'));
     var topFill = isActive ? (room.id === selectedRoomId ? '#1a2a2a' : '#111') : '#0e0e0e';
     var topStroke = isActive ? (room.id === selectedRoomId ? '#fff' : color) : '#444';
     var topStrokeW = isActive ? (room.id === selectedRoomId ? 2.5 : 1.5) : 0.8;
-    var leftFill = isActive ? isoDarken(color, 0.18) : '#0a0a0a';
-    var rightFill = isActive ? isoDarken(color, 0.12) : '#080808';
-    var sideStroke = isActive ? isoDarken(color, 0.35) : '#1a1a1a';
+    var leftFill = isActive ? isoDarken(color, 0.25) : '#0a0a0a';
+    var rightFill = isActive ? isoDarken(color, 0.18) : '#080808';
+    var sideStroke = isActive ? isoDarken(color, 0.45) : '#1a1a1a';
     // Left wall
     g.appendChild(el('polygon', {points: isoPts([left, bottom, [bottom[0], bottom[1]+ISO_WALL_H], [left[0], left[1]+ISO_WALL_H]]), fill: leftFill, stroke: sideStroke, 'stroke-width': 0.5, 'data-room-id': room.id, class: 'me-room-iso'}));
     // Right wall
@@ -834,9 +1033,10 @@
     var paneH = canvasWrap.clientHeight || 600;
     // Apply zoom: smaller viewBox = zoom in, larger = zoom out
     var vbW = paneW / zoomLevel, vbH = paneH / zoomLevel;
-    // Center on content
+    // Center on content + apply pan offset
     var contentCX = (minSX + maxSX) / 2, contentCY = (minSY + maxSY + ISO_WALL_H) / 2;
-    var vbX = contentCX - vbW / 2, vbY = contentCY - vbH / 2;
+    _isoContentCX = contentCX; _isoContentCY = contentCY;
+    var vbX = contentCX - vbW / 2 + isoPanX, vbY = contentCY - vbH / 2 + isoPanY;
 
     svg.setAttribute('viewBox', vbX + ' ' + vbY + ' ' + vbW + ' ' + vbH);
     svg.setAttribute('width', '100%');
@@ -905,17 +1105,6 @@
       var g = el('g', {opacity: opacity, 'data-z-level': z});
       g.style.cursor = 'pointer';
 
-      // Connectors first (behind tiles)
-      var drawnEdges = {};
-      (horizontalExitsByZ[z] || []).forEach(function(ex) {
-        var from = roomById[ex.from_room_id], to = roomById[ex.to_room_id];
-        if (!from || !to) return;
-        var key = [Math.min(ex.from_room_id, ex.to_room_id), Math.max(ex.from_room_id, ex.to_room_id)].join('-');
-        if (drawnEdges[key]) return;
-        drawnEdges[key] = true;
-        drawIsoConnector(g, from.map_x, from.map_y, to.map_x, to.map_y, z, ex, isActive);
-      });
-
       // Sort rooms back-to-front for correct overlap
       var sortedRooms = layerRooms.slice().sort(function(a, b) {
         var sa = a.map_x + a.map_y, sb = b.map_x + b.map_y;
@@ -923,7 +1112,29 @@
         return a.map_y - b.map_y;
       });
 
+      // Build per-room connector index for interleaved depth rendering
+      var exitsByRoom = {};
+      var drawnEdges = {};
+      (horizontalExitsByZ[z] || []).forEach(function(ex) {
+        var from = roomById[ex.from_room_id], to = roomById[ex.to_room_id];
+        if (!from || !to) return;
+        var key = [Math.min(ex.from_room_id, ex.to_room_id), Math.max(ex.from_room_id, ex.to_room_id)].join('-');
+        // Assign each connector to the room with LOWER depth (drawn first)
+        var fromDepth = from.map_x + from.map_y;
+        var toDepth = to.map_x + to.map_y;
+        var owner = fromDepth <= toDepth ? from.id : to.id;
+        if (!exitsByRoom[owner]) exitsByRoom[owner] = [];
+        exitsByRoom[owner].push({ex: ex, key: key, from: from, to: to});
+      });
+
+      // Interleaved draw: for each room (back-to-front), draw its connectors then its tile
       sortedRooms.forEach(function(r) {
+        // Draw connectors owned by this room (to rooms at same or greater depth)
+        (exitsByRoom[r.id] || []).forEach(function(c) {
+          if (drawnEdges[c.key]) return;
+          drawnEdges[c.key] = true;
+          drawIsoConnector(g, c.from.map_x, c.from.map_y, c.to.map_x, c.to.map_y, z, c.ex, isActive);
+        });
         drawIsoTile(g, r.map_x, r.map_y, z, r, isActive);
       });
 
@@ -967,8 +1178,14 @@
           (function(ghost) {
             ghostG.addEventListener('click', function(e) {
               e.stopPropagation();
-              if (confirm('Open zone "' + ghost.zone_name + '" in editor?')) {
-                navigateToZone(ghost.zone_id);
+              if (scope === 'region' && ghost.region_id) {
+                if (confirm('Open region "' + ghost.region_name + '" in editor?')) {
+                  navigateToRegion(ghost.region_id);
+                }
+              } else {
+                if (confirm('Open zone "' + ghost.zone_name + '" in editor?')) {
+                  navigateToZone(ghost.zone_id);
+                }
               }
             });
           })(gr);
@@ -1093,8 +1310,14 @@
       (function(room) {
         ghostG.addEventListener('click', function(e) {
           e.stopPropagation();
-          if (room.zone_id && confirm('Open zone "' + (room.zone_name || '') + '" in editor?')) {
-            navigateToZone(room.zone_id);
+          if (scope === 'region' && room.region_id) {
+            if (confirm('Open region "' + (room.region_name || '') + '" in editor?')) {
+              navigateToRegion(room.region_id);
+            }
+          } else if (room.zone_id) {
+            if (confirm('Open zone "' + (room.zone_name || '') + '" in editor?')) {
+              navigateToZone(room.zone_id);
+            }
           }
         });
       })(vr);
@@ -1106,13 +1329,39 @@
       svg.appendChild(el('line', {x1: localPos[0], y1: localPos[1], x2: cx, y2: cy, stroke: color, 'stroke-width': 2, 'stroke-dasharray': '8,5', opacity: 0.3}));
     });
 
+    // Zone labels (region scope) — draggable for repositioning
+    if (scope === 'region') {
+      (state.zones || []).forEach(function(zone) {
+        var zoneRooms = state.rooms.filter(function(r) { return r.grid_zone_id === zone.id; });
+        if (zoneRooms.length === 0) return;
+        // Find top-left room in isometric space (min map_x + map_y, then min map_x)
+        var labelRoom = zoneRooms.reduce(function(best, r) {
+          var bs = best.map_x + best.map_y, rs = r.map_x + r.map_y;
+          if (rs < bs || (rs === bs && r.map_x < best.map_x)) return r;
+          return best;
+        });
+        var lp = iso(labelRoom.map_x - 1, labelRoom.map_y - 0.5, labelRoom.map_z || 0);
+        var color = zone.color || '#00ffff';
+        var labelEl = el('text', {x: lp[0], y: lp[1] - 22,
+          fill: color, opacity: 0.6,
+          'font-family': "'Courier New', monospace",
+          'font-size': '11px', 'font-weight': 'bold',
+          class: 'me-zone-label', 'data-zone-id': zone.id,
+          style: 'cursor: move; user-select: none;'});
+        labelEl.textContent = zone.name + ' (' + zoneRooms.length + ')';
+        svg.appendChild(labelEl);
+      });
+    }
+
     // Draw line for exit drawing in progress
     drawLine = el('line', {x1: 0, y1: 0, x2: 0, y2: 0, stroke: '#00ffff', 'stroke-width': 2, 'stroke-dasharray': '6,4', visibility: 'hidden'});
     svg.appendChild(drawLine);
   }
 
   // ── Interaction: Room click/select ─────────────────────────
+  var _dragEndedAt = 0;
   svg.addEventListener('click', function(e) {
+    if (Date.now() - _dragEndedAt < 300) return;
     // Flat mode: .me-room, Iso mode: .me-room-iso on active layer
     var roomEl = e.target.closest('.me-room') || e.target.closest('.me-room-iso');
     if (roomEl && !e.target.classList.contains('me-port')) {
@@ -1125,14 +1374,15 @@
       selectRoom(id);
       return;
     }
-    // Click on empty space (not a room, not a connector, not ghost)
-    if (!e.target.closest('.me-ghost') && !e.target.closest('.me-connector') && !e.target.getAttribute('data-exit-id')) {
+    // Click on empty space (not a room, not a connector, not ghost, not zone label)
+    if (!e.target.closest('.me-ghost') && !e.target.closest('.me-connector') && !e.target.getAttribute('data-exit-id') && !e.target.closest('.me-zone-label')) {
       deselectRoom();
     }
   });
 
   svg.addEventListener('dblclick', function(e) {
-    if (e.target.closest('.me-room') || e.target.closest('.me-ghost') || e.target.closest('.me-room-iso')) return;
+    if (Date.now() - _dragEndedAt < 300) return;
+    if (e.target.closest('.me-room') || e.target.closest('.me-ghost') || e.target.closest('.me-room-iso') || e.target.closest('.me-zone-label')) return;
     // Double-click on empty space: create room
     var pt = svgPoint(e);
     var gx, gy;
@@ -1175,6 +1425,21 @@
       return;
     }
 
+    // Zone label drag (region scope — reposition entire zone cluster)
+    if (scope === 'region') {
+      var zoneLabelEl = e.target.closest('.me-zone-label');
+      if (zoneLabelEl) {
+        e.preventDefault();
+        var zid = parseInt(zoneLabelEl.getAttribute('data-zone-id'));
+        var zone = (state.zones || []).find(function(z) { return z.id === zid; });
+        if (!zone) return;
+        var pt = svgPoint(e);
+        var isoStart = mode25D ? isoInverse(pt.x, pt.y, currentZ) : null;
+        dragState = {type: 'zone', zoneId: zid, origZoneX: zone.map_x, origZoneY: zone.map_y, startX: pt.x, startY: pt.y, isoStartGrid: isoStart};
+        return;
+      }
+    }
+
     // Room drag (reposition)
     var roomG = e.target.closest('.me-room') || (mode25D ? e.target.closest('.me-room-iso') : null);
     if (roomG && !e.target.classList.contains('me-port')) {
@@ -1187,16 +1452,83 @@
       var pt = svgPoint(e);
       var isoStart = mode25D ? isoInverse(pt.x, pt.y, currentZ) : null;
       dragState = {type: 'room', roomId: id, startX: pt.x, startY: pt.y, origX: room.map_x, origY: room.map_y, isoStartGrid: isoStart};
+      return;
+    }
+
+    // Background pan — starts on empty space
+    if (!e.target.closest('.me-room') && !e.target.closest('.me-ghost') && !e.target.closest('.me-room-iso') && !e.target.closest('.me-zone-label')) {
+      dragState = {type: 'pan', startClientX: e.clientX, startClientY: e.clientY,
+        scrollLeft: canvasWrap.scrollLeft, scrollTop: canvasWrap.scrollTop,
+        origIsoPanX: isoPanX, origIsoPanY: isoPanY,
+        contentCX: _isoContentCX, contentCY: _isoContentCY, moved: false};
     }
   });
 
   document.addEventListener('mousemove', function(e) {
     if (!dragState) return;
+
+    if (dragState.type === 'pan') {
+      var dx = e.clientX - dragState.startClientX;
+      var dy = e.clientY - dragState.startClientY;
+      if (!dragState.moved && Math.abs(dx) + Math.abs(dy) > PAN_THRESHOLD) dragState.moved = true;
+      if (dragState.moved) {
+        if (mode25D) {
+          // Update viewBox directly — no full re-render needed, only the camera moves
+          var vb = svg.getAttribute('viewBox');
+          if (vb) {
+            var parts = vb.split(' ');
+            var vbW = parseFloat(parts[2]), vbH = parseFloat(parts[3]);
+            var svgW = svg.clientWidth || 1;
+            var scale = vbW / svgW;
+            isoPanX = dragState.origIsoPanX - dx * scale;
+            isoPanY = dragState.origIsoPanY - dy * scale;
+            var contentCX = dragState.contentCX, contentCY = dragState.contentCY;
+            svg.setAttribute('viewBox', (contentCX - vbW / 2 + isoPanX) + ' ' + (contentCY - vbH / 2 + isoPanY) + ' ' + vbW + ' ' + vbH);
+          }
+        } else {
+          canvasWrap.scrollLeft = dragState.scrollLeft - dx;
+          canvasWrap.scrollTop = dragState.scrollTop - dy;
+        }
+      }
+      return;
+    }
+
     var pt = svgPoint(e);
 
     if (dragState.type === 'port') {
       drawLine.setAttribute('x2', pt.x);
       drawLine.setAttribute('y2', pt.y);
+      return;
+    }
+
+    if (dragState.type === 'zone') {
+      var dx, dy;
+      if (mode25D && dragState.isoStartGrid) {
+        var curGrid = isoInverse(pt.x, pt.y, currentZ);
+        dx = curGrid[0] - dragState.isoStartGrid[0];
+        dy = curGrid[1] - dragState.isoStartGrid[1];
+      } else {
+        dx = Math.round((pt.x - dragState.startX) / STRIDE_X);
+        dy = Math.round((pt.y - dragState.startY) / STRIDE_Y);
+      }
+      var zone = (state.zones || []).find(function(z) { return z.id === dragState.zoneId; });
+      if (!zone) return;
+      var newZoneX = dragState.origZoneX + dx;
+      var newZoneY = dragState.origZoneY + dy;
+      if (zone.map_x !== newZoneX || zone.map_y !== newZoneY) {
+        var zoneDx = newZoneX - zone.map_x;
+        var zoneDy = newZoneY - zone.map_y;
+        zone.map_x = newZoneX;
+        zone.map_y = newZoneY;
+        // Move all rooms in this zone by the delta
+        state.rooms.forEach(function(r) {
+          if (r.grid_zone_id === dragState.zoneId) {
+            r.map_x += zoneDx;
+            r.map_y += zoneDy;
+          }
+        });
+        if (mode25D) render25D(); else render();
+      }
       return;
     }
 
@@ -1227,6 +1559,12 @@
   document.addEventListener('mouseup', function(e) {
     if (!dragState) return;
 
+    if (dragState.type === 'pan') {
+      if (dragState.moved) _dragEndedAt = Date.now();
+      dragState = null;
+      return;
+    }
+
     if (dragState.type === 'port') {
       drawLine.setAttribute('visibility', 'hidden');
       // Find target room under cursor
@@ -1243,24 +1581,14 @@
       return;
     }
 
-    if (dragState.type === 'room') {
-      var room = state.rooms.find(function(r) { return r.id === dragState.roomId; });
-      var origX = dragState.origX, origY = dragState.origY;
+    if (dragState.type === 'zone') {
+      _dragEndedAt = Date.now();
       dragState = null;
-      if (room && (room.map_x !== origX || room.map_y !== origY)) {
-        setStatus('Saving position...');
-        api('PATCH', 'rooms/' + room.id, {map_x: room.map_x, map_y: room.map_y}).then(function(d) {
-          if (d.success) {
-            room.position_source = 'stored';
-            setStatus('Position saved');
-          } else {
-            room.map_x = origX;
-            room.map_y = origY;
-            if (mode25D) render25D(); else render();
-            setStatus('Error: ' + (d.errors || []).join(', '));
-          }
-        });
-      }
+      return;
+    }
+
+    if (dragState.type === 'room') {
+      dragState = null;
     }
   });
 
@@ -1522,7 +1850,13 @@
 
     // Position info
     html += '<div style="border-top: 1px solid #333; padding-top: 10px; margin-top: 10px; color: #555; font-size: 0.8em;">';
-    html += 'Position: (' + room.map_x + ', ' + room.map_y + ') · ' + room.position_source;
+    if (scope === 'region') {
+      html += 'Grid: (' + room.map_x + ', ' + room.map_y + ')';
+      if (room.map_z) html += ' · z=' + room.map_z;
+    } else {
+      html += 'Grid: (' + room.map_x + ', ' + room.map_y + ')';
+      if (room.map_z) html += ' · z=' + room.map_z;
+    }
     html += ' · <a href="/root/grid_rooms/' + room.id + '/edit" style="color: #60a5fa; text-decoration: none;">Full Edit →</a>';
     html += '</div>';
 
@@ -1604,7 +1938,13 @@
       if (!targetId || !dir) { setStatus('Target and direction required'); return; }
       setStatus('Creating exit...');
       api('POST', 'exits', {from_room_id: room.id, to_room_id: targetId, direction: dir, bidirectional: bidi}).then(function(d) {
-        if (d.success) { setStatus('Exit created'); loadData(); }
+        if (d.success) {
+          patchExitsIntoState(d);
+          if (mode25D) render25D(); else render();
+          showPanel(room.id);
+          setStatus('Exit created');
+          loadData();
+        }
         else { setStatus('Error: ' + (d.errors || []).join(', ')); }
       });
     });
@@ -1830,6 +2170,9 @@
       }).then(function(result) {
         if (result.success) {
           hideDialogs();
+          patchExitsIntoState(result);
+          if (mode25D) render25D(); else render();
+          if (selectedRoomId) showPanel(selectedRoomId);
           setStatus('Exit created');
           loadData();
         } else {
@@ -1868,6 +2211,34 @@
     document.getElementById('me-room-dialog').style.display = 'block';
     document.getElementById('me-room-name').focus();
 
+    // Zone selector for region scope
+    var zoneWrap = document.getElementById('me-room-zone-wrap');
+    var zoneSel = document.getElementById('me-room-zone-select');
+    if (scope === 'region') {
+      zoneWrap.style.display = 'block';
+      zoneSel.innerHTML = '';
+      // Auto-detect zone from click position (closest zone bounding box)
+      var bestZone = null, bestDist = Infinity;
+      (state.zones || []).forEach(function(z) {
+        var zoneRooms = state.rooms.filter(function(r) { return r.grid_zone_id === z.id; });
+        if (zoneRooms.length === 0) return;
+        var cx = 0, cy = 0;
+        zoneRooms.forEach(function(r) { cx += r.map_x; cy += r.map_y; });
+        cx /= zoneRooms.length; cy /= zoneRooms.length;
+        var dist = Math.abs(gx - cx) + Math.abs(gy - cy);
+        if (dist < bestDist) { bestDist = dist; bestZone = z; }
+      });
+      (state.zones || []).forEach(function(z) {
+        var opt = document.createElement('option');
+        opt.value = z.id;
+        opt.textContent = z.name + ' (' + z.room_count + ' rooms)';
+        if (bestZone && z.id === bestZone.id) opt.selected = true;
+        zoneSel.appendChild(opt);
+      });
+    } else {
+      zoneWrap.style.display = 'none';
+    }
+
     // Auto-generate slug from name
     document.getElementById('me-room-name').oninput = function() {
       var name = this.value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
@@ -1882,10 +2253,17 @@
     var roomType = document.getElementById('me-room-type').value;
     if (!name) { setStatus('Name required'); return; }
 
+    var targetZoneId = zoneId;
+
+    if (scope === 'region') {
+      targetZoneId = parseInt(document.getElementById('me-room-zone-select').value);
+      if (!targetZoneId) { setStatus('Zone required'); return; }
+    }
+
     setStatus('Creating room...');
     api('POST', 'rooms', {
       name: name, slug: slug, room_type: roomType || null,
-      grid_zone_id: zoneId, map_x: pendingRoomPos.x, map_y: pendingRoomPos.y, map_z: currentZ, min_clearance: 0
+      grid_zone_id: targetZoneId, min_clearance: 0
     }).then(function(d) {
       if (d.success) {
         hideDialogs();
@@ -1909,17 +2287,9 @@
   overlay.addEventListener('click', hideDialogs);
 
   // ── Toolbar buttons ────────────────────────────────────────
-  document.getElementById('me-auto-layout').addEventListener('click', function() {
-    if (!confirm('Recompute positions via BFS for all rooms in this zone?\nExisting positions will be overwritten.')) return;
-    setStatus('Computing layout...');
-    api('POST', zoneId + '/auto_layout').then(function(d) {
-      if (d.success) {
-        setStatus('Layout computed (' + d.updated + ' rooms)');
-        loadData();
-      } else {
-        setStatus('Error');
-      }
-    });
+  document.getElementById('me-reset-layout').addEventListener('click', function() {
+    isoPanX = 0; isoPanY = 0;
+    loadData();
   });
 
   document.getElementById('me-zoom-in').addEventListener('click', function() {
@@ -1939,7 +2309,9 @@
 
   document.getElementById('me-25d-toggle').addEventListener('click', function() {
     mode25D = !mode25D;
+    isoPanX = 0; isoPanY = 0;
     var btn = document.getElementById('me-25d-toggle');
+    btn.textContent = mode25D ? '2D' : '2.5D';
     btn.className = mode25D ? 'tui-button cyan-168' : 'tui-button';
     zoomLevel = mode25D ? 1.25 : 1.0;
     canvasWrap.style.display = mode25D ? 'flex' : 'block';
@@ -1949,6 +2321,15 @@
     closePanel();
     loadData();
   });
+
+  // Ctrl/Cmd + scroll wheel zoom
+  canvasWrap.addEventListener('wheel', function(e) {
+    if (!e.ctrlKey && !e.metaKey) return;
+    e.preventDefault();
+    var delta = e.deltaY > 0 ? -0.1 : 0.1;
+    zoomLevel = Math.min(Math.max(zoomLevel + delta, 0.15), 5.0);
+    applyZoom();
+  }, {passive: false});
 
   function applyZoom() {
     if (mode25D) {
@@ -1966,6 +2347,43 @@
   }
 
   // ── Helpers ────────────────────────────────────────────────
+  // Optimistically patch new exits into local state so panel shows them
+  // before loadData returns with server truth
+  function patchExitsIntoState(result) {
+    if (!result.exit) return;
+    var fwd = result.exit;
+    var rev = result.reverse_exit;
+    // Find the rooms in state and push the new exits
+    var fromRoom = state.rooms.find(function(r) { return r.id === fwd.from_room_id; });
+    var toRoom = state.rooms.find(function(r) { return r.id === fwd.to_room_id; });
+    if (fromRoom) {
+      if (!fromRoom.exits) fromRoom.exits = [];
+      fromRoom.exits.push({
+        id: fwd.id, direction: fwd.direction, to_room_id: fwd.to_room_id,
+        to_room_name: toRoom ? toRoom.name : 'unknown',
+        to_zone_name: toRoom ? (toRoom.zone_name || '') : '',
+        locked: false, reverse_exit_id: rev ? rev.id : null,
+        cross_zone: fromRoom.grid_zone_id !== (toRoom ? toRoom.grid_zone_id : null)
+      });
+    }
+    if (rev && toRoom) {
+      if (!toRoom.exits) toRoom.exits = [];
+      toRoom.exits.push({
+        id: rev.id, direction: rev.direction, to_room_id: rev.from_room_id,
+        to_room_name: fromRoom ? fromRoom.name : 'unknown',
+        to_zone_name: fromRoom ? (fromRoom.zone_name || '') : '',
+        locked: false, reverse_exit_id: fwd.id,
+        cross_zone: toRoom.grid_zone_id !== (fromRoom ? fromRoom.grid_zone_id : null)
+      });
+    }
+    // Also push to top-level exits for connector rendering
+    if (!state.exits) state.exits = [];
+    state.exits.push({id: fwd.id, from_room_id: fwd.from_room_id, to_room_id: fwd.to_room_id, direction: fwd.direction, locked: false, reverse_exit_id: rev ? rev.id : null});
+    if (rev) {
+      state.exits.push({id: rev.id, from_room_id: rev.from_room_id, to_room_id: rev.to_room_id, direction: rev.direction, locked: false, reverse_exit_id: fwd.id});
+    }
+  }
+
   function esc(str) {
     var div = document.createElement('div');
     div.textContent = str || '';
@@ -1989,8 +2407,10 @@
           });
         });
       });
-      var curZoneId = state.zone ? state.zone.id : zoneId;
-      var curRegion = state.zone ? state.zone.region_name : '';
+      var curZoneId = scope === 'region' ? null : (state.zone ? state.zone.id : zoneId);
+      var curRegion = scope === 'region'
+        ? (state.region ? state.region.name : '')
+        : (state.zone ? state.zone.region_name : '');
       flat.sort(function(a, b) {
         var aZone = a.zone_id === curZoneId ? 0 : 1;
         var bZone = b.zone_id === curZoneId ? 0 : 1;
@@ -2029,8 +2449,10 @@
 
   function initRoomCombobox(uid, excludeId) {
     var items = getSortedRooms(excludeId);
-    var curZoneId = state.zone ? state.zone.id : zoneId;
-    var curRegion = state.zone ? state.zone.region_name : '';
+    var curZoneId = scope === 'region' ? null : (state.zone ? state.zone.id : zoneId);
+    var curRegion = scope === 'region'
+      ? (state.region ? state.region.name : '')
+      : (state.zone ? state.zone.region_name : '');
     AdminCombobox.init({
       inputId: uid + '-input',
       hiddenId: uid + '-hidden',
@@ -2088,7 +2510,65 @@
     });
   }
 
+  // ── Scope toggle ────────────────────────────────────────────
+  function updateScopeUI() {
+    var zoneBtn = document.getElementById('me-scope-zone');
+    var regionBtn = document.getElementById('me-scope-region');
+    var regionPicker = document.getElementById('me-region-picker');
+    var zonePicker = document.getElementById('me-zone-picker');
+    var zoneLabel = document.getElementById('me-zone-label');
+    var legendGhostDesc = document.getElementById('me-legend-ghost-desc');
+    var legendZoneDrag = document.getElementById('me-legend-zone-drag');
+
+    zoneBtn.className = scope === 'zone' ? 'tui-button cyan-168' : 'tui-button';
+    regionBtn.className = scope === 'region' ? 'tui-button cyan-168' : 'tui-button';
+    regionPicker.style.display = scope === 'region' ? 'inline-block' : 'none';
+
+    if (scope === 'region') {
+      zoneLabel.textContent = 'Create in:';
+      legendGhostDesc.textContent = 'cross-region room';
+      legendZoneDrag.style.display = 'inline';
+    } else {
+      zoneLabel.textContent = 'Zone:';
+      legendGhostDesc.textContent = 'cross-zone room';
+      legendZoneDrag.style.display = 'none';
+    }
+  }
+
+  document.getElementById('me-scope-zone').addEventListener('click', function() {
+    if (scope === 'zone') return;
+    // If a room is selected, switch to its zone; otherwise pick first zone
+    var targetZone = null;
+    if (selectedRoomId) {
+      var sel = state.rooms.find(function(r) { return r.id === selectedRoomId; });
+      if (sel) targetZone = (state.zones || []).find(function(z) { return z.id === sel.grid_zone_id; });
+    }
+    if (!targetZone) targetZone = (state.zones || state.available_zones || [])[0];
+    if (targetZone) {
+      navigateToZone(targetZone.id);
+    }
+  });
+
+  document.getElementById('me-scope-region').addEventListener('click', function() {
+    if (scope === 'region') return;
+    // Remember current zone to center on it in region view
+    var centerZone = zoneId;
+    // Derive region from zone data if available
+    var targetRegion = regionId;
+    if (state.zone && state.zone.region_id) targetRegion = state.zone.region_id;
+    navigateToRegion(targetRegion, centerZone);
+  });
+
+  updateScopeUI();
+
   // ── Init ───────────────────────────────────────────────────
+  // Apply initial 2.5D canvas styles
+  if (mode25D) {
+    zoomLevel = 1.25;
+    canvasWrap.style.display = 'flex';
+    canvasWrap.style.justifyContent = 'center';
+    canvasWrap.style.alignItems = 'center';
+  }
   loadData();
 })();
 </script>

--- a/app/views/admin/grid_mobs/_form.html.erb
+++ b/app/views/admin/grid_mobs/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render "admin/shared/combobox" %>
+
 <% if @mob.errors.any? %>
   <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
     <p class="red-255-text">ERRORS:</p>
@@ -31,7 +33,16 @@
 <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :grid_room_id, "ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
-    <%= f.select :grid_room_id, options_for_select(@rooms.map { |r| ["#{r.grid_zone.name} — #{r.name}", r.id] }, @mob.grid_room_id), { include_blank: "(select room)" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    <input type="hidden" name="grid_mob[grid_room_id]" id="room-cb-hidden" value="<%= @mob.grid_room_id %>">
+    <div class="admin-combobox">
+      <input type="text" id="room-cb-input" class="admin-combobox-input<%= ' selected' if @mob.grid_room_id.present? %>" autocomplete="off"
+        placeholder="Type to search rooms..."
+        value="<%= "#{@mob.grid_room&.grid_zone&.name} / #{@mob.grid_room&.name}" if @mob.grid_room_id.present? %>">
+      <div id="room-cb-dropdown" class="admin-combobox-dropdown"></div>
+    </div>
+    <p style="color: #666; margin-top: 4px; font-size: 0.85em;" id="room-cb-status">
+      <%= @rooms.size %> rooms
+    </p>
   </div>
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :grid_faction_id, "FACTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
@@ -346,6 +357,24 @@
     vBtnStructured.classList.add('green-168');
     vBtnRaw.classList.remove('green-168');
     vendorMode = 'structured';
+  });
+
+  // === Room Combobox ===
+  AdminCombobox.init({
+    inputId: 'room-cb-input',
+    hiddenId: 'room-cb-hidden',
+    dropdownId: 'room-cb-dropdown',
+    statusId: 'room-cb-status',
+    items: <%= raw @rooms.map { |r| { id: r.id, name: r.name, zone: r.grid_zone.name, region: r.grid_zone.grid_region.name } }.to_json %>,
+    getSearchText: function(r) { return (r.name + ' ' + r.zone + ' ' + r.region).toLowerCase(); },
+    getGroupKey: function(r) { return r.region + ' / ' + r.zone; },
+    renderOption: function(r, e) {
+      return '<span class="cb-name">' + e(r.name) + '</span> <span class="cb-meta">' + e(r.zone) + '</span>';
+    },
+    getId: function(r) { return String(r.id); },
+    getLabel: function(r) { return r.zone + ' / ' + r.name; },
+    emptyText: 'No rooms match',
+    selectedText: 'Room selected'
   });
 
   // === Serialize on form submit ===

--- a/app/views/admin/grid_regions/index.html.erb
+++ b/app/views/admin/grid_regions/index.html.erb
@@ -40,7 +40,8 @@
                   <td style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"><%= truncate(region.description, length: 60) %></td>
                   <td style="text-align: center;"><%= region.grid_zones.size %></td>
                   <td style="text-align: right; white-space: nowrap;">
-                    <%= link_to "Edit", edit_admin_grid_region_path(region), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "Map", admin_grid_map_editor_region_show_path(region_id: region.id), class: "tui-button cyan-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                    <%= link_to "Edit", edit_admin_grid_region_path(region), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= link_to "History", history_admin_grid_region_path(region), class: "tui-button purple-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;" %>
                     <%= button_to "Delete", admin_grid_region_path(region), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em; margin-left: 4px;", data: { confirm: "Delete '#{region.name}'?" } %>
                   </td>

--- a/app/views/admin/grid_zones/index.html.erb
+++ b/app/views/admin/grid_zones/index.html.erb
@@ -18,11 +18,15 @@
       <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
         <%= link_to "+ New Zone", new_admin_grid_zone_path, class: "tui-button green-168" %>
+        <span style="color: #333;">|</span>
+        <label class="white-text" style="font-weight: bold;">FILTER:</label>
+        <input type="text" id="zone-filter" class="tui-input" style="padding: 6px 10px; width: 250px;" placeholder="name, slug, region..." autocomplete="off">
+        <span id="zone-filter-status" style="color: #666; font-size: 0.85em;"><%= @zones.size %> zones</span>
       </div>
 
       <% if @zones.any? %>
         <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
-          <table class="tui-table" style="width: 100%;">
+          <table id="zone-table" class="tui-table" style="width: 100%;">
             <thead>
               <tr>
                 <th style="text-align: left;">Name</th>
@@ -79,3 +83,27 @@
     </div>
   </fieldset>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var input = document.getElementById('zone-filter');
+    var status = document.getElementById('zone-filter-status');
+    var rows = document.querySelectorAll('#zone-table tbody tr');
+    if (!input || !rows.length) return;
+    var total = rows.length;
+
+    input.addEventListener('input', function() {
+      var q = this.value.toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var cells = rows[i].querySelectorAll('td');
+        var text = '';
+        for (var c = 0; c < cells.length - 1; c++) text += cells[c].textContent + ' ';
+        var show = !q || text.toLowerCase().indexOf(q) !== -1;
+        rows[i].style.display = show ? '' : 'none';
+        if (show) visible++;
+      }
+      status.textContent = visible + ' of ' + total + ' zone' + (total === 1 ? '' : 's');
+    });
+  })();
+</script>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -99,7 +99,7 @@
           <%= link_to "Rooms", admin_grid_rooms_path, class: "green-168-text" %>
           <%= link_to "Mobs", admin_grid_mobs_path, class: "green-168-text" %>
           <%= link_to "Exits", admin_grid_exits_path, class: "green-168-text" %>
-          <%= link_to "Map Editor", admin_grid_map_editor_show_path(GridZone.first&.id || 0), class: "green-168-text" %>
+          <%= link_to "Map Editor", admin_grid_map_editor_region_show_path(region_id: GridRegion.first&.id || 0), class: "green-168-text" %>
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
           <%= link_to "Impound", admin_grid_impound_records_path, class: "green-168-text" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -322,7 +322,9 @@ Rails.application.routes.draw do
       delete "mobs/:id", to: "grid_map_editor#remove_mob", as: :remove_mob
       post "encounters", to: "grid_map_editor#create_encounter", as: :create_encounter
       delete "encounters/:id", to: "grid_map_editor#destroy_encounter", as: :destroy_encounter
-      post ":zone_id/auto_layout", to: "grid_map_editor#auto_layout", as: :auto_layout
+      # Region scope
+      get "region/:region_id", to: "grid_map_editor#region_show", as: :region_show
+      get "region/:region_id/data", to: "grid_map_editor#region_data", as: :region_data
     end
 
     # World resources (full CRUD)

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -5,14974 +5,11230 @@ rooms:
     description: "Office towers line both sides, their glass faces catching river light and throwing it back as white glare. Foot traffic moves fast between lobby entrances. The street narrows where two older buildings refuse to give ground to newer construction."
     zone_slug: the-towers
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Glass Lobby"
     slug: glass-lobby
     description: "Floor-to-ceiling windows frame the street in both directions, the security desk centered on a marble floor polished to a mirror. Climate control hums at the threshold, sealing conditioned air from river humidity. Employees badge through turnstiles without looking up."
     zone_slug: the-towers
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Intersection"
     slug: the-intersection
     description: "Four lanes of traffic converge beneath signal poles crusted with old sensor housings. Pedestrians cross in tight packs when the light changes, their reflections sliding across darkened storefronts. Wind funnels down the corridor of buildings and pulls at jacket hems."
     zone_slug: the-towers
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Sky Plaza"
     slug: sky-plaza
     description: "An elevated concrete platform connects three towers at the fourth floor, open to weather on all sides. Metal benches bolt to the deck at even intervals. The arch is visible from the south railing, its steel curve rising above the treeline like a second horizon."
     zone_slug: the-towers
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Express Elevator"
     slug: express-elevator
     description: "Brushed steel doors open onto a car that skips the first thirty floors. The acceleration presses weight into shoe soles. A small display counts floors in silence, the only sound the faint cable hum behind the walls."
     zone_slug: the-towers
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Corner Office"
     slug: corner-office
     description: "Windows on two walls meet at a right angle, framing the river's bend and the arch beyond it. The desk faces away from the view, toward the door. Everything in the room is deliberate — the chair height, the lamp angle, the single pen centered on the blotter."
     zone_slug: the-towers
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Courtyard"
     slug: the-courtyard
     description: "A square of open air enclosed by four towers, paved in brick with a single tree growing from a grated planter at the center. Office workers eat lunch on concrete ledges. Sound bounces off the walls — conversation, traffic, the distant bass of a street performer three blocks away."
     zone_slug: the-towers
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Parking Ramp"
     slug: parking-ramp
     description: "Spiraling concrete decks ascend six levels, each one slightly warmer than the last from engine heat and trapped sunlight. Oil stains mark the turns. The top level is uncovered, and on clear days you can see the arch from the northeast corner."
     zone_slug: the-towers
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Street Vendor"
     slug: street-vendor
     description: "A steel cart with a striped umbrella anchors the corner, the smell of grilled onions and burnt coffee cutting through exhaust. The vendor works without speaking, hands moving through the same sequence they have performed ten thousand times. A handwritten sign lists three items."
     zone_slug: the-towers
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Transit Stop"
     slug: transit-stop
     description: "A glass shelter with a bench and a route map faded to near-illegibility by years of sun. The stop serves four lines. People stand at the curb edge checking the time, their faces lit from below by handheld screens."
     zone_slug: the-towers
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Fountain"
     slug: the-fountain
     description: "Water spills over a series of granite steps into a shallow basin filled with corroded coins. The fountain sits at the center of a small plaza between two office buildings. Pigeons drink from the lowest tier."
     zone_slug: the-towers
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Tower Shadow"
     slug: tower-shadow
     description: "The tallest building on the block throws a shadow that reaches the river by late afternoon. The temperature drops noticeably at its edge. A few benches sit permanently in shade, their wood darkened by years without direct sun."
     zone_slug: the-towers
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Park Entrance"
     slug: park-entrance
     description: "Limestone pillars mark the north entrance, worn smooth by a century of hands brushing against them in passing. A paved path splits into three directions beyond the gate. Old elms arch overhead, their canopy filtering light into shifting green."
     zone_slug: monument-park
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Reflecting Pool"
     slug: the-reflecting-pool
     description: "A long rectangle of still water stretches toward the arch, its surface holding the structure's inverted image with precision that sharpens the longer you look. Concrete edges are stained with algae at the waterline. Small birds land and leave without disturbing the surface."
     zone_slug: monument-park
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Oak Grove"
     slug: oak-grove
     description: "Massive oaks crowd together, their trunks wider than doorways, branches interlocking overhead to form a ceiling dense enough to stop light rain. The ground beneath them is bare earth packed hard by foot traffic. Acorns crunch underfoot in autumn."
     zone_slug: monument-park
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Walking Path"
     slug: walking-path
     description: "Crushed gravel crunches under every step, the path curving between manicured lawns and older tree stands. Joggers pass in both directions. The arch grows larger with each turn southward, its silver surface catching whatever light the sky offers."
     zone_slug: monument-park
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Park Bench"
     slug: park-bench
     description: "A green-painted iron bench faces the walking path, its slats worn thin in the center from decades of use. The bolts anchoring it to the concrete pad have rusted orange. From here the arch fills the southern view, closer now, its scale becoming difficult to process."
     zone_slug: monument-park
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Lawn"
     slug: the-lawn
     description: "Flat open grass stretches two hundred meters without interruption, bordered by trees on three sides and the walking path on the fourth. Kites fly here when the wind comes off the river. The grass is thick and uneven, clipped but never manicured."
     zone_slug: monument-park
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Memorial Wall"
     slug: memorial-wall
     description: "Names etched into dark granite panels run the length of a low curved wall. The stone absorbs heat during the day and radiates it back at dusk. Visitors trace letters with their fingertips, leaning close to read in the shade."
     zone_slug: monument-park
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Flower Bed"
     slug: flower-bed
     description: "Seasonal plantings line the main path in organized rows — tulips in spring, marigolds through summer, mums into fall. Park maintenance keeps them sharp-edged and weed-free. The colors feel almost aggressive against the muted stone and iron of everything else."
     zone_slug: monument-park
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Steps"
     slug: the-steps
     description: "Broad limestone steps descend toward the arch grounds, each tread wide enough for three people abreast. The stone is lighter where foot traffic concentrates in the center. Sitting on the upper steps gives a clear sightline to the arch's full height."
     zone_slug: monument-park
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fountain Square"
     slug: fountain-square
     description: "A circular fountain anchors a paved plaza where four paths converge. Water jets arc from a ring of nozzles into a central basin. Children wade in the shallow pool during summer months. The spray carries on the breeze and spots the surrounding benches."
     zone_slug: monument-park
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Concession Stand"
     slug: concession-stand
     description: "A small brick building with a service window and a hand-lettered menu board. The smell of popcorn and soft pretzels drifts across the path. A short line forms at lunchtime. Metal tables with attached umbrellas cluster on the adjacent patio."
     zone_slug: monument-park
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Arch Shadow"
     slug: arch-shadow
     description: "The arch's shadow sweeps across the park grounds as the sun moves, a dark parabola sliding over grass and path and bench. At midday the shadow pools directly beneath the structure. Standing in it, the air tastes different — cleaner, less processed, stripped of something you did not know was there."
     zone_slug: monument-park
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Arch Base North"
     slug: arch-base-north
     description: "The north leg of the arch meets the ground in a massive triangular footing sunk into bedrock, the stainless steel skin riveted in panels that have weathered three centuries without losing their sheen. Up close the metal hums faintly in wind. The scale is disorienting — the leg is wider than most buildings at its base."
     zone_slug: the-arch
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Arch Base South"
     slug: arch-base-south
     description: "The south footing mirrors the north, anchoring the structure against the river bluffs. Grass grows to within a meter of the steel, then stops where maintenance crews keep the perimeter clear. Touch the metal and it vibrates — a low resonance that travels through the bones of the hand."
     zone_slug: the-arch
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Interior"
     slug: the-interior
     description: "A narrow corridor runs inside the arch's south leg, lit by caged bulbs at ten-meter intervals. The walls curve inward as the passage rises. The air inside is cool and still, sealed away from everything outside. Sound carries strangely — footsteps arrive before the person making them."
     zone_slug: the-arch
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Observation Deck"
     slug: observation-deck
     description: "A small enclosed room at the apex, 190 meters above the river, with narrow windows cut into the steel on both sides. The floor flexes perceptibly in high wind. Two rivers and three states are visible from here. Everything below looks simplified — streets become lines, buildings become geometry."
     zone_slug: the-arch
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Grounds"
     slug: the-grounds
     description: "Open parkland surrounds the arch in every direction, the grass kept short and the sightlines unobstructed. The structure dominates from every angle but never looks the same twice — the curve shifts as you move, catching light differently with each step. Colors here look saturated, almost raw."
     zone_slug: the-arch
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Maintenance Hatch"
     slug: maintenance-hatch
     description: "A steel door flush with the arch's skin, secured with heavy bolts, barely visible unless you know where to look. The access panel beside it has been modified — additional wiring runs behind the standard housing, routed with care that exceeds GovCorp maintenance specifications."
     zone_slug: the-arch
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Deadzone Edge"
     slug: deadzone-edge
     description: "The boundary is not a wall but a tide. Walking toward the arch, the world sharpens by degrees — an advertisement loses its warmth, a building's color shifts from the shade you expected to the shade it actually is. Most people feel nothing. Some feel seasick."
     zone_slug: the-arch
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Equipment Room"
     slug: equipment-room
     description: "Below ground level, accessible through a service entrance disguised as a utility access, a concrete room holds equipment that does not appear on any municipal inventory. The machines draw power from the arch's grounding system. Fracture Network technicians maintain the installation in rotating shifts."
     zone_slug: the-arch
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Visitor Center"
     slug: visitor-center
     description: "A low building of glass and limestone at the park's eastern edge, built to welcome tourists to a landmark most residents ignore. Display cases hold historical photographs and scale models. The gift shop sells miniature arches in three sizes."
     zone_slug: the-arch
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Gradient"
     slug: the-gradient
     description: "Halfway between the visitor center and the arch base, the transition becomes unmistakable to anyone paying attention. Surfaces lose a faint sheen you never noticed they had. Sounds arrive without the subtle processing that normally rounds their edges. The effect is cumulative and irreversible once perceived."
     zone_slug: the-arch
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Unfiltered Air"
     slug: unfiltered-air
     description: "Within a hundred meters of the arch, the air has a quality that resists description. It is not cleaner or colder — it is more present. Breathing here feels like remembering how breathing used to feel. The sky is a shade of blue that does not match the sky two blocks east."
     zone_slug: the-arch
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Legacy"
     slug: the-legacy
     description: "A granite marker at the arch's base records the structure's construction date and architect. Three centuries of weather have softened the lettering but not erased it. The monument was built to celebrate expansion. It has outlasted the nation that built it, the nation that replaced it, and the corporation that replaced that."
     zone_slug: the-arch
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "North Bank"
     slug: north-bank
     description: "The north bank slopes down to the waterline through a mix of riprap and mud, the ground soft and littered with driftwood after high water. Industrial buildings line the bank upstream. The current runs fast here, carrying silt from a thousand miles of farmland."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "South Bank"
     slug: south-bank
     description: "Concrete flood walls line the south bank, topped with iron railings that have rusted to a deep orange. Below the walls, the mud is permanent — it never fully dries. Barges pass close enough to read the hull numbers."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Point"
     slug: the-point
     description: "Where the two rivers meet, the water churns in visible seams — brown against gray-green, two currents refusing to merge for a hundred meters downstream. The point itself is a narrow spit of reinforced ground, barely wide enough to stand on. The wind here comes from two directions at once."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "River Walk"
     slug: river-walk
     description: "A paved path follows the riverbank for two miles, cracked and heaved by root growth and flood damage. Benches face the water at intervals. The path is busiest at dusk when the light off the water turns the arch's steel from silver to gold."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Current Break"
     slug: current-break
     description: "A concrete pier juts into the river at an angle, breaking the current into eddies that spin debris in slow circles. The pier's surface is slick with algae. Fishermen use it despite the posted warnings, their lines arcing out over the turbulent seam."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Flood Wall"
     slug: flood-wall
     description: "Concrete panels rise four meters above the bank, stained with horizontal lines marking previous flood crests — each one dated in spray paint by someone with steady hands. The highest mark is near the top. Behind the wall, the city continues as though the river were an abstraction."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Eddy"
     slug: the-eddy
     description: "A backwater pool forms behind a natural rock outcrop where the current slows to near-stillness. Leaves and foam collect in a rotating mat on the surface. The water is deeper than it looks, and the bottom is invisible beneath the silt."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Tugboat Dock"
     slug: tugboat-dock
     description: "Three rusted cleats bolt to a concrete apron at the water's edge, the dock built for vessels that no longer operate on this stretch. The pilings are wrapped in old tires. A fuel pump stands disconnected, its hose coiled and locked."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Sandbar"
     slug: the-sandbar
     description: "A crescent of sand and gravel emerges when the river drops to summer levels, visible from the overlook as a pale smear in the brown water. Herons stand motionless on its upstream edge. By October it will be twenty feet underwater."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Observation Pier"
     slug: observation-pier
     description: "A wooden platform extends over the water on steel pilings, built for tourists but used mostly by locals. The railing is smooth from hands. From the pier's end the confluence is visible as a long diagonal line of turbulence stretching downstream."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Under the Bridge"
     slug: under-the-bridge
     description: "The highway bridge's underside is a cathedral of steel I-beams and concrete decking, the sound of traffic above a constant low rumble. Pigeons roost in the girder joints. The light here is gray and even, filtered through the structure. Graffiti covers the abutments to a height of three meters."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Meeting"
     slug: the-meeting
     description: "The precise point where the rivers converge is not a fixed location but a shifting zone, its position determined by rainfall and snowmelt hundreds of miles upstream. Standing near it, the water sounds different — two rhythms layering into something that is neither one nor the other."
     zone_slug: the-confluence
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Loading Dock One"
     slug: loading-dock-one
     description: "A concrete platform at truck-bed height, the dock face scarred by decades of trailer impacts. A single mercury vapor light buzzes overhead, casting everything in pale blue. The roll-up door behind it is dented but functional."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Alley"
     slug: the-alley
     description: "Narrow enough that two people cannot walk abreast, the alley runs between two brick warehouses whose walls are close enough to touch simultaneously. Condensation drips from window-unit air conditioners overhead. The pavement is always damp."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Brick Facade"
     slug: brick-facade
     description: "Red brick darkened by a century of soot and weather, the warehouse front presents a row of arched windows — most bricked over, a few fitted with modern glass. Iron stars mark the anchor points of structural tie rods. The original company name is still visible in faded paint above the third floor."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Iron Door"
     slug: iron-door
     description: "A riveted steel door set into a brick arch, the handle worn bright by use against a surface gone dark with oxidation. The hinges are oiled and silent. Behind it, a stairwell descends to a sub-level that does not appear on building plans."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Loft"
     slug: the-loft
     description: "Open floor plan, timber columns, original hardwood floors scarred by decades of heavy equipment. The ceiling is pressed tin, water-stained in places. Windows on three sides let in flat gray light. The space echoes."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Freight Elevator"
     slug: freight-elevator
     description: "A cage elevator with an accordion gate, the platform large enough for a loaded pallet. The motor whines on the ascent and groans on the descent. The control is a brass lever that requires a firm hand. Grease marks the walls at shoulder height."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Stockroom"
     slug: the-stockroom
     description: "Metal shelving runs floor to ceiling in tight rows, the aisles barely wide enough for a hand truck. Inventory is organized by a system known only to the person who built it. The air smells of cardboard and machine oil."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Roll-Up Gate"
     slug: roll-up-gate
     description: "A corrugated steel door rattles in its tracks when the wind hits it, the chain pull hanging from a release mechanism crusted with old grease. The gate opens onto the alley, and when it is up, the interior is visible from the street — which is why it stays down."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Cobblestone Lane"
     slug: cobblestone-lane
     description: "Original cobblestones surface the lane between warehouses, the stones worn smooth and uneven, treacherous when wet. Cart ruts from a previous century have been ground into permanent grooves. Modern tire tracks follow the same paths."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fire Escape"
     slug: fire-escape
     description: "Wrought iron zigzags up the warehouse exterior, the bolts pulling slightly from aging mortar. The lowest ladder is retracted ten feet above the alley on a counterweight system. The landings are just wide enough to stand on. Paint flakes off in rust-colored chips."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Catbird"
     slug: the-catbird
     description: "A rooftop perch atop the tallest warehouse on the row, accessible only by fire escape and a final ladder bolted to the parapet wall. The view takes in the river, the arch, and the full downtown skyline. Wind is constant at this height. Someone has left a folding chair and a coffee tin of cigarette butts."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Empty Bay"
     slug: empty-bay
     description: "A warehouse bay stripped to bare concrete, the loading dock door open to the street, the interior dark beyond the reach of daylight. Pigeon droppings cover the floor near the entrance. Deeper in, the floor is clean — someone has been here recently."
     zone_slug: warehouse-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Stone Wall"
     slug: stone-wall
     description: "A low wall of fitted limestone runs along the bluff's edge, the stones settling into each other over decades without mortar. Moss fills the joints on the north-facing side. The top is flat enough to sit on, worn smooth by the habit."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Vista"
     slug: the-vista
     description: "The bluff drops away and the view opens — river, floodplain, far bank, and the arch rising from the park below like a needle threading the sky. On clear days the horizon is sixty miles deep. The scale makes thought quiet."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Telescope Mount"
     slug: telescope-mount
     description: "A coin-operated telescope on a brass pedestal, the lenses scratched but functional. It points toward the confluence by default. The coin slot accepts currency that has not been minted in decades, but someone keeps it working."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Wind Point"
     slug: wind-point
     description: "The bluff's western tip catches wind from the river valley, a steady pressure that flattens grass and forces conversation to a shout. Nothing grows taller than knee height here. The wind strips away the ambient haze and leaves the air transparent."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Bench Row"
     slug: bench-row
     description: "Five iron benches face the river in a line, their green paint chipping to reveal older layers — brown, then white, then bare metal. The spacing is generous, each bench private. The middle one has the best angle on the arch."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Drop"
     slug: the-drop
     description: "The bluff face falls away in a near-vertical limestone cliff, sixty meters of exposed strata ending in a talus slope at the riverbank. Safety railings have been installed and repaired and replaced. The stone face shows fossil shapes if you look closely."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sunset View"
     slug: sunset-view
     description: "The western exposure catches the sun's last hour, the light turning the river to copper and the arch to a dark silhouette. The colors are not enhanced or adjusted — they are the actual colors of light passing through unprocessed atmosphere. The difference is subtle until you have seen it."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Railing"
     slug: the-railing
     description: "Iron railings line the bluff edge, their posts sunk into drilled limestone. The top rail is smooth from decades of gripped hands. Rust bleeds down the stone in orange streaks. The railing has been rebuilt three times. The anchors are original."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Pathway"
     slug: pathway
     description: "A flagstone path winds along the bluff top, following the contour of the edge through a series of gentle curves. The stones are set in sand and shift slightly underfoot. Wildflowers grow in the gaps. The path predates the park by at least a century."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Tourist Stand"
     slug: tourist-stand
     description: "A wooden kiosk sells postcards, bottled water, and miniature arch replicas made of stamped tin. The vendor reads a paperback between customers. Business peaks in the afternoon when tour buses arrive. The postcards show the arch from angles that make it look like it belongs to a different city."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Bluff"
     slug: the-bluff
     description: "Bare limestone ledge extending beyond the tree line, the rock surface pocked with solution holes and scored by ice. Lichen crusts the stone in pale green and orange. Standing here at the bluff's edge with wind off the river, every surface in sight is hard and actual."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Night View"
     slug: night-view
     description: "After dark, the arch is lit from below by ground-mounted floods, the steel curve glowing against a black sky. The city spreads behind it in a grid of light. From the overlook the scene has the quality of something observed rather than experienced — too still, too composed, until the wind reminds you where you are."
     zone_slug: the-overlook
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Row House"
     slug: the-row-house
     description: "Red brick, three stories, built tight to its neighbors with no gap between walls. White stone lintels cap the windows. The front is flat and unadorned except for the house number in iron numerals above the door. The brick has darkened unevenly with age, each building a slightly different shade of rust."
     zone_slug: brick-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Stoop Steps"
     slug: stoop-steps
     description: "Four stone steps rise from the sidewalk to a small landing and the front door. The steps are concave from use, the center of each tread dished by generations of feet. Neighbors sit here in warm weather, the stoop serving as porch and social infrastructure."
     zone_slug: brick-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Alley Gate"
     slug: alley-gate
     description: "A wrought iron gate closes off the narrow passage between row houses, the ironwork simple — vertical bars, a latch, no ornament. The alley beyond leads to small rear yards and detached garages. The gate is never locked. Everyone on the block knows this."
     zone_slug: brick-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Courtyard"
     slug: brick-row-the-courtyard
     description: "A shared interior courtyard accessible from the alleys of four surrounding row houses, the space just large enough for a mature tree, a few garden plots, and a communal table. Brick walls rise on all four sides. Sound collects here — conversation, kitchen noise, radio through open windows."
     zone_slug: brick-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Ivy Wall"
     slug: ivy-wall
     description: "English ivy covers the east-facing wall of the end unit, the leaves so dense the brick beneath is invisible. The vine's main trunk is as thick as a wrist, rooted in a crack at the foundation. In winter the bare stems reveal the wall's original face like an X-ray."
     zone_slug: brick-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Corner Pub"
     slug: corner-pub
     description: "A brick building on the corner, its ground floor converted to a bar sometime in the previous century. The windows are small and deep-set, the interior dim even at noon. Three taps serve local brews. A chalkboard lists the day's single food item."
     zone_slug: brick-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Bakery"
     slug: the-bakery
     description: "The smell reaches the sidewalk twenty meters before the door — yeast, butter, hot sugar. The bakery occupies a row house ground floor, the display case visible through a window kept clear of condensation by constant wiping. The baker starts at three in the morning. The neighborhood knows this by the light."
     zone_slug: brick-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Iron Lamp"
     slug: iron-lamp
     description: "A cast-iron street lamp stands at the corner, converted from gas to electric decades ago but retaining its original form — fluted post, scrollwork arm, hexagonal lantern. The light it casts is warm and insufficient, leaving pools of dark between it and the next lamp."
     zone_slug: brick-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Brick Arch"
     slug: brick-arch
     description: "A decorative arch spans the entrance to the block, built from the same red brick as the houses, the keystone carved with a date worn past legibility. The arch serves no structural purpose — it is a threshold, a declaration that this block is a place and not merely a space between other places."
     zone_slug: brick-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Garden"
     slug: the-garden
     description: "A narrow lot between two row houses has been converted to a community garden, the beds built from reclaimed lumber and filled with dark soil. Tomato cages stand in rows. A rain barrel collects runoff from the adjacent roof. The garden is tended by several households, their plots marked with hand-lettered stakes."
     zone_slug: brick-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Cellar Door"
     slug: cellar-door
     description: "Heavy wooden doors set at a forty-five-degree angle against the row house foundation, their paint peeling down to gray wood. A padlock secures the handles. The stairs below lead to a stone-walled basement with a dirt floor. The air that rises when the doors open is cold and mineral."
     zone_slug: brick-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Chimney"
     slug: the-chimney
     description: "The row house chimney rises above the roofline, its brick lighter than the wall below — replaced once, maybe twice, over the building's life. A metal cap keeps out rain. In winter, smoke rises from it straight up in still air or tears sideways in wind, the only movement on an otherwise static roofline."
     zone_slug: brick-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Market Square"
     slug: market-square
     description: "An open-air market occupies a cobblestone square bordered by brick commercial buildings, the vendor stalls arranged in rows under canvas awnings. The noise is constant — transaction, greeting, the thump of produce on wooden crates. Morning light hits the east side first and works its way across."
     zone_slug: river-market
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Fresh Catch"
     slug: fresh-catch
     description: "A refrigerated display case on a stainless steel cart, the fish arranged on crushed ice with their eyes still clear. The vendor wears rubber boots and an apron that has never been fully clean. The smell is sharp and honest — salt, cold, the river."
     zone_slug: river-market
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Flower Seller"
     slug: flower-seller
     description: "Buckets of cut flowers line the pavement in front of a market stall, the colors almost painful against the gray stone and brick. Roses, sunflowers, lilies — arranged by type, not aesthetics. The seller wraps bundles in newspaper and makes change from a belt pouch."
     zone_slug: river-market
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Awning"
     slug: the-awning
     description: "A broad canvas awning extends from the market hall's facade, its fabric faded by sun and tightened by rain into a drum-taut surface. Water pools in the center during storms and dumps without warning. The shade beneath it drops the temperature five degrees."
     zone_slug: river-market
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Produce Stand"
     slug: produce-stand
     description: "Wooden crates stacked in tiers display tomatoes, peppers, and greens still dusty from the field. Hand-lettered price cards stick into the fruit on wooden picks. The produce comes from farms within a day's drive. The vendor can name the field each item came from."
     zone_slug: river-market
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "River View Table"
     slug: river-view-table
     description: "A handful of metal tables occupy a terrace at the market's river edge, the chairs mismatched and slightly unstable on the uneven brick. The view is of the far bank and the bridge crossing upstream. Coffee from the adjacent stall is strong and served without ceremony."
     zone_slug: river-market
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Butcher Block"
     slug: the-butcher-block
     description: "A wooden block scored deep with knife marks dominates the counter, the surface scrubbed white but permanently stained in its grain. Cuts hang from hooks behind glass. The butcher works with the economy of someone who has broken down ten thousand animals and finds no romance in it."
     zone_slug: river-market
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Spice Cart"
     slug: spice-cart
     description: "A wheeled cart with dozens of small bins, each holding a different spice or dried herb, the colors ranging from turmeric yellow to paprika red to the near-black of whole cloves. The air around the cart is thick with scent. Hand-scooped portions go into paper bags folded shut with a single practiced motion."
     zone_slug: river-market
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Coffee Roaster"
     slug: coffee-roaster
     description: "A small-batch roaster occupies the corner of the market hall, the machine visible through an open door, its drum turning slowly while green beans darken and crack. The smell carries across the entire square. The roaster sells by the cup and by the bag, both at prices that reflect the cost of doing one thing well."
     zone_slug: river-market
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Bread Line"
     slug: bread-line
     description: "A queue forms at the bakery stall before the market officially opens, the bread pulled from ovens in the building behind and carried out on wooden boards. The loaves are round, dense, and crusted dark. By ten in the morning, the day's bake is sold. No one has ever seen bread remain past noon."
     zone_slug: river-market
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Fountain"
     slug: river-market-the-fountain
     description: "A stone fountain at the market's center, its basin shallow and its jet modest — a single column of water that rises and falls with the municipal pressure. Market vendors fill buckets from it. Pigeons perch on its rim. The stone is old enough that the carved figures have lost their features."
     zone_slug: river-market
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Market Close"
     slug: market-close
     description: "The square empties in the late afternoon, vendors breaking down stalls and loading crates into waiting trucks. The cobblestones are littered with produce scraps and flower petals. A cleanup crew sweeps through with brooms and a hose. By evening, the square is bare and wet and quiet."
     zone_slug: river-market
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Portal"
     slug: the-portal
     description: "A wide archway cut through a limestone building marks the formal entrance to the arch grounds, its proportions scaled to accommodate crowds. The stone is carved with geometric patterns that belong to no specific tradition. Passing through it, the view opens onto the park and the arch beyond."
     zone_slug: gateway
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Ticket Booth"
     slug: ticket-booth
     description: "A small glass-fronted booth occupies one side of the portal, the ticket seller visible through a circle cut in the glass. The booth was built for a time when admission was charged. Admission is no longer charged. The booth remains, staffed by a volunteer who hands out maps."
     zone_slug: gateway
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Welcome Center"
     slug: welcome-center
     description: "A single-room building of glass and stone, its interior bright with displays no one reads and a scale model of the arch under a plexiglass dome. A video loops on a wall-mounted screen, narrating history in a cheerful tone that matches nothing about the structure it describes."
     zone_slug: gateway
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Turnstile"
     slug: the-turnstile
     description: "Metal arms rotate on a central post, counting visitors as they pass through. The mechanism is mechanical — no electronics, no sensor, just a ratchet and a counter. The click of each rotation is audible from ten meters away. The count resets at midnight."
     zone_slug: gateway
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Map"
     slug: the-map
     description: "A large illustrated map mounted on a metal panel shows the park, the arch, and the surrounding landmarks in a style that flatters every building by ten percent. The \"You Are Here\" arrow is slightly misplaced. Paint chips at the corners where weather has worked under the sealant."
     zone_slug: gateway
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Gift Shop"
     slug: gift-shop
     description: "A narrow retail space filled with arch-themed merchandise — keychains, magnets, snow globes, shot glasses, T-shirts in every size. The fluorescent lighting is unforgiving. A teenager behind the register appears to be reading something concealed below the counter. The best-selling item is a postcard that costs less than a dollar."
     zone_slug: gateway
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Queue"
     slug: the-queue
     description: "Stanchions and retractable belts create a winding path through an open area, designed for crowds that rarely materialize in full. The path is laid out for maximum throughput. On slow days the belts hang loose and people walk straight through, ignoring the suggested route."
     zone_slug: gateway
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Information Desk"
     slug: information-desk
     description: "A curved wooden counter staffed by a park employee who knows the answer to every question tourists ask because they always ask the same six. Brochures fan across the surface in overlapping rows. The desk lamp is always on, the overhead lights always off."
     zone_slug: gateway
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Security Station"
     slug: security-station
     description: "A checkpoint with a walk-through scanner and a conveyor belt for bags, installed after a threat assessment that was never made public. The guards are polite and bored. The scanner beeps for keys and belt buckles. No one has ever been turned away."
     zone_slug: gateway
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Passage"
     slug: the-passage
     description: "A covered walkway connects the gateway to the park grounds, its walls lined with historical photographs mounted behind glass. The passage is dim and cool, a compression chamber between the city and the park. Footsteps echo off the tile floor. The final photograph shows the arch under construction, skeletal and incomplete."
     zone_slug: gateway
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Departure Point"
     slug: departure-point
     description: "A paved circle where tour groups assemble and buses idle, the exhaust mixing with river air. A flagpole stands at the center, the flag audible in any wind. Departing visitors pause here to photograph the arch one last time, framing it between the gateway columns."
     zone_slug: gateway
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Threshold"
     slug: the-threshold
     description: "The precise line where the gateway's shadow ends and the park begins, marked by a change in pavement — from poured concrete to original limestone. The transition is barely perceptible underfoot, but the light changes. Shadows sharpen. The air carries the river more directly. Something unnamed falls away."
     zone_slug: gateway
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Railing"
     slug: the-promenade-the-railing
     description: "A continuous iron railing follows the river's edge for the length of the promenade, its posts capped with simple finials worn round by weather. The rail is at elbow height, perfect for leaning. Rust has been painted over so many times the surface is textured like bark."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "River Bench"
     slug: river-bench
     description: "Heavy wooden benches face the water at twenty-meter intervals, bolted to concrete pads. Each one is identical. Each one offers a slightly different angle on the river, the far bank, and the bridge upstream. The wood is warm in sun and cold by evening."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cobblestone Walk"
     slug: cobblestone-walk
     description: "The promenade surface is original cobblestone, the individual stones rounded by a century of foot traffic into smooth irregular shapes. Walking on them requires attention. Heels catch between stones. The uneven surface slows the pace, which may be the point."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Street Performer"
     slug: street-performer
     description: "A busker occupies a widened section of the promenade, the case open on the cobblestones, a few bills and coins visible inside. The music carries over the river noise. The performer's eyes are closed. The songs are old — older than the RIDE, older than the corporation, from a time when the city had a different name."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Lamp Post"
     slug: the-lamp-post
     description: "A cast-iron lamp post at the promenade's midpoint, its design matching the ones on Brick Row — fluted column, scrollwork bracket, hexagonal lantern. At night it casts a circle of warm light on the cobblestones. Moths orbit the glass in summer. The light does not flicker."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Cafe Table"
     slug: cafe-table
     description: "A cluster of small round tables extends from a riverfront cafe onto the promenade, each table topped with a glass weighted against wind. The coffee is adequate. The view is the reason people sit here — the river moving left to right, slow and brown and constant."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The View"
     slug: the-view
     description: "A gap in the tree line opens a sightline from the promenade to the arch, the structure framed between two elms whose branches do not quite meet overhead. The view is accidental — no one planned it — but it is the most photographed angle in the city. From here the arch looks like it is holding the sky open."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Iron Bridge"
     slug: iron-bridge
     description: "A pedestrian bridge of riveted iron crosses a drainage channel that empties into the river, its deck grated so the water below is visible between your feet. The bridge is thirty meters long and curves slightly, the handrails cold in any weather. The ironwork dates to the same era as the promenade."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Evening Walk"
     slug: evening-walk
     description: "The promenade fills at dusk with people walking slowly, their pace matching the river's current. The light goes soft and orange. Conversation drops to murmurs. The arch silhouettes against the western sky. The walk has no destination — it exists for the walking."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Gazebo"
     slug: the-gazebo
     description: "A hexagonal wooden structure with a shingled roof and built-in benches, positioned at the promenade's widest point overlooking the river. The floor planks are spaced to let rain through. Someone has carved initials into every available surface, layer upon layer, a palimpsest of presence."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bird Fountain"
     slug: bird-fountain
     description: "A low stone basin set into a garden bed along the promenade, fed by a slow trickle from a pipe hidden in the surrounding plantings. Sparrows and finches crowd its edge in mornings. The basin fills and overflows onto the cobblestones, darkening them in a circle that shifts with the seasons."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Curve"
     slug: the-curve
     description: "The promenade bends to follow the river's course, the cobblestones narrowing where the bank cuts close. The inner edge presses against a retaining wall; the outer edge drops to the water. At the apex of the curve the view opens in both directions, upstream and down, and the arch hangs in the sky above the tree line to the south."
     zone_slug: the-promenade
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entrance"
     slug: the-entrance
     description: "A heavy steel door set into a hillside, painted the same ochre as the surrounding rock. No indicator lights, no keypads — just a mechanical deadbolt and a hand-lettered sign bleached by decades of sun."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Tape Library"
     slug: tape-library
     description: "Floor-to-ceiling wooden shelves hold thousands of magnetic tapes in archival sleeves, organized by date and band. The air is climate-controlled and dead silent. A hand-written index card system tracks every recording the Fracture Network has ever made."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Vinyl Vault"
     slug: vinyl-vault
     description: "Reinforced shelving holds pressed vinyl in acid-free sleeves, sorted by label color into narrow aisles. The concrete floor absorbs footsteps. Temperature holds at a constant 65 degrees, maintained by passive ventilation cut through the hillside."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Pressing Room"
     slug: pressing-room
     description: "A manual record press dominates the center of the room, its chrome arm polished to a mirror shine. Bins of raw PVC pellets line one wall. Stamper plates hang on hooks, each one engraved with a catalog number that corresponds to nothing in any digital database."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Listening Station"
     slug: listening-station
     description: "A worn leather chair faces a turntable and a reel-to-reel deck, both connected to a pair of monitor speakers on stands. No headphone jack, no output port — the only way to hear what plays here is to be in the room."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Label Machine"
     slug: label-machine
     description: "A manual label printer sits on a wooden workbench, surrounded by ink rollers and stacks of blank center labels. Each label is typeset by hand, letter by letter. The process takes longer than the pressing itself."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Climate Control"
     slug: climate-control
     description: "Analog thermometers and mechanical hygrometers line the walls, each one connected to passive ventilation louvers by a system of cables and counterweights. No circuit boards. No sensors. The system regulates itself through thermal expansion of metals."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Catalog"
     slug: the-catalog
     description: "A card catalog fills an entire wall — hundreds of small wooden drawers, each with a brass pull. Every recording in the Archive is cross-referenced by artist, date, location, and format. The catalog itself is the only index that exists."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Master Tape"
     slug: master-tape
     description: "A small vault within the vault, its door thick enough to stop a bullet. The master tapes of every Fracture Network recording rest here on climate-controlled reels. Some of these tapes are the only proof that certain performances ever happened."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Preservation Lab"
     slug: preservation-lab
     description: "A workbench holds demagnetizers, splice blocks, and alignment tools for maintaining tape integrity. Rolls of archival-grade leader tape hang from wall pegs. The work here is slow and manual — one damaged tape can take days to restore."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Collection"
     slug: the-collection
     description: "The deepest room in the Archive holds recordings that predate the Fracture Network itself. Unlabeled reels and unmarked vinyl sit in protective cases, their provenance documented only in a hand-bound ledger chained to the shelf."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Secure Storage"
     slug: secure-storage
     description: "A fireproof room with walls of poured concrete and a door that seals with a wheel lock. Backup copies of the most critical recordings are stored here in vacuum-sealed containers. If the rest of the Archive burns, this room survives."
     zone_slug: the-analog-archive
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Base"
     slug: the-base
     description: "Loose scree fans out from the foot of the butte where the rock meets the prairie. Sage and rabbitbrush grow in the runoff channels. The wind carries fine grit that stings exposed skin."
     zone_slug: the-butte
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Scramble"
     slug: the-scramble
     description: "A steep pitch of broken sandstone leads upward through a gap in the butte's lower cliff band. Handholds are worn smooth by weather and the occasional climber. The route is obvious but not easy."
     zone_slug: the-butte
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sage Brush"
     slug: sage-brush
     description: "Waist-high sage covers the slopes below the butte's rock face, its silver-green leaves sharp with camphor. The ground is dry and sandy between the plants. Jackrabbit trails thread through the brush in every direction."
     zone_slug: the-butte
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Wind Face"
     slug: wind-face
     description: "The west-facing wall of the butte takes the full force of the prevailing wind. The rock is sculpted into smooth curves and pockets, sandblasted over millennia. Standing here means leaning into a constant push."
     zone_slug: the-butte
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Ledge"
     slug: the-ledge
     description: "A narrow shelf of rock runs along the butte's midsection, wide enough to walk single file. The drop below is clean — nothing to grab on the way down. Pebbles kicked loose take a long time to hit bottom."
     zone_slug: the-butte
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Raptor Nest"
     slug: raptor-nest
     description: "A red-tailed hawk has built a nest of sticks and prairie grass in a crack near the butte's upper rim. Sun-bleached bones and pellets litter the ledge below. The birds tolerate human presence at a distance but not close."
     zone_slug: the-butte
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Summit"
     slug: the-summit
     description: "A flat cap of wind-scoured stone tops the butte, no larger than a small room. The view extends to the horizon in every direction — plains, sky, and nothing else. On a clear day the curvature of the earth is almost visible."
     zone_slug: the-butte
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Rock Face"
     slug: rock-face
     description: "Vertical sandstone banded in red and cream, its surface pocked with wind-carved holes and iron-stained streaks. Fossils of ancient sea creatures show in cross-section where slabs have calved away. The rock is warm to the touch even after sunset."
     zone_slug: the-butte
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Shadow"
     slug: the-shadow
     description: "The east side of the butte casts a long shadow in the afternoon, creating a cool corridor across the prairie floor. The temperature drops noticeably in the shade. Animals bed down here during the hottest part of the day."
     zone_slug: the-butte
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Prairie View"
     slug: prairie-view
     description: "A vantage point on the butte's south shoulder looks out over miles of unbroken grassland. The grass moves in patterns that track the wind across the plain. No structures are visible in any direction."
     zone_slug: the-butte
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Fossil Bed"
     slug: fossil-bed
     description: "A layer of exposed limestone near the butte's base holds the compressed remains of creatures that lived when this was an ocean floor. Ammonite spirals and crinoid stems show in clean relief. The rock crumbles at the edges where frost has worked it loose."
     zone_slug: the-butte
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Sun Throne"
     slug: sun-throne
     description: "A natural seat of eroded sandstone near the summit catches the morning sun full on. The stone is shaped like a chair back, worn smooth by wind. Someone has been sitting here long enough to polish the seat with use."
     zone_slug: the-butte
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Open Prairie"
     slug: open-prairie
     description: "Flat grassland stretches to the horizon without a single vertical interruption. The sky is two-thirds of the visible world. Wind moves through the grass in waves that look like breathing."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Spiral"
     slug: the-spiral
     description: "A dust devil spins across the dry ground, pulling loose soil into a tight column that wobbles and drifts. The air around it is still. The column moves with a slow purpose that almost looks intentional."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Kicked Dust"
     slug: kicked-dust
     description: "A stretch of bare ground where the topsoil has been stripped by wind, leaving hardpan clay cracked into polygons. Dust hangs in the air long after anything passes through. Footprints fill in within hours."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Calm Eye"
     slug: the-calm-eye
     description: "A patch of dead-still air sits at the center of the wind patterns that cross this stretch of prairie. The grass stands straight up. The silence has a physical weight — no rustle, no whistle, nothing."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Dry Lake"
     slug: dry-lake
     description: "A broad depression of cracked white alkali marks where a lake once stood. The surface is flat and hard, reflecting heat in visible waves. Nothing grows here. The nearest water is miles away and underground."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Chase"
     slug: the-chase
     description: "Open ground where dust devils race across the flats in parallel lines, chasing each other at walking speed. The columns are thin and weak — they collapse when they hit anything solid. The pattern reforms within minutes."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Clearing Dust"
     slug: clearing-dust
     description: "The air carries a fine haze of suspended silt that softens the horizon to a blur. The sun is a white disc without edges. Breathing through fabric becomes automatic after a few minutes."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Bare Rock"
     slug: bare-rock
     description: "A shelf of exposed bedrock breaks through the prairie surface, scoured clean by wind and grit. The rock is dark basalt, older than anything around it by hundreds of millions of years. It absorbs heat all day and radiates it back all night."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Stillness"
     slug: the-stillness
     description: "A point on the prairie where the wind drops to nothing and the world goes quiet. No bird calls, no insect noise, no movement in the grass. The silence is so complete it registers as pressure in the ears."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Heat Column"
     slug: heat-column
     description: "Rising air shimmers above a patch of dark rock, bending the horizon into liquid shapes. The thermal is strong enough to lift a hawk without it moving a feather. The ground temperature here runs twenty degrees above the surrounding soil."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Sand Blast"
     slug: sand-blast
     description: "A low ridge catches the wind and accelerates it through a narrow gap, driving fine sand horizontally at shin height. The rock on the downwind side is polished smooth. Anything left here long enough gets etched to bare metal."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Aftermath"
     slug: the-aftermath
     description: "A swath of flattened grass and scattered debris marks where a dust storm passed through recently. Small objects — a fence post, a bleached bone, a rusted can — have been rearranged by the wind. The ground is swept clean to hardpan."
     zone_slug: dust-devil
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Porch"
     slug: the-porch
     description: "A covered wooden porch faces west across empty prairie, its planks bleached gray by sun and scoured by wind-driven grit. Two chairs and a table sit against the wall. The view from here is a hundred miles of nothing."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Supply Room"
     slug: supply-room
     description: "Shelves of canned goods, water containers, and dry stores line the walls of a small interior room with no windows. Everything is inventoried on a clipboard hanging by the door. The supplies rotate on a schedule measured in months."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Radio Mast"
     slug: radio-mast
     description: "A steel mast rises from the roof of the outpost, its guy wires singing in the constant wind. The antenna at the top is simple — a dipole cut for a specific frequency. Reception out here is clean because there is nothing else on the air."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Generator Shed"
     slug: generator-shed
     description: "A small outbuilding houses a diesel generator bolted to a concrete pad. The fuel tank holds enough for two weeks of continuous run time. The exhaust pipe exits through the roof and the wind carries the fumes away instantly."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Water Tank"
     slug: the-water-tank
     description: "A cylindrical steel tank stands on legs behind the outpost, its surface pocked with rust and patched with riveted plates. A windmill pump feeds it from a deep well. The water is cold and tastes of mineral."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Observation Post"
     slug: observation-post
     description: "A raised platform on the outpost roof provides a 360-degree view of the surrounding plains. A pair of mounted binoculars on a swivel bracket covers the western approach. At night the darkness is total except for stars."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Bunk"
     slug: the-bunk
     description: "A narrow room with two cots, wool blankets, and a wood stove vented through the wall. The mattresses are thin but the building blocks the wind. A kerosene lamp on a shelf provides the only light."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Map Wall"
     slug: map-wall
     description: "A wall-mounted map of the surrounding region shows terrain features, water sources, and distances in pencil annotations. The map is old — printed on heavy stock, folded and refolded until the creases are wearing through. Pins mark locations that correspond to nothing on any official survey."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Fence"
     slug: the-fence
     description: "A barbed wire fence runs from the outpost toward the horizon in both directions, its posts leaning with the prevailing wind. The fence marks nothing — no property line, no boundary on any map. It was here before the outpost was."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Solar Panel"
     slug: solar-panel
     description: "A rack of solar panels tilted south on a steel frame provides power to the outpost's batteries. The panels are dusty and need wiping after every windstorm. Output is more than enough — the outpost draws almost nothing."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Approach"
     slug: the-approach
     description: "A dirt track leads to the outpost from the east, two ruts worn into the prairie grass by infrequent traffic. The track is visible for miles. Anyone coming this way is seen long before they arrive."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Night Watch"
     slug: night-watch
     description: "The outpost after dark, when the kerosene lamps are out and the generator is off. The only light comes from stars — more of them visible here than most people have ever seen. The wind drops at night and the silence deepens until it fills every room."
     zone_slug: the-outpost
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entrance"
     slug: echo-chamber-the-entrance
     description: "A brushed-steel door set into the side of a decommissioned broadcast relay station. The walls absorb sound so completely that footsteps vanish before they reach the floor. Nothing about the exterior suggests what the building holds."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Reception Desk"
     slug: reception-desk
     description: "A curved console sits beneath a single overhead light, its surface worn smooth by decades of use. Racks of unlabeled access cards line the wall behind it. The air carries the faint chemical sweetness of magnetic tape."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Archive Hall"
     slug: archive-hall
     description: "Floor-to-ceiling shelving stretches the full length of the room, every slot filled with indexed containers of transmissions captured from THE WIRE. The temperature holds at exactly sixty-two degrees. A century of intercepted signal lives here, organized by date, frequency, and origin point."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Listening Room"
     slug: listening-room
     description: "Six isolated stations line the walls, each fitted with shielded headphones and waveform displays. Acoustic dampening panels eliminate every ambient frequency. This is where raw WIRE intercepts get their first human ear."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Tape Library"
     slug: echo-chamber-tape-library
     description: "Thousands of archival tapes fill climate-controlled racks under amber lighting. The indexing system is handwritten, deliberately analog, immune to network intrusion. Some of these recordings predate the RIDE by decades."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Vault"
     slug: the-vault
     description: "A reinforced room behind a cipher-locked door, holding the most sensitive material in the archive. The walls are Faraday-shielded and the air is independently circulated. Whatever is stored here, the Fracture Network considers it worth dying to protect."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Playback Station"
     slug: playback-station
     description: "A console built around salvaged broadcast equipment, adapted for every format the archive holds. Reel-to-reel decks sit beside digital decoders and analog patch bays. Operators can reconstruct transmissions from fragments here."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Climate Control"
     slug: echo-chamber-climate-control
     description: "Banks of dehumidifiers and temperature regulators hum in a windowless utility room. The system maintains preservation-grade conditions throughout the facility. One degree of drift could degrade a century's worth of captured signal."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Stacks"
     slug: the-stacks
     description: "Dense rows of shelving narrow the walkways to single-file passage. Each shelf holds standardized containers, their spines marked with date ranges and frequency bands. The deeper sections require a flashlight; overhead lighting was sacrificed for additional storage."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Index Terminal"
     slug: index-terminal
     description: "A standalone terminal connects to the archive's internal catalog, air-gapped from every external network. Search queries return location codes, not content. To hear what the archive holds, you walk to the shelf and pull it yourself."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Silent Room"
     slug: silent-room
     description: "The quietest space in the facility, engineered for zero ambient noise. Analysts use it to review the faintest intercepts, the ones buried beneath static and interference. The silence is so total it becomes a pressure against the ears."
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Emergency Seal"
     slug: emergency-seal
     description: "Heavy blast doors stand ready to isolate the archive from the rest of the facility. Manual release levers and analog failsafes ensure the seal functions without power. If the archive is compromised, this room becomes a tomb for what it protects. ---"
     zone_slug: echo-chamber
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Neon Boulevard"
     slug: neon-boulevard
     description: "Towers of light climb the faces of buildings for blocks in every direction, each sign competing for attention with the next. The glow reflects off polished sidewalks and tinted glass, turning the street into a canyon of manufactured color. Even at three in the morning, The Strip performs."
     zone_slug: the-strip
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Sidewalk Stars"
     slug: sidewalk-stars
     description: "Names are embedded in the walkway beneath scuffed boot prints and spilled drinks, each one commemorating a Cultural Zone celebrity. Most of the names belong to entertainers nobody remembers. The stars keep shining anyway."
     zone_slug: the-strip
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Red Carpet"
     slug: red-carpet
     description: "A stretch of deep crimson runs from the curb to a set of glass doors, flanked by velvet ropes and portable lighting rigs. Holographic camera flashes simulate the press line even when no one is arriving. The carpet is replaced weekly to keep the color fresh."
     zone_slug: the-strip
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Premiere"
     slug: the-premiere
     description: "A grand theater entrance with a towering marquee displaying tonight's featured event in shifting light. Crowds gather on the sidewalk to watch arrivals they will never meet. The lobby beyond the doors smells like new upholstery and cold air conditioning."
     zone_slug: the-strip
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Paparazzi Corner"
     slug: paparazzi-corner
     description: "A wedge of sidewalk where sightlines converge on three major venue exits. Photographers staked out this position so long ago that the concrete has worn smooth where their tripods stand. The angle captures everyone coming or going."
     zone_slug: the-strip
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Limousine Lane"
     slug: limousine-lane
     description: "A dedicated lane runs parallel to the boulevard, buffered from regular traffic by concrete planters. Tinted windows slide past in a slow procession, each vehicle identical to the last. The exhaust hangs in the warm air like a signature."
     zone_slug: the-strip
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Club Entrance"
     slug: club-entrance
     description: "A matte-black facade with a single door and no signage, the line extending down the block. A velvet rope and a bouncer with an earpiece control the flow. The bass from inside vibrates the sidewalk underfoot."
     zone_slug: the-strip
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Billboard Row"
     slug: billboard-row
     description: "Massive displays cover the upper stories of every building along this stretch, cycling through advertisements for products, experiences, and lifestyles. The images shift every eight seconds. Standing here long enough, it becomes difficult to remember what any of them were selling."
     zone_slug: the-strip
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Street Performer"
     slug: the-strip-street-performer
     description: "A small clearing in the pedestrian traffic where a performer works the crowd with practiced energy. The act changes nightly but the spot never goes empty. A hat on the ground collects tips that nobody bends down to count."
     zone_slug: the-strip
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The After Party"
     slug: the-after-party
     description: "A rooftop lounge accessible only through an unmarked elevator in an adjacent parking structure. The furniture is low, the lighting is warm, and the music is quieter than the conversations. This is where The Strip goes when it is done being watched."
     zone_slug: the-strip
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Dawn Patrol"
     slug: dawn-patrol
     description: "The boulevard in the thin light before sunrise, emptied of crowds and stripped of its nighttime glamour. Street cleaners work the gutters while maintenance crews swap burned-out bulbs. For an hour, The Strip looks like what it is: infrastructure."
     zone_slug: the-strip
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Searchlight"
     slug: searchlight
     description: "A pair of high-powered beams sweep the sky from a rooftop platform, carving white arcs through the Basin haze. The lights advertise nothing specific. They exist to remind the skyline that something is happening down here. ---"
     zone_slug: the-strip
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Sound Stage One"
     slug: sound-stage-one
     description: "A cavernous black box, sixty feet to the ceiling, with catwalks and rigging grids lost in shadow overhead. The concrete floor is scarred with paint marks from a hundred different set configurations. Whatever is being built in here today will be torn down by Friday."
     zone_slug: studio-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Sound Stage Three"
     slug: sound-stage-three
     description: "Smaller than Stage One but fully soundproofed, with walls thick enough to block a thunderstorm. A half-dressed set fills the center of the floor, its plywood walls painted to look like marble. The craft is in the camera angle, not the materials."
     zone_slug: studio-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sound Stage Alley"
     slug: sound-stage-alley
     description: "A narrow service road between the stages, lined with dumpsters full of discarded set pieces and rolls of seamless backdrop paper. Grips smoke cigarettes against the corrugated walls between setups. Forklifts have worn ruts into the asphalt."
     zone_slug: studio-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Prop House"
     slug: prop-house
     description: "Floor-to-ceiling shelves hold furniture, weapons, dishware, and objects from every era and genre, all meticulously cataloged. A Roman shield leans against a mid-century television set. Nothing here is real, and all of it is convincing."
     zone_slug: studio-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Wardrobe"
     slug: wardrobe
     description: "Racks of costumes fill a climate-controlled warehouse, organized by period, character type, and size. Seamstresses work at industrial sewing machines beneath fluorescent lights. The air smells like fabric sizing and steam."
     zone_slug: studio-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Director's Chair"
     slug: directors-chair
     description: "A canvas chair sits beside a bank of monitors at the edge of the active stage, surrounded by scripts, coffee cups, and discarded headsets. The name on the back changes with every production. The chair itself never moves."
     zone_slug: studio-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Commissary"
     slug: the-commissary
     description: "A utilitarian cafeteria serves the studio workforce from behind a long counter of steam trays and heat lamps. Actors in full costume sit beside electricians in tool belts. The food is adequate and the coffee is endless."
     zone_slug: studio-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Post-Production"
     slug: post-production
     description: "A suite of darkened editing bays where screens glow with timelines and waveforms. The rooms are cool and quiet, insulated from the chaos of production. Raw footage enters from one end; finished content emerges from the other."
     zone_slug: studio-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Screening Room"
     slug: screening-room
     description: "Thirty plush seats face a wall-sized screen in a room that smells like new carpet and popcorn oil. Studio executives preview finished work here before it reaches the public. The lighting dims on a single switch."
     zone_slug: studio-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Water Tower"
     slug: water-tower
     description: "A steel water tower rises above the studio buildings, its tank painted with the studio logo visible from the highway. Maintenance ladders climb its legs, but the platform at the top has been locked for years. It has become more landmark than infrastructure."
     zone_slug: studio-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Security Gate"
     slug: security-gate
     description: "A guard booth controls access to the studio complex, checking credentials against a daily call sheet. The barrier arm rises and falls with mechanical regularity. Beyond it, the outside world and its concerns stop mattering."
     zone_slug: studio-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Writer's Room"
     slug: writers-room
     description: "A windowless conference room with a long table buried under scripts, notecards, and empty takeout containers. A whiteboard covers one wall, dense with story arcs in three colors of marker. The room smells like stale coffee and desperation. ---"
     zone_slug: studio-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Gate"
     slug: main-gate
     description: "Wrought iron and stucco mark the entrance to the studio lot, designed to look timeless and important. A guard checks names against the list. The gate itself is decorative; the real security is electronic and invisible."
     zone_slug: the-lot
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Guard House"
     slug: guard-house
     description: "A small air-conditioned booth at the main entrance, staffed around the clock. Monitors show feeds from cameras across the lot. The guard knows every face that belongs here and remembers every one that does not."
     zone_slug: the-lot
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Studio Map"
     slug: studio-map
     description: "A large illustrated map stands behind glass near the main gate, showing the lot's stages, offices, and facilities in a style that makes the place look like a theme park. Visitors study it with genuine excitement. Workers walk past without looking."
     zone_slug: the-lot
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Fountain"
     slug: the-lot-the-fountain
     description: "A circular fountain sits in the center of the main courtyard, its water tinted blue and lit from below. Benches around its rim are positioned for photographs. The fountain has appeared in the background of more productions than any actor on the lot."
     zone_slug: the-lot
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Executive Bungalow"
     slug: executive-bungalow
     description: "A low Spanish-style building with terracotta roof tiles and bougainvillea climbing the walls. Inside, the offices are cool and quiet, furnished with taste that communicates authority. Deals are made in these rooms that determine what the Basin produces for the next five years."
     zone_slug: the-lot
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Talent Trailer"
     slug: talent-trailer
     description: "A row of white trailers lines the back of the active stage, each one a temporary home for performers between scenes. Names are printed on paper and taped to the doors. The interiors range from spartan to lavish depending on the contract."
     zone_slug: the-lot
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Craft Services"
     slug: craft-services
     description: "A tent canopy covers folding tables loaded with snacks, drinks, and warming trays of food available to the crew around the clock. The coffee urn is industrial-sized and always half-empty. It is the one location on the lot where hierarchy dissolves."
     zone_slug: the-lot
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Electric Cart Path"
     slug: electric-cart-path
     description: "A paved path winds between stages and office buildings, shared by electric carts, bicycles, and pedestrians. The carts hum past at a speed that is almost walking pace. Everyone on this path is going somewhere that feels urgent."
     zone_slug: the-lot
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Mill"
     slug: the-mill
     description: "A workshop where sets are built from raw lumber, steel, and foam, staffed by carpenters and welders who work from blueprints pinned to plywood walls. Sawdust covers the floor and the scream of table saws fills the air. The smell of fresh-cut wood is constant."
     zone_slug: the-lot
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Paint Shop"
     slug: paint-shop
     description: "A long open bay where scenic painters transform plywood and plaster into marble, brick, sky, and forest. Cans of every color line the shelves, and the floor is a Jackson Pollock of accumulated drips. The painters work fast and their illusions are flawless."
     zone_slug: the-lot
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Back Gate"
     slug: back-gate
     description: "A utilitarian exit on the far side of the lot, used for deliveries and crew parking. No signage, no decoration, no pretense. The contrast with the main gate says everything about which side of the camera matters."
     zone_slug: the-lot
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Tour Route"
     slug: tour-route
     description: "A designated path through the lot marked with ropes and signage, guiding visitors past carefully selected points of interest. The route avoids anything genuinely operational. What the tour shows is another production in itself. ---"
     zone_slug: the-lot
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Western Street"
     slug: western-street
     description: "A full-scale frontier town built from aged wood and painted signage, complete with hitching posts, a saloon, and a general store. None of the buildings have back walls. From the right angle, it is 1885; from the wrong one, it is plywood and two-by-fours."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "New York Street"
     slug: new-york-street
     description: "Brownstone facades line a narrow street with fire escapes, awnings, and parked cars from no particular decade. The storefronts have real glass but nothing behind them. Rain machines are mounted on the roofline, ready to make it any season on command."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Suburban Block"
     slug: suburban-block
     description: "A cul-de-sac of identical houses with manicured lawns, white fences, and driveways. The houses are three-quarter scale, built to look right on camera rather than feel right in person. Walking through it produces an uncanny sense of recognition without memory."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Tank"
     slug: the-tank
     description: "A massive water tank sunk into the ground, capable of simulating oceans, rivers, and floods on command. The water is chemically treated to photograph blue. When drained, it is just a concrete pit with painted walls."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Jungle Set"
     slug: jungle-set
     description: "Dense artificial foliage fills a section of the backlot, wired with sprinkler systems to simulate tropical rain. The plants are a mix of real and synthetic, indistinguishable from three feet away. Recorded bird calls play from hidden speakers."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Burned Building"
     slug: burned-building
     description: "A permanent set piece designed to look like the aftermath of a structural fire, with charred beams, collapsed walls, and ash-covered debris. It has been used in so many productions that the scorch marks are real now. The smell of old smoke clings to the wood."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Fake Rain"
     slug: fake-rain
     description: "An open area beneath a grid of overhead pipes that can produce anything from a light drizzle to a downpour. The water collects in drains cut into the asphalt. Crews in rain gear adjust the valves while actors in summer clothes stand just outside the wet zone."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Scaffolding"
     slug: the-scaffolding
     description: "A permanent framework of steel and wood that serves as the skeleton for whatever facade is needed next. Grips climb it with the ease of dockworkers. Between productions, it stands bare against the sky like a building that forgot to finish."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Cemetery Set"
     slug: cemetery-set
     description: "Rows of foam headstones and artificial turf create a graveyard that has served as backdrop for grief, horror, and comedy in equal measure. The headstones bear names that recur across productions, inside jokes among the prop department. A single plastic tree provides shade that never moves."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Empty House"
     slug: empty-house
     description: "A complete house exterior with a door that opens onto nothing. The interior was never built. It stands at the end of a cul-de-sac on the suburban block, looking occupied from the street, hollow from any other angle."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Green Screen"
     slug: the-green-screen
     description: "A towering wall of chromakey green covers the side of a warehouse, used for shots where the background will be added later. The paint is touched up weekly to maintain uniform color. Standing in front of it, a person could be anywhere."
     zone_slug: the-backlot
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Tear-Down"
     slug: tear-down
     description: "A section of the backlot where decommissioned sets are dismantled and sorted for salvage or disposal. Walls lean against each other in stacks, their painted surfaces facing outward like postcards from places that never existed. The dumpsters here are full of someone's vision. ---"
     zone_slug: the-backlot
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Subdivision Gate"
     slug: subdivision-gate
     description: "A decorative stone entrance with the development name in brass letters, flanked by landscaped berms and a nonfunctional guard booth. The gate stands open permanently; closing it would require someone to care enough to try. Beyond it, the houses begin."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Cul-de-Sac"
     slug: cul-de-sac
     description: "A circle of driveways and garage doors, each house a minor variation on the same floor plan. Sprinklers hiss on timers across lawns that are uniformly green. The only sound is the hum of central air conditioning units."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Model Home"
     slug: model-home
     description: "The demonstration unit, furnished and staged to sell the lifestyle the development promises. The furniture is slightly too perfect, the fruit bowl on the counter is wax. A faded banner out front still reads GRAND OPENING though the development sold out years ago."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Strip Mall"
     slug: strip-mall
     description: "A single-story L-shaped building with a nail salon, a phone repair shop, a taqueria, and three vacant storefronts with papered windows. The parking lot is half-empty at all hours. Sun has faded the awnings to a uniform beige."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Gas Station"
     slug: gas-station
     description: "A canopy over four pump islands, fluorescent lights buzzing day and night. The convenience store inside sells energy drinks, lottery tickets, and air fresheners shaped like palm trees. Heat radiates off the concrete in visible waves."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Highway On-Ramp"
     slug: highway-on-ramp
     description: "A curving lane of asphalt merges with the freeway above, the roar of traffic constant. Chain-link fencing lines both sides, threaded with windblown trash. From here, the Sprawl is just another exit to pass."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Fast Food Row"
     slug: fast-food-row
     description: "A quarter-mile stretch of drive-throughs and franchise signage, each building designed to be identified at sixty miles an hour. The parking lots connect to each other in a continuous loop of asphalt. The smell of fryer oil carries for blocks."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Parking Lot"
     slug: the-parking-lot
     description: "Acres of painted lines and sun-softened asphalt, serving a big-box store whose facade is visible from the highway. Shopping carts cluster against light poles in the wind. The heat shimmer makes the far end of the lot look like open water."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Identical House"
     slug: identical-house
     description: "Stucco walls, tile roof, two-car garage, small yard. The floor plan is mirrored from the house next door, which is mirrored from the one beside it. Variations in paint color are the only way to tell them apart, and several have chosen the same shade."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Dead Lawn"
     slug: dead-lawn
     description: "A front yard where the grass has gone brown and brittle, the sprinkler system either broken or shut off. The house behind it shows curtains drawn against the sun. A real estate lockbox hangs from the front door handle."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "For Sale Sign"
     slug: for-sale-sign
     description: "A weathered sign leans slightly forward in a yard, its colors bleached by the sun. The listing agent's phone number has been covered by a PRICE REDUCED sticker, which has itself begun to peel. The house behind it looks the same as every other house on the block."
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Traffic Light"
     slug: traffic-light
     description: "An intersection controlled by a signal that cycles through its colors for no one in particular. The crosswalk lines have faded to ghosts on the asphalt. During rush hour, the light creates a brief gathering of strangers who will never acknowledge each other. ---"
     zone_slug: the-sprawl
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Avenue"
     slug: the-avenue
     description: "A wide boulevard divided by a grass median, lined with tall palms whose shadows stripe the road in the late afternoon. The houses behind the hedges are large and set far back from the street. Even the air feels curated here, warm and faintly floral."
     zone_slug: palm-line
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Palm Shadow"
     slug: palm-shadow
     description: "Long diagonal shadows fall across the road from a row of towering palms, their fronds clicking in the breeze. The light between the shadows is sharp enough to squint. Cars glide through the alternating bands of sun and shade without slowing."
     zone_slug: palm-line
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Median"
     slug: the-median
     description: "A manicured strip of grass and bird-of-paradise plants runs between the lanes, maintained to a standard that makes it look like part of a private estate. Irrigation heads pop up at scheduled intervals. The median is better kept than most public parks."
     zone_slug: palm-line
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Wrought Iron"
     slug: wrought-iron
     description: "An ornamental fence runs along the front of a property, its black iron scrollwork framing a view of terraced gardens and a circular drive. The craftsmanship is genuine but the design is borrowed from somewhere older and farther away. It communicates wealth by referencing tradition."
     zone_slug: palm-line
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Luxury Sedan"
     slug: luxury-sedan
     description: "A dark vehicle with tinted windows sits in a driveway, its finish reflecting the palms and sky with mirror clarity. The engine ticks as it cools in the shade of a porte-cochere. The car costs more than most houses in the Sprawl."
     zone_slug: palm-line
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Bougainvillea Wall"
     slug: bougainvillea-wall
     description: "A cascade of magenta blossoms covers a high wall, obscuring the property beyond in a curtain of color. The thorns beneath the flowers are vicious, a fact the beauty effectively conceals. The wall runs the length of the block without a single gap."
     zone_slug: palm-line
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Gate House"
     slug: the-gate-house
     description: "A small stucco building beside a private entrance, manned by security that checks license plates against a resident list. The gate is iron and opens slowly, with the deliberation of something that has no reason to hurry. The neighborhood beyond is quieter than the street."
     zone_slug: palm-line
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Pool Deck"
     slug: pool-deck
     description: "A turquoise rectangle of water set into limestone, surrounded by loungers and potted palms. The surface is perfectly still, reflecting the sky and the roofline of a house large enough to have wings. The only sound is the soft purr of the filtration system."
     zone_slug: palm-line
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Tennis Court"
     slug: tennis-court
     description: "A green hard court behind a windscreen, its lines freshly painted and its net taut. A ball machine sits at one end, loaded but idle. The court sees less use than the effort of its maintenance suggests."
     zone_slug: palm-line
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Cabana"
     slug: the-cabana
     description: "A shaded structure beside a pool, furnished with cushioned seating and a wet bar stocked with glassware. Ceiling fans turn slowly overhead. The cabana is designed to make doing nothing feel like an accomplishment."
     zone_slug: palm-line
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Sunset Drive"
     slug: sunset-drive
     description: "A curving road that follows the contour of the hills, offering views of the basin floor below as the light goes amber. The houses on the uphill side are invisible behind hedges and gates. On the downhill side, the city grid stretches to the haze."
     zone_slug: palm-line
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Hilltop View"
     slug: hilltop-view
     description: "A vantage point at the road's highest elevation, where the entire basin opens up below in a panorama of rooftops, palms, and distant mountains. The air is clearer up here, the heat less oppressive. Even the RIDE looks beautiful from this distance. ---"
     zone_slug: palm-line
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Velvet Rope"
     slug: velvet-rope
     description: "A heavy rope on brass stanchions separates the line on the sidewalk from the entrance, tended by a doorman whose selections appear arbitrary and are not. The rope is actual velvet, replaced monthly. Being on the wrong side of it is the point."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Lobby"
     slug: the-lobby
     description: "Low-lit and furnished in dark leather, the lobby serves as a transition between the street and the interior. Music pulses through the walls but remains muffled here, a promise of what lies deeper inside. A hostess behind a podium controls access to the rooms beyond."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Dance Floor"
     slug: dance-floor
     description: "A sunken floor of polished black tile, ringed by elevated booths and washed in colored light that shifts on a slow cycle. The bass is physical here, felt in the chest and the floor. Bodies move in patterns that look choreographed from above but are not."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "DJ Platform"
     slug: dj-platform
     description: "An elevated booth at the head of the dance floor, surrounded by equipment and bathed in its own lighting rig. The DJ is visible to the entire room but separated from it by height and glass. The sound is controlled from here with surgical precision."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "VIP Table"
     slug: vip-table
     description: "A curved booth on a raised platform overlooking the dance floor, roped off and attended by dedicated staff. Bottles are displayed on the table like trophies. The elevation is three feet, but the social distance is measured in zeroes."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Champagne Room"
     slug: champagne-room
     description: "A private lounge behind frosted glass doors, furnished with low seating and indirect lighting. The champagne is poured from bottles that cost more than most people earn in a week. Conversations here are conducted at a volume that requires leaning in."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Private Balcony"
     slug: private-balcony
     description: "A narrow terrace overlooking the dance floor from the second story, accessible through the VIP section. The railing is glass, the seating is minimal, and the view makes the crowd below look like a living art installation. The air up here is cooler."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Bathroom Mirror"
     slug: bathroom-mirror
     description: "A wall of mirrors above black marble sinks, lit to be flattering from every angle. The bathroom is quieter than the main room, a space for recalibration between appearances. Even the hand towels are cloth."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Coat Check"
     slug: coat-check
     description: "A counter staffed by a single attendant, backed by a wall of numbered hooks. In the Basin's climate, coats are rarely necessary, but the check exists for bags, wraps, and anything else that might compromise the silhouette. The attendant remembers faces better than ticket numbers."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Booth"
     slug: the-booth
     description: "A deep semicircular seat tucked into an alcove, partially concealed by a curtain. The lighting here is low enough to make faces indistinct. It is the most private table in a room designed for being seen, which makes it the most coveted."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Back Stairwell"
     slug: back-stairwell
     description: "A narrow staircase behind a staff door, connecting the main floor to the offices and storage above. The walls are unpainted concrete, a sharp contrast to the velvet on the other side of the door. Staff use it between floors; management uses it to leave unseen."
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Office"
     slug: the-office
     description: "A windowless room on the second floor, furnished with a desk, a safe, and a bank of security monitors. The room is soundproofed against the bass from below. Whatever happens on the floor, the decisions that shape it are made here. ---"
     zone_slug: the-velvet-room
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Elevator Up"
     slug: elevator-up
     description: "A mirrored elevator opens onto the street level and climbs without stopping to the rooftop. The ascent takes forty seconds, during which the city drops away floor by floor through a narrow window. The doors open onto a different world than the one left below."
     zone_slug: skybar
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Reception"
     slug: reception
     description: "A sleek desk at the elevator landing, staffed by someone whose job is to make the transition from arrival to experience feel effortless. The guest list is checked with a glance, not a clipboard. Beyond the desk, the sky opens up."
     zone_slug: skybar
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Pool"
     slug: the-pool
     description: "A narrow rectangle of illuminated water set into the rooftop deck, too small for laps and too beautiful to ignore. Guests lounge at its edges with drinks in hand, their reflections rippling in the turquoise glow. The pool is for looking at, not swimming in."
     zone_slug: skybar
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Infinity Edge"
     slug: infinity-edge
     description: "The pool's far edge drops away to meet the cityscape below, water and skyline blending into a single plane. The illusion of endlessness is engineered with plumbing and precise angles. Standing here, the city feels like it was built as a backdrop for this pool."
     zone_slug: skybar
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Cabana Row"
     slug: cabana-row
     description: "A line of draped daybeds along the pool deck, each one a private island of cushions and white fabric. Bottle service appears without being summoned. The cabanas face west, positioned for the sunset like theater seats for the only show that costs nothing."
     zone_slug: skybar
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Fire Pit"
     slug: the-fire-pit
     description: "A circular gas flame set into a stone table, surrounded by low seating. The fire is decorative, its warmth unnecessary in the Basin's climate, but the primal draw of flame does its work regardless. Conversations settle into a slower rhythm around it."
     zone_slug: skybar
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Cocktail Bar"
     slug: cocktail-bar
     description: "A backlit bar of frosted glass runs along one edge of the rooftop, staffed by bartenders who move with rehearsed efficiency. The drinks are architectural, garnished with precision. The markup is staggering and no one mentions it."
     zone_slug: skybar
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Cityscape View"
     slug: cityscape-view
     description: "The rooftop's edge offers an unobstructed panorama of the basin, its grid of lights stretching to the mountains. The view is the same every night and it never stops working. Guests stand at the railing with phones raised, trying to capture something the camera always flattens."
     zone_slug: skybar
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The DJ"
     slug: the-dj
     description: "A compact booth in the corner of the rooftop, the DJ visible but not dominant, the music present but subordinate to conversation. The set is ambient and warm, curated to complement the view rather than compete with it. Volume stays low enough to talk over."
     zone_slug: skybar
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Daybed"
     slug: daybed
     description: "A cushioned platform at the pool's edge, wide enough for two and angled toward the sunset. The fabric is white, the frame is teak, and the position guarantees visibility from every other seat on the deck. Reclining here is a performance."
     zone_slug: skybar
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Railing"
     slug: skybar-the-railing
     description: "A glass barrier at the rooftop's perimeter, high enough for safety and transparent enough to preserve the view. Smudges from hands and foreheads are wiped away every hour. The drop beyond it is forty stories of glass and concrete."
     zone_slug: skybar
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Last Call"
     slug: last-call
     description: "The rooftop in the final hour before closing, the crowd thinned and the music fading. The bartenders begin to consolidate bottles. The city below continues without pause, indifferent to the small civilization winding down above it. ---"
     zone_slug: skybar
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "White Room"
     slug: white-room
     description: "A large rectangular space with white walls, white floors, and track lighting aimed at whatever occupies the center. The room erases context, forcing attention onto the work displayed within it. The air conditioning maintains the temperature of a museum vault."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Installation"
     slug: the-installation
     description: "A room-sized piece occupies the main gallery space, its materials and dimensions shifting with each exhibition cycle. Visitors move through it rather than past it. The installation is always experiential, always temporary, and always discussed as though it were permanent."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sculpture Garden"
     slug: sculpture-garden
     description: "An outdoor courtyard enclosed by gallery walls, planted with drought-tolerant species and populated with large-scale works in steel, stone, and glass. The pieces cast shadows that change through the day. A fountain provides the only sound."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Opening Night"
     slug: opening-night
     description: "The gallery on exhibition night, filled with people dressed to be seen holding wine they are not drinking. The art becomes a backdrop for social positioning. Conversations are conducted at a volume calibrated to seem casual while carrying across the room."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Wine Reception"
     slug: wine-reception
     description: "A side table set with glasses of red and white, attended by a server who refills without being asked. The wine is good enough to be credible and cheap enough to pour freely. It exists to lubricate the social machinery of the evening."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Curator's Office"
     slug: the-curators-office
     description: "A glass-walled room overlooking the main gallery, furnished with a desk, art books, and a single significant piece on the wall that is never for sale. The curator's taste determines what the Basin considers important this season. The pressure is invisible and total."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Back Gallery"
     slug: back-gallery
     description: "A smaller exhibition space behind the main rooms, used for emerging artists and experimental work. The lighting is less refined and the walls show nail holes from previous hangings. The work here is riskier, which sometimes means it is better."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Annex"
     slug: the-annex
     description: "A connected building used for storage, crating, and the unglamorous logistics of moving art. Paintings lean against walls in bubble wrap and wooden frames are stacked in corners. The annex smells like packing material and linseed oil."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Loading Dock"
     slug: loading-dock
     description: "A concrete bay at the gallery's rear, where crated works arrive and depart in climate-controlled trucks. Handlers move pieces with the care of surgeons. The dock is the last place art exists as a physical object before it becomes a cultural event."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Private Viewing"
     slug: private-viewing
     description: "A small room accessible by appointment, where serious buyers examine work under controlled lighting without the pressure of an audience. The door is closed during viewings. Prices are discussed here in a tone that treats numbers as confidential information."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Gift Shop"
     slug: the-gallery-gift-shop
     description: "A curated retail space near the entrance selling prints, catalogs, and objects that reference the current exhibition without reproducing it. The merchandise is priced at the outer edge of impulse. The shop exists to give visitors something to take home besides an opinion."
     zone_slug: the-gallery
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Street Entrance"
     slug: street-entrance
     description: "A minimalist glass door at street level, marked only by a small plaque with the gallery name. The understatement is intentional, a signal that if you need to be told what this place is, it may not be for you. The door is always unlocked during hours. ---"
     zone_slug: the-gallery
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Dam"
     slug: the-dam
     description: "A concrete wall curves across the canyon mouth, holding back the reservoir's dark water. The face is stained with mineral deposits in long vertical streaks. A chain-link fence topped with barbed wire runs along the crest, vibrating faintly in the wind."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Spillway"
     slug: spillway
     description: "A sloped concrete channel descends from the dam's overflow point, dry and sun-bleached for most of the year. Debris collects at the bottom where the angle flattens. When the rains come, this channel roars, but the Basin rarely remembers what rain sounds like."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Walking Path"
     slug: the-reservoir-walking-path
     description: "A paved trail circles the reservoir, shaded at intervals by planted sycamores. Joggers and dog walkers share the path in practiced avoidance patterns. The surface is maintained just well enough to keep the neighborhood from complaining."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Pump House"
     slug: the-pump-house
     description: "A squat concrete building at the water's edge, its door padlocked and its windows covered with steel mesh. Pipes emerge from its walls and descend into the water. The hum of machinery inside carries across the surface on still mornings."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Observation Point"
     slug: observation-point
     description: "A concrete platform with a metal railing extends over the water's edge, offering a view across the reservoir to the hills beyond. A faded informational plaque describes the structure's history in language no one reads. Pigeons have claimed the railing."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Chain Link Fence"
     slug: chain-link-fence
     description: "A perimeter fence circles the reservoir, its metal dulled by sun and salt air. Signs at regular intervals warn against trespassing, swimming, and fishing. The fence has been cut and repaired in enough places to suggest the warnings are decorative."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Still Surface"
     slug: still-surface
     description: "The reservoir's water lies flat and dark, reflecting the sky and the surrounding hillside with photographic precision. No boats disturb it, no current moves it. The stillness makes the surface feel like a solid, something that could be walked on."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Overflow Channel"
     slug: overflow-channel
     description: "A secondary drainage route branches from the main spillway, designed to handle volume the primary channel cannot. The concrete is rougher here, less maintained. Graffiti marks the walls where the channel passes under a road."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Control Building"
     slug: control-building
     description: "A low building on the dam's crest, housing the mechanical systems that regulate water levels and flow. The windows are narrow and reinforced. Inside, gauges and valve controls line the walls, most of them original to the facility."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Filter"
     slug: the-filter
     description: "A fenced compound of concrete basins where reservoir water is processed before entering the municipal system. The basins are exposed to the sky, their surfaces catching the sunlight. The chemicals used here leave a sharp, clean smell in the air."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Concrete Lip"
     slug: concrete-lip
     description: "The reservoir's edge where water meets the engineered shore, a clean line of formed concrete stained with algae at the waterline. The lip is too narrow to sit on comfortably, but people do anyway. It is the closest the public gets to the water."
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dog Walk"
     slug: dog-walk
     description: "A stretch of the perimeter path where dog owners cluster in the early morning and late afternoon, their animals pulling at leashes or running off them. Plastic bag dispensers are mounted on posts at each end. The grass beside the path is worn to dirt. ---"
     zone_slug: the-reservoir
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Concrete Bed"
     slug: concrete-bed
     description: "A wide channel of poured concrete stretches in a straight line toward the horizon, its surface cracked and stained by seasons of runoff and drought. The bed is dry more often than not, baking in the sun. Skateboarders have waxed the smoother sections."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Bridge Crossing"
     slug: bridge-crossing
     description: "A road bridge spans the aqueduct, its underside tagged with spray paint and darkened by exhaust. Traffic rumbles overhead without pause. From the aqueduct floor, the bridge frames a rectangle of sky."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Culvert"
     slug: the-culvert
     description: "A circular concrete pipe feeds into the aqueduct from a side channel, its opening dark and echoing. Water trickles from it in a thin stream even in dry months. The edges are slick with algae and the smell is mineral and stale."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Graffiti Mile"
     slug: graffiti-mile
     description: "A long stretch of aqueduct wall covered in layers of paint, each piece partially obscured by the next. The colors are vivid against the gray concrete, some of the work ambitious in scale. Older pieces at the bottom have been there long enough to feel permanent."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Chain Link Path"
     slug: chain-link-path
     description: "A maintenance trail runs along the top of the aqueduct bank, enclosed by chain-link fencing on both sides. The path is cracked and weedy, used more by pedestrians than the utility crews it was built for. The fencing rattles in the wind."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Underpass"
     slug: the-underpass
     description: "The aqueduct passes beneath a freeway interchange, the concrete walls narrowing and the light dropping to a murky gray. The sound of traffic is amplified into a continuous roar. Camp debris and shopping carts accumulate in the shadowed corners."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Flood Control"
     slug: flood-control
     description: "A section of the aqueduct widened and reinforced to handle surge volume, its walls higher and smoother than the surrounding channel. Warning signs are bolted to the concrete at intervals. The engineering is brutalist and effective."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Dry Season"
     slug: dry-season
     description: "The aqueduct floor in summer, bleached white by the sun and littered with the remains of whatever the last rain carried. Cracks web the concrete in patterns that look deliberate. The heat rises from the channel in visible waves."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Homeless Camp"
     slug: homeless-camp
     description: "A cluster of tents and tarps occupies a section of the aqueduct bank, arranged with a permanence that suggests the residents have been here a while. Shopping carts serve as storage. The camp is visible from the road above but no one on the road looks down."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Rapids"
     slug: the-rapids
     description: "A section where the aqueduct narrows over a steeper grade, and during the rare rains, water moves fast enough to be dangerous. The concrete here is scoured smooth. In dry months, it is just another empty chute, silent and hot."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Junction Point"
     slug: junction-point
     description: "Two aqueduct channels converge in a Y-shaped intersection, the concrete walls marked with flow direction arrows and utility codes. A metal catwalk spans the junction overhead. The engineering is visible and unadorned."
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Channel"
     slug: the-channel
     description: "The aqueduct's final stretch before it reaches the treatment facility, running straight and deep between featureless walls. The scale of the channel dwarfs anything walking through it. The sky above is a narrow strip between concrete edges. ---"
     zone_slug: the-aqueduct
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Breakwater"
     slug: the-breakwater
     description: "A long arm of stacked stone and concrete extends into the harbor, absorbing wave energy before it reaches the docks. Spray kicks up over the seaward face in white bursts. The landward side is calm, its water flat and oily."
     zone_slug: the-channel
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Channel Marker"
     slug: channel-marker
     description: "A steel piling topped with a flashing light stands at the channel's edge, marking the navigable depth for vessel traffic. Barnacles coat its base to the waterline. The light blinks on a three-second cycle, day and night, indifferent to whether anyone is watching."
     zone_slug: the-channel
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tight Passage"
     slug: tight-passage
     description: "The channel narrows between two concrete jetties, forcing vessel traffic into single file. The current accelerates through the gap, pulling at anything in the water. Tugs idle on either side, waiting their turn."
     zone_slug: the-channel
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Shipping Lane"
     slug: shipping-lane
     description: "A dredged corridor of deep water runs through the center of the channel, marked by buoys and patrolled by port authority vessels. Container ships pass through with a slowness that makes their size comprehensible. The wake takes minutes to reach the shore."
     zone_slug: the-channel
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Harbor Mouth"
     slug: harbor-mouth
     description: "The point where the channel opens into the harbor proper, the water widening and the current slackening. The city skyline becomes visible across the flat water. The transition from confined channel to open harbor is sudden and spatial."
     zone_slug: the-channel
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Jetty"
     slug: the-jetty
     description: "A stone and concrete structure extending into the channel, used as a mooring point and wave break. Fishermen line its length on weekends, their lines dropping into water too deep to see the bottom. The stone is salt-stained and warm."
     zone_slug: the-channel
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Tug Berth"
     slug: tug-berth
     description: "A section of dock where harbor tugs tie up between jobs, their bows scarred with rubber and paint from the hulls they push. Diesel exhaust hangs in the air. The tugs are squat, powerful, and ugly in the way that functional things often are."
     zone_slug: the-channel
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Channel Light"
     slug: channel-light
     description: "A navigation light mounted on a concrete platform at the channel's edge, its beam cutting across the water in a fixed arc. The platform is accessible only by boat. Maintenance crews visit once a month to check the lamp and the solar panels that power it."
     zone_slug: the-channel
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Sand Bar"
     slug: sand-bar
     description: "A shallow area where silt has accumulated at the channel's edge, visible as a lighter patch of water at low tide. Small boats sometimes ground here when they stray from the marked lane. The bar shifts with every storm."
     zone_slug: the-channel
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Dock Side"
     slug: dock-side
     description: "A commercial dock along the channel's inner edge, fitted with bollards, cleats, and rubber bumpers. Cargo nets hang from crane arms overhead. The concrete surface is stained with hydraulic fluid and saltwater in equal measure."
     zone_slug: the-channel
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Container Yard"
     slug: container-yard
     description: "Stacked shipping containers form a grid of steel canyons behind the dock, their corrugated walls painted in faded corporate colors. Gantry cranes move above them on rails. The yard operates on a logic invisible to anyone outside the port authority."
     zone_slug: the-channel
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Turn"
     slug: the-turn
     description: "A bend in the channel where the navigable route shifts direction, marked by buoys and range markers. The current pushes against vessel hulls at the turn, requiring correction. Pilots earn their pay at this point. ---"
     zone_slug: the-channel
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Last Gas"
     slug: last-gas
     description: "A single fuel station stands at the point where the basin's development gives way to open desert, its canopy bleached and its pumps slow. The convenience store inside sells water, sunscreen, and maps that nobody uses. Beyond the parking lot, the pavement ends."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Wash"
     slug: the-wash
     description: "A dry riverbed of sand and gravel cuts through the desert floor, smooth stones polished by flash floods that come once or twice a year. The rest of the time, it is a path of least resistance through the scrub. Tire tracks follow its curves."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Joshua Tree"
     slug: joshua-tree
     description: "A single twisted tree stands against the sky, its branches reaching upward like arms frozen mid-gesture. The bark is fibrous and rough, the shadow it casts too small to matter. It is the most distinctive landmark for miles in any direction."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Sand Drift"
     slug: sand-drift
     description: "Wind has piled fine sand against a chain-link fence, burying the lower sections and spilling through the gaps. The drift changes shape with every windstorm, erasing footprints and covering roads. The desert is patient and it is winning."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Coyote Trail"
     slug: coyote-trail
     description: "A faint track through the scrub, maintained by animal traffic rather than human intention. Paw prints mark the dust between creosote bushes. The trail follows water, or the memory of water, along the contour of the land."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Wind Farm"
     slug: wind-farm
     description: "Rows of turbines stand on ridgeline above the desert floor, their blades turning in the steady wind that pours through the pass. The scale is difficult to process until a maintenance truck parks at the base of one and disappears. The sound is a low, rhythmic pulse."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Abandoned Motel"
     slug: abandoned-motel
     description: "A single-story L-shaped building with a faded sign and empty pool, its rooms open to the wind through doorless frames. The parking lot has been reclaimed by sand and scrub. Whatever travelers once stopped here, the road has moved on without them."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Desert Highway"
     slug: desert-highway
     description: "A two-lane road cuts straight through the desert toward mountains that never seem to get closer. Heat mirage liquefies the asphalt at the vanishing point. The only traffic is long-haul trucks and the occasional vehicle moving fast enough to suggest urgency or escape."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Mirage"
     slug: the-mirage
     description: "A patch of desert floor where the heat creates a convincing illusion of standing water, shimmering and retreating as the distance closes. The effect is strongest at midday when the ground temperature exceeds the air by forty degrees. It looks real. It is always nothing."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Rock Garden"
     slug: rock-garden
     description: "A field of dark boulders scattered across the desert floor, placed by geology rather than design. Lizards claim the sun-warmed surfaces during the day and vanish into the gaps at dusk. The rocks are too hot to touch by noon."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Solar Array"
     slug: solar-array
     description: "A grid of photovoltaic panels covers several acres of desert floor, angled toward the southern sky. The panels are spotless, maintained by automated cleaning systems. The facility generates power for a city that does not know it is here."
     zone_slug: desert-edge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Creosote Flat"
     slug: creosote-flat
     description: "An expanse of evenly spaced bushes stretches to the horizon, each plant maintaining its territory through chemical warfare in the soil. The smell after rain is sharp and resinous, one of the few honest scents left in the Basin. Most days, it just smells like heat. ---"
     zone_slug: desert-edge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Blacktop"
     slug: blacktop
     description: "A stretch of asphalt absorbs the sun and radiates it back with interest, the surface soft enough to leave footprints by midafternoon. The air above it shimmers. Everything here is designed to function, not to be looked at, and the heat makes even function difficult."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Vent"
     slug: the-vent
     description: "A large industrial vent protrudes from a concrete wall, expelling hot air from the building's interior systems in a steady blast. Standing near it feels like opening an oven. The noise is white and constant."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Radiator Wall"
     slug: radiator-wall
     description: "A south-facing concrete wall absorbs solar energy all day and releases it all night, maintaining temperatures that make the surrounding air feel like exhaust. The surface is too hot to touch from ten in the morning to eight at night. Paint has blistered and peeled in sheets."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Sunstroke Corner"
     slug: sunstroke-corner
     description: "An intersection with no shade, no awning, and no tree within a hundred yards. The crosswalk signal takes ninety seconds, during which pedestrians stand in direct sunlight on concrete that reflects heat upward. The corner is an endurance test disguised as urban planning."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Awning"
     slug: heat-sink-the-awning
     description: "A metal awning extends from a building face, providing a narrow band of shade over the sidewalk. The shade is populated at all hours by anyone who can claim a piece of it. The temperature difference between sun and shadow is measurable and meaningful."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Cool Shadow"
     slug: cool-shadow
     description: "A gap between two buildings creates a permanent shadow corridor, ten degrees cooler than the surrounding street. The air here moves slightly, funneled by the walls. People detour through it even when it is not on their way."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Water Station"
     slug: water-station
     description: "A public drinking fountain mounted on a concrete pedestal, its chrome surface too hot to touch though the water runs cold. A small puddle around its base evaporates within minutes. The station is the only public amenity for three blocks."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Tin Building"
     slug: tin-building
     description: "A corrugated metal structure that expands audibly in the morning sun, its walls popping and creaking as they heat. The interior is an oven by ten a.m. unless the industrial fans are running. The building serves a utility function that no one would choose to perform here."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Glare"
     slug: the-glare
     description: "A point where sunlight reflects off a glass-fronted building and concentrates on the pavement opposite, creating a zone of amplified brightness. Drivers squint through it. Pedestrians shield their eyes or cross the street to avoid it."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Exhaust Fan"
     slug: exhaust-fan
     description: "An industrial fan mounted in a wall opening, pushing heated air from a building interior into the already-hot street. The blast is visible as a heat distortion. Standing in its path is like being dried by a machine designed for something other than people."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Melted Asphalt"
     slug: melted-asphalt
     description: "A section of road where the surface has softened and deformed under sustained heat, tire tracks pressed into it like fossils. The tar smell is strong in the afternoons. Maintenance crews patch it every summer and the sun undoes their work by August."
     zone_slug: heat-sink
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Furnace"
     slug: the-furnace
     description: "A dead-end alley between a bakery exhaust and a laundromat vent, where the combined heat output creates a microclimate ten to fifteen degrees above the surrounding area. Nothing grows here. The concrete has darkened to the color of ash. Even the rats avoid it at midday. ---"
     zone_slug: heat-sink
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Drainage Access"
     slug: drainage-access
     description: "A rusted steel hatch set flush with a sidewalk grate, hidden in plain sight beneath a service alley off Canal Street. The ladder drops eight meters into darkness. The rungs are slick with condensation. The sound of moving water rises from below."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Main Tunnel"
     slug: the-main-tunnel
     description: "A concrete tube three meters in diameter, its floor permanently submerged in six inches of slow-moving water. Cabling runs along the ceiling in bundled conduit, some original, some added by hands that understood the infrastructure better than its builders. The walls sweat."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Graffiti Gallery"
     slug: graffiti-gallery
     description: "Spray paint covers every surface for a hundred-meter stretch of tunnel wall — layered, overlapping, aggressive. Some of it is art. Some of it is territorial. Koda's work is identifiable by its precision: reality-glitch patterns that make the concrete appear to fold inward on itself, as though the wall were remembering a different shape."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Broadcast Booth"
     slug: broadcast-booth
     description: "A converted utility closet reinforced with soundproofing foam and scavenged acoustic tile. A mixing board and transmitter occupy a steel shelf bolted to the wall. The signal reaches the surface through wiring threaded up through three levels of infrastructure. The booth smells of solder and damp concrete."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Stage"
     slug: the-stage
     description: "A cleared section of tunnel where the floor has been raised with wooden pallets and plywood to create a platform above the water line. Battery-powered stage lights clamp to overhead pipes. The acoustics are brutal — every sound bounces off curved concrete until it multiplies. System Rot prefers it this way."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Water Line"
     slug: water-line
     description: "A high-water mark stains the tunnel walls at chest height, the mineral deposit forming a continuous white band that records the last major flood event. Below the line, the concrete is dark with permanent moisture. Above it, the surface is dry and chalky. The line is a warning and a history."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Generator Room"
     slug: generator-room
     description: "A diesel generator occupies a raised concrete pad in a side chamber, its exhaust routed through a series of filters and into the existing ventilation system. The machine runs twelve hours a day. The room vibrates when it is on. Fuel cans line the walls in neat rows, each labeled with a date."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Storage Cache"
     slug: storage-cache
     description: "Waterproof containers stack on metal shelving in a dry alcove off the main tunnel, their contents inventoried on a clipboard hanging from a nail. Medical supplies, dry food, electronics in vacuum-sealed bags. The cache is maintained with military discipline by people who have never served in any military."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Koda's Corner"
     slug: kodas-corner
     description: "A dead-end spur tunnel claimed by Koda as workspace and living quarters, the walls covered floor to ceiling in his reality-glitch art — patterns that make surfaces appear to breathe, shift, fold. A cot, a portable light, and cans of spray paint in every color. The air is thick with fumes. He sleeps here more often than anywhere else."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Mural"
     slug: the-mural
     description: "A single unbroken image spans the full width and height of a tunnel junction wall. The mural depicts the city above as seen from below — inverted, its buildings hanging from the ground like stalactites, the river flowing across the ceiling. The perspective is disorienting on purpose. Koda spent three months on it."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Drip Hall"
     slug: drip-hall
     description: "A long passage where groundwater seeps through a thousand hairline cracks in the ceiling, creating a constant rain of individual drops that strike the standing water below with a sound like static. The air is saturated. Lights short out here regularly. Walking through it soaks you to the skin in thirty seconds."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Emergency Hatch"
     slug: emergency-hatch
     description: "A secondary exit point — a vertical shaft with iron rungs leading up to a sealed manhole in a churchyard. The cover is heavy enough to require two people to move. The hatch is tested monthly. The route to it from the main tunnel is marked with reflective tape at ankle height, visible only from below."
     zone_slug: the-undercity
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Wrought Iron Balcony"
     slug: wrought-iron-balcony
     description: "Iron lacework hangs from the second-floor facade, the scrollwork blackened by weather and detailed enough to cast shadow patterns on the sidewalk below. The balcony sags slightly at the center where a century of weight has bent the supports. Ferns grow from hanging baskets hooked to the railing."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Courtyard"
     slug: courtyard
     description: "A private courtyard behind a carriageway entrance, its walls three stories of stuccoed brick draped with jasmine and bougainvillea. A fountain burbles at the center, the basin stained green. The courtyard traps heat and scent — gardenia, mildew, something sweet and rotting — and holds them in still air."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Fountain"
     slug: the-quarter-the-fountain
     description: "A tiered fountain in a small public square, the water spilling from one level to the next through the mouths of cast-iron fish whose features have eroded to smooth lumps. The basin is full of pennies turned black by the mineral content of the water. The sound of it covers conversation at close range."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Jazz Club"
     slug: jazz-club
     description: "A ground-floor room behind a heavy door, the interior dark except for a blue spotlight on a low stage. The bar runs along the back wall. Chairs crowd small tables, every surface covered in the rings left by a decade of cocktail glasses. Music starts at ten and stops when the last musician stops playing."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Street Corner"
     slug: street-corner
     description: "Two narrow streets intersect at unequal angles, creating a triangular patch of sidewalk where a saxophone player has set up a folding chair and a tip jar. The buildings at the corner are old enough that their walls are not plumb. The music echoes off both streets simultaneously."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Apothecary"
     slug: the-apothecary
     description: "A narrow storefront with dark wood shelving reaching to the ceiling, the shelves lined with glass jars containing dried herbs, tinctures, and preparations whose labels are handwritten in faded ink. The proprietor is older than the neighborhood and speaks less than the building. The air smells of camphor and lavender."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Antique Shop"
     slug: antique-shop
     description: "Display windows clouded with age show furniture, silverware, and framed photographs arranged without system or intention. The interior is a maze of stacked inventory, navigable only by turning sideways between armoires. Dust covers everything evenly, establishing a democracy of neglect. Prices are negotiated, never posted."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Cathedral"
     slug: the-cathedral
     description: "Stone walls rise to a vaulted ceiling blackened by centuries of candle smoke. The nave is cool regardless of the temperature outside, the stone holding winter in its mass. Stained glass fragments the light into colored pools on the floor. The building predates Consolidation by three hundred years and shows no awareness of anything that has happened since."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Cobblestone Walk"
     slug: the-quarter-cobblestone-walk
     description: "Uneven stones laid in fan patterns surface the narrow street, their edges worn round by centuries of foot traffic, horse hooves, cart wheels. Water collects in the gaps after rain and reflects the balconies above. Walking here requires watching your feet, which means the architecture reveals itself in glances upward between steps."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Speakeasy"
     slug: the-speakeasy
     description: "Behind an unmarked door, down a flight of stairs, a low-ceilinged room serves drinks from behind a wooden bar that has been polished by elbows since before anyone alive can remember. The walls are exposed brick. The lighting is a single amber bulb behind the bar. Conversation is the entertainment."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bead Shop"
     slug: bead-shop
     description: "Strings of glass beads hang in the doorway like a curtain, clicking against each other when anyone enters or when the ceiling fan moves the air. Inside, beads of every color fill shallow trays on a long counter. The shop is smaller than it appears from outside, the walls lined with drawers."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Alley"
     slug: the-quarter-the-alley
     description: "A passage barely wider than a person, the walls close enough to touch on both sides, the ground a mix of brick and packed dirt. Ferns grow from the joints where wall meets ground. A single light fixture halfway down casts more shadow than illumination. The alley connects two streets that the city forgot are connected."
     zone_slug: the-quarter
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Brass Band"
     slug: brass-band
     description: "A five-piece band plays on the sidewalk, their instruments dented and tarnished and producing sound that fills the street like liquid filling a vessel. The tuba player anchors the corner. The trumpet carries above the roofline. Tourists stop. Locals adjust their walking pace to the beat without noticing they have done so."
     zone_slug: brass-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Open Door Bar"
     slug: open-door-bar
     description: "The doors are always open — removed from their hinges years ago and never rehung. Music and air-conditioning pour onto the sidewalk in equal measure. The bar is ten meters long, the bartenders working in constant motion. Drinks come in plastic cups. The floor is sticky and no one cares."
     zone_slug: brass-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Balcony"
     slug: the-balcony
     description: "A second-floor ironwork balcony overlooking the street, crowded with people holding drinks and leaning over the railing to watch the crowd below. The iron is warm from absorbed heat. Beads hang from the railing in tangled strands, accumulated over years of throws from above. The view from here is of hats, shoulders, and the tops of brass instruments."
     zone_slug: brass-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Hurricane Glass"
     slug: hurricane-glass
     description: "A specialty drink bar serving a single item: a frozen cocktail in a tall curved glass shaped like a hurricane lamp. The machine behind the counter churns continuously, producing an endless supply of sweet, cold, dangerously strong slush. The line extends onto the sidewalk. The glasses accumulate on every flat surface within a block radius."
     zone_slug: brass-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Neon Sign"
     slug: neon-sign
     description: "A three-story neon sign dominates the building facade, its tubing spelling a name in cursive script that buzzes and flickers but never goes dark. The neon is pink and blue, casting the sidewalk below in cotton-candy light. The sign has been repaired so many times that none of the original tubing remains, but the name has never changed."
     zone_slug: brass-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Street Musician"
     slug: street-musician
     description: "A solo performer on a wooden crate, guitar case open on the pavement, playing songs that predate the RIDE by centuries — blues, standards, hymns rearranged for a single voice and six strings. The crowd parts around the performer like water around a stone. Tips accumulate in the case between songs."
     zone_slug: brass-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Daiquiri Shop"
     slug: the-daiquiri-shop
     description: "A walk-up window in a cinder block wall, three flavors rotating in cylindrical machines visible through the glass. The transaction takes fifteen seconds: order, pay, receive. No tables, no seating, no pretense. Customers drink while walking. The cups sweat in the heat and drip on the sidewalk."
     zone_slug: brass-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Second Floor"
     slug: second-floor
     description: "Above the street-level bars, a row of second-floor establishments accessible by narrow staircases, each one slightly quieter, slightly more expensive, slightly less likely to admit strangers without introduction. The balconies connect, and on crowded nights people move between them without descending to the street."
     zone_slug: brass-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Dance Hall"
     slug: dance-hall
     description: "A long room with a stage at one end, the floor hardwood scarred to splinters by decades of dancing. The ceiling fans turn slowly, doing nothing against the heat generated by bodies in motion. A band plays from behind chicken wire — a tradition whose origin no one remembers but no one questions. The music is loud enough to feel in the sternum."
     zone_slug: brass-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Crawl"
     slug: the-crawl
     description: "The practice of moving from bar to bar down Brass Row, drinking at each one, constitutes not a room but a condition — a state of motion through sound and heat and neon. The crawl has no beginning point and no end point. It starts when you start walking and stops when your legs do."
     zone_slug: brass-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Trash Alley"
     slug: trash-alley
     description: "The narrow service alley behind Brass Row's bars, lined with dumpsters and stacked with empty kegs and broken glass. The ground is wet with runoff from ice machines and hose-downs. Rats move without hurry. Kitchen staff take smoke breaks against the wall, their faces lit by phone screens."
     zone_slug: brass-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dawn Cleanup"
     slug: dawn-cleanup
     description: "The street at five in the morning, empty of people, the pavement littered with cups, beads, napkins, and the occasional shoe. A cleanup crew works south to north with push brooms and a flatbed truck. Hosing starts at six. By eight, the street is wet and clean and shows no evidence of the previous twelve hours."
     zone_slug: brass-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Church"
     slug: the-church
     description: "White clapboard walls and a steeple visible from six blocks away, the building settled into its foundation at a slight angle that makes the doorframe trapezoidal. The interior is cool and dim, rows of wooden pews facing a simple altar. Ceiling fans turn overhead with a rhythm that matches nothing."
     zone_slug: the-parish
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Parish Hall"
     slug: parish-hall
     description: "A multipurpose room attached to the church by a covered walkway, its linoleum floor scuffed by folding chair legs. Long tables fold out for community suppers. The kitchen in back serves red beans and rice on Mondays. The hall smells of coffee, floor wax, and generations of potluck casseroles."
     zone_slug: the-parish
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cemetery Gate"
     slug: cemetery-gate
     description: "Wrought iron gates stand permanently open between brick pillars topped with stone urns. The gates have not been closed in living memory; the hinges are fused with rust. Beyond them, rows of above-ground tombs crowd together like a miniature city, their whitewashed surfaces flaking in the humidity."
     zone_slug: the-parish
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Above-Ground Tomb"
     slug: above-ground-tomb
     description: "Stone and stucco vaults arranged in rows, each one sealed with a marble tablet inscribed with names and dates. The tombs are built above grade because the water table lies less than a meter below the surface — dig a hole here and it fills. Some tombs have sunk slightly, their foundations losing the argument with mud."
     zone_slug: the-parish
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Garden"
     slug: the-parish-the-garden
     description: "Behind the church, a walled garden of subtropical plants — banana, bird-of-paradise, crape myrtle — growing in soil so rich it is nearly black. A statue of a saint stands on a pedestal, its features smoothed by weather into a gentle anonymity. The garden is tended by parishioners who are older each year."
     zone_slug: the-parish
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Spanish Moss"
     slug: spanish-moss
     description: "Live oaks arch over the parish road, their branches draped with Spanish moss that hangs in gray curtains, swaying in any breeze. The moss filters light into a greenish diffusion. The effect is of walking through rooms made of living architecture, each tree defining a space with its canopy and its drapery."
     zone_slug: the-parish
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Rectory"
     slug: the-rectory
     description: "A two-story house of painted wood behind the church, its porch sagging at the corners and its shutters permanently open. The house is always cooler than the street by five degrees, a function of thick walls and cross-ventilation. The current occupant has lived here for thirty years and shows no intention of leaving."
     zone_slug: the-parish
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Parish Road"
     slug: parish-road
     description: "A two-lane road shaded by oaks, the pavement buckled by root growth into a surface that requires driving at walking speed. Shotgun houses line both sides, their doors open to catch the breeze, voices and television sound drifting across the narrow front yards. The road dead-ends at the bayou."
     zone_slug: the-parish
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Bayou Edge"
     slug: the-bayou-edge
     description: "Where the road dissolves into mud and the land gives way to water, the boundary between solid and liquid is negotiated daily. Cypress knees break the surface of brown water. The air is thick with moisture and the sound of insects. A wooden dock extends eight meters into the bayou on pilings that are slowly losing to rot."
     zone_slug: the-parish
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Old Oak"
     slug: old-oak
     description: "A live oak estimated at four hundred years old, its trunk six meters in circumference, its lowest branches resting on the ground and re-rooting into the soil. The tree predates every structure in the parish. Its canopy covers a quarter-acre. Sitting beneath it, you can hear the wood creak as the branches shift their enormous weight."
     zone_slug: the-parish
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Fence"
     slug: the-parish-the-fence
     description: "A wrought iron fence borders the cemetery, its vertical pickets topped with fleur-de-lis finials, the iron pitted by salt air and rain. Gaps in the fence have been repaired with wire and wood at various points over the years, each repair reflecting the resources available at the time."
     zone_slug: the-parish
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Quiet Corner"
     slug: quiet-corner
     description: "A section of the cemetery where the oldest tombs have settled into the ground, their tablets cracked, their inscriptions illegible. Ferns and resurrection plants grow in the joints between stones. The quiet here is different from silence — it is the accumulated weight of years during which nothing was expected to happen."
     zone_slug: the-parish
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Warehouse"
     slug: the-warehouse
     description: "A corrugated metal building at the end of a dead-end street, its interior large enough to hold three parade floats in various stages of construction. The concrete floor is stained with paint in every color. The ceiling trusses support block-and-tackle systems for lifting heavy structural elements."
     zone_slug: the-float
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Float Construction"
     slug: float-construction
     description: "A float frame sits on a steel chassis, its superstructure built from welded pipe, chicken wire, and papier-mache in a process that has not fundamentally changed in a century. Workers climb scaffolding to apply the upper layers. The scale is difficult to grasp until a person stands next to the finished figure and reaches only to its knee."
     zone_slug: the-float
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Paint Shop"
     slug: the-float-paint-shop
     description: "A section of the warehouse partitioned with plastic sheeting, the floor covered in drop cloths layered so thick they have become a single stiff mat. Spray guns hang from hooks on a pegboard wall. The ventilation is inadequate, and the air is sweet and chemical. Paint cans line the shelves in chromatic order."
     zone_slug: the-float
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Fabric Storage"
     slug: fabric-storage
     description: "Rolls of sequined fabric, satin, tulle, and mylar lean against the walls and fill metal racks, organized by color into sections that glow under the fluorescent lights. Cutting tables occupy the center of the room, their surfaces scarred by utility knives. Scraps cover the floor like confetti."
     zone_slug: the-float
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Route"
     slug: the-route
     description: "The parade route runs through the city in a fixed path that has not changed in decades. The streets along it are wider than they need to be for traffic, built to accommodate floats and the crowds that watch them. Balconies along the route rent for prices that rise every year."
     zone_slug: the-float
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Viewing Stand"
     slug: viewing-stand
     description: "Temporary bleachers bolt together on the sidewalk, their aluminum seats cold in February morning air. The stands face the street at a height that puts seated spectators at eye level with the float riders above. The bolts are never fully tightened, and the stands sway when the crowd moves together."
     zone_slug: the-float
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Bead Throw"
     slug: bead-throw
     description: "A float rider's perspective: standing on a moving platform, arms full of bead strands, throwing them into a crowd of upraised hands. The beads arc through air thick with music and engine exhaust. The throw is indiscriminate, generous, a gesture of pure excess with no expectation of return."
     zone_slug: the-float
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "King Cake"
     slug: king-cake
     description: "A bakery display of ring-shaped cakes iced in purple, green, and gold, each one hiding a small plastic figure baked into its body. Finding the figure obligates you to provide the next cake. The tradition is circular, self-perpetuating, a closed loop of sugar and obligation that lasts the length of the season."
     zone_slug: the-float
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Den"
     slug: the-den
     description: "A private club whose membership is determined by invitation and whose function is the planning and funding of a single float in the annual parade. The den occupies a rented hall furnished with mismatched furniture, a bar, and a wall of photographs documenting every float the organization has ever built."
     zone_slug: the-float
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Costume Room"
     slug: costume-room
     description: "Racks of costumes fill a room above the float warehouse — feathered headdresses, sequined capes, velvet robes, masks in every style from simple domino to elaborate animal heads. The costumes are repaired and reused, each one carrying the sweat and champagne stains of multiple seasons. Pins and needles litter every surface."
     zone_slug: the-float
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Torch Bearer"
     slug: torch-bearer
     description: "Flambeaux carriers march ahead of the floats, each one carrying a kerosene torch on a pole, the flames illuminating the parade route in flickering orange. The carriers spin the torches in choreographed patterns. The heat is tangible from the sidewalk. Their faces glisten with exertion and reflected fire."
     zone_slug: the-float
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Roll Out"
     slug: roll-out
     description: "The moment the float clears the warehouse door and enters the street, the construction becomes spectacle. The papier-mache catches streetlight. The sequins fire. The sound system engages with a bass note felt in the pavement. Everything that was labor becomes celebration in the span of a doorway."
     zone_slug: the-float
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entry"
     slug: the-entry
     description: "Wrought iron gates twelve feet tall swing inward on hinges set into brick pillars, the ironwork depicting vines and flowers in a style that required a blacksmith with the patience of a portraitist. The drive beyond the gates is crushed oyster shell, white and crunching underfoot."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Garden Path"
     slug: garden-path
     description: "A brick path winds through formal gardens gone half-wild, the boxwood hedges grown past their intended geometry into organic shapes. Azaleas crowd the path's edges, their blooms violent pink against dark green foliage. The path turns at angles designed for leisurely walking, not efficiency."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Arbor"
     slug: the-arbor
     description: "A wooden arbor draped with wisteria, the vine's trunk as thick as a forearm, its purple flowers hanging in dense clusters that brush the heads of anyone walking through. Bees work the blossoms in a low steady hum. The arbor frames a view of the main house at the end of the path."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Iron Trellis"
     slug: iron-trellis
     description: "Wrought iron panels support climbing roses against the garden wall, the iron forged into a lattice pattern and the roses threaded through every opening. The thorns have scratched the metal bright where they press against it. In bloom, the trellis is more flower than iron."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Lantern Hook"
     slug: lantern-hook
     description: "Cast-iron hooks project from the garden wall at head height, each one designed to hold an oil lantern. A few still hold lanterns — dented, soot-blackened, their glass chimneys cracked. Most hooks are empty, the lanterns lost to storms and time. The hooks themselves will outlast everything else on the property."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Patio"
     slug: the-patio
     description: "Flagstone pavers laid in an irregular pattern form a patio behind the main house, partially shaded by a massive magnolia whose leaves are thick and waxy and fall year-round. Iron furniture — a table, four chairs — occupies the center, their surfaces always slightly gritty with pollen and leaf debris."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Fountain Court"
     slug: fountain-court
     description: "A courtyard centered on a three-tiered fountain, the basins carved from limestone that has developed a green patina in the perpetual humidity. Water circulates through a pump hidden in the base, the flow just strong enough to keep mosquitoes from breeding. The sound of it is the courtyard's primary feature."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Servants' Quarters"
     slug: servants-quarters
     description: "A two-story brick building behind the main house, its rooms small and plainly finished compared to the house it served. The staircase is narrow, the doorways low. The building has been converted to storage, its rooms stacked with furniture, crates, and objects deemed too valuable to discard but too inconvenient to use."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Upper Gallery"
     slug: upper-gallery
     description: "A second-floor porch running the full length of the main house, supported by slender columns and shaded by the roof overhang. The gallery floor is heart pine, its surface worn to a silver sheen by generations of foot traffic. Ceiling fans turn slowly overhead. The gallery overlooks the garden and, beyond it, the street."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Wine Cellar"
     slug: wine-cellar
     description: "Below the main house, a vaulted brick chamber maintains the constant cool temperature that the water table and clay soil provide without mechanical assistance. Wooden racks line the walls, their bottles dust-covered and unlabeled. The cellar floods in heavy rain, and the waterline mark is visible on the brick at knee height."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Library"
     slug: the-library
     description: "A high-ceilinged room with floor-to-ceiling bookshelves of dark wood, the books arranged by a system that reflects the interests of multiple generations — agricultural manuals beside novels beside legal treatises. A rolling ladder on a brass rail reaches the upper shelves. The room smells of old paper and furniture polish."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Secret Garden"
     slug: secret-garden
     description: "Behind a section of ivy-covered wall, through a gate nearly invisible beneath the vine growth, a small enclosed garden holds a single bench beneath a crepe myrtle. The space is barely large enough for the tree, the bench, and a narrow brick path. The enclosure traps sound — the street is inaudible from here."
     zone_slug: iron-gate
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Intake Valve"
     slug: intake-valve
     description: "A cast-iron valve wheel the size of a steering wheel controls the water intake, its spokes oxidized to a reddish-brown that leaves residue on the hands. The valve is mounted on a pipe that descends through the concrete floor into the canal system below. Turning it requires both hands and a willingness to listen to metal scream."
     zone_slug: pump-station
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Turbine"
     slug: the-turbine
     description: "A turbine pump occupies the center of the station's main hall, its housing painted industrial gray and bolted to a concrete foundation that goes down to bedrock. When the pump runs, the building vibrates at a frequency felt in the teeth. The turbine was installed to fight a water table that has been winning for three centuries."
     zone_slug: pump-station
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Control Room"
     slug: control-room
     description: "A room of gauges, switches, and analog dials mounted on a steel panel that spans one wall. The instruments measure water level, pump pressure, flow rate, and a dozen other variables that determine whether the city above stays dry. The operator's chair faces the panel. A radio on the desk receives weather reports."
     zone_slug: pump-station
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Dry Side"
     slug: dry-side
     description: "The portion of the station above the flood line, where the floors are concrete and the walls are painted cinder block and everything is designed to remain functional when the wet side fails. Equipment stored here is elevated on platforms. Extension cords are coiled and hung from ceiling hooks, never left on the floor."
     zone_slug: pump-station
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Wet Side"
     slug: wet-side
     description: "Below the flood line, the station's lower level exists in a state of permanent dampness. The walls are streaked with mineral deposits. The floor drains are always running. Equipment here is marine-grade or expendable. The air smells of standing water and rust, and the lighting is waterproof and insufficient."
     zone_slug: pump-station
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Levee Gate"
     slug: the-levee-gate
     description: "A steel floodgate set into the levee wall, operated by a hand crank that raises and lowers the gate in six-inch increments. The gate is tested monthly. When closed, it holds back the river. When open, it allows controlled drainage into the canal system. The decision of when to open and when to close is the station operator's alone."
     zone_slug: pump-station
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Backup Generator"
     slug: backup-generator
     description: "A diesel generator on a raised platform, plumbed into the station's electrical system through an automatic transfer switch. The generator starts within fifteen seconds of a power failure. Fuel supply is maintained at seventy-two hours. The machine is tested every Sunday morning at six, and the neighborhood has learned to sleep through it."
     zone_slug: pump-station
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Gauge Panel"
     slug: gauge-panel
     description: "A wall of circular gauges with brass bezels and glass faces, each one measuring a different parameter of the water system. The gauges are analog — needle and dial, no digital readout. The operators read them by habit, their eyes moving across the panel in a pattern learned in the first week of employment and never forgotten."
     zone_slug: pump-station
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Discharge Channel"
     slug: discharge-channel
     description: "An open concrete channel carries pumped water from the station to the outfall, the flow constant during rain and intermittent during dry spells. The channel walls are slick with algae. The water moves fast enough to carry debris — branches, bottles, the occasional shoe. A grate at the outfall catches the larger items."
     zone_slug: pump-station
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Catwalk"
     slug: the-catwalk
     description: "A metal grate walkway suspended above the pump room floor, connecting the control room to the turbine housing and the gauge panel. The catwalk sways perceptibly when walked on. The view below is of machinery, pipe, and water — always water, in puddles and streams and condensation on every metal surface."
     zone_slug: pump-station
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Relief Valve"
     slug: relief-valve
     description: "A spring-loaded valve mounted on the main discharge line, designed to open automatically when pressure exceeds safe limits. When the valve releases, the sound is a sustained shriek of pressurized water escaping through a narrow aperture. The surrounding walls are stained by years of spray. The valve has saved the station twice."
     zone_slug: pump-station
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Rain Gauge"
     slug: rain-gauge
     description: "A simple graduated cylinder mounted on a post outside the station door, measuring rainfall in increments that determine the station's operational posture. The gauge is read manually every four hours during storms. The readings are recorded in a logbook that goes back decades. The handwriting changes, the data does not."
     zone_slug: pump-station
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Streetcar"
     slug: the-streetcar
     description: "A green-painted streetcar runs on tracks set into the center of the street, its bell clanging at intersections and its wooden seats polished by decades of sliding passengers. The car rocks on the rails. The windows are open, admitting air that is warm and wet and scented with exhaust and jasmine in equal measure."
     zone_slug: canal-street
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Neutral Ground"
     slug: neutral-ground
     description: "The wide median strip that divides Canal Street, planted with grass and live oaks whose roots have buckled the sidewalks on both sides. The neutral ground is not neutral — it is contested by tree roots, pedestrians, streetcar tracks, and the competing claims of the neighborhoods it separates."
     zone_slug: canal-street
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Overpass"
     slug: the-overpass
     description: "A concrete highway overpass crosses Canal Street, its shadow falling across four lanes of traffic and the neutral ground. The pillars are thick with graffiti at their base, the concrete stained by exhaust above. Beneath the overpass the noise is compressed, concentrated, a physical pressure on the ears."
     zone_slug: canal-street
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Neon Pharmacy"
     slug: neon-pharmacy
     description: "A drugstore on the corner with a neon mortar-and-pestle sign in the window, the tubing casting green light on the sidewalk at all hours. The interior is a maze of narrow aisles, the shelves stocked with patent remedies, toiletries, and a lunch counter at the back that serves sandwiches and fountain drinks."
     zone_slug: canal-street
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Hotel"
     slug: the-hotel
     description: "A grand hotel built in a previous century, its facade of white stone blackened by pollution and cleaned and blackened again. The lobby is marble and brass, the elevators slow, the hallways wide enough for two bell carts to pass. The building's air conditioning system predates central air and still works better than modern units."
     zone_slug: canal-street
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Shoe Store"
     slug: shoe-store
     description: "A narrow storefront between larger buildings, its window displaying shoes on tilted stands. The store has occupied this location for three generations of the same family, each one adjusting the inventory to match the times while keeping the wooden floor, the mirror on a stand, and the row of chairs where customers sit to be fitted."
     zone_slug: canal-street
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Canal Walk"
     slug: canal-walk
     description: "A paved path along the canal's edge, built after the canal was covered and converted to a drainage channel running beneath the street. The walk is below street level, accessible by stairs at each block. Down here the traffic noise diminishes and the sound of water moving through the covered channel is audible through the grates."
     zone_slug: canal-street
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Bank Building"
     slug: the-bank-building
     description: "A limestone building with columns and a pediment, built to house a bank that no longer exists under that name. The lobby retains its original bronze teller windows and marble counter, now serving a different financial entity. The vault door is visible from the lobby — open during business hours, its thickness a statement."
     zone_slug: canal-street
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Intersection"
     slug: canal-street-the-intersection
     description: "Canal Street crosses a major cross-street at a wide intersection controlled by signals on all four corners. The crossing takes two light cycles for a pedestrian. Traffic turns from three directions. The intersection is where uptown meets downtown, and the architectural styles on each corner mark the boundary."
     zone_slug: canal-street
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Traffic Island"
     slug: traffic-island
     description: "A raised concrete island in the center of the intersection, large enough for six people to stand on while waiting for the next signal change. The island has a bollard at each end, both dented by impacts. Standing here with traffic circling on all sides, you are equidistant from four different neighborhoods."
     zone_slug: canal-street
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Awning"
     slug: canal-street-the-awning
     description: "A series of connected canvas awnings extend from the storefronts on the shaded side of Canal Street, creating a continuous covered walkway for the length of a block. The awnings are striped, each store choosing its own colors, the effect a patchwork of red and white, green and white, blue and gold. Rain drums on the canvas like applause."
     zone_slug: canal-street
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Last Stop"
     slug: last-stop
     description: "The streetcar line terminates at the river end of Canal Street, the track curving into a loop where the car turns around. The conductor steps off to switch the seat backs. Passengers who have ridden to the end step out onto a small plaza facing the levee, the river invisible but present beyond the concrete wall."
     zone_slug: canal-street
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Access Hatch"
     slug: access-hatch
     description: "A cast-iron hatch set into the floor of a utility building, its cover heavy enough to require a pry bar. The hinge screams when opened. Below, stone steps descend into a darkness that smells of wet brick and standing water. The air rising from the hatch is cool, ten degrees below the surface temperature in any season."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Stone Steps"
     slug: stone-steps
     description: "Cut limestone steps spiral down into the cistern, each tread worn into a shallow bowl by decades of foot traffic. The walls are close — you can touch both sides simultaneously. Moisture beads on the stone and runs in slow threads toward the water below. The last three steps are permanently submerged."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Chamber"
     slug: the-chamber
     description: "A circular room of vaulted brick, the ceiling supported by columns that rise from the standing water like the trunks of stone trees. The water is knee-deep, still, and black with tannin. Every sound multiplies — a single footstep becomes a dozen, a whispered word returns from three directions."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Brick Arch"
     slug: the-cistern-brick-arch
     description: "The cistern's arched ceiling is a masterwork of brickwork, each course laid in a pattern that distributes weight outward to the walls. The brick is dark red, stained darker by mineral seepage, the mortar joints picked out in white where lime has crystallized. The arch has supported the weight of the city above for longer than the city has had its current name."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Standing Water"
     slug: standing-water
     description: "The water in the cistern is not stagnant — it moves, slowly, fed by seepage through the walls and drained through channels cut into the floor. The surface is mirror-still, reflecting the brick ceiling with such clarity that looking down produces vertigo. The water is cold. It has always been cold."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Column"
     slug: the-column
     description: "A single brick column at the cistern's center, thicker than the rest, its surface carved with marks that may be construction records or may be something older. The column rises from the water to the ceiling's apex, bearing the full weight of the central vault. Press a hand to it and the brick vibrates with a frequency too low to hear."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Echo Point"
     slug: echo-point
     description: "A specific location in the cistern where the acoustics converge — a spot where a whisper spoken facing the wall returns as a clear voice from behind. The effect is architectural, a consequence of the curved ceiling and parallel walls, but knowing the explanation does not diminish the strangeness of hearing your own voice arrive from a direction you did not send it."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Dry Ledge"
     slug: dry-ledge
     description: "A raised stone shelf along the cistern's east wall, above the waterline by half a meter, dry enough to sit on. The ledge runs for twenty meters before descending back below the surface. It is the only place in the cistern where you can stop moving without standing in water. The stone is smooth and cold."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Flow"
     slug: the-flow
     description: "A channel cut into the cistern floor directs water toward the discharge point, the current visible as a subtle directional pull on floating debris. The channel is only a few centimeters deep, but the flow is constant — fed by the water table, drained by gravity, the system functioning without pumps or intervention on principles older than engineering."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Moss Wall"
     slug: moss-wall
     description: "The cistern's north wall is covered in a thick mat of moss that thrives in the perpetual damp and darkness, its color a green so deep it approaches black. The moss is soft to the touch and cold, and it absorbs sound the way the brick amplifies it. Standing near this wall, the cistern goes quiet."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Deep End"
     slug: the-deep-end
     description: "The cistern floor slopes downward at the western end, the water deepening from knee to waist to chest over a distance of ten meters. The bottom is not visible. The water here is colder than the rest, fed by a spring or a breach in the foundation wall that no one has located. No one goes past chest depth."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Exit Ladder"
     slug: exit-ladder
     description: "An iron ladder bolted to the cistern wall, its rungs spaced for adult stride, leading up to a hatch that opens into a different building than the one you entered from. The ladder is newer than the cistern — installed within the last few decades, its bolts bright against the old brick. The hatch at the top is unbarred from below."
     zone_slug: the-cistern
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Ferry Terminal"
     slug: ferry-terminal
     description: "Concrete pilings worn smooth by decades of salt spray and rain. The terminal roof leaks in three places, puddles reflecting the schedule board's amber glow. Commuters stand with hoods up, watching the next ferry cut through gray chop."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Seawall Walk"
     slug: seawall-walk
     description: "A raised concrete path traces the harbor edge, bolted railings slick with condensation. Gulls work the wind above fishing boats rocking at their lines. The city rises behind in glass and steel, softened by low cloud."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tower Lobby"
     slug: tower-lobby
     description: "Polished floors catch the gray light pouring through two-story windows facing the harbor. A coffee stand occupies the southeast corner, its espresso machine hissing beneath the atrium's echo. Security badges tap against turnstiles in a steady rhythm."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Fish Bar"
     slug: fish-bar
     description: "Cedar-planked counter worn pale by elbows and spilled beer. The fryer exhales a permanent haze of battered cod and malt vinegar. Stools face the harbor through salt-fogged windows."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Dock"
     slug: the-dock
     description: "Creosote pilings groan under the weight of tied-off boats shifting with the tide. Crab pots stacked three high along the edge smell of brine and rust. Diesel rainbows swirl in the water between hulls."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Harborview"
     slug: harborview
     description: "Floor-to-ceiling glass frames the working harbor — container cranes, tugboats, the slow passage of freighters. Rain streaks the windows diagonally when the wind picks up from the south. The bench here stays warm from a heating vent beneath the seat."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Public Market"
     slug: public-market
     description: "Cast-iron columns hold up a vaulted ceiling blackened by a century of commerce. Vendors call across aisles of stacked fruit, fresh dungeness, and hand-lettered chalkboard signs. The floor is perpetually damp from boots and dripping umbrellas."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Observation Wheel"
     slug: observation-wheel
     description: "Enclosed gondolas rotate slowly above the waterfront, their glass beaded with rain. At the top, the harbor spreads out in miniature — ferries, cranes, the dark line of mountains behind clouds. The mechanism hums through the structure's steel bones."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Rain Shelter"
     slug: rain-shelter
     description: "A glass-and-timber overhang along the waterfront path, designed for waiting. Wooden benches line the back wall beneath a living roof of sedum and moss. Water sheets off the angled glass in a continuous curtain."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Waterfront Park"
     slug: waterfront-park
     description: "Manicured grass slopes toward the seawall, too green for the perpetual overcast. Sculpture pieces in weathered bronze punctuate the lawn at odd intervals. Joggers pass on the gravel path, breath visible in the marine air."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Sea Breeze"
     slug: sea-breeze
     description: "An open stretch of waterfront where the wind comes off the water unbroken. Salt air mixes with the smell of roasting coffee from somewhere inland. Benches here face west, positioned for sunsets that rarely break through the cloud cover."
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Glass Bridge"
     slug: glass-bridge
     description: "A pedestrian span arcs over the waterfront road, its transparent floor showing traffic below. Rain collects in the slight curve of the glass panels, distorting the headlights underneath. The bridge connects the market district to the observation wheel platform. ---"
     zone_slug: the-waterfront
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Coffee Roaster"
     slug: the-pearl-coffee-roaster
     description: "Burlap sacks of green beans line the exposed brick walls, and the roaster itself dominates the back — iron drum, copper pipes, the smell of dark roast saturating everything. Baristas pull shots behind a reclaimed-wood counter scored with cup rings. A chalkboard lists single-origin pours in tight handwriting."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Book Bar"
     slug: the-book-bar
     description: "Shelves floor to ceiling, paperbacks organized by color rather than author. Wine by the glass and drip coffee share a counter made from a salvaged door. Mismatched armchairs cluster near the window where the rain makes reading feel deliberate."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mural Alley"
     slug: mural-alley
     description: "A narrow passage between buildings covered wall to wall in layered paint — wheat-paste portraits peeling over spray-painted geometry over older murals fading underneath. The ground is permanently wet, puddles catching fragments of color. One light fixture halfway down buzzes and flickers."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Vintage Store"
     slug: vintage-store
     description: "Racks of denim and corduroy pressed tight together, the air heavy with cedar and old fabric. A glass case near the register holds turquoise rings, brass belt buckles, and a collection of enamel pins. The fitting room curtain is a repurposed quilt."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Art Gallery"
     slug: art-gallery
     description: "White walls in a converted warehouse space, concrete floor sealed to a dull shine. Track lighting follows the current installation — abstract pieces in rust and verdigris that echo the waterfront's palette. The gallerist works from a desk made of stacked apple crates."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Craft Studio"
     slug: craft-studio
     description: "Communal worktables scarred with knife marks and paint drips fill a bright ground-floor space. Shelving units hold supplies — clay, printmaking ink, bookbinding linen — organized by medium. Finished pieces dry on a rack near the rain-streaked front window."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Ramen Shop"
     slug: ramen-shop
     description: "Steam rolls out every time the door opens, fogging the narrow windows. Eight counter seats face the open kitchen where broth has been simmering since morning. The walls are bare except for a single framed photo of a mountain."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Record Store"
     slug: record-store
     description: "Crates of vinyl line the center aisle, organized by genre with hand-labeled dividers. A turntable near the register plays whatever the clerk pulled this hour, the sound warm and slightly scratched. Gig posters cover every surface above eye level."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Tattoo Parlor"
     slug: tattoo-parlor
     description: "Buzzing needles behind a curtain, the antiseptic smell mixing with incense burning on the front counter. Flash sheets cover the walls in dense grids — traditional anchors alongside geometric blackwork. A leather couch in the waiting area has been repaired with duct tape twice."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Loft"
     slug: the-pearl-the-loft
     description: "Exposed timber beams and original brick, a residential space above the shops reached by a narrow staircase. Rain drums on the skylight set into the sloped ceiling. The view through tall windows catches rooftops, fire escapes, and the tops of street trees."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bike Rack"
     slug: bike-rack
     description: "A covered area between two buildings where wet frames drip onto the concrete. Locks and chains rattle against the rack when someone pulls a bike free. A puddle in the low spot has become permanent, reflecting the overcast."
     zone_slug: the-pearl
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Rainy Corner"
     slug: rainy-corner
     description: "The intersection where two commercial streets meet at an angle, creating a triangular plaza. An awning over the corner cafe extends just far enough to shelter four outdoor tables. Pedestrians cross in clusters between light changes, umbrellas bumping. ---"
     zone_slug: the-pearl
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Crate Dig"
     slug: crate-dig
     description: "Bins of used records fill a basement shop, the stairs down creaking underfoot. Fluorescent light washes out the album art, but the organization is meticulous — alphabetical within genre within decade. Dust and vinyl smell compete in the close air."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Sound Check"
     slug: the-sound-check
     description: "A narrow room behind a venue stage, cables coiled on the floor and amps stacked against the wall. Someone is always adjusting levels, the thump of a kick drum bleeding through the cinder-block partition. Gaffer tape marks the floor in faded colors."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Dive Bar"
     slug: dive-bar
     description: "Low ceiling stained amber by years of smoke that ended a decade ago but never quite left. The bartender pours well drinks without measuring, and the jukebox in the corner takes coins. Three booths along the wall have carved initials in the tabletops."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Open Mic"
     slug: open-mic
     description: "A small stage barely raised above the floor, one spotlight, one microphone on a dented stand. The sign-up sheet by the door fills up by seven on weeknights. Audience noise settles into respectful quiet when someone steps up, then rebuilds between acts."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Turntable"
     slug: the-turntable
     description: "A DJ setup in the window of a street-level shop, visible from the sidewalk. Two decks and a mixer on a plywood table, headphones hung on a nail. The bass carries through the glass and into the wet pavement outside."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Band Poster Wall"
     slug: band-poster-wall
     description: "A long exterior wall layered thick with wheat-pasted gig flyers, the oldest ones reduced to fragments of typography under newer prints. Rain has blurred some into abstract color fields. Staples and tape residue fill every gap."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Green Room"
     slug: the-green-room
     description: "A cramped backstage space with a sagging couch, a mini fridge, and a mirror ringed with dead bulbs. Sharpie signatures cover the concrete walls — band names and dates going back years. The door to the stage leaks sound and colored light around its edges."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Smoker's Alley"
     slug: smokers-alley
     description: "A narrow gap between the venue and the next building, just wide enough for two people to stand shoulder to shoulder. Cigarette butts collect in the corners despite the rain. The muffled thump of the set inside vibrates through the brick."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Listening Booth"
     slug: listening-booth
     description: "A plywood partition in the back of a record shop, fitted with decent headphones and a turntable. The stool is uncomfortable by design — this is for sampling, not loitering. Album covers lean against the wall in the current recommendations stack."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Show Flyer"
     slug: show-flyer
     description: "A telephone pole wrapped in layers of stapled paper — upcoming shows, album releases, band callouts. The rain dissolves the bottom edges of each flyer into pulp. Fresh ones go up over old ones every Thursday."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Door"
     slug: the-door
     description: "A nondescript entrance marked only by a street number and the faint pulse of bass from within. The doorperson sits on a stool under a bare bulb, checking IDs without looking up. A short line forms on the wet sidewalk on weekends."
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Last Set"
     slug: last-set
     description: "The final hour of a show, when the crowd has thinned and the band plays loose. Spilled beer dries tacky on the floor, and the bartender starts wiping down. The energy shifts from performance to something more like conversation. ---"
     zone_slug: vinyl-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Railing"
     slug: the-boardwalk-the-railing
     description: "Weathered timber railing along the boardwalk's seaward edge, smoothed by decades of leaning. Paint peels in long strips revealing older paint beneath. The view opens to gray water, gray sky, and the occasional freighter on the horizon."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Taffy Stand"
     slug: taffy-stand
     description: "A small booth with a mechanical puller stretching colored taffy in the window. The sugar smell cuts through the salt air for twenty feet in every direction. Wax paper bags line the counter in neat rows."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Telescope"
     slug: telescope
     description: "A coin-operated viewfinder bolted to the railing, its brass housing green with patina. On clear days it reaches the far headlands; most days it shows fog and the silhouettes of passing ships. The eyepiece is always cold."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Skate Park"
     slug: skate-park
     description: "Poured concrete bowls and rails beneath the boardwalk's south end, the surface darkened by permanent damp. Wheels hiss on the wet surface, wheels and trucks echoing off the understructure above. Graffiti tags cover every vertical surface below five feet."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Cotton Candy"
     slug: cotton-candy
     description: "A cart with a spinning drum producing pink clouds of spun sugar. The operator works under a striped umbrella that does little against sideways rain. Sweet residue makes the surrounding boardwalk planks slightly sticky."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Bench"
     slug: the-bench
     description: "A single wooden bench set back from the railing, angled to face both the ocean and the boardwalk foot traffic. The seat is bowed from years of use, the armrest worn smooth. Pigeons gather underneath, unafraid."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Busker Spot"
     slug: busker-spot
     description: "A widened section of boardwalk where a guitar case lies open on the planks. The spot is prime — good foot traffic, partial shelter from a nearby overhang. Whoever plays here by noon claims it for the day."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Carousel"
     slug: the-carousel
     description: "A covered carousel with hand-painted wooden horses, their colors faded but maintained. The calliope plays the same twelve songs on rotation, audible from three blocks away. It runs rain or shine, though the crowds thin in weather."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Fishing Pier"
     slug: fishing-pier
     description: "An extension of the boardwalk jutting straight out over the water, lined with rod holders bolted to the rail. Regulars claim spots by dawn, bait buckets and thermoses arranged around folding chairs. The planks are slippery with fish scales and salt spray."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Sunset Watch"
     slug: sunset-watch
     description: "A westward-facing platform at the boardwalk's end, built for the rare evenings when the clouds part. Most days it offers only gradations of gray fading to darker gray. The locals come anyway, standing at the rail with coffee or beer."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Ice Cream Window"
     slug: ice-cream-window
     description: "A walk-up window in the side of a shingled building, the menu painted directly on the wood. The server leans out through a sliding panel, scooping from steel tubs. A short line forms regardless of temperature or rain."
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Driftwood Art"
     slug: driftwood-art
     description: "Sculptures assembled from beach debris occupy a roped-off section of the boardwalk — twisted wood, sea glass, rusted hardware shaped into figures and abstractions. A hand-painted sign credits no one, just reads \"from the sea.\" New pieces appear; old ones disappear. ---"
     zone_slug: the-boardwalk
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Fish Stall"
     slug: fish-stall
     description: "Crushed ice piled high on stainless steel, whole salmon and halibut arranged head to tail. The fishmonger calls out the morning catch, voice carrying over the crowd noise. Scales glint under the overhead fluorescents, and the drain runs constantly."
     zone_slug: the-market
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Flower Stand"
     slug: flower-stand
     description: "Buckets of dahlias, peonies, and wildflower bundles crowd a narrow stall, their colors almost aggressive against the gray day. Water pools on the concrete from overfilled containers. The seller wraps bouquets in brown paper with practiced speed."
     zone_slug: the-market
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Baker"
     slug: the-baker
     description: "A stall backed by a wood-fired oven, the heat radiating into the market aisle. Sourdough rounds cool on wire racks, their crusts cracked and dark. The line moves slowly because everyone asks what just came out."
     zone_slug: the-market
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Cheese Counter"
     slug: cheese-counter
     description: "Wheels and wedges under glass, some wrapped in wax, others in cloth, a few in ash. Small tasting portions sit on a wooden board with toothpicks. The vendor explains provenance with the patience of someone who has answered the same question ten thousand times."
     zone_slug: the-market
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Produce Row"
     slug: produce-row
     description: "Wooden crates stacked with apples, root vegetables, and greens still wet from the morning harvest. Hand-lettered signs list the farm name and the price. Mud clings to the carrots and the boots of the people buying them."
     zone_slug: the-market
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Butcher"
     slug: the-butcher
     description: "A glass case displaying cuts on white butcher paper, a band saw visible in the back. Sawdust covers the floor behind the counter. The butcher works in a stained apron, cleaver marks scoring the maple cutting block."
     zone_slug: the-market
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Craft Booth"
     slug: craft-booth
     description: "A table spread with handmade goods — beeswax candles, wool socks, carved wooden spoons. The maker sits behind the display, working on the next piece while waiting for customers. Rain patters on the canvas awning overhead."
     zone_slug: the-market
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Spice Vendor"
     slug: spice-vendor
     description: "Small glass jars and burlap sacks arranged on tiered shelving, the combined smell almost dizzying — cumin, cardamom, smoked paprika, dried chili. Handwritten labels in neat block print identify each one. Test spoons sit in the most popular blends."
     zone_slug: the-market
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Busker"
     slug: the-busker
     description: "A fiddle player set up at the market's main intersection, case open at their feet. The melody weaves between vendor calls and crowd noise, rising and dipping with the energy of the foot traffic. Coins and small bills accumulate on the velvet lining."
     zone_slug: the-market
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Coffee Cart"
     slug: coffee-cart
     description: "A converted cargo trailer with an espresso machine plumbed to an external water line. The barista steams milk in a steel pitcher, producing a sound that cuts through market noise. A short menu hangs from the awning on a piece of cardboard."
     zone_slug: the-market
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Rainy Awning"
     slug: rainy-awning
     description: "The market's main covered section, a corrugated metal roof over the central aisle. Rain hammers the metal in a continuous white noise, and conversation underneath requires raised voices. Vendors along this stretch never have to worry about their displays getting wet."
     zone_slug: the-market
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Loading Zone"
     slug: loading-zone
     description: "A service alley behind the market stalls where delivery trucks idle and vendors haul crates on hand trucks. Broken pallets and flattened boxes stack against the wall. The pavement here is always wet, stained with produce runoff and motor oil. ---"
     zone_slug: the-market
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Entry Gate"
     slug: entry-gate
     description: "A heavy acoustic door set into a moss-covered stone wall, the transition from forest to facility abrupt and deliberate. Sound drops away the moment the door seals — outside rain, wind, birdsong cut to near silence. The path forward is lined with baffled panels that absorb even footstep echoes."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Low-Frequency Chamber"
     slug: low-frequency-chamber
     description: "A cavernous room with walls curved to channel subsonic waves, their passage felt in the chest and stomach more than heard. The ceiling arches high overhead, every surface shaped to sustain frequencies below fifty hertz. Standing in the center produces a hum that seems to originate inside the body itself."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mid-Range Room"
     slug: mid-range-room
     description: "Panels of varying density and angle cover every wall, tuned to sustain frequencies in the vocal range. Speech in this room gains an uncanny clarity, each word arriving with its full harmonic structure intact. Cascade designed this space to make the human voice sound the way it looks to her — warm amber, threaded with copper."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "High-Frequency Suite"
     slug: high-frequency-suite
     description: "Small and precisely angled, the surfaces here are hard — polished stone, glass, metal — reflecting treble frequencies into crystalline detail. The air feels sharp, almost brittle. Even quiet sounds — a zipper, a breath, fabric shifting — arrive with startling definition."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Harmonic Hall"
     slug: harmonic-hall
     description: "The largest space in the facility, an elongated chamber where the resonant frequencies of the other rooms converge. Instruments played here produce overtones that shouldn't be possible, sympathetic vibrations awakened by the architecture. The walls are irregular by design, each facet calculated to reinforce a different harmonic series."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Quiet Room"
     slug: the-quiet-room
     description: "Near-total acoustic isolation. The walls, floor, and ceiling are layered in deep-wedge foam that absorbs everything above the threshold of hearing. Silence here is aggressive, almost pressurized — visitors report hearing their own blood circulate within thirty seconds. The door closes with a soft, final click."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sound Lock"
     slug: sound-lock
     description: "A transitional corridor between rooms, lined with offset baffles that prevent acoustic bleed between spaces. Two doors are never open simultaneously. The passage deadens whatever frequency profile the previous room sustained, resetting the ear for the next."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Resonance Chamber"
     slug: resonance-chamber
     description: "A circular room where any pitch finds its resonant frequency almost instantly, the walls shaping sound into self-sustaining loops. A single struck note can ring for minutes, building and evolving as the architecture feeds it. Cascade uses this room to test new compositions before committing them to performance."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Garden Path"
     slug: the-garden-path
     description: "An outdoor corridor between structures, open to the forest canopy above. Rain filters through the trees, and the acoustic difference from the engineered interiors is jarring — natural sound in all its ragged, overlapping complexity. The path is flagstone, bordered by ferns that dampen footfall."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Control Booth"
     slug: control-booth
     description: "A small room overlooking the Harmonic Hall through a triple-paned window, filled with analog monitoring equipment. VU meters twitch and peak meters spike, translating sound into visual data. The mixing board is custom-built, its channels labeled in Cascade's handwriting."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Meditation Cell"
     slug: meditation-cell
     description: "A single-occupancy room shaped like the interior of an egg, every surface curved. Sound placed here wraps around the occupant, arriving from no identifiable direction. The chair at the center is positioned at the exact focal point of the room's geometry."
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Open Air"
     slug: open-air
     description: "A clearing at the facility's edge where the engineered acoustics surrender to the forest. The canopy opens slightly, admitting rain and the ambient sound of wind through old-growth evergreens. Performers sometimes play here to hear their work stripped of all architectural enhancement. ---"
     zone_slug: frequency-gardens
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Fern Floor"
     slug: fern-floor
     description: "Sword ferns rise waist-high from the forest floor, their fronds heavy with collected rain. The canopy blocks most direct light, leaving a green-filtered dimness. Footsteps compress decades of decomposing needles into silent, spongy ground."
     zone_slug: the-understory
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Mushroom Log"
     slug: mushroom-log
     description: "A fallen hemlock colonized by shelf fungus in overlapping tiers — white, amber, rust. The log is soft enough to push a finger into, its heartwood consumed and replaced by mycelia. Beetles track the surface in purposeful lines."
     zone_slug: the-understory
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Fallen Giant"
     slug: fallen-giant
     description: "A massive cedar toppled across the forest floor, root plate vertical and taller than a person. The trunk spans a depression, creating a natural bridge draped in moss. Seedlings have already taken root along its upper surface, feeding on its decay."
     zone_slug: the-understory
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Root Hollow"
     slug: root-hollow
     description: "Where a large tree's roots meet the ground, erosion has carved a sheltered cavity beneath the trunk. The space is dry relative to the surrounding forest, the soil held together by a lattice of exposed roots. Small animals have worn the entrance smooth."
     zone_slug: the-understory
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Spider Web"
     slug: spider-web
     description: "An orb web stretched between two saplings catches the mist, each strand beaded with water until the whole structure glows. The builder sits at the center, legs reading vibrations. When the light shifts, the web disappears entirely."
     zone_slug: the-understory
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Nurse Log"
     slug: the-nurse-log
     description: "A decomposing trunk serving as seedbed for a row of young hemlocks, their roots straddling the log like stilts. The nurse log is more soil than wood now, crumbling at the touch. In a century, the young trees will stand on arched roots where the log used to be."
     zone_slug: the-understory
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sword Fern"
     slug: sword-fern
     description: "A dense stand of ferns taller than head height, fronds arching overhead to form a green tunnel. The air beneath is still and humid, sound muffled by the layered foliage. Spore dots line the underside of each frond in precise rows."
     zone_slug: the-understory
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Bracket Fungus"
     slug: bracket-fungus
     description: "Concentric shelves of fungus jut from a standing dead tree, each ring harder than wood. The outermost edges are white with active growth, the inner rings darkened and rigid. Rain taps on them like drum heads, each shelf a different pitch."
     zone_slug: the-understory
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Slug Trail"
     slug: slug-trail
     description: "A slick of mucus across a moss-covered rock, the banana slug that left it still visible two feet ahead — bright yellow against the green. The trail glistens in whatever light reaches the forest floor. Other trails cross and overlap on every surface."
     zone_slug: the-understory
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Moss Carpet"
     slug: moss-carpet
     description: "Sphagnum moss covers the ground in an unbroken sheet, inches deep, saturated with rain. Every step leaves a print that slowly fills with water. The green is so uniform and continuous it obscures the terrain underneath — dips, roots, and rocks hidden beneath the surface."
     zone_slug: the-understory
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Filtered Light"
     slug: filtered-light
     description: "A gap in the canopy where a tree fell years ago, admitting a column of diffused light. Dust and pollen drift in the pale shaft. The understory plants here grow denser and taller, competing for the rare direct illumination."
     zone_slug: the-understory
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Animal Path"
     slug: animal-path
     description: "A narrow trail worn through the undergrowth by repeated passage — deer, most likely, given the height of the clearance. The path follows the path of least resistance, contouring around logs and through gaps. Tracks pressed into the mud are fresh, half-filled with rain. ---"
     zone_slug: the-understory
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Bridge Approach"
     slug: bridge-approach
     description: "The trail narrows and the sound of water grows louder. Ferns close in from both sides, and the ground turns from soil to exposed rock, slick and dark. The bridge becomes visible through the trees as a low arch of stone."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Moss Mat"
     slug: moss-mat
     description: "Thick moss covers the bridge surface completely, several inches deep, obscuring the stone beneath. Each step is uncertain — the moss compresses, water squeezes out, the footing shifts. The mat extends over the bridge edges, hanging down like a green curtain."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Bridge Span"
     slug: bridge-span
     description: "The midpoint of the arch, the creek audible directly below through gaps in the moss covering. The stone is old, dressed by hand, the mortar between blocks long since replaced by root and lichen. The span is wide enough for two to pass, barely."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Fern Rail"
     slug: fern-rail
     description: "Instead of a railing, dense sword ferns grow from the moss along both edges of the bridge. Their fronds arch outward over the drop, heavy with water. Grabbing one for balance leaves a hand wet and smelling of green."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Creek Below"
     slug: creek-below
     description: "Visible through gaps in the moss and between the bridge stones, the creek runs fast and clear over rounded cobble. The water is snowmelt-cold, stained faintly amber by tannins. The sound fills the space under the bridge and echoes off the stone."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Stone Arch"
     slug: stone-arch
     description: "The underside of the bridge, seen from the creek bank — fitted stone darkened by permanent moisture, ferns and liverworts hanging from every crack. The arch frames the creek's passage in a rough oval. Water drips from the keystone in a steady rhythm."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Drip"
     slug: the-drip
     description: "A point where groundwater seeps through the bridge stonework and falls in a thin stream to the creek. The drip has worn a small basin into the rock below, perfectly round. In freezing weather the drip builds a column of ice."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Old Root"
     slug: old-root
     description: "A massive root from a nearby cedar has grown across the bridge approach, partially lifting the stonework. The root is as thick as a thigh, its bark rough and furrowed. Foot traffic has polished the top of the root where people step over it."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Bridge Crown"
     slug: bridge-crown
     description: "The highest point of the arch, where the view opens upstream and downstream through corridors of overhanging trees. Wind funnels through the creek channel, carrying mist from the water below. The moss here is thinner, worn by weather and foot traffic."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Far Side"
     slug: far-side
     description: "The bridge deposits the trail onto a steep bank of exposed root and rock. The forest on this side is older, the trees wider-spaced, the understory darker. A trail marker carved into a cedar trunk is nearly swallowed by new bark growth."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Slippery Step"
     slug: slippery-step
     description: "A section of bare rock descending from the bridge where water runs across the trail in a thin sheet. Boot treads have polished the stone, and lichen fills the low spots. Careful foot placement is the only option — there is nothing to hold."
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Gorge"
     slug: the-gorge
     description: "The creek drops through a narrow slot in the rock below the bridge, the walls vertical and close. The sound amplifies in the confined space, a low roar disproportionate to the water's volume. Mist rises from the turbulence and drifts across the bridge above. ---"
     zone_slug: moss-bridge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entrance"
     slug: cedar-hall-the-entrance
     description: "A gap in the bark of an ancient cedar wide enough to step through, the tree's hollow interior opening into darkness. The threshold is polished smooth by passage, and the smell of cedar resin is immediate and thick. Light enters only through the opening and through cracks high above."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Central Pillar"
     slug: central-pillar
     description: "The heartwood column at the center of the hollow cedar, still structurally sound while the surrounding wood has rotted away. The pillar is pale and smooth, striated with the tree's original grain. The space around it feels architectural, like a nave."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Bark Wall"
     slug: bark-wall
     description: "The inner surface of the living bark, rough and furrowed, still damp with sap in places. The wall curves continuously, enclosing the interior space. Pressing a hand against it and waiting reveals a faint warmth — the tree is alive."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Root Floor"
     slug: root-floor
     description: "The floor of the hollow is a lattice of exposed roots worn smooth by foot traffic, the gaps between them filled with packed cedar duff. Footing is uneven but solid. Water collects in the lowest depressions after heavy rain."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Loft"
     slug: cedar-hall-the-loft
     description: "A natural platform where a large branch once connected to the trunk, leaving a shelf of solid wood ten feet above the floor. Accessible by climbing the interior bark wall. The shelf is wide enough to sit on, the vantage point looking down into the hollow."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Amber Light"
     slug: amber-light
     description: "Resin deposits in the wood glow a deep amber when sunlight finds its way through cracks in the trunk. The effect is transient, lasting only when the angle aligns — certain times of day, certain seasons. In those moments the interior fills with warm, golden light."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Knot Hole"
     slug: knot-hole
     description: "A circular opening in the trunk wall where a branch fell away decades ago, now a window to the forest outside. The hole is fist-sized, perfectly round, the wood around it healed into a smooth lip. Light and sound from outside enter through it like a lens."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Alcove"
     slug: the-alcove
     description: "A natural recess in the interior wall where the wood grain curves inward, creating a sheltered niche. The alcove is large enough for one person to sit with knees drawn up. The cedar smell is strongest here, concentrated in the enclosed space."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Cedar Bench"
     slug: cedar-bench
     description: "A section of fallen interior wood propped against the wall, flat enough to serve as seating. The surface has been worn smooth by use, the grain pattern visible in fine detail. Sitting here puts the back against living bark, the contact grounding."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Resin Drip"
     slug: resin-drip
     description: "A slow seep of cedar resin down the interior wall, the amber sap building in layers over years. The newest resin is translucent and sticky; the oldest has hardened to a dark, brittle shell. The smell is concentrated — sharp, sweet, medicinal."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Ring Count"
     slug: ring-count
     description: "A section of the interior where the heartwood has been cut or worn away, exposing the tree's growth rings. The rings are tight and numerous, each one paper-thin, the count running into centuries. Running a finger across them produces a faint ridged texture."
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Hollow Core"
     slug: hollow-core
     description: "The very center of the tree, where the oldest wood has completely decomposed, leaving empty space. The air here is still and cool, insulated by the surrounding trunk. Sound from outside is reduced to a distant murmur, the cedar walls absorbing everything. ---"
     zone_slug: cedar-hall
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Forest Edge"
     slug: forest-edge
     description: "The tree line ends abruptly, a wall of dark trunks and hanging moss giving way to open sky. The transition is marked by a change in ground cover — forest duff to grass in a single step. Light pours into the gap, startling after the canopy's perpetual shade."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Tall Grass"
     slug: tall-grass
     description: "Meadow grass waist-high, seed heads heavy and bent with rain. The grass moves in waves when wind crosses the clearing, revealing brief glimpses of the ground beneath. Walking through it leaves a visible trail of flattened stems."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Stump"
     slug: the-stump
     description: "A cedar stump six feet across, the cut surface weathered silver-gray. Growth rings are still countable at the edges, the center rotted to a shallow basin that collects rainwater. Seedlings have rooted in the stump's decomposing perimeter."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Wildflower"
     slug: wildflower
     description: "Clusters of native wildflowers — foxglove, lupine, Indian paintbrush — scattered through the meadow grass. The colors are vivid against the green, drawing pollinators audible from several feet away. Each cluster marks slightly different soil conditions beneath the surface."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Sun Patch"
     slug: sun-patch
     description: "A section of the clearing where the sun, on rare clear days, reaches the ground without obstruction. The grass here is thicker, greener, the growth noticeably more vigorous. Even under overcast skies, this spot receives more diffused light than the rest."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Deer Trail"
     slug: deer-trail
     description: "A narrow path pressed into the meadow by regular animal passage, the grass flattened and the soil compacted. The trail enters from the forest edge and crosses to the opposite tree line in a gentle curve. Pellets and hoof prints confirm its regular use."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Boulder"
     slug: the-boulder
     description: "A glacial erratic dropped in the clearing's center, granite among basalt, its surface covered in map lichen. The rock is large enough to sit on top of, its upper face worn smooth by weather. It holds warmth longer than the surrounding ground."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Berry Bush"
     slug: berry-bush
     description: "Salal and huckleberry growing in a dense thicket at the clearing's edge, the berries dark and small. Birds have stripped the accessible branches; the interior of the thicket still holds fruit. Stained droppings mark the ground beneath."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Bird Song"
     slug: bird-song
     description: "The acoustic center of the clearing, where sound from the surrounding forest converges. Wrens, thrushes, and varied thrushes layer their calls from every direction. The open sky above amplifies what the canopy normally dampens."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Center"
     slug: the-center
     description: "The geometric middle of the clearing, equidistant from every tree line. The grass here has been pressed flat by something — wind, animals, use — into a rough circle. Standing here, the forest is a continuous dark wall in every direction, the sky a gray dome overhead."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Shadow Line"
     slug: shadow-line
     description: "The edge of the clearing where the forest's shadow falls, its position shifting with the sun's arc through the day. The line is precise on sunny days, diffuse under cloud. Grass on the shadow side grows differently — thinner, reaching for light."
     zone_slug: the-clearing
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Star Window"
     slug: star-window
     description: "A view straight up from the clearing's center, unobstructed by canopy. On clear nights — rare in this climate — the sky opens in a circle of stars framed by black treetops. Most nights it shows only the undersides of clouds catching distant light. ---"
     zone_slug: the-clearing
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Fog"
     slug: the-fog
     description: "Visibility drops to arm's length. The air is more water than air, saturating everything — clothes, hair, the mossy ground underfoot. Sound flattens, arriving muffled and directionless, the forest reduced to vague shapes dissolving at ten paces."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Mist Trail"
     slug: mist-trail
     description: "The path climbs through drifting fog banks that part and reform without pattern. The trail surface is slick rock and exposed root, every handhold wet. Trees appear suddenly, loom close, and disappear behind within a few steps."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cloud Break"
     slug: cloud-break
     description: "A momentary thinning in the overcast reveals a sky almost blue, the forest below dropping away in waves of dark green. The break closes within minutes, the view replaced by gray. The mountains stay hidden, their presence known only by the upward slope of the land."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Gray Ceiling"
     slug: gray-ceiling
     description: "Solid cloud cover pressing down on the treetops, the boundary between forest and sky dissolved. The trees disappear upward into white-gray nothing. Rain falls from this ceiling in a fine, persistent mist that makes drops indistinguishable from fog."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Wet Rock"
     slug: wet-rock
     description: "An exposed granite face where the trail crosses bare stone, the surface running with condensation. Every crack channels a tiny stream, and the rock's texture provides just enough grip. Lichen grows in the depressions — orange, pale green, black."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Drizzle"
     slug: the-drizzle
     description: "Not quite rain, not quite mist — a perpetual fine precipitation that collects on surfaces rather than falling. Branches drip with accumulated moisture, each drop triggering the next in slow chains. Gore-tex beads it; wool absorbs it; cotton surrenders to it."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Hidden Peak"
     slug: hidden-peak
     description: "A volcanic summit known to exist behind the cloud cover, its presence indicated by the terrain's upward angle. On the rarest days — perhaps twice a year — the peak appears above the clouds, massive and snow-covered and closer than expected. Then the clouds close again."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Damp Meadow"
     slug: damp-meadow
     description: "A high-elevation meadow where the ground never fully dries, the soil spongy with retained moisture. Wildflowers adapted to the wet grow low and dense — shooting stars, marsh marigolds, elephant heads. Stepping off the trail leaves prints that fill with water immediately."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Fog Drift"
     slug: fog-drift
     description: "Fog moves through the trees in slow, visible currents, following the contours of the terrain. Watching it reveals the air patterns the forest creates — eddies behind large trunks, acceleration through gaps, pooling in hollows. The drift carries the smell of wet evergreen."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Precipice"
     slug: the-precipice
     description: "A cliff edge concealed by fog, the drop invisible until the ground simply ends. The void beyond is white and featureless, the wind rising from below with a faint roar. Stepping close enough to see down is stepping too close."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Cloud Pool"
     slug: cloud-pool
     description: "A depression where fog collects and thickens, the air dense enough to obscure one's own feet. The pool has a perceptible boundary — walking into it is like wading into still water. Sound inside is dead, swallowed by the saturated air."
     zone_slug: cloud-line
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Above the Trees"
     slug: above-the-trees
     description: "An exposed ridgeline where the last stunted trees give way to bare rock and alpine scrub. On days when the cloud layer sits below, the forest is invisible beneath a white sea, and peaks rise like dark islands. The sun, when visible here, feels like a different climate entirely. ---"
     zone_slug: cloud-line
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Root Arch"
     slug: root-arch
     description: "Two major roots from neighboring trees have grown together overhead, forming a natural doorway. The arch is thick with moss, the joint where the roots fused visible as a swollen knot. Passing beneath requires ducking, the roots close enough to brush the top of a head."
     zone_slug: root-system
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Mycelia"
     slug: the-mycelia
     description: "A section of forest floor where the duff has been pulled back, revealing a dense white web of fungal threads lacing through the soil. The network connects root systems across the visible area, each thread finer than hair. Disturbing it releases an earthy, mineral smell."
     zone_slug: root-system
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Underground Spring"
     slug: underground-spring
     description: "Water surfaces through a seam in the rock, pooling briefly before disappearing back into the ground. The water is cold and clear, tasting of stone. Moss grows thick around the seep, and the surrounding soil stays dark and saturated."
     zone_slug: root-system
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Root Tunnel"
     slug: root-tunnel
     description: "A passage beneath a massive fallen tree where erosion has carved a crawl space through the root ball. The tunnel is dark, the walls dense with tangled roots and packed soil. Water drips from the root ceiling, and the air smells of earth and decomposition."
     zone_slug: root-system
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Soil Chamber"
     slug: soil-chamber
     description: "A cavity where a root system has collapsed, leaving an underground room walled in compacted earth. Tree roots form the ceiling, penetrating the space in slow, downward-reaching fingers. The floor is damp clay, the darkness total without a light source."
     zone_slug: root-system
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Network"
     slug: the-network
     description: "A stretch of forest where the interconnection between root systems is visible on the surface — roots crossing, merging, splitting, forming a continuous mesh. Stepping on one root transmits vibration to the next. The trees here share resources, disease, and chemical signals through these physical connections."
     zone_slug: root-system
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Root Bridge"
     slug: root-bridge
     description: "A living root spanning a small ravine, thick enough to walk across with care. The root has flattened where it bears weight, developing a natural walkway along its upper surface. Moss provides traction, but the curve requires attention."
     zone_slug: root-system
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Dark Earth"
     slug: dark-earth
     description: "Soil so rich with organic material it is nearly black, loose and fragrant. Earthworms are visible in cross-section where the trail has been cut through. The fertility is palpable — every seed that lands here germinates."
     zone_slug: root-system
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Tap Root"
     slug: the-tap-root
     description: "The main root of an enormous cedar, exposed where water has washed away the surrounding soil. The root descends vertically into the earth, its diameter larger than most tree trunks. It anchors the tree against the lateral force of wind from every storm in its lifetime."
     zone_slug: root-system
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Root Crown"
     slug: root-crown
     description: "The point where trunk meets root system, the base of a large tree flaring outward into buttressed roots. The crown is a meeting of textures — bark giving way to root skin, vertical growth becoming horizontal. Moss fills every crevice, softening the geometry."
     zone_slug: root-system
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Beetle Bore"
     slug: beetle-bore
     description: "Galleries carved just beneath the bark of a standing dead tree, the patterns exposed where bark has fallen away. The channels are precise and branching, each one the work of a single beetle larva. The wood around the galleries is stained blue by the fungus the beetles carry."
     zone_slug: root-system
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Foundation"
     slug: the-foundation
     description: "The root plate of the forest itself — the collective anchoring system of hundreds of trees, visible in cross-section along a creek bank's eroded face. Layers of root generation stack in the soil, the oldest dark and compressed, the newest pale and flexible. The entire forest stands on this interlock. ---"
     zone_slug: root-system
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Crest"
     slug: the-crest
     description: "Water gathers speed as the streambed narrows and tilts, the surface going from rippled to smooth and glassy at the lip. The roar begins here — not loud yet, but felt in the rock underfoot. The current is deceptively fast, pulling everything toward the edge."
     zone_slug: the-falls
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Free Fall"
     slug: free-fall
     description: "The water leaves the rock and drops, a curtain of white and green twisting as it falls. Wind catches the spray and flings it outward in sheets. The fall is long enough for the water to separate into individual streams before impact."
     zone_slug: the-falls
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mist Pool"
     slug: mist-pool
     description: "The basin at the base of the falls, the water churned white where it impacts and smoothing to dark green a few yards out. Mist hangs permanently over the pool, soaking everything within fifty feet. Ferns along the bank grow enormous in the constant moisture."
     zone_slug: the-falls
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Behind the Falls"
     slug: behind-the-falls
     description: "A shallow rock shelf tucked behind the curtain of falling water, the space dim and thunderously loud. The view outward is filtered through the falls — fragmented light, warped shapes, the world reduced to water and sound. The rock floor is perpetually wet and cold."
     zone_slug: the-falls
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Rainbow Spray"
     slug: rainbow-spray
     description: "When sunlight hits the mist at the right angle — a narrow window on clear mornings — the spray produces a persistent rainbow arc. The colors hang in the air, moving with the viewer's position. Most days the light is too diffuse, and the spray is simply wet."
     zone_slug: the-falls
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Plunge Pool"
     slug: the-plunge-pool
     description: "Deep water at the base of the falls, its depth concealed by turbulence and suspended sediment. The pool is cold year-round, fed by snowmelt from the volcanic peaks above. Swimming here is possible but numbing, the water stealing heat in minutes."
     zone_slug: the-falls
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Wet Rock Face"
     slug: wet-rock-face
     description: "The cliff wall beside the falls, permanently darkened by spray, covered in liverworts and water-loving mosses. The rock is basalt, columnar in places, the joints between columns channeling water in thin streams. Touching the surface finds it slick and surprisingly warm from trapped moisture."
     zone_slug: the-falls
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Observation Trail"
     slug: observation-trail
     description: "A maintained path along the gorge rim offering views of the falls from above. Wooden railings and gravel surface keep the trail accessible, though the mist soaks everything within reach. Interpretive signs have been rendered illegible by persistent moisture."
     zone_slug: the-falls
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Cascade"
     slug: the-cascade
     description: "Above the main falls, the river drops in a series of stepped cascades over layered basalt. Each step produces its own curtain and pool, the effect like a staircase of water. The sound builds cumulatively, each cascade adding its voice to the one below."
     zone_slug: the-falls
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Salmon Ladder"
     slug: salmon-ladder
     description: "A fish passage built into the rock beside the falls — a series of stepped pools connected by notches in concrete baffles. In season, salmon rest in each pool before launching themselves up to the next. The water in the ladder is calmer than the falls, purposeful."
     zone_slug: the-falls
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Fern Grotto"
     slug: fern-grotto
     description: "A recess in the cliff face beside the falls, its walls carpeted in maidenhair fern. Water seeps from every crack, feeding the ferns in a perpetual drip. The grotto is cool and quiet relative to the falls, the sound reduced to a dull roar by the intervening rock."
     zone_slug: the-falls
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Thunder Point"
     slug: thunder-point
     description: "An overlook where the falls' sound is loudest, the noise reflecting off a concave rock wall and focusing at this spot. Conversation is impossible. The vibration is physical, felt in the sternum, and the mist is dense enough to obscure the falls themselves. ---"
     zone_slug: the-falls
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Crater Rim"
     slug: crater-rim
     description: "The trail emerges from treeline onto bare volcanic rock, the crater opening below in a broad bowl. Wind whips across the exposed rim, unobstructed. The scale is disorienting — the far rim is miles away, the lake at the bottom impossibly blue against black rock."
     zone_slug: the-crater
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Descent"
     slug: the-descent
     description: "A switchback trail carved into the crater's inner wall, dropping steeply through layers of volcanic deposit. The rock changes color with each stratum — black basalt, red scoria, pale ash, gray pumice. Loose gravel makes every step a negotiation with gravity."
     zone_slug: the-crater
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Lava Tube"
     slug: lava-tube
     description: "A tunnel formed by flowing lava that crusted over and drained, leaving a hollow tube through the rock. The ceiling is smooth, the floor rough where the last flow solidified. The tube is cold, dark, and perfectly silent. Roots from surface trees penetrate through cracks."
     zone_slug: the-crater
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Steam Vent"
     slug: steam-vent
     description: "A fissure in the rock releasing a steady plume of sulfurous steam, the surrounding stone stained yellow and white by mineral deposits. The air above the vent shimmers with heat. The ground nearby is warm to the touch, and the warmth draws moss and small plants to improbable positions on bare rock."
     zone_slug: the-crater
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Obsidian Flow"
     slug: obsidian-flow
     description: "A broad expanse of volcanic glass, its surface fractured into angular chunks that gleam where broken. The obsidian is black and reflective, each piece showing a conchoidal fracture — smooth, curved, sharp. Walking on it produces a distinctive crunching ring."
     zone_slug: the-crater
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Hot Spring"
     slug: hot-spring
     description: "A pool of geothermally heated water in a depression of mineral-stained rock. The water is clear and faintly blue, steam rising from its surface into the cold air. The temperature drops from scalding at the source to tolerable at the edges where cold creek water mixes in."
     zone_slug: the-crater
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sulfur Field"
     slug: sulfur-field
     description: "Yellow and white mineral crusts cover the ground in a broad, flat area where gases seep from below. The smell is sharp and inescapable — hydrogen sulfide, sulfur dioxide, the breath of the volcano. Nothing grows here. The ground is fragile, thin crusts over soft, hot mud."
     zone_slug: the-crater
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Caldera"
     slug: the-caldera
     description: "The broad floor of the crater, relatively flat, covered in a thin layer of volcanic ash and sparse alpine vegetation. The walls rise on all sides, creating a bowl that traps weather — fog pools here, rain falls harder here, snow lingers longer. The scale makes individuals invisible."
     zone_slug: the-crater
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Ash Bed"
     slug: ash-bed
     description: "A deposit of fine volcanic ash, gray-white and soft as flour. Footprints sink several inches, and the ash packs into every fold of clothing and gear. Wind lifts it in low clouds that sting exposed skin. The deposit is deep — probing with a stick finds no bottom at arm's length."
     zone_slug: the-crater
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fumarole"
     slug: fumarole
     description: "A vent releasing volcanic gas with a low, continuous hiss, the opening encrusted with crystallized minerals in yellow, white, and pale blue. The plume is visible against the dark rock, bending with the wind. The temperature near the vent makes the air waver."
     zone_slug: the-crater
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Rock Fall"
     slug: rock-fall
     description: "A field of angular boulders where the crater wall has collapsed, the debris fanning out in a rough cone. The rocks are unstable, shifting underfoot, each one balanced on the ones below it. Passage through the rock fall requires choosing each step deliberately, testing weight before committing."
     zone_slug: the-crater
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Crater Lake"
     slug: crater-lake
     description: "Deep blue water filling the lowest point of the crater, its color a product of depth and clarity. The lake has no visible inlet or outlet, fed entirely by rain, snowmelt, and subterranean seep. The surface is often perfectly still, reflecting the crater walls like a mirror. ---"
     zone_slug: the-crater
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Last Tree"
     slug: last-tree
     description: "A solitary subalpine fir at the upper edge of treeline, stunted and asymmetric, shaped by a lifetime of prevailing wind. Its branches grow only on the leeward side, the windward trunk bare and polished. The tree marks the boundary between forest and alpine exposure."
     zone_slug: timberline
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Alpine Meadow"
     slug: alpine-meadow
     description: "A high-elevation meadow carpeted in short, dense wildflowers — lupine, paintbrush, avalanche lily — compressed into a brief growing season. The colors are concentrated and vivid against the rocky surroundings. Snow patches linger at the meadow's upper edge well into summer."
     zone_slug: timberline
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Krummholz"
     slug: krummholz
     description: "A band of wind-deformed trees growing horizontally, their trunks twisted and pressed flat against the ground by decades of storm. The trees are alive — green needles sprout from branches growing in mats close to the soil. Walking through requires stepping over rather than around them."
     zone_slug: timberline
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Snow Field"
     slug: the-snow-field
     description: "A persistent snow patch that survives into late summer, its surface compacted and granular. The snow is gray with windblown dust and volcanic ash, the edges melting into rivulets that feed the meadows below. Crossing it requires kicking steps, the surface alternating between firm and rotten."
     zone_slug: timberline
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Rock Garden"
     slug: timberline-rock-garden
     description: "Natural arrangements of alpine plants growing in the shelter of volcanic boulders. Cushion plants, phlox, and dwarf lupine fill the gaps between rocks, their roots threading deep into the thin soil. Each rock creates its own microclimate — warmer, less windy, slightly wetter."
     zone_slug: timberline
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Wind Scour"
     slug: wind-scour
     description: "A ridgeline where wind has stripped the soil down to bare rock, the surface polished smooth and etched with fine parallel grooves. Nothing grows here. The wind is constant and hard, the kind that makes standing difficult and tears moisture from exposed skin."
     zone_slug: timberline
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Mountain Goat"
     slug: mountain-goat
     description: "A high ledge frequented by goats, their white shapes visible against the dark rock when they choose to be seen. Tufts of white wool cling to rough rock edges where they have passed. Droppings and hoof scratches mark the traverse they use to cross the cliff face."
     zone_slug: timberline
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Timber Trail"
     slug: timber-trail
     description: "The last maintained section of trail before it dissolves into alpine scramble routes marked by cairns. The trail is cut into thin soil over rock, roots from the last scattered trees acting as steps. Blaze marks on the trees end here."
     zone_slug: timberline
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Glacial Erratic"
     slug: glacial-erratic
     description: "A granite boulder deposited by ice thousands of years ago, sitting incongruously on volcanic bedrock. The boulder is smooth and rounded where the basalt is angular and rough. Lichen covers its upper surface in a patchwork of gray-green and orange."
     zone_slug: timberline
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Heather Slope"
     slug: heather-slope
     description: "A south-facing slope covered in mountain heather, the small pink and white flowers dense and low to the ground. The slope catches whatever sun breaks through the overcast, and snow melts here earliest. Bees work the flowers with single-minded purpose during the short bloom."
     zone_slug: timberline
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Tarn"
     slug: the-tarn
     description: "A small alpine lake trapped in a bedrock depression, its water clear and cold, the bottom visible in every detail — rock, sand, the occasional drowned insect. Wind ripples the surface. The tarn has no fish, no inlet large enough to name — just snowmelt, rain, and sky."
     zone_slug: timberline
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Summit Trail"
     slug: summit-trail
     description: "The final approach to a volcanic peak, traversing exposed rock above treeline. The trail is marked by cairns — stacked stones at irregular intervals, some ancient, some recent. The air thins perceptibly, and the view expands with each switchback until the horizon includes other peaks, other ranges, other weather. ---"
     zone_slug: timberline
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Cathedral Trunk"
     slug: cathedral-trunk
     description: "A Douglas fir so large that three people linking arms cannot encircle it, the trunk rising branchless for a hundred feet before the canopy begins. The bark is deeply furrowed, each ridge the width of a hand. Standing at its base and looking up produces vertigo."
     zone_slug: old-growth
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Canopy Gap"
     slug: the-canopy-gap
     description: "An opening in the old-growth canopy where a giant fell years ago, the resulting light column supporting a riot of undergrowth. Vine maple, salal, and young conifers compete in the gap, growing fast. The surrounding old trees lean slightly toward the light."
     zone_slug: old-growth
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Ancient Stump"
     slug: ancient-stump
     description: "The remains of a tree logged a century ago, the cut surface silver-gray but the wood still sound. The stump is wide enough to stand on, its growth rings telling a story of fire, drought, and recovery spanning half a millennium. Huckleberry grows from its perimeter."
     zone_slug: old-growth
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Trail Marker"
     slug: trail-marker
     description: "A wooden post driven into the ground where two paths diverge, its sign faded to near illegibility by weather and lichen. The post itself is sinking, tilted by frost heave and root growth. Carved initials on the back side suggest decades of passage."
     zone_slug: old-growth
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Bear Claw Tree"
     slug: bear-claw-tree
     description: "A cedar trunk scored with parallel claw marks at various heights — the lowest at five feet, the highest at nine. The gouges are deep, exposing pale wood beneath the bark. The marks accumulate over years, old ones weathering as new ones appear each spring."
     zone_slug: old-growth
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Giant"
     slug: the-giant
     description: "The largest tree in the grove, its vital statistics impossible to estimate by eye. The trunk has the slight taper and perfect verticality of a tree that has never known serious competition for light. Moss covers it to head height; above that, the bark is bare and deeply ridged."
     zone_slug: old-growth
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Owl Nest"
     slug: owl-nest
     description: "A cavity high in a broken-topped snag, the entrance worn smooth by talons. Pellets accumulate on the ground below — compressed bundles of bone, fur, and feather. The owl is rarely seen but often heard at dusk, its call low and resonant in the still air."
     zone_slug: old-growth
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Fern Valley"
     slug: fern-valley
     description: "A depression between ridges where moisture collects and ferns grow to extraordinary size. Lady ferns and sword ferns form a continuous canopy at waist height, their fronds meeting overhead. Walking through the valley is wading through green."
     zone_slug: old-growth
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Deadfall"
     slug: deadfall
     description: "A tangle of fallen trees stacked at angles, the result of a windstorm that took several large trees at once. The deadfall blocks the trail, requiring either climbing over or detouring around. New growth is already colonizing the gaps, filling them with salal and huckleberry."
     zone_slug: old-growth
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Elder"
     slug: the-elder
     description: "A tree older than any recorded history of the region, its age estimated only by girth and the depth of its bark furrows. The Elder grows slowly now, adding wood at a rate measured in fractions of an inch per decade. Its lower branches, each as thick as a normal tree, have become ecosystems of their own."
     zone_slug: old-growth
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Lichen Beard"
     slug: lichen-beard
     description: "Old-man's-beard lichen drapes from the branches of a large hemlock in pale green curtains, some strands reaching several feet in length. The lichen sways in air currents too subtle to feel. Its presence indicates air quality — this deep in the old growth, the air has not been compromised."
     zone_slug: old-growth
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Silent Floor"
     slug: silent-floor
     description: "A section of old-growth forest where the duff is so deep and the canopy so complete that ambient sound drops to near nothing. Footsteps make no sound on the compressed needles. The silence is not empty but dense, filled with the absence of wind, traffic, machinery — everything the RIDE usually carries. ---"
     zone_slug: old-growth
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Seedling Bed"
     slug: seedling-bed
     description: "Raised beds of forest soil sheltered under shade cloth, each one dense with conifer seedlings at various stages. The seedlings are finger-height, their first true needles just emerging. Mist systems keep the beds damp, the water beading on every surface."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Greenhouse"
     slug: the-greenhouse
     description: "A structure of salvaged glass panels and cedar framing, its interior warm and humid. Propagation trays fill the benches — cuttings, seeds, grafts — each labeled with species, source, and date. Condensation runs down the glass in constant rivulets."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Potting Shed"
     slug: potting-shed
     description: "A workbench against the back wall holds soil mixes in labeled bins — peat, perlite, forest duff, sand. Clay pots in graduated sizes stack on shelves. The floor is packed earth, permanently stained dark by spilled water and soil."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Germination"
     slug: germination
     description: "A climate-controlled chamber where seeds are coaxed through dormancy. Temperature and moisture follow precise schedules, mimicking seasonal cycles compressed into weeks. The seeds are tiny — some no larger than dust — each one containing the blueprint for a tree that could live centuries."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Sprout"
     slug: the-sprout
     description: "A single bench dedicated to the most recent germinations, each container showing the first pale curve of a stem breaking soil. The sprouts are fragile and translucent, entirely dependent on the controlled environment. Labels track their origin — seed stock from specific old-growth specimens."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Sapling Row"
     slug: sapling-row
     description: "Young trees in graduated containers lining an outdoor path, arranged by size from knee-height to overhead. The saplings are hardening off — transitioning from greenhouse to forest conditions. Their branches are thin and flexible, their root systems developing in the containers."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Compost Heap"
     slug: compost-heap
     description: "A series of bins in various stages of decomposition — fresh green matter, partly broken down, and finished compost black as coffee grounds. The heap generates its own heat, steam rising from the active bin on cold mornings. The smell is rich, organic, alive."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Watering"
     slug: the-watering
     description: "A gravity-fed irrigation system running from a spring uphill through a network of channels and drip lines. The system is simple — no pumps, no electronics — just water following grade. Each bed receives a calibrated flow, the excess returning to the forest floor."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Transplant Row"
     slug: transplant-row
     description: "Trees ready for planting, their root balls wrapped in burlap, lined up along a gravel path. Each one has been grown for years to reach this stage — stable enough to survive transplant to the forest. Tags note the intended planting site and the soil conditions there."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "New Growth"
     slug: new-growth
     description: "A recently planted section of forest where nursery stock has been established among the existing trees. The transplants are obvious — smaller, straighter, their growth habits not yet shaped by wind and competition. Protective tubes surround the most vulnerable specimens."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Propagation"
     slug: the-propagation
     description: "A workspace for vegetative reproduction — cuttings dipped in rooting hormone, air-layered branches wrapped in damp moss, grafts bound with tape. The work is slow and precise. Success rates vary by species, and the failures are composted without sentiment."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Young Forest"
     slug: young-forest
     description: "The nursery's oldest section, where trees planted decades ago have grown into a functioning young forest. The canopy is closing, the understory establishing, the first cycles of decay and renewal underway. It is recognizably different from old growth — the trees too uniform, too evenly spaced — but it is forest nonetheless."
     zone_slug: the-nursery
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Visitor Center"
     slug: the-rim-visitor-center
     description: "A low stone building with plate glass windows overlooking the canyon, built to frame the view. Interpretive displays line the interior walls with GovCorp-approved messaging about natural heritage. The air conditioning hums steadily, keeping the desert heat at bay."
     zone_slug: the-rim
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Rim Trail"
     slug: rim-trail
     description: "A paved path follows the canyon edge, lined with low stone walls and spaced benches. The trail is flat and easy — designed for the Cultural Zone experience of controlled wonder. The canyon drops away inches from the railing."
     zone_slug: the-rim
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Overlook"
     slug: the-overlook
     description: "A stone platform cantilevered over the canyon rim, fenced with steel cable. The view is a vertical mile of layered rock dropping to a thin green line of river. Wind rising from the depths carries a faint mineral smell and a temperature ten degrees cooler than the rim."
     zone_slug: the-rim
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Guard Rail"
     slug: guard-rail
     description: "Steel cable strung between stone posts marks the boundary between the maintained trail and the unprotected edge. Beyond the rail the rock is fractured and unreliable. The drop is immediate and absolute."
     zone_slug: the-rim
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Parking Area"
     slug: parking-area
     description: "A broad asphalt lot baking in full sun, lined with faded stripes and bordered by desert scrub. Heat radiates from the blacktop in visible waves. Tour buses idle in a designated row, their engines running to keep the interiors cool."
     zone_slug: the-rim
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Lodge"
     slug: the-lodge
     description: "A timber-and-stone building perched on the canyon rim, its back porch hanging over empty air. The interior is climate-controlled and tastefully rustic — the Cultural Zone's version of frontier hospitality. The windows face the canyon but the glass is tinted to soften the view."
     zone_slug: the-rim
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sunset Point"
     slug: sunset-point
     description: "A designated viewing area on the western rim where the canyon walls catch the last light and shift through red, orange, and violet. The stone benches are arranged in rows like theater seating. Every evening the same performance plays to a rotating audience."
     zone_slug: the-rim
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Mule Trail Start"
     slug: mule-trail-start
     description: "A wooden gate marks the beginning of the descent trail, where the maintained rim path ends and the switchbacks begin. A posted sign lists distances and warnings. Beyond the gate the pavement ends and the rock begins."
     zone_slug: the-rim
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Photo Spot"
     slug: photo-spot
     description: "A marked position on the rim trail where the canyon composition is most photogenic, with a convenient ledge for setting up cameras. The angle is calculated — the Cultural Zone wants specific images in circulation. The actual canyon is more complex than any single frame can hold."
     zone_slug: the-rim
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Gift Shop"
     slug: the-rim-gift-shop
     description: "A retail space attached to the Visitor Center, stocked with canyon-branded merchandise and GovCorp-approved media. The shelves are well-lit and the prices are high. Nothing sold here contains information that contradicts the Cultural Zone narrative."
     zone_slug: the-rim
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Precipice"
     slug: the-rim-the-precipice
     description: "The point where the rim trail reaches its narrowest gap between path and edge. The stone here is fractured by frost and tilted slightly outward. The view straight down is unobstructed — layered rock bands shrinking to a thread of water that looks motionless from this height."
     zone_slug: the-rim
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Condor Watch"
     slug: condor-watch
     description: "A section of rim where the canyon's thermal updrafts bring large birds to eye level. Condors ride the rising air in slow circles, close enough to see the numbered tags on their wings. The birds ignore the watchers completely."
     zone_slug: the-rim
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Landing"
     slug: the-landing
     description: "A flat area of packed dirt and rock where the switchback trail levels out after the first major descent. The rim is visible above but already feels remote. RIDE signal is noticeably weaker — colors seem slightly different, sounds slightly sharper."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Switchback Trail"
     slug: switchback-trail
     description: "A narrow trail carved into the canyon wall, zigzagging down through layers of sandstone and limestone. The footing is loose gravel on solid rock. Each switchback reveals a new band of color in the exposed strata."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Rock Shelter"
     slug: rock-shelter
     description: "An overhang of dark limestone creates a shallow cave large enough for several people to rest out of the sun. The back wall is smoke-blackened from centuries of use. The temperature drops sharply in the shade."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Relay Station"
     slug: relay-station
     description: "A small equipment cache bolted to the canyon wall behind a natural rock screen. Signal relay hardware maintains partial RIDE coverage at this depth — enough to function but prone to dropout and distortion. The installation is camouflaged to look like geological survey equipment."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Water Cache"
     slug: the-water-cache
     description: "Plastic containers of water stacked in a wire cage bolted to the rock, maintained by trail crews. The cache sits in permanent shade beneath an overhang. In the canyon's heat, water is the difference between a hike and an emergency."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Mule Rest"
     slug: mule-rest
     description: "A widened section of trail with a stone trough fed by a drip spring, where pack animals stop on the descent. The ground is worn to smooth rock by hooves. The smell of animals lingers between visits."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Petroglyph Wall"
     slug: petroglyph-wall
     description: "A panel of desert-varnished sandstone covered in pecked images — spirals, handprints, animals, and geometric shapes made centuries before GovCorp existed. The rock surface is dark with manganese oxide. The images are precise and deliberate."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Shadow Line"
     slug: second-terrace-shadow-line
     description: "The boundary where direct sunlight ends and the canyon wall's shadow begins, moving across the terrace as the sun tracks overhead. The temperature difference across the line is immediate — fifteen degrees in the space of a single step."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Traverse"
     slug: the-traverse
     description: "A horizontal section of trail cut into a sheer rock face, with the wall on one side and open air on the other. The path is three feet wide and the exposure is total. The rock underfoot is solid but the visual drop pulls at the balance."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Hanging Garden"
     slug: hanging-garden
     description: "A seep spring supports a patch of ferns, columbine, and moss on an otherwise bare rock face. The water trickles from a crack in the limestone and the plants cling to the damp zone in a vertical stripe of green. The garden exists because the rock holds moisture the desert cannot."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Stone Bench"
     slug: stone-bench
     description: "A natural ledge of sandstone shaped by erosion into a smooth seat overlooking the inner canyon. The rock is warm in the morning and cool by afternoon as the shadow claims it. The view from here reaches deeper than the rim allows."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Descent"
     slug: second-terrace-the-descent
     description: "The trail drops steeply through a break in the cliff band, using natural fractures in the rock as steps. The stone changes color with each layer — red to ochre to cream to gray. RIDE signal cuts in and out with every turn, the canyon walls creating interference patterns that shift by the hour."
     zone_slug: second-terrace
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Overhang"
     slug: the-overhang
     description: "A massive slab of red sandstone juts from the canyon wall, creating a sheltered space fifty feet wide and deep enough to block the sky. The underside of the rock is smooth and cool. Sound behaves differently here — voices carry but the canyon's ambient noise drops away."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Red Wall"
     slug: red-wall
     description: "The dominant rock layer at this depth is Supai sandstone, deep red and iron-rich. The wall face runs unbroken for hundreds of yards, its surface carved by water into flutes and channels. In the late afternoon light the red deepens until the rock looks almost liquid."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Drip Spring"
     slug: drip-spring
     description: "Water seeps from a horizontal crack in the limestone and falls in a thin curtain to a shallow pool worn into the rock below. The water is cold and slightly mineralized. The sound of the drip is the only constant noise at this depth."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Camp"
     slug: the-camp
     description: "A flat area of sand and gravel sheltered by canyon walls on three sides, used by those who descend below the RIDE coverage threshold. Fire rings built of river rock show long use. The sky above is a narrow strip of blue between red walls."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Narrow Trail"
     slug: narrow-trail
     description: "The path squeezes between a boulder and the canyon wall, forcing single-file passage through a gap barely wider than a person's shoulders. The rock on both sides is polished smooth by contact. Light comes from above and ahead but not from the sides."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Ochre Stripe"
     slug: ochre-stripe
     description: "A horizontal band of yellow-ochre mudstone runs through the red sandstone like a painted line. The layer is softer than the rock above and below it, eroding into a shallow shelf that runs the length of the visible wall. The color contrast is stark and precise."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Chimney"
     slug: red-ledge-the-chimney
     description: "A vertical crack in the canyon wall wide enough to climb, with handholds and footholds worn into the rock by water and use. The chimney connects two ledge systems and serves as a route between depths. Looking up through it frames a slot of sky."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Iron Band"
     slug: iron-band
     description: "A thin layer of dark ironstone runs through the canyon wall at this depth, harder than the surrounding sandstone and protruding slightly from the weathered face. The band is rust-colored and dense, ringing like metal when struck. It marks a specific moment in geological time."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Wind Cave"
     slug: wind-cave
     description: "A solution cavity carved into the limestone by millennia of chemical weathering, large enough to stand in. The cave breathes — air moves in and out as atmospheric pressure changes, creating a low sound that is felt more than heard. RIDE signal does not penetrate the rock."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Scree Slope"
     slug: scree-slope
     description: "A steep fan of broken rock fragments below a crumbling cliff face, each piece sharp-edged and unstable. The slope shifts underfoot and small rockfalls are triggered by footsteps. The safest route crosses the top edge where the fragments are smallest."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Ancient Path"
     slug: ancient-path
     description: "A route along the ledge worn into the rock by foot traffic over centuries, predating any modern trail system. The path is narrow and unmaintained but legible — polished stone and cleared edges show where people walked. It follows the logic of the rock, not the convenience of switchbacks."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The View"
     slug: red-ledge-the-view
     description: "An unobstructed vantage from the Red Ledge looking straight down to the river and straight up to the rim. The full depth of the canyon is visible from this single point — a mile of layered stone compressed into a vertical frame. RIDE signal is fragmentary here, and the colors of the rock seem more saturated than they did above."
     zone_slug: red-ledge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Shore"
     slug: the-shore
     description: "Coarse sand and water-polished cobbles line the riverbank at the canyon floor. The river is green and fast, carrying snowmelt from mountains hundreds of miles away. The air is cooler here and smells of wet stone and cottonwood. Everything is sharper — edges, sounds, the light itself."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Rapid Run"
     slug: rapid-run
     description: "The river narrows between boulders and drops through a sequence of standing waves, the water white and loud. Spray hangs in the air and coats the surrounding rocks with a permanent sheen. The sound fills the canyon floor and echoes off both walls."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Beach Camp"
     slug: beach-camp
     description: "A crescent of sand deposited by flood currents on the inside of a river bend, flat enough to sleep on and sheltered by tamarisk and willow. The sand is deep and clean. At night the canyon walls block everything except a strip of stars directly overhead."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Eddy"
     slug: river-bottom-the-eddy
     description: "A still pool behind a large boulder where the current reverses and the water moves in a slow circle. Driftwood and foam collect against the upstream face of the rock. The pool is deep and clear enough to see the bottom — smooth stones in green water."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Canyon Floor"
     slug: canyon-floor
     description: "The flat rock shelf that forms the base of the canyon, carved and polished by the river over geological time. The stone is dark schist, the oldest visible rock — nearly two billion years compressed into this single layer. There is no RIDE signal here. Reality is unmediated and unfiltered."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Driftwood Fire"
     slug: driftwood-fire
     description: "A fire ring on the beach built from river cobbles, surrounded by bleached driftwood dragged above the high-water line. The wood burns hot and clean. The firelight reaches the lower canyon walls and stops, absorbed by the darkness above."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Star Strip"
     slug: star-strip
     description: "The narrow band of sky visible from the canyon floor, framed by walls that rise a vertical mile on either side. Stars appear earlier here than on the rim — the canyon creates its own dusk. The strip of visible sky rotates through the night as the earth turns."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Crossing"
     slug: the-crossing
     description: "A point where the river widens and shallows over a gravel bar, the water ankle-deep and fast. The crossing connects the two sides of the canyon floor. The current pushes hard enough to require bracing against it. The water is cold enough to ache."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Rock Garden"
     slug: river-bottom-rock-garden
     description: "A stretch of canyon floor where the river has deposited boulders of every size in a seemingly deliberate arrangement. The stones are rounded and dark, spaced apart on pale sand. The garden was arranged by floodwater, not intent, but the pattern looks composed."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Sandbar"
     slug: sandbar
     description: "A temporary island of fine sand deposited by the last flood, exposed now that the water has dropped. The bar shifts with every high-water event — its shape is never the same twice. Tracks in the sand show that animals use it as a crossing point."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Still Pool"
     slug: still-pool
     description: "A deep pool where the river fills a scoured basin in the bedrock and goes quiet. The water is clear to the bottom — fifteen feet of green transparency over dark stone. The surface reflects the canyon walls in a perfect mirror broken only by the occasional ring of a rising fish."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Echo Wall"
     slug: echo-wall
     description: "A concave section of canyon wall that focuses sound back to a point on the river shore. A whisper aimed at the right angle returns clearly from two hundred feet away. The wall is smooth limestone, polished by ancient floods to an acoustic surface. Down here, with no signal and no filter, the echo is the realest sound there is."
     zone_slug: river-bottom
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Floor"
     slug: the-floor
     description: "The drilling floor sits thirty feet above ground level on a steel substructure, exposed to wind on all sides. Pipe tongs, slips, and rotary equipment are bolted to the platform in a layout dictated by the physics of drilling. Mud and diesel coat every surface in a slick film."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Kelly Table"
     slug: kelly-table
     description: "The rotary table sits at center deck, its square kelly bushing worn smooth from turning thousands of joints of drill pipe. The table is idle, locked in position, but the mechanism is maintained — someone keeps grease on the bearings. Chain tongs hang from a hook nearby."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mud Pit"
     slug: mud-pit
     description: "Open steel tanks hold drilling mud mixed to specific weight and viscosity, its brown surface thick and slow-moving. Agitators churn the fluid in lazy circles. The chemical smell is sharp and persistent — bentonite, barite, and petroleum distillates in a suspension engineered to hold pressure."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Dog House"
     slug: dog-house
     description: "The driller's shack at the edge of the floor, a steel box with windows facing the rotary table. Gauges monitor weight on bit, pump pressure, and mud returns. A logbook sits open on the desk, entries in pencil recording footage drilled per shift. A coffee pot sits on a hot plate, permanently stained."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Crown"
     slug: the-crown
     description: "At the top of the derrick, the crown block hangs motionless — a massive sheave assembly through which the drilling line is threaded. From up here the prairie extends flat in every direction, unbroken to the horizon. Wind makes the derrick sway in a rhythm too slow to feel on the floor below."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Monkey Board"
     slug: monkey-board
     description: "A narrow platform ninety feet up the derrick where the derrickman handles pipe during trips in and out of the hole. The safety belt clips to a rail that runs the width of the board. Pipe fingers extend from the platform to hold stands of drill pipe racked vertically against the derrick frame."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Pipe Rack"
     slug: pipe-rack
     description: "Joints of drill pipe and casing are laid out on wooden racks beside the derrick, organized by diameter and grade. The pipe is doped at the connections, its threads protected by steel caps. A forklift with flat tires sits at the end of the rack, abandoned mid-task."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Shale Shaker"
     slug: shale-shaker
     description: "Vibrating screens separate rock cuttings from drilling mud as it circulates back from downhole. The shakers rattle constantly when the rig is active, their screens clogged with gray-brown formation material. Cuttings pile up in a disposal trough, each layer a record of what lies below."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Generator Pad"
     slug: generator-pad
     description: "Diesel generators sit on a concrete pad downwind of the rig floor, their exhaust stacks pointing away from the crew quarters. The generators run continuously, their combined noise a low-frequency hum that saturates everything within half a mile. Fuel tanks flank the pad on both sides."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Pump Jack"
     slug: the-pump-jack
     description: "A horsehead pump jack nods up and down on a nearby well, its counterweight rising and falling in a mechanical rhythm that never varies. The beam and walking beam are painted safety yellow, the only bright color on the location. Each stroke pulls crude oil from a formation thousands of feet down."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Tank Battery"
     slug: tank-battery
     description: "Cylindrical storage tanks sit in an earthen berm designed to contain spills, their sides streaked with paraffin and crude oil residue. Gauges on the sides show fluid levels, read by hand once per shift. The tanks smell of petroleum and warm steel, stronger in the afternoon heat."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Flame Stack"
     slug: flame-stack
     description: "A flare stack burns excess gas at the edge of the pad, its flame visible for miles across the flat prairie. The roar is constant and directional, bending with the wind. At night the flare paints the rig in orange light and throws long shadows across the caliche lease road."
     zone_slug: the-derrick
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Road"
     slug: the-road
     description: "A caliche road runs straight to the horizon, its white surface reflecting heat in waves that blur the distance. No painted lines, no shoulders, no guardrails. Tire tracks are the only evidence of traffic, pressed into the soft surface and slowly erasing in the wind."
     zone_slug: dust-line
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Fence Post"
     slug: fence-post
     description: "Cedar fence posts stand in a line across the prairie, their tops split and weathered to a silver gray. Most still hold three strands of barbed wire. The posts lean at slight angles, shifted over decades by the expansion and contraction of clay soil that never fully dries or fully saturates."
     zone_slug: dust-line
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Barbed Wire"
     slug: barbed-wire
     description: "Three strands of rusted barbed wire stretch between posts, sagging in the middle spans and singing in the wind. The wire defines a property line that has no other marker — no ditch, no change in vegetation, no difference between one side and the other. The barbs have dulled to nubs."
     zone_slug: dust-line
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Cattle Guard"
     slug: the-cattle-guard
     description: "Steel pipes set in a concrete foundation span the road where it crosses a fence line, their spacing designed to stop hooves but allow tires. The pipes ring hollow when driven over. Dust has filled the pit beneath them to within inches of the bottom rail."
     zone_slug: dust-line
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Mesquite Tree"
     slug: mesquite-tree
     description: "A single mesquite grows beside the road, its trunk twisted and its canopy spread wide and low. The shade it casts is the only shade for a mile in any direction. Cattle have worn the ground beneath it to bare dirt, standing here in the heat of the day until the shadow moves."
     zone_slug: dust-line
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Dry Creek"
     slug: dry-creek
     description: "A creek bed cuts across the flat land, its banks cracked white clay and its bottom dry gravel. It carries water only during heavy rain, and then briefly. Tire tracks cross the bed at a low-water crossing, and someone has stacked rocks on the far bank to mark the exit point."
     zone_slug: dust-line
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Windmill"
     slug: the-windmill
     description: "An Aermotor windmill stands on a lattice tower, its fan wheel turning slowly in whatever breeze the prairie offers. The sucker rod below pumps water from an aquifer into a galvanized stock tank at the base. The tower creaks with each revolution, a rhythmic complaint audible from a quarter mile."
     zone_slug: dust-line
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Stock Tank"
     slug: stock-tank
     description: "A round galvanized tank sits beneath the windmill, filled with water pumped from below. Algae grows in a green ring at the waterline. Cattle have churned the ground around it into a muddy wallow that dries in concentric rings of cracked earth expanding outward from the tank."
     zone_slug: dust-line
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Buzzard Circle"
     slug: buzzard-circle
     description: "Turkey vultures wheel in a thermal column above something dead in the grass, their shadows passing over the ground in slow rotation. The birds are patient and unhurried, spiraling lower in increments too small to see. The grass below them is undisturbed — whatever they are watching is still too fresh."
     zone_slug: dust-line
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Horizon"
     slug: the-horizon
     description: "The horizon is a clean line separating brown earth from white sky, unbroken in every direction. There is nothing to fix the eye on — no tree, no building, no elevation change. Distance becomes abstract without landmarks. The flatness is not peaceful. It is absolute."
     zone_slug: dust-line
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Mile Marker"
     slug: mile-marker
     description: "A small concrete post marks a distance from a reference point no longer identified, its numbers faded to shadows. The post stands at a slight lean, undermined by erosion on one side. It is the only vertical element for a hundred meters in any direction."
     zone_slug: dust-line
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Heat Mirage"
     slug: heat-mirage
     description: "The air above the road shimmers in layers, bending light until the horizon appears to ripple like water. Distant objects float above their actual position, stretched and inverted. The mirage retreats at the speed of approach, always the same distance ahead, promising something that resolves into more road."
     zone_slug: dust-line
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Stack"
     slug: the-stack
     description: "A catalytic cracking unit towers above the refinery complex, its steel column rising into a sky stained yellow-white by process emissions. Pipes enter and exit the column at multiple levels, each carrying a different fraction of crude. The stack radiates heat that distorts the air around it."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Pipe Bridge"
     slug: pipe-bridge
     description: "An elevated rack of pipes crosses above the access road, each pipe color-coded by contents — silver for steam, yellow for gas, green for water, unmarked for everything else. The bridge supports carry dozens of lines in parallel, some insulated, some bare and hot enough to burn at a touch."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cracking Tower"
     slug: cracking-tower
     description: "The fractional distillation column stands at the heart of the refinery, a cylinder of riveted steel plates rising eighty feet. Temperature decreases with elevation, separating crude into its component products at different heights. Vapor plumes escape from relief valves in intermittent bursts."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Control Room"
     slug: the-refinery-control-room
     description: "Behind blast-resistant walls, instrument panels monitor every process in the refinery through analog gauges and digital displays installed decades apart. Operators sit in swivel chairs watching flow rates, temperatures, and pressures that represent millions of barrels moving through the system. The air conditioning runs cold."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Cooling Tower"
     slug: cooling-tower
     description: "Hyperbolic concrete shells pull air through cascading water to reject waste heat from the refinery processes. The towers exhale continuous plumes of steam that drift across the complex depending on wind direction. The water at the base smells of treatment chemicals and warm metal."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Tank Farm"
     slug: tank-farm
     description: "White cylindrical storage tanks fill a fenced compound, each one large enough to hold a day's production of refined product. Floating roofs rise and fall with inventory levels. Earthen berms surround each tank, sized to contain the full volume in case of rupture."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Flare"
     slug: the-flare
     description: "A tall steel pipe vents excess hydrocarbon gas, its tip burning with a flame that ranges from invisible blue to bright orange depending on composition. The flare roars when relief valves open during process upsets. At night it is the brightest point on the coastal prairie."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Valve Manifold"
     slug: valve-manifold
     description: "A junction where multiple pipelines converge, controlled by a bank of gate valves each requiring two hands to operate. The manifold allows routing of product between units, storage, and pipeline connections. Valve handles are numbered and painted, their positions logged by hand in a clipboard hanging from a chain."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Catalyst Bed"
     slug: catalyst-bed
     description: "Inside a reactor vessel, catalyst material processes hydrocarbon streams at high temperature and pressure. The bed is accessed through a manway that requires confined-space entry procedures. The catalyst itself is pelletized and coated with precious metals, worth more per pound than the product it creates."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Separator"
     slug: the-separator
     description: "A horizontal pressure vessel separates oil, gas, and water by density and retention time. Sight glasses on the side show the interfaces between phases — a dark band of oil floating on murky water, gas space above. The vessel hums with the vibration of fluid flowing through it."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Rail Spur"
     slug: rail-spur
     description: "A single track enters the refinery through a gate, running past a loading rack where tank cars are filled with refined products. The rack has multiple loading arms, each one designed for a specific product grade. Drip pans beneath the connections catch the residual flow when hoses are disconnected."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Night Shift"
     slug: night-shift
     description: "The refinery never stops. At night the complex becomes a geometry of lights — work lights, warning lights, flame from the flare and the process heaters. The skeleton crew moves between units with flashlights, checking gauges and listening for sounds that do not belong. Silence here means something is wrong."
     zone_slug: the-refinery
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Pen"
     slug: the-pen
     description: "Pipe-rail fencing divides the yard into holding pens sized for different lot counts. The ground is packed dirt mixed with manure and straw, worn to hardpan by hooves. Flies circle in the heat, undisturbed by the industrial fans mounted on the corner posts."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Auction Block"
     slug: auction-block
     description: "A raised platform with a microphone and a electronic board faces tiered seating under a corrugated steel roof. The auctioneer's cadence still echoes in the architecture — the platform angled so the crowd can see the stock, the gate positioned for quick movement through. Sawdust covers the floor."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Loading Chute"
     slug: loading-chute
     description: "A narrow ramp funnels cattle from the pens onto waiting trucks, its sides tall enough that the animals can only move forward. The chute is built from heavy pipe welded at angles designed to discourage balking. Manure and boot mud cake the non-skid surface."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Trough"
     slug: the-trough
     description: "A long concrete water trough runs the length of the main pen, fed by a float valve that maintains a constant level. The water is warm and green-tinged by afternoon. Cattle crowd the trough in the heat, shouldering each other for position along its length."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Hay Barn"
     slug: hay-barn
     description: "An open-sided pole barn shelters round bales stacked two high, their twine-wrapped surfaces bleached blond by sun exposure. Loose hay covers the ground in a thick mat that muffles footsteps. Barn swallows nest in the rafters, darting in and out through the open sides."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Brand Station"
     slug: brand-station
     description: "A squeeze chute and headgate hold cattle for branding, vaccination, and ear-tagging. Propane-heated irons hang from a rack beside the chute, each bearing a registered brand. The smell of singed hair and hide lingers in the steel framework long after the work is done."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Scale"
     slug: the-scale
     description: "A platform scale set flush with the ground weighs cattle as they cross between pens, its readout displayed on a post at eye level. The scale is calibrated weekly, its accuracy a legal requirement for commerce. Pen gates on either side control the flow of animals onto the platform."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Saddle Room"
     slug: saddle-room
     description: "A small cinder-block building holds saddles on wall-mounted racks, bridles on pegs, and working tack organized by use. The room smells of leather, neatsfoot oil, and horse sweat. A boot scraper is bolted to the concrete outside the door, crusted with dried mud and worse."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Rail"
     slug: the-rail
     description: "A pipe-rail fence runs the perimeter of the stockyard, its horizontal rails dented by the weight of cattle pressing against them. The posts are set in concrete, leaning outward under years of pressure. Cowboys sit on the top rail to watch pens, their boot heels hooked on the second bar."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Manure Pile"
     slug: manure-pile
     description: "A front-end loader has pushed manure into a composting pile at the downwind edge of the yard, its mass steaming in the cooler hours. The pile is large enough to have its own topography — peaks, valleys, and a crust that dries and cracks in the sun. The smell is territorial."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Water Tank"
     slug: water-tank
     description: "An elevated steel tank on a concrete base provides water pressure to the troughs and wash racks throughout the stockyard. The tank sweats in the humidity, rivulets running down its sides through rust streaks. A ladder bolted to the support frame leads to an inspection hatch at the top."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Gate"
     slug: the-gate
     description: "The main gate to the stockyard is a double-wide pipe gate hung on heavy-duty hinges, its latch a chain and pin system designed to be operated from horseback. The gate opens onto a county road that runs straight in both directions. Cattle trucks idle here in the early hours, waiting for lots to load."
     zone_slug: the-stockyard
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Pump Station"
     slug: pump-station
     description: "A fenced compound houses mainline pumps that push product through the pipeline at pressures measured in hundreds of PSI. The pumps are driven by diesel or electric motors, their noise a constant vibration that travels through the ground. Pressure gauges on the manifold are read and recorded hourly."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Right-of-Way"
     slug: the-right-of-way
     description: "A cleared corridor cuts across the prairie in a straight line, its path marked by brown grass where the pipeline was buried and the soil never fully recovered. Marker posts identify the line at regular intervals, warning against excavation. The cleared strip runs to the horizon in both directions."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Valve Station"
     slug: valve-station
     description: "Above-ground valves enclosed in a fenced pad allow operators to isolate sections of the pipeline for maintenance or emergency shutdown. The valve wheels are large enough to require both hands and full body weight to turn. Emergency shutdown handles are painted red and sealed with breakaway locks."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Dig"
     slug: the-dig
     description: "An excavation exposes a section of pipe for inspection, its coating stripped back to reveal the steel beneath. The trench walls show the pipeline's burial depth — six feet of clay, caliche, and rock removed by machine. Inspection crews use ultrasonic gauges to measure wall thickness at each clock position."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Inspection Point"
     slug: inspection-point
     description: "A test station allows technicians to measure the pipeline's cathodic protection levels and check for coating damage without excavation. The station is a small metal box on a post, connected to the pipeline by buried wires. Readings are taken with a voltmeter and recorded in a logbook chained to the post."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Weld"
     slug: the-weld
     description: "A circumferential weld joins two sections of pipe, its bead visible as a raised ring beneath the coating. Every weld is X-rayed and documented before burial, its radiograph filed and retained for the life of the pipeline. The weld here was flagged for reinspection — a notation on the marker post records the date."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Pig Launch"
     slug: pig-launch
     description: "A barrel-shaped launcher allows pipeline pigs — cleaning and inspection devices — to be inserted into the flowing product stream. The launcher has a quick-opening closure on one end and a reducer connecting it to the mainline on the other. Pig tracking equipment sits on a shelf inside the fence."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Cathodic Test"
     slug: cathodic-test
     description: "A test point where the pipeline's corrosion protection system is monitored through sacrificial anodes and impressed current. The test wires emerge from the ground at a junction box, each labeled with a pipeline identifier. Readings here determine whether the metal is losing electrons — and therefore losing integrity."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Creek Crossing"
     slug: creek-crossing
     description: "The pipeline passes beneath a creek bed, its burial depth increased to account for scour during high water. The crossing is marked on both banks with warning signs and concrete markers. The creek itself runs shallow and brown, indifferent to the infrastructure beneath it."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Easement"
     slug: the-easement
     description: "A legal boundary marked by survey stakes defines the corridor where the pipeline company has the right to access, maintain, and operate the buried line. The easement crosses private land without owning it. Landowners farm and graze up to the edge, but nothing permanent is built within the stakes."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Compressor Station"
     slug: compressor-station
     description: "Gas compressors boost pressure in the pipeline to maintain flow over long distances, their turbines running on a fraction of the gas they move. The station is loud — a high-pitched whine underlaid by deep mechanical vibration. Exhaust stacks vent hot combustion gases into the flat sky."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Emergency Shutoff"
     slug: emergency-shutoff
     description: "A remote-operated valve can isolate this section of the pipeline within seconds if sensors detect a pressure drop or flow anomaly. The shutoff is marked by a red beacon and surrounded by a gravel pad cleared of all vegetation. It has activated twice — once for a test, once not."
     zone_slug: the-pipeline
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Horizon"
     slug: flatline-the-horizon
     description: "The land and the sky meet in a line so straight it looks ruled, the color difference between them the only proof that either exists. There is no depth here, no foreground and background — just a single plane extending until vision gives out. The wind crosses it without resistance."
     zone_slug: flatline
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Dead Signal"
     slug: dead-signal
     description: "A transmission tower stands skeletal against the sky, its antenna array intact but receiving nothing. The tower's warning lights are dark. Whatever signal it was built to carry has been absent long enough that the access road to its base has grown over with grass."
     zone_slug: flatline
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Empty Road"
     slug: empty-road
     description: "Pavement runs due west until it dissolves into heat shimmer, its center line worn away by sun exposure. No vehicles have passed recently enough to leave tracks in the dust that drifts across the surface. The road was built to connect two points, and at least one of them no longer exists."
     zone_slug: flatline
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Crossroads"
     slug: the-crossroads
     description: "Two roads intersect at right angles, each running to the horizon without a curve or bend. There is no stop sign, no traffic signal, no indication that either road has priority. The intersection is marked only by the crossing of painted lines, both faded nearly to invisibility."
     zone_slug: flatline
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Abandoned House"
     slug: abandoned-house
     description: "A frame house stands alone on a lot that was never part of a neighborhood, its windows dark and its porch roof collapsed on one side. The yard is bare dirt — no grass, no landscaping, just the house and the ground it sits on. The front door is closed but not locked."
     zone_slug: flatline
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Tower Base"
     slug: tower-base
     description: "The concrete foundation of a demolished communication tower sits in a cleared area, its anchor bolts cut flush with the surface. The tower was removed but the base remains — too massive to extract, too useless to maintain. Cables emerge from conduits in the concrete and end in nothing."
     zone_slug: flatline
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Static"
     slug: the-static
     description: "Atmospheric interference creates a low hiss that is not quite silence, filling the space where signal should be. Equipment brought here registers noise on every frequency — random, patternless, without source. The static is not broadcast. It is the sound of nothing arriving."
     zone_slug: flatline
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Tumbleweed"
     slug: tumbleweed
     description: "Dried Russian thistle rolls across the road in the wind, collecting against fence lines and abandoned structures in piles that grow until something sets them free again. The plants are dead — skeletons of stems and thorns tumbling across a landscape that produced them and has no further use for them."
     zone_slug: flatline
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "No Service"
     slug: no-service
     description: "The last indication of network coverage ended miles back. Here, devices search for signal and find nothing — no tower, no relay, no reflection strong enough to register. The absence is not jamming. There is simply no infrastructure. The Flats forgot this place, or never knew it."
     zone_slug: flatline
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Silence"
     slug: the-silence
     description: "Without signal, without traffic, without machinery, what remains is the sound of wind over open ground. It is not peaceful — it is the sound of a frequency band with nothing on it. The silence has weight. It presses on the ears like pressure differential."
     zone_slug: flatline
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bare Ground"
     slug: bare-ground
     description: "The soil here supports nothing — no grass, no brush, not even the hardiest pioneer species. The ground is alkaline hardpan, white-crusted and cracked in polygonal patterns. Rain beads on the surface and evaporates before it can soak in. This is where the land itself gives out."
     zone_slug: flatline
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Last Light"
     slug: last-light
     description: "The western edge of Flatline, where the sun sets into an unobstructed horizon and the last light stretches shadows to infinite length. There is nothing beyond this point that the Grid maps or the signal reaches. The light lingers here longer than it should, as if it too has nowhere further to go."
     zone_slug: flatline
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Entry Point"
     slug: entry-point
     description: "Gravel gives way to hardpan where the trail markers stop making sense. The air tastes metallic, faintly charged. Something about the light here refuses to settle."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Flicker Zone"
     slug: flicker-zone
     description: "The tree line ahead blinks — present, then not, then doubled. Shadows land in the wrong places, attached to nothing. Footing feels solid until it doesn't."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Stutter"
     slug: the-stutter
     description: "A section of trail that takes three steps to cross and five to remember. Sound arrives late or early, never on time. Boot prints appear ahead of the person making them."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Temporal Echo"
     slug: temporal-echo
     description: "Voices carry here from conversations that ended seconds ago or haven't started yet. The wind shifts direction mid-gust. A bird crosses the same patch of sky twice."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Disruption Wall"
     slug: disruption-wall
     description: "A visible boundary where the air thickens into something almost solid. Colors on the far side run a half-tone off, greens trending blue, earth trending red. Stepping through feels like pushing through wet curtain."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Reality Seam"
     slug: reality-seam
     description: "Two versions of the same ridgeline overlap at slightly different angles. The ground holds boot prints that fill with dust and then un-fill. Equipment readings spin without cause."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Gradient"
     slug: the-fault-line-the-gradient
     description: "The transition happens in degrees — stable ground fading through static into raw noise. Compass needles drift in lazy circles. The temperature changes three times in ten meters."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Signal Break"
     slug: signal-break
     description: "Transmission equipment on both sides has burned through this corridor, leaving a strip of dead air. Nothing renders here — not GovCorp's version, not anyone else's. Just rock, wind, and the actual sky."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Double Vision"
     slug: double-vision
     description: "Every surface holds a faint second image, offset by centimeters. Trees cast two shadows from one sun. Walking produces a companion footstep a half-beat behind, matching stride for stride."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Overlap"
     slug: the-overlap
     description: "Two competing signal fields crash into each other and neither wins. The landscape strobes between versions — mountain meadow, then bare scree, then meadow again. Standing still is the only sane option."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Raw Terrain"
     slug: raw-terrain
     description: "Past the last interference pattern, the land just exists. No rendering, no correction, no signal of any kind. Bare granite and alpine scrub under a sky that looks somehow more blue than it should."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Edge"
     slug: the-edge
     description: "The boundary where interference ends and clean mountain begins. One step back and the air hums with competing signals. One step forward and there is nothing but wind and stone and silence."
     zone_slug: the-fault-line
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Base Clearing"
     slug: base-clearing
     description: "A flat patch of packed earth at the upper edge of the tree line, ringed by wind-bent spruce. Boot-worn paths radiate outward like spokes. The altitude makes every task take twice the effort."
     zone_slug: high-camp
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Tent Row"
     slug: tent-row
     description: "Canvas and nylon shelters staked against the prevailing wind, guy-lines humming. Rocks weigh down every loose edge. The arrangement suggests long occupation rather than passing use."
     zone_slug: high-camp
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Fire Ring"
     slug: the-fire-ring
     description: "Blackened stones in a circle, ash compacted into a hard gray disc. The ring sits in a natural windbreak between two boulders. Smoke rises straight up in the thin air, then shreds apart at twenty feet."
     zone_slug: high-camp
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Equipment Cache"
     slug: equipment-cache
     description: "Gear piled under a weathered tarp, lashed to a rock face with climbing rope. Ice axes, fuel canisters, coiled line. Everything arranged for fast access in the dark."
     zone_slug: high-camp
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Lookout Point"
     slug: lookout-point
     description: "A flat boulder jutting over the eastern face, offering a view across three valleys. Wind velocity doubles at the exposed edge. On clear days the plains are visible as a brown smear far below."
     zone_slug: high-camp
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Spring"
     slug: the-spring
     description: "Water seeps from a crack in the rock, channeled into a shallow pool by stacked stones. The water runs ice-cold year-round, mineral-heavy. Green moss rings the overflow in a bright stripe against gray granite."
     zone_slug: high-camp
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Latrine Trail"
     slug: latrine-trail
     description: "A narrow path beaten through dwarf willows, ending at a trench screened by a canvas panel. The ground is loose scree, unstable underfoot. Nobody lingers here longer than necessary."
     zone_slug: high-camp
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Radio Post"
     slug: radio-post
     description: "A small platform of stacked flat stones supporting a weather-beaten antenna and a sealed equipment case. Reception is intermittent — the altitude helps, but the terrain blocks half the horizon. Static fills the gaps between transmissions."
     zone_slug: high-camp
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Mess"
     slug: the-mess
     description: "A tarp-covered cooking area with a propane burner bolted to a flat rock. Dented pots hang from a line strung between poles. The smell of instant coffee and dehydrated meals hangs in the still air."
     zone_slug: high-camp
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Supply Drop"
     slug: supply-drop
     description: "A clearing marked with orange panels where gear arrives by whatever means the altitude allows. Cargo nets lie flattened against the ground, weighted with stones. The supply schedule is irregular at best."
     zone_slug: high-camp
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Star Watch"
     slug: star-watch
     description: "A flat expanse of exposed rock above the camp, away from any light source. At this altitude the stars don't twinkle — they burn steady and hard. The Milky Way casts a faint shadow on the stone."
     zone_slug: high-camp
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Lean-To"
     slug: the-lean-to
     description: "Three walls of stacked stone with a corrugated metal roof wedged between rock faces. The interior stays dry but never warm. Wind finds the gaps and makes them sing."
     zone_slug: high-camp
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Ridge Trail"
     slug: ridge-trail
     description: "A narrow track running along the spine of the range, dropping off steeply on both sides. Loose stone makes every step a negotiation. The wind is constant and comes from everywhere."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Knife Edge"
     slug: the-knife-edge
     description: "The ridge narrows to less than a meter across, with exposure on both flanks that turns the stomach. Hands-and-knees terrain. The rock is sharp enough to cut through gloves."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Wind Gap"
     slug: wind-gap
     description: "A saddle in the ridge where wind accelerates through the notch like water through a nozzle. Standing upright requires leaning thirty degrees into the gale. Sound is stripped away entirely."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Rock Scramble"
     slug: rock-scramble
     description: "A section where the trail disappears into a field of house-sized boulders. Route-finding means reading the scratches left by previous boots on rock faces. Every handhold needs testing before trusting."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "False Summit"
     slug: false-summit
     description: "The ridge crests here and the ground levels out, but the actual summit stands another three hundred meters higher behind it. The disappointment is a physical weight. Wind-scoured rock offers no shelter."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Cairn"
     slug: the-cairn
     description: "A stack of flat stones rising shoulder-high, built by generations of hands. Smaller stones ring the base, each one placed deliberately. The cairn marks a junction where three routes converge."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Cornice"
     slug: cornice
     description: "An overhang of wind-packed snow curls over the ridge's lee side, beautiful and lethal. The edge is impossible to judge — solid ground becomes unsupported snow without warning. Cracks run through the surface in jagged lines."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Ridge Camp"
     slug: ridge-camp
     description: "A few flat spots scraped from the ridge, just wide enough for a bivy. The exposure is total — nothing between the sleeper and the sky. Anchoring anything requires drilling into rock."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Traverse"
     slug: the-ridge-the-traverse
     description: "A horizontal crossing of a near-vertical face, following a ledge that narrows to boot-width. Fixed ropes mark the route, sun-bleached and fraying. The drop below disappears into cloud."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Drop-Off"
     slug: drop-off
     description: "The ridge terminates in a vertical face that falls away without transition. The edge is sharp, clean-cut by frost action over centuries. Vertigo hits before the eyes fully register the depth."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Ridge View"
     slug: ridge-view
     description: "A wide spot on the ridge where the panorama opens in every direction. Mountain ranges stack to the horizon in blue-gray layers. The scale makes human presence feel like a surveying error."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Col"
     slug: the-col
     description: "A low point between two peaks where the ridge dips into a sheltered saddle. Snow lingers here into summer, compacted into blue ice. The wind drops to almost nothing, and the silence is sudden and total."
     zone_slug: the-ridge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Last Spruce"
     slug: last-spruce
     description: "A single tree, bent horizontal by decades of wind, marks the boundary where forest gives up. Its trunk is polished smooth on the windward side. Everything above this point is rock, ice, and sky."
     zone_slug: treeline
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Krummholz"
     slug: the-krummholz
     description: "Knee-high trees twisted into dense mats by wind and snow load. Walking through them means walking over them. Branches grab at ankles and pack straps with surprising strength."
     zone_slug: treeline
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Scree Field"
     slug: scree-field
     description: "Loose angular rock covering a steep slope, shifting underfoot with every step. Two steps up, one step back. The sound of sliding stone carries for hundreds of meters in the thin air."
     zone_slug: treeline
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Marmot Rock"
     slug: marmot-rock
     description: "A sun-warmed boulder surrounded by smaller stones, riddled with burrow entrances. Sharp whistles erupt from invisible sentries at any approach. Droppings and gnawed stems litter the surrounding ground."
     zone_slug: treeline
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Snow Patch"
     slug: snow-patch
     description: "A remnant of last winter's snowpack, gone granular and gray with trapped dust. Meltwater seeps from its lower edge, feeding a trickle that disappears into the scree. The surface is pocked with sun cups."
     zone_slug: treeline
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Bog"
     slug: the-bog
     description: "An alpine wetland trapped in a shallow depression, spongy with moss and standing water. Boot prints fill immediately. The ground moves underfoot in slow, queasy waves."
     zone_slug: treeline
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Wind Shelter"
     slug: wind-shelter
     description: "A natural pocket in the rock where the wind drops to nothing. The temperature rises ten degrees inside. Lichen grows thick on the sheltered walls, the only color above the treeline."
     zone_slug: treeline
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Alpine Garden"
     slug: alpine-garden
     description: "A patch of improbable color — dwarf wildflowers clinging to a south-facing slope in thin soil. The blooming season lasts weeks. Bees work the flowers in the brief calm of midday."
     zone_slug: treeline
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Mountain Stream"
     slug: mountain-stream
     description: "Snowmelt running fast over polished stone, clear enough to count pebbles on the bottom. The water is cold enough to ache on contact. It braids and re-braids across a gravel fan before dropping over a ledge."
     zone_slug: treeline
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Notch"
     slug: the-notch
     description: "A V-shaped cleft in a rock wall, barely wide enough to pass through with a pack. The walls rise vertically on both sides, funneling wind into a sustained roar. Through the gap, the terrain changes completely."
     zone_slug: treeline
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bare Rock"
     slug: treeline-bare-rock
     description: "Exposed bedrock scraped clean by glaciation, marked with parallel scratches running north-south. No soil, no vegetation, no purchase. Rain pools in shallow depressions and evaporates before it can drain."
     zone_slug: treeline
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Lichen Field"
     slug: lichen-field
     description: "A vast expanse of rock covered in orange, green, and black lichen, growing at the rate of millimeters per century. The patterns look deliberate, like a slow-motion map. Walking here feels like walking on something alive."
     zone_slug: treeline
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Street"
     slug: base-town-main-street
     description: "A two-lane road through the center of town, lined with false-front buildings and angle-parked trucks. Elevation signs on the lampposts read above three thousand meters. The mountains fill the sky at the end of every cross street."
     zone_slug: base-town
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Outfitter"
     slug: the-outfitter
     description: "Racks of technical gear fill a converted hardware store, the floors worn smooth by boot traffic. Topographic maps cover one wall. The staff size up customers by their hands and their boots, not their questions."
     zone_slug: base-town
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mountain Hotel"
     slug: mountain-hotel
     description: "A three-story wood-frame building with a wraparound porch and steam rising from the kitchen vent. The lobby smells of wood polish and wet wool. Room keys hang on brass hooks behind a counter scarred with decades of use."
     zone_slug: base-town
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "General Store"
     slug: general-store
     description: "Shelves stocked with shelf-stable food, batteries, fuel canisters, and duct tape. A chest freezer hums against the back wall. The prices reflect the cost of hauling everything up from the plains."
     zone_slug: base-town
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Guide Post"
     slug: the-guide-post
     description: "A bulletin board under a shingled overhang, layered with weather reports, trail conditions, and hand-drawn route maps. Faded business cards for guide services ring the edges. The current conditions sheet is updated daily in careful handwriting."
     zone_slug: base-town
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Trailhead"
     slug: trailhead
     description: "A wide spot at the end of the pavement where the road becomes trail. A registration box stands next to a carved wooden sign listing distances and elevation gains. Boot prints overlap in the mud like a record of ambition."
     zone_slug: base-town
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Parking Lot"
     slug: parking-lot
     description: "Gravel and packed earth, vehicles dusted with road grit and bearing plates from a dozen regions. Windshield wipers hold notes for returning drivers. The lot empties as the weather window opens and fills when it closes."
     zone_slug: base-town
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Lodge"
     slug: base-town-the-lodge
     description: "Heavy timber construction, smoke threading from a stone chimney. The great room centers on a fireplace large enough to stand in. Elk antlers and route photos cover the walls between windows that frame the range."
     zone_slug: base-town
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Gear Shop"
     slug: gear-shop
     description: "A narrow storefront crammed with technical equipment — ropes, harnesses, protection, helmets. Everything hangs from pegboard or sits in labeled bins. The proprietor can fit a crampon by sight."
     zone_slug: base-town
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Ranger Station"
     slug: ranger-station
     description: "A government-green building with a flagpole and a radio antenna on the roof. Topo maps and fire danger signs fill the front window. The ranger knows every trail and every way to die on them."
     zone_slug: base-town
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Diner"
     slug: the-diner
     description: "Formica countertop, chrome stools, and a griddle that hasn't cooled in years. The menu runs to eggs, burgers, and pie. Climbers and truckers sit elbow to elbow at the counter, refueling on calories and coffee."
     zone_slug: base-town
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Bus Depot"
     slug: bus-depot
     description: "A concrete-block shelter with a bench and a schedule posted behind scratched plexiglass. The bus comes twice daily when the pass is open, less when it isn't. Exhaust fumes mix with cold mountain air in the loading area."
     zone_slug: base-town
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Tap Handle"
     slug: the-tap-handle
     description: "A long wooden bar backed by thirty-two tap handles, each one a different local or regional craft. The bartender pulls pints without looking at the labels. Condensation runs down the brass rail in steady drips."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Craft Pour"
     slug: craft-pour
     description: "A narrow tasting room with a flight board and a chalkboard listing today's small-batch options. The brewer works visible behind a glass partition. Hop dust and yeast sweetness saturate the air."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Patio Heater"
     slug: patio-heater
     description: "A flagstone patio ringed with propane heaters casting warm circles in the mountain cold. Picnic tables bear the rings of a thousand pint glasses. The stars are sharp and close above the amber glow."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Fire Pit"
     slug: tap-alley-the-fire-pit
     description: "A stone-walled pit at the center of the outdoor area, flames throwing shadows across faces. Adirondack chairs ring the perimeter, all angled for warmth. The smell of cedar smoke mixes with cold pine air."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Live Acoustic"
     slug: live-acoustic
     description: "A low stage in the corner of a taproom, one guitarist and a microphone. The sound is clean and unamplifed against the brick wall. Conversations drop to murmurs during the quiet songs."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Apres Bar"
     slug: apres-bar
     description: "A warm, crowded room where the day's climbing stories compete for volume. Gear dries on hooks by the door. The specialty is a hot whiskey drink that burns going down and radiates outward."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Flight"
     slug: the-flight
     description: "A standing bar with paddle boards of four-ounce tasters arranged lightest to darkest. Tasting notes are scrawled on recycled cardboard in marker. Arguments about hop profiles are constant and unresolvable."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Chalkboard Menu"
     slug: chalkboard-menu
     description: "A wall-sized slate listing rotating taps, kitchen specials, and tomorrow's weather forecast. The handwriting changes with the shift. Someone has drawn a mountain range across the top in white chalk."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "String Lights"
     slug: string-lights
     description: "Edison bulbs strung between posts along the alley, casting warm amber light across the cobblestones. The glow turns the narrow space into something close to intimate. Laughter and clinking glass echo off the brick walls."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Local Band"
     slug: local-band
     description: "A four-piece wedged into a corner, playing folk-rock through a modest PA. The drummer keeps time on a cajon. The crowd knows the chorus to every original and sings along without being asked."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Growler Fill"
     slug: growler-fill
     description: "A counter with a row of taps and a shelf of empty glass jugs, a steady stream of locals swapping full for empty. The fill list is handwritten on a whiteboard. Regulars don't need to read it."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Closing Time"
     slug: closing-time
     description: "The alley at the end of the night — last call echoing from open doorways, staff stacking chairs. Cold mountain air rushes in through propped doors. The string lights click off one strand at a time."
     zone_slug: tap-alley
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "East Approach"
     slug: east-approach
     description: "The road climbs in a series of curves carved from the rock face, gaining elevation with each switchback. Guardrails end where the budget ran out. The valley below shrinks to a green thread between gray walls."
     zone_slug: the-pass
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "West Approach"
     slug: west-approach
     description: "A gentler grade on the leeward side, the road cutting through dense forest before emerging above the trees. Snow poles line both shoulders, marking the road's edge when drifts bury the pavement. The sky opens up with disorienting speed."
     zone_slug: the-pass
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Summit"
     slug: the-pass-the-summit
     description: "The highest point of the pass, marked by a wind-battered sign and a pull-off barely wide enough for two vehicles. The air is noticeably thinner. Views open in both directions, east to plains, west to more mountains."
     zone_slug: the-pass
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Switchback One"
     slug: switchback-one
     description: "The first turn above the valley floor, tight enough to make a loaded truck swing wide into the oncoming lane. Rubber marks stripe the pavement at the apex. The drop-off is immediate and unguarded."
     zone_slug: the-pass
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Switchback Five"
     slug: switchback-five
     description: "High enough now that the trees have thinned to scattered individuals. The road surface changes to cracked asphalt patched with gravel. Wind hits broadside at this exposure, shoving vehicles toward the edge."
     zone_slug: the-pass
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Snowshed"
     slug: the-snowshed
     description: "A concrete tunnel built over the road where avalanche paths cross the route. Inside, the light drops to a gray twilight and engine noise amplifies to a roar. Icicles hang from the ceiling joints year-round."
     zone_slug: the-pass
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Avalanche Chute"
     slug: avalanche-chute
     description: "A wide scar in the tree line where slides have stripped everything down to bare rock and rubble. Debris from the last cycle — snapped trunks, boulders, dirty snow — litters the road margins. The crossing takes five seconds at speed."
     zone_slug: the-pass
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Pass Marker"
     slug: pass-marker
     description: "A stone pillar at the continental divide, elevation carved deep into the granite. Wind has polished the west face smooth. Snow gathers in the carved numbers and freezes there."
     zone_slug: the-pass
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Wind Blast"
     slug: wind-blast
     description: "An exposed section of road where the pass funnels wind into sustained gale force. Vehicles rock on their suspension. Loose snow travels horizontally across the pavement like white smoke."
     zone_slug: the-pass
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Corridor"
     slug: the-corridor
     description: "A stretch of road cut through solid rock, walls rising vertically on both sides. The corridor blocks all wind but channels engine noise into a deafening echo. Seep water freezes on the walls in layered sheets of green ice."
     zone_slug: the-pass
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Road Cut"
     slug: road-cut
     description: "A section where the road was blasted through a granite ridge, exposing banded layers of stone in cross-section. The cut faces weep groundwater that freezes into curtains of ice in winter. Rockfall netting sags with accumulated debris."
     zone_slug: the-pass
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Descent"
     slug: the-pass-the-descent
     description: "The far side of the pass, where the road drops through a series of engineered curves toward the lowlands. Brake check areas are carved into the shoulder at regular intervals. The temperature rises perceptibly with each hundred meters of lost elevation."
     zone_slug: the-pass
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Platform"
     slug: the-platform
     description: "Concrete and steel, swept clear of accumulation by wind and maintenance crews. A covered waiting area provides minimal shelter. Departure boards show schedules that weather regularly invalidates."
     zone_slug: snow-station
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Warming Hut"
     slug: warming-hut
     description: "A small timber building heated by a wood stove, the interior air thick and drowsy. Benches line the walls, worn smooth by layers of ski pants and parkas. The windows are permanently fogged."
     zone_slug: snow-station
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Gondola Base"
     slug: gondola-base
     description: "The lower terminal of the lift system, cables humming as cabins cycle through the loading area. Hydraulic mechanisms clunk at regular intervals. The upper station is visible as a dark speck against the white slope above."
     zone_slug: snow-station
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Ski Rack"
     slug: ski-rack
     description: "Rows of wooden slats holding skis and boards upright, organized by nothing, abandoned by their owners. Meltwater pools beneath the racks on the concrete pad. The collection tells a story of every ability level."
     zone_slug: snow-station
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Lift"
     slug: the-lift
     description: "Steel towers marching up the mountain in a straight line, carrying chairs through wind and snow. The cable sings a low tone that changes pitch with the load. Empty chairs swing and spin on their way back down."
     zone_slug: snow-station
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Hot Cocoa Stand"
     slug: hot-cocoa-stand
     description: "A window in the side of a timber building, a handwritten menu offering three variations on the same drink. Steam rises from paper cups in the cold air. The line is always six people deep."
     zone_slug: snow-station
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Deck"
     slug: the-deck
     description: "A broad wooden platform facing south, lined with tables and chairs in full sun exposure. The wood is weathered silver-gray. Sunburn and frostbite are simultaneously possible from a seated position."
     zone_slug: snow-station
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Chair One"
     slug: chair-one
     description: "The oldest lift on the mountain, a fixed-grip double chair that moves at a deliberate pace. The seats are cracked vinyl over metal frames. Riders' legs dangle over the treetops, then over open snow, then over rock."
     zone_slug: snow-station
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Poma"
     slug: the-poma
     description: "A surface lift for beginners — a spring-loaded disc on a cable that pulls skiers uphill. The mechanism jerks and releases with unreliable timing. The run it serves is gentle enough that falling off is merely embarrassing."
     zone_slug: snow-station
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Emergency Sled"
     slug: emergency-sled
     description: "An orange fiberglass toboggan chained to a rack at the patrol station, ready for extraction. Medical supplies are strapped inside under a weatherproof cover. Its presence is both reassuring and ominous."
     zone_slug: snow-station
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Snow Cat"
     slug: snow-cat
     description: "A tracked vehicle idling in a maintenance bay, exhaust condensing in the cold air. The cab is warm and smells of diesel and hand salve. The machine weighs twelve tons and climbs sixty-degree slopes."
     zone_slug: snow-station
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Mountain View"
     slug: mountain-view
     description: "An unobstructed vista from the station's upper level, encompassing the full range and the plains beyond. Distance collapses in the clear air — peaks fifty kilometers away look close enough to touch. Cloud shadows move across the valleys like slow animals."
     zone_slug: snow-station
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Lip"
     slug: the-lip
     description: "The top edge of a vertical rock face, where flat ground simply ends. Approaching on hands and knees is the rational choice. Pebbles kicked over the edge vanish without a sound for a long time."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Exposed Face"
     slug: exposed-face
     description: "A wall of rock tilted past vertical, swept by wind and intermittent ice. The surface is fractured into holds that may or may not support weight. Sunlight reaches this face for exactly two hours per day."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Rock Overhang"
     slug: rock-overhang
     description: "A horizontal lip of stone jutting out from the face, creating a sheltered space underneath. The ceiling is low enough to force a crouch. Drip lines mark the edge where meltwater falls free."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Loose Scree"
     slug: loose-scree
     description: "A chute filled with unstable angular rock, every piece resting on the piece below it in fragile equilibrium. Moving through it starts a chain reaction of sliding stone. The sound carries across the cirque like dry applause."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Fixed Rope"
     slug: fixed-rope
     description: "A length of weathered static line bolted to the rock face with expansion anchors. The rope's age and condition are open questions. It provides the only security on a traverse where the consequences of a slip are absolute."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Piton"
     slug: the-piton
     description: "An old chromoly spike driven into a crack in the rock, the eye rusted but still solid. It marks a belay station on a route that predates modern protection. The metal is cold enough to stick to bare skin."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Hanging Bivouac"
     slug: hanging-bivouac
     description: "A portaledge bolted to the face at a stance too small to stand on, the fabric platform hanging over empty air. Sleeping here requires absolute trust in the anchor system. The exposure is total and inescapable."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Ice Sheet"
     slug: ice-sheet
     description: "A section of the face coated in a thin, transparent layer of verglas — ice formed from refreezing meltwater. It turns reliable rock into frictionless glass. Crampons bite, but only just."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Chimney"
     slug: the-shelf-the-chimney
     description: "A vertical crack wide enough to climb inside, using opposing pressure against both walls. The interior is dark, damp, and claustrophobic. Upward progress is measured in body lengths."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Friction Slab"
     slug: friction-slab
     description: "A smooth, angled expanse of granite with no visible holds — just texture and the coefficient of rubber on stone. Movement depends entirely on trust in the shoe. The angle looks mild until a person is on it."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Belay"
     slug: the-belay
     description: "A small ledge with bolted anchors, just large enough for two people and a rope pile. The stance looks down the full length of the pitch below. Communication happens through rope tugs and shouted single words."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Crow's Ledge"
     slug: crows-ledge
     description: "A narrow shelf high on the face where ravens nest in a crack in the rock. The birds are unbothered by altitude and indifferent to visitors. Their calls echo off the surrounding walls and return as distorted copies."
     zone_slug: the-shelf
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Turn One"
     slug: turn-one
     description: "The first bend in the mountain road, banking hard against a rock wall cut with drill marks. Fresh gravel fills the shoulder where the last slide came through. Downhill traffic rides the brakes, engines whining."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Turn Three"
     slug: turn-three
     description: "The road doubles back on itself, stacked above the previous turn by a single lane's width. Looking down through the guard rail reveals the roof of a vehicle on the level below. The pavement here is scarred with chain marks."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Turn Seven"
     slug: turn-seven
     description: "The altitude shows in the vegetation — full forest at the bottom, scattered krummholz here, nothing above. The turns have grown tighter and the drops longer. Engine temperature gauges climb with the road."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Gravel Pullout"
     slug: gravel-pullout
     description: "A widened shoulder scraped from the hillside, just large enough for a vehicle to stop and let others pass. Tire tracks in the gravel show heavy use. The view from here reaches across the valley to the facing range."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Guard Rail"
     slug: the-switchback-guard-rail
     description: "Bent steel W-beam bolted to posts sunk in concrete, the paint scratched away in places to bare metal. It represents the engineered margin between the road and a very long fall. Some sections have been replaced more recently than others."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Hairpin"
     slug: the-hairpin
     description: "The tightest turn on the road, requiring a full lock in either direction. Mirrors mounted on the rock wall show oncoming traffic around the blind corner. Tire rubber is embedded in the pavement at the apex."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Steep Grade"
     slug: steep-grade
     description: "A straight section tilted at the maximum engineered angle, the road climbing through a notch in the ridge. Gravity is palpable in both directions. Runaway ramp signs appear with increasing frequency."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Runaway Ramp"
     slug: runaway-ramp
     description: "A gravel escape road angling uphill off the main route, designed to stop vehicles that have lost their brakes. The gravel is deep and loose, calculated to absorb momentum. Ruts from past use tell their own stories."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Scenic Overlook"
     slug: scenic-overlook
     description: "A paved pull-off with a stone wall and an interpretive sign describing the geology visible in the opposite face. The sign's information is secondary to the view. Wind makes standing at the wall a matter of deliberate effort."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Rockfall Zone"
     slug: rockfall-zone
     description: "A section of road beneath an unstable face, marked with warning signs and flashing lights. Debris from previous falls has been bulldozed to the shoulder. Crossing quickly is the only mitigation available."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Engine Brake"
     slug: engine-brake
     description: "A stretch of steep descent where the sound of compression braking fills the canyon — a sustained mechanical groan echoing off the rock walls. The air smells of hot metal and brake pad. Pullouts are spaced for cooling stops."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Grade"
     slug: the-grade
     description: "The long, sustained climb that defines the approach — kilometers of steady upward angle without a flat section. Transmission temperature dictates speed. The mountains grow larger with every switchback until they fill the entire field of view."
     zone_slug: the-switchback
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Fisherman's Wharf"
     slug: fishermans-wharf
     description: "Weathered planks run along the waterfront where commercial fishing boats still dock between GovCorp research vessels. The smell of brine and diesel fuel cuts through the fog, and handwritten price boards compete with holographic Cultural Zone displays for attention."
     zone_slug: the-pier
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Crab Stand"
     slug: crab-stand
     description: "A narrow counter wedged between two bait shops serves Dungeness crab from steaming pots. The vendor works without looking up, cracking shells with mechanical precision while fog condenses on the metal awning above."
     zone_slug: the-pier
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sea Lion Dock"
     slug: sea-lion-dock
     description: "A floating platform at the pier's edge where sea lions haul out on sun-bleached wood, barking over each other in territorial disputes. Tourists press against the railing to watch, unaware that the maintenance hatch beneath the platform leads to a service corridor running under the entire wharf."
     zone_slug: the-pier
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Tourist Trap"
     slug: tourist-trap
     description: "Racks of magnets, shot glasses, and miniature cable cars fill a storefront painted in aggressive pastels. The proprietor watches foot traffic through a window clouded with salt residue and the ghostly reflection of neon signage."
     zone_slug: the-pier
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Rail"
     slug: the-pier-the-rail
     description: "A rusted iron railing runs along the pier's outer edge, bolted into concrete that crumbles where the salt has worked its way in. Fishing lines dangle over the side into gray-green water, and the city skyline floats behind a curtain of mist across the bay."
     zone_slug: the-pier
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Boat Launch"
     slug: boat-launch
     description: "A concrete ramp descends into the harbor at a steep grade, its surface slick with algae below the tide line. Small craft bob in their slips nearby, hulls knocking against rubber bumpers in the light chop."
     zone_slug: the-pier
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Tackle Shop"
     slug: tackle-shop
     description: "Pegboard walls display lures, hooks, and spools of monofilament under fluorescent lights that haven't been changed in years. The proprietor keeps a marine radio behind the counter, tuned to weather frequencies that occasionally pick up something else entirely."
     zone_slug: the-pier
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Chowder Bowl"
     slug: chowder-bowl
     description: "A diner built into a converted shipping container serves chowder in sourdough bread bowls to a line that wraps around the corner on clear days. The kitchen exhaust fan pushes warm, briny steam into the fog, creating a pocket of visibility in an otherwise gray afternoon."
     zone_slug: the-pier
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Fog"
     slug: the-pier-the-fog
     description: "The end of the pier disappears into a wall of white moisture that rolls in from the ocean. Sound dampens here — the city behind becomes muffled, and the rhythmic groan of a foghorn somewhere in the strait is the only reliable landmark."
     zone_slug: the-pier
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Pier's End"
     slug: piers-end
     description: "Wooden pilings mark the terminus where the pier juts into open water. The planks are newer here, replaced after storm damage, and a single bench faces west toward the strait and the headlands beyond."
     zone_slug: the-pier
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Street Performer"
     slug: the-pier-street-performer
     description: "A semicircle of tourists gathers around a performer working a painted silver robot act near the pier entrance. The cobblestones are marked with chalk outlines from previous acts, layered over each other like a palimpsest of minor spectacles."
     zone_slug: the-pier
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Souvenir Stand"
     slug: souvenir-stand
     description: "A rolling cart stacked with postcards and printed t-shirts occupies the same spot every day, chained to a bollard overnight. The vendor sells images of the bridge and the bay that look nothing like the fog-choked reality three meters away."
     zone_slug: the-pier
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Wall"
     slug: the-wall
     description: "A solid mass of marine fog presses against the western hills like something with weight and intention. Visibility drops to arm's length, and the moisture beads on every surface — metal, glass, skin."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Cold Front"
     slug: cold-front
     description: "The temperature drops sharply where the ocean air undercuts the warmer inland atmosphere. The boundary is almost visible, a shimmer in the gray where two air masses grind against each other."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Dripping Eave"
     slug: dripping-eave
     description: "A Victorian cornice line drips steadily onto the sidewalk below, condensation running along century-old gutter work that GovCorp preservation orders keep immaculate. The drops hit the pavement in a rhythm that sounds almost deliberate."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Foghorn"
     slug: the-foghorn
     description: "A low-frequency blast rolls across the water at regulated intervals from a station somewhere on the headlands. The sound enters the chest before the ears register it, vibrating through the fog like a pulse."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Low Visibility"
     slug: low-visibility
     description: "The street narrows to a canyon between row houses, and the fog thickens until headlights become diffuse halos moving at walking speed. Pedestrians materialize and dissolve within steps, faces briefly visible before the white absorbs them again."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Damp Walk"
     slug: damp-walk
     description: "A brick path winds through a hillside park where every surface glistens. The benches are permanently wet, the iron railings cold enough to sting, and the eucalyptus trees overhead shed bark that sticks to the walkway in damp curls."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Gray Light"
     slug: gray-light
     description: "Daylight here has no source — it arrives evenly from all directions, filtered through the fog layer into a flat, shadowless illumination. Colors desaturate to pastels, and depth perception becomes unreliable."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Mist"
     slug: the-mist
     description: "Lighter than true fog, a fine mist hangs between the buildings on the hill's eastern slope. It catches in window screens and spider webs, turning them into beaded curtains that glitter when a rare shaft of sun breaks through."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Condensation"
     slug: condensation
     description: "Water collects on the inside of windows facing the bay, running in slow rivulets down glass that distorts the view of the street below. Climate control systems in the older buildings fight a losing battle against the moisture."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fog Drift"
     slug: fog-bank-fog-drift
     description: "Tendrils of fog move through the streets at shin height, pulled by pressure differentials between the avenues. They curl around lampposts and pool in doorways, thinning and thickening as the wind shifts."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Fog Break"
     slug: fog-break
     description: "A temporary clearing where the fog has parted, revealing blue sky and hard sunlight that feels almost aggressive after hours of gray. The break moves slowly across the hillside, closing behind itself as it passes."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dewpoint"
     slug: dewpoint
     description: "The fog is thickest here at the base of a hill where cold air settles and moisture precipitates on every surface. A fire hydrant weeps condensation. Mailboxes are beaded with water. Even the pavement looks freshly rained on, though no rain has fallen."
     zone_slug: fog-bank
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Peak"
     slug: the-peak
     description: "The highest point on the peninsula, a wind-scoured hilltop where the city falls away in every direction. GovCorp communications arrays share the summit with century-old park benches, both bolted to the same rock."
     zone_slug: the-summit
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Observation Deck"
     slug: the-summit-observation-deck
     description: "A concrete platform with a waist-high wall offers a three-hundred-sixty-degree view on clear days. On most days, it offers a view of the inside of a cloud and the faint suggestion of a city somewhere below."
     zone_slug: the-summit
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Radio Tower"
     slug: radio-tower
     description: "A lattice of painted steel rises from the hilltop, bristling with antennae and dishes that serve the Cultural Zone's broadcast infrastructure. The tower hums at certain wind speeds, a low drone that residents on the upper slopes have learned to sleep through."
     zone_slug: the-summit
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Steps"
     slug: the-summit-the-steps
     description: "A mosaic-covered staircase descends the hill's eastern face in switchbacks, each landing decorated with tile fragments pressed into mortar by volunteers decades before GovCorp made public art a permitted activity. The grout is cracking but the images hold."
     zone_slug: the-summit
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Switchback Trail"
     slug: the-summit-switchback-trail
     description: "A dirt path zigzags up the hill's north face through coastal scrub, the footing loose in dry weather and treacherous when the fog drips. Each turn reveals a slightly different angle on the bay and the bridge spanning the strait."
     zone_slug: the-summit
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Wind Point"
     slug: the-summit-wind-point
     description: "An exposed shoulder of the hill where the wind accelerates between two rock outcrops. The grass grows sideways here, permanently bent, and anything not secured will end up in the valley below."
     zone_slug: the-summit
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Hillside Garden"
     slug: hillside-garden
     description: "Terraced beds cut into the south-facing slope catch the afternoon sun when it appears. Native plants grow in deliberate arrangements, maintained by a neighborhood collective that predates the Cultural Zone by forty years."
     zone_slug: the-summit
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Bench"
     slug: the-summit-the-bench
     description: "A single wooden bench faces west at a bend in the trail, positioned to catch the last light as the sun drops toward the strait. The seat is worn smooth, and someone has carved initials into the backrest that have been there long enough to round over."
     zone_slug: the-summit
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Panorama"
     slug: panorama
     description: "A wide section of trail where the hillside opens to a view spanning from the headlands to the downtown skyline. Interpretive signs from three different eras layer over each other — the oldest barely legible, the newest GovCorp-branded with Cultural Zone messaging."
     zone_slug: the-summit
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Stone Wall"
     slug: the-stone-wall
     description: "A retaining wall of local sandstone runs along the trail's lower edge, built by hand in a style that predates heavy equipment. Lichens and moss colonize the joints, and ferns grow from cracks where enough soil has accumulated."
     zone_slug: the-summit
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Eucalyptus Grove"
     slug: eucalyptus-grove
     description: "A stand of introduced eucalyptus trees creates a fragrant microclimate on the hill's sheltered side. The bark peels in long strips that litter the ground, and the canopy filters the fog into individual drops that fall with audible taps on the leaf litter below."
     zone_slug: the-summit
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The View"
     slug: the-summit-the-view
     description: "A gap between two hillside houses frames a corridor of sky and water, the kind of accidental vista that real estate listings describe and fog renders theoretical. On the rare clear evening, the strait glows orange and the headlands darken to silhouettes."
     zone_slug: the-summit
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Bluff"
     slug: headlands-the-bluff
     description: "A grass-covered cliff edge overlooks the strait where the bay opens to the Pacific. The soil is undercut and crumbling — sections of trail have been rerouted inland three times in the last century."
     zone_slug: headlands
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Sea Cliff"
     slug: sea-cliff
     description: "Vertical rock faces drop to the surf line, stained white with guano and carved into shelves by wave action. The wind is constant here, strong enough to lean into, carrying salt spray fifty meters above the waterline."
     zone_slug: headlands
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Battery Bunker"
     slug: battery-bunker
     description: "A concrete fortification from a war fought two centuries ago sits half-buried in the hillside, its gun ports now framing views of container ships and research vessels. The walls are three meters thick and the interior stays cold year-round."
     zone_slug: headlands
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Lighthouse"
     slug: the-lighthouse
     description: "A white tower stands at the headlands' western point, its automated light sweeping the strait at intervals. The keeper's quarters were converted to a GovCorp monitoring station decades ago, though the original brass hardware remains on the doors."
     zone_slug: headlands
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Hawk Watch"
     slug: hawk-watch
     description: "A wooden platform built for raptor observation overlooks a migration corridor above the bluffs. Raptors ride the updrafts here in autumn, and someone has logged sightings in a weatherproof notebook bolted to the railing since before anyone can verify."
     zone_slug: headlands
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Wind Trail"
     slug: wind-trail
     description: "A narrow path along the cliff edge where the wind strips moisture from the fog and drives it horizontally across the trail. Hikers walk bent forward, hands pressed to their thighs, moving against resistance that feels personal."
     zone_slug: headlands
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Pillbox"
     slug: the-pillbox
     description: "A small concrete observation post from wartime sits embedded in the hillside with narrow viewing slits facing the ocean approach. The walls are covered in decades of graffiti, each layer a geological record of whoever found their way here."
     zone_slug: headlands
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Thistle Field"
     slug: thistle-field
     description: "A meadow of purple-topped thistles occupies a flat section of the headlands where the soil is thin over bedrock. Bees work the flowers in warm weather, and the seed heads drift across the trail on any breeze."
     zone_slug: headlands
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Seal Point"
     slug: seal-point
     description: "A rocky promontory where harbor seals gather on the rocks below, visible from above as dark shapes on wet stone. The sound of their calls carries up the cliff face, distorted by wind into something almost like speech."
     zone_slug: headlands
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Bridge View"
     slug: the-bridge-view
     description: "The most photographed vantage point on the headlands, where the suspension bridge spanning the strait fills the frame against the city behind it. The scale is deceptive — the bridge looks close enough to touch but is a kilometer away across open water."
     zone_slug: headlands
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Wildflower Hill"
     slug: wildflower-hill
     description: "A south-facing slope that blooms in rotating color from early spring through summer — lupine, poppy, paintbrush. The Cultural Zone claims credit for the display through its environmental stewardship program, though the flowers have been here since before the organization existed."
     zone_slug: headlands
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Coastal Scrub"
     slug: coastal-scrub
     description: "Low, wind-shaped shrubs cover the headlands in a dense mat that resists foot traffic. Coyote brush and sage grow waist-high, and the trail is the only reliable passage through vegetation that closes behind anything that leaves the path."
     zone_slug: headlands
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Lookout"
     slug: the-lookout
     description: "A paved terrace above the waterfront where the harbor spreads out below in a grid of piers and jetties. Binocular stations line the railing, most of them functional, their coin slots long since overridden by whoever maintains them."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Bay Window"
     slug: bay-window
     description: "A curved glass wall in a hilltop building frames the entire bay in a single panoramic sweep. The building's original function — private residence, consulate, restaurant — has been lost under layers of GovCorp renovation, but the window remains."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Coin Telescope"
     slug: coin-telescope
     description: "A mounted telescope on a pivot post offers magnified views of the harbor traffic below. The optics are scratched from decades of use, and the focus wheel sticks at certain points, but the shipping channel fills the eyepiece with hulls and wake patterns."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Park Bench"
     slug: harbor-view-park-bench
     description: "A wrought-iron bench faces the water from a gravel path lined with ice plant. The bench is dedicated to someone whose plaque has weathered past legibility, leaving only the date — a year that means nothing to anyone passing through."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Railing"
     slug: harbor-view-the-railing
     description: "A cast-iron railing follows the contour of the hillside along a walking path above the harbor. The paint is layered thick from decades of maintenance, and the top rail has been polished smooth by hands leaning on it to watch the ships below."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Night View"
     slug: harbor-view-night-view
     description: "After dark, the harbor transforms into a field of navigation lights — red, green, white — moving in slow patterns against the black water. The city reflects off the bay surface in wavering columns of color that break apart in the wake of passing vessels."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Container Ship"
     slug: container-ship
     description: "From this elevation, the container ships in the harbor look like children's toys, stacked with colored blocks in geometric precision. They move with agonizing slowness through the channel, pushed by tugs that are invisible until they appear as white wakes at the hull line."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Sailboat Watch"
     slug: sailboat-watch
     description: "A section of the overlook where the recreational marina is visible below, its forest of masts tilting in unison with the swell. On weekends the boats scatter across the bay like seeds, returning by evening to cluster at their slips."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Horizon"
     slug: harbor-view-the-horizon
     description: "The line where the Pacific meets the sky is rarely visible — the fog and haze merge water and air into a single gray field. On the clearest days, the horizon draws a hard line that makes the ocean look like it has an edge."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Morning Fog"
     slug: morning-fog
     description: "At dawn the fog fills the bay like a lake of white, flowing between the hills and pooling in the low places. The bridge towers rise above it, disconnected from the water below, and the hilltops float like islands in a still, white sea."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Clear Day"
     slug: clear-day
     description: "A rare event that brings the far shore into focus with unsettling clarity. Details that are normally theoretical — individual buildings, roads climbing distant hills — become suddenly real, and the scale of the bay is momentarily comprehensible."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Terrace"
     slug: the-terrace
     description: "A stepped concrete platform descends the hillside in tiers, each level offering a slightly lower and closer view of the harbor. Planters built into the retaining walls hold succulents that thrive on fog moisture and neglect."
     zone_slug: harbor-view
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Dock"
     slug: drydock-the-dock
     description: "A massive basin carved from the waterfront, capable of holding vessels up to two hundred meters. The dock walls are stained with waterline marks from decades of use, and the gate mechanism at the harbor end groans when the pumps cycle."
     zone_slug: drydock
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Hull Bottom"
     slug: hull-bottom
     description: "The exposed underside of a vessel resting on keel blocks, its hull plating streaked with antifouling paint in shades of red and copper. Workers move beneath the hull on scaffolding, their voices echoing off the curved steel above them."
     zone_slug: drydock
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Keel Block"
     slug: keel-block
     description: "Massive timber and concrete blocks arranged in a precise line down the dock floor, bearing the full weight of a drydocked vessel. The blocks are scored with pressure marks from previous occupants, each groove a record of a different hull's geometry."
     zone_slug: drydock
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Paint Bay"
     slug: paint-bay
     description: "An enclosed section of the dock where hull painting happens under ventilation hoods. The floor is layered with dried paint drips in every marine color — red, black, gray, blue — creating an accidental mosaic that no one has reason to clean."
     zone_slug: drydock
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Crane"
     slug: the-crane
     description: "A gantry crane spans the dock on rails, its operator cab suspended forty meters above the dock floor. The crane moves with a low mechanical whine, repositioning loads with a precision that makes the massive equipment feel almost delicate."
     zone_slug: drydock
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Welding Station"
     slug: welding-station
     description: "A work platform where welders repair hull plating behind portable screens that flash with blue-white light. The air smells of burned metal and shielding gas, and the sparks fall in arcs that expire before reaching the dock floor."
     zone_slug: drydock
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Propeller Shop"
     slug: propeller-shop
     description: "A workshop where bronze propellers the size of small rooms are balanced, polished, and repaired. The floor vibrates from the lathe work, and the finished props lean against the walls like sculptures waiting for installation."
     zone_slug: drydock
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Rigging Loft"
     slug: rigging-loft
     description: "An upper-floor workspace where cables, chains, and rigging hardware are stored and assembled. The ceiling is high enough to accommodate standing lifts, and the floor is marked with wear patterns from decades of heavy loads being dragged to the staging area."
     zone_slug: drydock
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Scaffold"
     slug: the-scaffold
     description: "A lattice of aluminum scaffolding clings to a vessel's hull inside the dock, reaching from the dock floor to the gunwale. Workers climb between levels on ladder sections, their tools clipped to harness rings that clink with each step."
     zone_slug: drydock
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Bilge Pump"
     slug: bilge-pump
     description: "A pump station at the dock's lowest point that keeps the basin dry when a vessel is resting on the blocks. The pump runs on a cycle, its rhythm a low throb that dock workers use unconsciously to time their breaks."
     zone_slug: drydock
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Launch Rail"
     slug: launch-rail
     description: "A set of greased rails angled into the harbor water, used for smaller vessels that slide rather than float into position. The rails are scored with use marks and the grease collects grit, creating a surface that gleams darkly in the dock lights."
     zone_slug: drydock
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Christening"
     slug: the-christening
     description: "A small platform at the dock's edge where vessels are named before launch. A collection of broken bottle glass has been ground into the concrete by foot traffic over the years, glittering green and brown in the right light."
     zone_slug: drydock
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Street"
     slug: cinder-town-main-street
     description: "A two-lane road runs through what remains of the town, its asphalt buckled by frost heave and split by weeds. The buildings on either side are shells — walls standing, roofs gone, interiors open to weather. The street is straight enough to see both ends from the middle."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Burned Church"
     slug: burned-church
     description: "A white clapboard church reduced to its frame, the steeple collapsed into the nave. The fire took everything combustible and left the stone foundation and a few charred studs. The bell lies in the rubble where it fell, its bronze surface darkened but intact."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Collapsed Roof"
     slug: collapsed-roof
     description: "A company house with its roof caved in, the rafters snapped like broken fingers and the ceiling insulation exposed to rain. Wallpaper peels from the interior walls in long strips. The floor is a compost of shingles, plaster, and leaf litter."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Foundation"
     slug: cinder-town-the-foundation
     description: "A rectangle of poured concrete marks where a building stood, its purpose identifiable only by the pipe stubs and bolt patterns in the slab. Weeds grow from every crack. The foundation is the last thing to go and will outline this building long after everything else has returned to soil."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Empty Schoolhouse"
     slug: empty-schoolhouse
     description: "A brick building with its windows gone and its front steps crumbling, the word SCHOOL still visible in carved stone above the door. Desks and chairs are overturned inside, covered in plaster dust from the failing ceiling. A chalkboard on the far wall still shows the ghost of cursive exercises."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Charred Frame"
     slug: charred-frame
     description: "The skeleton of a wood-frame house stands among the ruins, its timbers blackened and checked by heat. The fire burned fast enough to leave the structure standing but slow enough to consume everything inside. Rain has washed the char smooth."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Fire Hydrant"
     slug: fire-hydrant
     description: "A cast-iron hydrant stands at the curb, still connected to pipes that lead to a dry water main. The hydrant is painted red but the paint is flaking to bare metal. It marks the edge of a municipal system that served a town that no longer exists."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Old Well"
     slug: old-well
     description: "A stone-lined well behind the main street buildings, its wooden cover rotted through and its depth hidden by shadow. The water table is still there — drop a stone and the splash comes back after a count of three. The well predates the town by decades."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Company Store"
     slug: company-store
     description: "A large building with GENERAL MERCHANDISE painted on the brick in faded letters. The interior is gutted — shelves torn out, floor stripped to joists. The store was where miners spent company scrip at company prices. The building outlasted the system it enforced."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Cellar Hole"
     slug: the-cellar-hole
     description: "A rectangular pit where a house once stood, its stone walls still holding back the hillside. Ferns grow from the joints in the masonry and rainwater pools on the earthen floor. The cellar was dug by hand into the ridge, and the ridge is slowly taking it back."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Ash Heap"
     slug: ash-heap
     description: "A mound of coal ash and cinder behind the main street, decades of burned fuel dumped in the same spot until it formed a gray hill. Nothing grows on it. Rain carves channels in its surface and the runoff stains the creek downstream a chalky white."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Memorial Cross"
     slug: memorial-cross
     description: "A wooden cross on a hillside above the town, its white paint renewed by someone at intervals. The names carved into its base are coal miners killed in a collapse that the company records no longer exist to document. The cross is the only maintained thing in Cinder Town."
     zone_slug: cinder-town
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Conveyor"
     slug: the-conveyor
     description: "A steel conveyor frame runs at an angle from the mine entrance to the sorting floor, its belt long rotted away. The frame is rusted but structurally sound — built to carry tons of coal per hour. Pulleys the size of wagon wheels still turn on their bearings."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Sorting Floor"
     slug: sorting-floor
     description: "A concrete slab beneath the tipple structure where coal was graded by size through a series of screens and shakers. The screens are rusted in place. Coal dust has stained the concrete permanently black, and it crunches underfoot like coarse sand."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Coal Chute"
     slug: coal-chute
     description: "A sheet-metal chute angled steeply from the sorting floor to the loading bins below. The inside is worn smooth by millions of tons of sliding coal. The chute still smells of carbon and sulfur when the air is damp."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Hopper"
     slug: the-hopper
     description: "A large steel bin suspended above the rail tracks, designed to drop measured loads of coal into waiting railcars. The hopper's gate is jammed open, its mechanism seized by rust. Coal dust coats every surface in a fine black film."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Tipple Tower"
     slug: tipple-tower
     description: "The tallest structure remaining at the mine site, a framework of steel beams rising sixty feet above the sorting floor. The tower held the top of the conveyor system and provided a vantage over the entire operation. The wind through its open frame makes a low harmonic drone."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Rail Scale"
     slug: rail-scale
     description: "A section of rail track built over a weighing mechanism set into a concrete pit. The scale measured loaded railcars to determine payment. The brass dial face is still readable though the needle is frozen. The numbers are in tons."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Loading Bin"
     slug: loading-bin
     description: "A concrete bunker with a steel gate at its base, positioned directly over the rail spur. Coal dropped from the hopper into the bin and from the bin into the railcar in a gravity-fed sequence. The bin walls are stained black to a uniform depth."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Slack Pile"
     slug: slack-pile
     description: "A mound of fine coal waste — slack too small to sell — dumped beside the tipple over decades of operation. The pile is thirty feet high and still black after years of weather. Rain does not wash it clean. It is coal all the way through."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Crusher"
     slug: the-crusher
     description: "A heavy steel drum with internal teeth, mounted in a frame at the top of the tipple structure. The crusher broke oversized coal into marketable pieces. The drum no longer turns but the teeth are intact, each one a forged steel wedge the size of a fist."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Belt Drive"
     slug: belt-drive
     description: "A massive electric motor connected to the conveyor system by a series of belts and reduction gears. The motor housing is cast iron, still bolted to its mounting pad. The belts have perished but the pulleys remain, their surfaces grooved by years of friction."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Weigh Station"
     slug: weigh-station
     description: "A small enclosed booth where the weighmaster recorded each railcar's load against the mine's production quota. The booth still contains a desk, a stool, and a wall-mounted ledger rack. The ledgers are gone but the pencil marks on the desk remain."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dead Track"
     slug: dead-track
     description: "The rail spur that served the tipple ends here in a barrier of wooden ties stacked across the rails. The track beyond is torn up — the rails salvaged for scrap. Ballast stone and rotted ties mark the path the line used to follow down the hollow."
     zone_slug: the-tipple
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entrance"
     slug: the-shaft-the-entrance
     description: "A timber-framed opening cut into the hillside, its portal dark and exhaling cool air that smells of damp rock and old coal. The timbers are massive — whole tree trunks squared by ax and set deep into the mountain. A set of narrow-gauge rails runs from the darkness into daylight."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Timber Brace"
     slug: timber-brace
     description: "Squared timbers support the roof and walls of the mine passage, set at regular intervals into the rock. Some are original — hand-hewn and dark with age. Others are replacements, their wood still pale. The mountain presses against all of them equally."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Car Track"
     slug: car-track
     description: "Narrow-gauge steel rails run along the mine floor, carrying the route that coal cars once followed from the working face to daylight. The rails are worn bright on top and rusted on the sides. The gauge is too narrow for any standard equipment."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Air Shaft"
     slug: air-shaft
     description: "A vertical bore cut from the surface to the working level, providing ventilation to the deep passages. Air moves through it with enough force to flutter loose clothing. The shaft is lined with timber cribbing and disappears upward into darkness."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Vein"
     slug: the-vein
     description: "A seam of coal shows in the passage wall — a black stripe running through gray shale at an angle that follows the mountain's folded geology. The coal is anthracite, hard and glassy. It fractures along flat planes and reflects lamplight."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Drill Face"
     slug: drill-face
     description: "The working face of the mine where coal was cut from the seam by hand and later by machine. The drill marks are still visible in the rock — parallel holes where charges were set. The face is a wall of alternating coal and shale."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Tool Niche"
     slug: tool-niche
     description: "A recess cut into the passage wall where miners stored hand tools between shifts. The niche still holds a few rusted implements — a pick head, a shovel blade, a coil of wire. The rock around the niche is polished smooth by years of reaching hands."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Water Seep"
     slug: water-seep
     description: "Groundwater bleeds through a crack in the passage ceiling, running down the wall in a thin sheet that collects in a shallow channel along the floor. The water is cold and iron-rich, staining the rock orange where it flows. The sound of dripping never stops."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Canary Post"
     slug: canary-post
     description: "A small hook set into a timber brace at head height, where a cage was hung to hold the canary that tested for gas. The hook is still there, rusted to a nub. The practice saved lives by spending smaller ones."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Winch"
     slug: the-winch
     description: "A hand-cranked winch mounted on a timber frame at the junction of two passages, its drum holding a length of braided steel cable. The winch hauled loaded coal cars up the grade from the deeper workings. The crank handle is worn to fit a specific grip."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Deep Level"
     slug: deep-level
     description: "The lowest accessible passage in the mine, where the air is still and the temperature holds constant year-round. The walls weep moisture and the floor is standing water an inch deep. Sound carries strangely — footsteps ahead sound like they come from behind."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Sump"
     slug: the-sump
     description: "The lowest point in the mine, where all groundwater collects in a pool of black water that reflects lamplight. A rusted pump sits at the pool's edge, its discharge pipe running uphill toward the entrance. When the pump ran, it kept the mine workable. Now the water rises slowly."
     zone_slug: the-shaft
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Creek Bottom"
     slug: creek-bottom
     description: "A narrow creek runs along the floor of the hollow, its water stained amber by tannins from the rhododendron thickets upstream. The creek bed is smooth stone and gravel. The sound of moving water fills the hollow from wall to wall."
     zone_slug: the-holler
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Foot Bridge"
     slug: the-foot-bridge
     description: "Two logs span the creek, their tops flattened with an adze and their surfaces worn smooth by boot traffic. A single handrail of peeled sapling completes the crossing. The bridge bounces underfoot but holds."
     zone_slug: the-holler
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Front Porch"
     slug: front-porch
     description: "A covered porch runs the full width of a frame house built into the hillside, its floor of rough-sawn planks and its roof supported by peeled locust posts. The view from the porch is the opposite ridge, two hundred yards away and straight up. A rocking chair sits by the door."
     zone_slug: the-holler
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Garden Patch"
     slug: garden-patch
     description: "A fenced rectangle of dark soil on the only flat ground in the hollow, bordered by creek on one side and hillside on the other. Bean poles and tomato stakes stand in rows. The soil has been worked by hand for generations and it shows — loose, dark, and deep."
     zone_slug: the-holler
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Still"
     slug: the-still
     description: "A copper pot still sits on a stone furnace behind a laurel thicket, connected to a coil condenser fed by creek water. The setup is old and well-maintained. The ground around it is packed hard by feet that know the path without needing to see it."
     zone_slug: the-holler
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Dog Run"
     slug: dog-run
     description: "The open breezeway between two sections of a log house, roofed but unwalled, where hounds sleep in the shade during the day. The logs are hand-hewn and chinked with clay. The dogs stir when someone approaches but do not bark unless the visitor is unfamiliar."
     zone_slug: the-holler
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Spring"
     slug: the-holler-the-spring
     description: "A limestone spring emerges from the hillside into a stone basin, its water cold enough to numb fingers in seconds. A dipper on a nail serves anyone who passes. The spring has never gone dry — not in drought, not in the deepest freeze."
     zone_slug: the-holler
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Wood Pile"
     slug: wood-pile
     description: "Stacked cordwood under a lean-to shelter, split and ranked by size — kindling to the left, stove-lengths in the middle, fireplace rounds to the right. The pile represents weeks of work with an ax and a maul. The wood is seasoned and dry, popping with stored energy."
     zone_slug: the-holler
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Clothesline"
     slug: clothesline
     description: "A wire line strung between two poles in the yard, hung with work clothes and bed linens that move in the hollow's updraft. The line runs east-west to catch the narrow band of direct sun that reaches the hollow floor. Wooden pins hold everything in place."
     zone_slug: the-holler
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Smokehouse"
     slug: the-smokehouse
     description: "A small log building with no windows and a heavy door, its interior blackened by years of hickory smoke. Hams and shoulders hang from hooks in the ceiling. The smoke keeps the insects out and the temperature inside holds steady regardless of the season."
     zone_slug: the-holler
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Church Clearing"
     slug: church-clearing
     description: "A flat area on the hillside above the hollow where a small congregation gathers under a pole shelter with a tin roof. The benches are split-log puncheons. The clearing looks down into the hollow and up at the ridge, framing the view between earth and sky."
     zone_slug: the-holler
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Night Sounds"
     slug: night-sounds
     description: "The hollow after dark, when the creek is the loudest thing and the ridge blocks all ambient light from beyond the mountain. Whippoorwills call from the laurel. Tree frogs pulse in rhythm. The darkness is total between the trees and the stars show only in the gap above the creek."
     zone_slug: the-holler
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Trail"
     slug: the-trail
     description: "A footpath follows the spine of the ridge through mixed hardwood forest, its surface packed earth and exposed root. The trail is old — worn a foot below the surrounding ground level by generations of foot traffic. It follows the path of least resistance along the ridgetop."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Pine Top"
     slug: pine-top
     description: "A stand of Virginia pines crowns a high point on the ridge, their straight trunks rising to a canopy that blocks the sky. The ground beneath them is a mat of brown needles. The air smells of resin and the wind in the pine crowns makes a sound distinct from hardwood."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Rock Outcrop"
     slug: rock-outcrop
     description: "A shelf of sandstone breaks through the ridge surface, creating a natural overlook. The rock is flat on top and drops away steeply on the downhill side. Lichen covers the surface in patches of gray-green. The view from here reaches across three parallel hollows to the next ridge and the next."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Fire Tower"
     slug: the-fire-tower
     description: "A steel tower on the ridge's highest point, its cab sixty feet above the canopy. The stairs switch back through an open frame. The cab at the top is enclosed with glass on all four sides and holds a map table and a pair of binoculars bolted to a swivel mount. The view extends to the horizon in every direction."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Ridge Gap"
     slug: ridge-gap
     description: "A low point on the ridge where a saddle connects two higher knobs, creating a natural pass. Wind funnels through the gap with enough force to keep the trees stunted. The gap has been used as a crossing point for as long as people have walked these mountains."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Wind Break"
     slug: wind-break
     description: "A thick stand of rhododendron on the lee side of the ridge, dense enough to block the wind completely. The interior of the thicket is still and sheltered, the branches interlocking overhead to form a low ceiling. The ground is carpeted with leathery leaves."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Lookout"
     slug: ridgeback-the-lookout
     description: "A cleared spot on the ridge where the canopy opens to a view of the hollow below and the ridges beyond. A flat rock provides seating. The lookout shows the pattern of the landscape — ridge, hollow, ridge, hollow — repeating to the horizon like the folds of a crumpled cloth."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Blaze Mark"
     slug: blaze-mark
     description: "A painted rectangle on a trailside tree, marking the route along the ridge. The blaze is white, the standard color for a main trail. The paint is layered thick from years of renewal — the oldest layer is barely visible beneath the newest."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Rhododendron Tunnel"
     slug: rhododendron-tunnel
     description: "A section of trail where rhododendron bushes arch overhead from both sides, forming a living tunnel. The passage is dim and cool, the leaves filtering the light to a green shade. The trail narrows to single file and the branches brush against shoulders."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Bald"
     slug: the-bald
     description: "A treeless summit covered in native grass and low shrubs, offering an unobstructed panorama. The bald is natural — maintained by wind and thin soil, not by clearing. The grass moves in waves and the sky is enormous from here. On clear days the visibility approaches seventy miles."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Berry Patch"
     slug: berry-patch
     description: "A slope below the ridge crest thick with wild blackberry canes, their thorned branches heavy with fruit in season and bare wire in winter. Bear scat in the patch is fresh and frequent. The berries are small and intensely flavored — nothing cultivated tastes like this."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Summit Cairn"
     slug: summit-cairn
     description: "A pile of stones at the ridge's highest point, built by hikers adding one stone each over years of passage. The cairn is waist-high and roughly conical. It serves no navigational purpose — the summit is obvious. The cairn is an accumulation of individual decisions to mark the same spot."
     zone_slug: ridgeback
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Creek"
     slug: the-creek
     description: "A creek runs the length of the hollow, its water dark with coal fines washed from the exposed seams and abandoned workings upstream. The creek bed is stained black over natural stone. Crayfish still live in it, their shells darkened to match the substrate."
     zone_slug: coal-run
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Black Water"
     slug: black-water
     description: "A section of creek where coal runoff has turned the water opaque and dark, moving but impenetrable to sight. The surface reflects light like polished metal. The banks are stained to a permanent tide line of black residue."
     zone_slug: coal-run
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tipple Bridge"
     slug: tipple-bridge
     description: "A narrow bridge of steel and timber spans the creek at the point where the tipple's rail spur crossed the hollow. The bridge deck is intact but the rails are gone, leaving bolt holes in the timbers. The creek runs black beneath it."
     zone_slug: coal-run
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Coal Seam"
     slug: coal-seam
     description: "An exposed vein of coal shows in the creek bank where the water has cut through the overburden. The seam is eighteen inches thick, angled sharply by the mountain's folded geology. The coal is hard anthracite, fractured into angular blocks by natural jointing."
     zone_slug: coal-run
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Culvert"
     slug: coal-run-the-culvert
     description: "A corrugated metal pipe channels the creek under a road crossing, its intake end half-blocked by debris and its discharge end stained with mineral deposits. The water accelerates through the pipe and emerges in a turbulent plume. The pipe groans in high water."
     zone_slug: coal-run
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Slag Bank"
     slug: slag-bank
     description: "A hillside of mine waste — rock, shale, and low-grade coal — dumped over decades of extraction and now stabilized by scrub growth. The bank is steep and loose underfoot. Acidic runoff from the waste has killed the vegetation at its base, leaving a bare zone of orange-stained ground."
     zone_slug: coal-run
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Mine Mouth"
     slug: mine-mouth
     description: "The entrance to an abandoned drift mine, its portal timbers sagging and its interior black beyond the reach of daylight. Cool air flows from the opening. A rusted rail track emerges from the darkness and ends in the weeds. The mountain's interior is on the other side of that threshold."
     zone_slug: coal-run
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Hollow Road"
     slug: the-hollow-road
     description: "A single-lane road follows the creek through the hollow, its asphalt crumbling at the edges and patched with gravel where it has washed out. The road hugs the creek on one side and the hillside on the other, with room for neither shoulder nor sidewalk."
     zone_slug: coal-run
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Rock Dump"
     slug: rock-dump
     description: "A pile of mine spoil — sandstone, shale, and ironstone pulled from the mine and dumped at the hollow's edge. The rock is angular and loose, shifting underfoot. Sulfur-yellow staining marks where iron pyrite in the waste has oxidized on exposure to air."
     zone_slug: coal-run
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Water Treatment"
     slug: water-treatment
     description: "A series of settling ponds built to catch acid mine drainage before it reaches the main creek. Lime-green water sits in rectangular basins, its chemistry slowly neutralizing. The system works but the problem is permanent — the mountain will leach acid as long as the coal is exposed."
     zone_slug: coal-run
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Creek Bend"
     slug: creek-bend
     description: "A sharp curve in the creek where the water has undercut the outside bank, exposing a cross-section of soil, clay, and coal-bearing shale. The inside of the bend is a gravel bar deposited by slowing current. The creek is audible around the bend before it is visible."
     zone_slug: coal-run
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Hollow Bottom"
     slug: hollow-bottom
     description: "The lowest point in the hollow where the creek widens and the valley floor opens to its maximum width — perhaps forty yards. The flat ground holds a few structures and the road. The ridges rise steeply on both sides, close enough to block direct sunlight for much of the day."
     zone_slug: coal-run
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Drive"
     slug: the-drive
     description: "A long gravel drive lined with mature oaks arches uphill from an iron gate to the house. The trees form a continuous canopy overhead, their branches interlocking like the vaults of a cathedral. The gravel is white limestone, raked and maintained."
     zone_slug: the-manor
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Wrought Iron Gate"
     slug: wrought-iron-gate
     description: "A pair of iron gates hung on stone pillars marks the entrance to the property. The gates are ornate — scrollwork and spear points, painted black and kept free of rust. The pillars are capped with carved stone urns. A small gatehouse sits to one side, its windows dark."
     zone_slug: the-manor
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Portico"
     slug: the-portico
     description: "A columned entrance shelters the front door of a stone house built in a style that predates the region's coal economy by a century. The columns are Doric, the proportions correct. The house was built by money that came from the land before it came from beneath it."
     zone_slug: the-manor
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Grand Foyer"
     slug: grand-foyer
     description: "A two-story entrance hall with a curved staircase rising to a gallery landing. The floor is marble, the walls are paneled in walnut, and a chandelier hangs from the ceiling on a chain. The air inside is cool and still, sealed from the mountain humidity."
     zone_slug: the-manor
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Parlor"
     slug: the-parlor
     description: "A formal sitting room with tall windows, plaster moldings, and furniture arranged for conversation. The fireplace is marble with a carved mantel. The room is maintained in a state of permanent readiness — flowers in the vase, fire laid in the grate, not a surface out of place."
     zone_slug: the-manor
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Study"
     slug: the-study
     description: "A wood-paneled room lined with bookshelves and dominated by a desk positioned to face the door. The books are bound in leather and arranged by subject. The desk is mahogany, its surface clear except for a lamp, a blotter, and a pen stand. The room smells of old paper and furniture oil."
     zone_slug: the-manor
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Fox Run"
     slug: fox-run
     description: "A stretch of open meadow bordered by stone walls and hardwood forest, maintained as pasture for horses and as terrain for the hunt. The grass is kept short by grazing. The stone walls are dry-stacked — no mortar — and follow the contour of the land with practiced precision."
     zone_slug: the-manor
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Stable"
     slug: the-stable
     description: "A stone building with a slate roof, its interior divided into stalls with oak partitions and brass fittings. The floor is brick, sloped to drains. The building is warm in winter and cool in summer, its mass regulating the temperature. The smell is clean straw and leather."
     zone_slug: the-manor
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Garden Maze"
     slug: garden-maze
     description: "A formal hedge maze of boxwood, its walls six feet high and precisely trimmed. The paths are pea gravel, raked smooth. The maze has a center with a stone bench and a small fountain. The design is geometric and deliberate — the hedges are older than anyone currently alive."
     zone_slug: the-manor
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Veranda"
     slug: the-veranda
     description: "A stone-flagged porch runs along the back of the house, overlooking a terraced garden that descends the hillside in formal tiers. Wisteria climbs the columns and shades the seating area. The view from here is the hollow below, seen from above for the first time."
     zone_slug: the-manor
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Servant's Entrance"
     slug: servants-entrance
     description: "A plain door at the side of the house, opening onto a flagstone path that leads to the kitchen and service areas. The door is functional — no ornament, no columns. The path is worn by daily use and leads to a world that runs parallel to the front of the house but never intersects it socially."
     zone_slug: the-manor
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Carriage House"
     slug: carriage-house
     description: "A stone outbuilding with wide doors and a hayloft above, originally built for carriages and now used for vehicles and storage. The interior is clean and dry, the stone walls thick enough to maintain a constant temperature. The loft still smells of hay that has not been stored there in decades."
     zone_slug: the-manor
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Paddock"
     slug: the-paddock
     description: "A fenced enclosure of post-and-rail behind the stable, its ground worn to bare earth by horses circling and standing. The fence is white-painted oak, maintained without exception. The paddock sits on the only flat ground on the property — everything else tilts toward the hollow."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Stone Wall"
     slug: hunt-country-stone-wall
     description: "A dry-stacked stone wall runs along the property line, following the ridge contour. The wall is three feet high and built without mortar, each stone fitted to its neighbors by shape and weight. The wall has stood for over a century and requires no maintenance — gravity does the work."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Stable"
     slug: hunt-country-the-stable
     description: "A long stone building with a row of stalls, each one fitted with oak doors and brass hardware. The center aisle is brick, swept clean. Tack hangs on the walls in orderly rows — bridles, saddles, and blankets, each item in its assigned place."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Hunt Club"
     slug: hunt-club
     description: "A stone lodge set among oaks at the edge of the property, its interior furnished with leather chairs, a fieldstone fireplace, and mounted heads on the walls. The bar is stocked and the hearth is laid. The club operates by invitation and its membership has not changed in years."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Meadow"
     slug: the-meadow
     description: "A broad field of maintained grass occupying a high bench on the ridge, bordered by stone walls and hardwood forest. The grass is the deep green of managed pasture. The meadow is used for events — hunts, gatherings, celebrations — that require flat ground and distance from observation."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Cross-Country"
     slug: cross-country
     description: "An established course through forest and over fences, marked with flags and maintained by groundskeepers. The course follows the terrain's natural features — stone walls, creek crossings, uphill runs. The footing is firm and the jumps are solid. The course tests horse and rider equally."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Jump"
     slug: the-jump
     description: "A series of post-and-rail fences set at intervals across a meadow, each one higher than the last. The fences are built to break if hit hard enough — designed to protect the horse, not the score. The ground on the landing side is churned from repeated impact."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Hound Kennel"
     slug: hound-kennel
     description: "A low building of stone and timber housing the hunt's pack of foxhounds. The kennel is clean and well-ventilated, the runs spacious, the dogs well-fed and trained. The hounds respond to voice and horn with identical obedience. The kennel master's quarters are attached to the building."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Country Road"
     slug: country-road
     description: "A two-lane road of old asphalt running along the ridge between stone-walled properties. The road is narrow and shoulderless, canopied by hardwoods. Traffic is rare and unhurried. The road connects estates that have existed in relation to each other for longer than the road has been paved."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Lodge"
     slug: hunt-country-the-lodge
     description: "A timber-frame building at the edge of the hunt club property, its porch facing the meadow and the mountain beyond. The lodge serves as quarters for visiting riders and as the staging point for the hunt. The interior is rustic but well-appointed — no expense spared, no luxury displayed."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Tack Room"
     slug: tack-room
     description: "A room in the stable building devoted to the storage and maintenance of riding equipment. Saddles sit on wooden racks, bridles hang from brass hooks, and leather care supplies line a workbench. The room smells of saddle soap, neatsfoot oil, and dry leather. Everything is organized by horse and rider."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Fox Chase"
     slug: fox-chase
     description: "A stretch of open country between the lodge and the tree line, where the hunt unfolds across rolling terrain of grass and stone walls. The ground is firm underfoot and the sight lines are long. The landscape was shaped for this purpose — or the purpose was shaped to fit this landscape. The distinction blurred generations ago."
     zone_slug: hunt-country
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Glass Canyon"
     slug: glass-canyon
     description: "A corridor of glass and steel rising forty stories on either side. Wind funnels between the towers, carrying the hum of climate systems overhead. Pedestrians move in practiced currents below mirrored facades that reflect everything and reveal nothing."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Plaza"
     slug: the-plaza
     description: "Open concrete stretches between tower bases, scoured clean by lake wind. A few trees struggle in raised planters, their branches permanently bent inland. Office workers cross in tight clusters during lunch hour, then the space empties again."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Revolving Door"
     slug: revolving-door
     description: "Brass and glass spinning on a central axis, pushing bodies in and pulling them out in a slow mechanical pulse. The lobby beyond is visible in slices — marble floor, security desk, elevator bank. Cold air trades with warm air in each rotation."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Lobby Level"
     slug: lobby-level
     description: "Marble floors amplify every footstep into an announcement. Security turnstiles divide the space between public and private, green lights clicking in rhythm. The ceiling rises three stories to a chandelier that hasn't been cleaned in years."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Atrium"
     slug: the-atrium
     description: "A hollow core running up through the center of the building, ringed by walkways at every level. Natural light filters down through a glass ceiling forty floors above, arriving at the ground floor as a pale gray wash. Ferns grow in the corners where the climate system keeps things humid."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Sky Lobby"
     slug: sky-lobby
     description: "Express elevators open onto polished stone at the thirty-fifth floor. Floor-to-ceiling windows frame the lake stretching east to the horizon, flat and silver in the afternoon light. The air smells faintly of recycled oxygen and carpet adhesive."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Observation Deck"
     slug: the-skyline-observation-deck
     description: "The wind hits hard at this height, pressing against the glass so steadily that the panels flex. The lake dominates the eastern view — an inland sea, gray-blue, its far shore invisible. Below, the city grid stretches flat in every direction until it dissolves into industrial haze."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Executive Floor"
     slug: executive-floor
     description: "Thick carpet absorbs all sound. The doors are solid wood, the nameplates brushed steel. A receptionist sits behind a desk the size of a small boat, and the windows behind her show nothing but sky."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Parking Structure"
     slug: parking-structure
     description: "Raw concrete spirals upward, oil-stained and cold. Fluorescent tubes buzz overhead, half of them dead. The wind whistles through the open sides, carrying exhaust fumes and the distant clatter of the elevated rail."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Pedway"
     slug: the-pedway
     description: "An enclosed walkway bridges the gap between two towers at the third-floor level. Scuffed linoleum underfoot, fluorescent light above, and through the windows on either side, the street below looks miniature and cold. Fast food wrappers collect in the corners."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Transit Hub"
     slug: transit-hub
     description: "Underground platforms connect to surface bus loops through a maze of tiled corridors. The air is warm and stale, thick with brake dust and the ozone smell of electrified rail. Departure boards cycle through routes nobody reads."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Rooftop Garden"
     slug: rooftop-garden
     description: "Wind-stunted shrubs in concrete boxes, a few benches bolted to the deck. Someone planted tomatoes in a repurposed utility cart. The view north stretches to the wealthy lakefront, south to the smokestacks, and the lake fills the east like a second sky."
     zone_slug: the-skyline
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Boulevard"
     slug: the-boulevard
     description: "Wide sidewalks lined with young trees pruned into identical shapes. Brass-capped bollards separate foot traffic from the street, where black sedans idle at every curb. The storefronts are all glass, all spotless, all displaying things most people cannot afford."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Boutique Row"
     slug: boutique-row
     description: "Narrow shops shoulder to shoulder behind matching awnings. Mannequins in the windows wear clothes without price tags. A doorman in a long coat stands at every third entrance, hands clasped, watching the sidewalk with professional disinterest."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Lakefront Drive"
     slug: lakefront-drive
     description: "Four lanes of asphalt hugging the shoreline, separated from the water by a low stone wall. Lake spray coats the pavement in winter, freezing into a thin glass sheet. The condominiums on the inland side rise in tiers, each balcony angled for a water view."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Promenade"
     slug: the-promenade
     description: "A paved walkway following the curve of the shore, dotted with benches and decorative lampposts. Joggers pass in both directions, earbuds in, eyes forward. The lake stretches out flat and enormous, its color shifting with the cloud cover."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Private Marina"
     slug: private-marina
     description: "White hulls bob in ordered rows behind a locked gate. The dock creaks underfoot, and halyards clang against aluminum masts in the wind. A harbormaster's shack at the entrance smells of diesel and varnish."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Café Row"
     slug: caf-row
     description: "Sidewalk tables under retractable awnings, heat lamps glowing orange in the cold months. Espresso machines hiss behind plate glass. The conversations are quiet, the laptops are expensive, and the coffee costs more than a meal in The Ward."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Valet Circle"
     slug: valet-circle
     description: "A curved driveway of interlocking brick, flanked by topiary in stone urns. Valets in matching vests jog between idling vehicles with practiced efficiency. The hotel entrance behind them is all brass and beveled glass."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Clocktower"
     slug: the-clocktower
     description: "A limestone tower rising above the surrounding rooflines, its four clock faces lit from within. The mechanism still runs on gears — you can hear it ticking if you stand close enough to the base. Pigeons roost in the belfry where the bell was removed decades ago."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Wine Bar"
     slug: wine-bar
     description: "Exposed brick and dim pendant lights. The bar is a single slab of reclaimed wood, and the bottles behind it are arranged by region in floor-to-ceiling racks. Conversation stays low, glasses stay full, and the staff remembers what you ordered last time."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Manicured Park"
     slug: manicured-park
     description: "Hedgerows trimmed to geometric precision surround a lawn so even it looks synthetic. Iron benches face a small fountain that runs from spring to first frost. Groundskeepers appear at dawn and vanish by the time anyone arrives to sit."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Penthouse"
     slug: the-penthouse
     description: "Floor-to-ceiling windows on three sides, the lake filling the eastern wall like a living mural. The furniture is minimal, the surfaces bare, the silence absolute. An elevator opens directly into the foyer, requiring a key that fewer than six people carry."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Jeweler's Row"
     slug: jewelers-row
     description: "Small storefronts with barred windows and buzzer-entry doors. Display cases glow under focused halogen, diamonds and gold arranged on black velvet. Security cameras track every angle, and the salespeople size you up before you reach the counter."
     zone_slug: gold-mile
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Tree-Lined Avenue"
     slug: tree-lined-avenue
     description: "Old hardwoods arch over the street, their canopy filtering light into green-gold patches on the sidewalk. The homes behind wrought-iron fences are brick and limestone, three stories, with window boxes that bloom in season. Leaves gather in the gutters every fall and nobody seems to mind."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Brownstone"
     slug: the-brownstone
     description: "Three stories of dark brick, a limestone stoop with iron railings worn smooth by hands. The front door is solid oak with a brass knocker shaped like a lion's head. Window curtains move faintly in the draft from old radiators working overtime."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Garden Walk"
     slug: garden-walk
     description: "A flagstone path winding between perennial beds, bordered by low boxwood hedges. Someone tends this carefully — the mulch is fresh, the edges clean. A wrought-iron bench sits beneath a magnolia tree that drops white petals across the stones in late spring."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Corner Bistro"
     slug: corner-bistro
     description: "A small restaurant on the ground floor of a brownstone, its windows fogged from kitchen heat. The menu is handwritten on a chalkboard, the tables are marble-topped, and the bread arrives warm. Regulars nod to each other without speaking."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Courtyard"
     slug: the-terrace-the-courtyard
     description: "A shared space behind a row of townhouses, accessible through a gated archway. Brick pavers, a central planting bed, a few iron chairs. Laundry lines cross overhead between upper-floor balconies, and someone always has music playing softly from an open window."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Balcony View"
     slug: balcony-view
     description: "A narrow iron balcony on the third floor, just wide enough for two chairs and a small table. The view stretches over rooftops toward the lake, church steeples and water towers breaking the skyline. Morning light arrives here first, then moves west through the neighborhood."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Townhouse"
     slug: the-townhouse
     description: "Tall and narrow, wedged between its neighbors with shared walls on both sides. The staircase creaks, the kitchen is in the back, and the front parlor hasn't changed its wallpaper in forty years. Original hardwood floors show their age in the traffic patterns."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Quiet Park"
     slug: quiet-park
     description: "A pocket park on a residential block, no larger than two lots. A sandbox, a swing set with rubber seats, a drinking fountain that works in summer. The benches face inward, away from the street, and the noise of the city feels distant even though it isn't."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Bookshop"
     slug: the-bookshop
     description: "A narrow storefront with a hand-painted sign and a bell on the door. Shelves floor to ceiling, organized by a system only the owner understands. The carpet is worn, the reading chairs are deep, and there is always a cat sleeping somewhere."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Morning Market"
     slug: morning-market
     description: "A weekend market that sets up in a church parking lot — folding tables, hand-lettered signs, canvas canopies. Produce, baked goods, jars of preserves, cut flowers in plastic buckets. The vendors know their regulars by name and save the good tomatoes for them."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Lakeside Path"
     slug: lakeside-path
     description: "A gravel path running along the bluff above the lakeshore, lined with wooden benches at intervals. The lake stretches out below, waves lapping at the rocks. Dog walkers and elderly couples share the path in the mornings, and by evening the benches fill with people watching the light change over the water."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Iron Fence Gate"
     slug: iron-fence-gate
     description: "A wrought-iron gate between brick pillars, the metalwork heavy and ornate. It opens onto a flagstone walk leading to a brownstone's front door. The hinges are oiled and silent, and the latch is the kind you have to know to work."
     zone_slug: the-terrace
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Loading Dock"
     slug: sector-x-loading-dock
     description: "A concrete bay recessed into the side of a defunct manufacturing plant, the roll-up door stuck at three-quarters. Tire marks in the dust suggest recent use despite the official condemnation notice bolted to the wall. The loading dock faces a dead-end alley where the streetlights have been systematically disabled."
     zone_slug: sector-x
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Corridor"
     slug: sector-x-the-corridor
     description: "Bare concrete walls, industrial cable trays overhead carrying power and data lines that shouldn't exist in an abandoned building. The floor has been swept clean — conspicuously clean. Emergency lighting casts a low amber glow at ankle level, just enough to navigate without drawing attention from outside."
     zone_slug: sector-x
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Control Room"
     slug: sector-x-control-room
     description: "Monitors bank three walls, cycling through feeds from cameras XERAEN placed across The Lakeshore. The center console holds the temporal interface — a repurposed industrial control panel rewired to process trans-temporal data streams. The hum of active electronics fills the room like a held breath."
     zone_slug: sector-x
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Server Alcove"
     slug: server-alcove
     description: "A climate-controlled closet behind a reinforced steel door, racks of salvaged hardware running hot. Cable bundles snake through the ceiling into the broadcast suite next door. The air conditioning unit is military surplus, oversized for the space, keeping the servers alive through Lakeshore summers."
     zone_slug: sector-x
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Broadcast Suite"
     slug: broadcast-suite
     description: "Acoustic foam lines the walls, and a transmission rig occupies the far corner — antenna cables running up through the ceiling to the roof. This is where the signal goes out. The equipment is mismatched, scavenged, rebuilt, but XERAEN has tuned it into something that works."
     zone_slug: sector-x
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Equipment Bay"
     slug: equipment-bay
     description: "Metal shelving units stocked with components, tools, backup hardware, and spare cable in organized bins. Everything labeled in XERAEN's hand. A soldering station occupies one workbench, a signal analyzer the other. The overhead fluorescent has been replaced with a directional LED that doesn't leak light through the windows."
     zone_slug: sector-x
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Map Room"
     slug: the-map-room
     description: "A wall-sized projection displays THE PULSE GRID — every zone, every node, every operative position in real time. The map updates constantly, small indicators shifting as data flows in from across the network. A table beneath it holds paper maps as backup, marked in pencil, erasable."
     zone_slug: sector-x
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Supply Cache"
     slug: supply-cache
     description: "Shelves of non-perishable food, water filtration units, medical supplies, and clothing in neutral colors. Enough to sustain a small team for weeks without surfacing. The inventory is rotated regularly — nothing here is expired, nothing is wasted."
     zone_slug: sector-x
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Vault"
     slug: sector-x-the-vault
     description: "A repurposed industrial safe room with walls thick enough to block signal in both directions. Sensitive materials are stored here — physical drives, printed documents, anything too dangerous to keep on a networked system. The door requires a combination known to two people."
     zone_slug: sector-x
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Roof Access"
     slug: roof-access
     description: "A steel ladder bolted to the wall leads up through a hatch to the flat roof. The antenna array is visible from here, disguised as derelict HVAC equipment. The roofline offers sight lines across the industrial periphery, and the RIDE coverage thins enough at this distance that perception occasionally stutters."
     zone_slug: sector-x
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Emergency Exit"
     slug: emergency-exit
     description: "A reinforced door opening onto a narrow alley behind the building, hidden by overgrown vegetation and a strategically placed dumpster. The path leads to a storm drain that connects to three different surface exits. The lock opens from inside only."
     zone_slug: sector-x
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Generator Room"
     slug: sector-x-generator-room
     description: "A diesel generator on a vibration-dampened platform, exhaust routed through the building's original ventilation stack to mask the output. Fuel drums line one wall, enough for seventy-two hours of continuous operation. The generator kicks in automatically when grid power drops — and out here on the periphery, it drops often."
     zone_slug: sector-x
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "East Platform"
     slug: east-platform
     description: "A concrete platform jutting out from the east tower, wind cutting across it from the lake. The railing is chest-high steel, and beyond it the city drops away thirty floors. Elevator doors open onto the platform, depositing passengers into the cold."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "West Platform"
     slug: west-platform
     description: "The western terminus of the skybridge, sheltered slightly by the tower behind it. Ice forms on the deck in winter, and salt bins sit chained to the railing. The view west stretches over flat rooftops toward the inland neighborhoods."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Glass Tunnel"
     slug: glass-tunnel
     description: "An enclosed section of the skybridge walled in tempered glass, the city visible in every direction. Wind presses against the panels, making them flex and groan. Condensation fogs the glass on cold mornings, and the walkway feels suspended in cloud."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Midspan"
     slug: midspan
     description: "The center point of the bridge, where the structure sways most noticeably in high wind. The floor grating is open mesh — through it, the street is visible far below, toy-sized vehicles crawling between buildings. A maintenance access panel is bolted flush to the deck."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Wind Gap"
     slug: the-skybridge-wind-gap
     description: "A section where the bridge narrows between structural supports, channeling wind into a sustained blast. Hair and clothing snap sideways, and conversation becomes impossible. Most people lower their heads and push through without stopping."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Junction"
     slug: the-junction
     description: "Where two skybridge paths intersect, a wider platform with benches that nobody uses because the wind never stops. Directional signs point toward the connected towers. A coffee vendor tried to set up here once — the cart lasted three days."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Observation Node"
     slug: observation-node
     description: "A glass-walled alcove bulging out from the side of the skybridge, offering an unobstructed view north along the lakefront. Coin-operated telescopes stand at the railing, their lenses scratched and salt-fogged. On clear days, the Gold Mile is visible as a strip of white stone against the gray water."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Service Hatch"
     slug: service-hatch
     description: "A heavy steel plate set flush into the skybridge floor, secured with recessed bolts. Below it, a maintenance ladder descends into the structural framework — a lattice of steel beams exposed to the open air. Only utility workers have the key, and they come up looking windburned."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Above the Street"
     slug: above-the-street
     description: "A section of skybridge with transparent floor panels installed as an architectural novelty. The street below is fully visible through the glass — pedestrians, vehicles, the tops of lampposts. Some people walk the edges. Others stop in the center and look straight down."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Frozen Walkway"
     slug: frozen-walkway
     description: "In winter, this stretch of the skybridge ices over where a drainage issue lets water pool on the deck. Salt and sand get scattered every morning and wash away every night. The footing is treacherous, and the railing wears a sleeve of frozen spray from the lake wind."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Emergency Shelter"
     slug: emergency-shelter
     description: "A small enclosed room at the bridge's midpoint, originally intended as a windbreak during extreme weather. Metal benches line the walls, and a first-aid box hangs near the door. The heating element stopped working years ago, but the walls still cut the wind."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Maintenance Catwalk"
     slug: maintenance-catwalk
     description: "A narrow steel grate path running beneath the main deck of the skybridge, accessible through service hatches at either end. The catwalk is open to the air on both sides, nothing but cable railing between the walkway and a thirty-story drop. Maintenance crews clip in with harnesses before stepping out."
     zone_slug: the-skybridge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Concourse"
     slug: main-concourse
     description: "A vaulted ceiling of iron and glass arches over a wide marble floor, footsteps echoing in every direction. Kiosks and benches line the center, and departure information scrolls overhead on boards that were digital before they were analog, and now are something in between. The air smells of brake dust and old stone."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Ticket Hall"
     slug: ticket-hall
     description: "Brass grilles over the ticket windows, most of them shuttered now. The floor is terrazzo, cracked along the seams, and the ceiling murals — idealized lakefront scenes — have faded to pastels. One window still operates, its clerk visible behind smudged glass."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Platform One"
     slug: platform-one
     description: "Concrete and steel under a corrugated metal roof, the tracks stretching north and south until they curve out of sight. The platform edge is painted yellow, worn to bare concrete where thousands of feet have stood. A cold wind blows through from the lake side."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Platform Two"
     slug: platform-two
     description: "Identical to Platform One but less trafficked, used for freight and overnight service. Pigeons roost in the rafters, and their droppings whiten the bench seats. The departure board above the platform has been stuck on the same arrival time for months."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Baggage Claim"
     slug: baggage-claim
     description: "A low-ceilinged room behind the main concourse, the carousel belt motionless and dusty. Fluorescent lights hum overhead, several tubes flickering. Unclaimed luggage from years past sits on a shelf behind the counter, tagged and forgotten."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Clock"
     slug: the-clock
     description: "A four-faced clock hanging from the center of the main concourse ceiling on a brass pole, its faces visible from every angle. The mechanism still keeps accurate time, wound weekly by a maintenance worker who takes the job seriously. Travelers meet beneath it by habit."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Boarded Window"
     slug: boarded-window
     description: "A grand arched window on the terminal's east wall, the glass long gone and replaced with plywood sheets that have weathered to gray. Light leaks through the gaps between boards, casting thin bright lines across the floor. Someone has scratched a date into the wood — the year the glass broke."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Waiting Room"
     slug: waiting-room
     description: "Wooden benches in rows, backs worn smooth and seats hollowed by decades of sitting. The room is warm in winter because the old radiators still work, clanking and hissing along the baseboards. A vending machine in the corner dispenses coffee that tastes like it was brewed in the last century."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Track Level"
     slug: track-level
     description: "Below platform grade, down a set of iron stairs, where the rails sit in their stone ballast bed. Grease and iron filings coat every surface. The tunnel mouths at either end of the track swallow the light, and the air moves in slow drafts that smell of ozone and damp stone."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Signal Tower"
     slug: signal-tower
     description: "A narrow brick structure rising above the terminal's roof, its windows offering a view of every track and switch in the yard. The signal levers inside are original — iron handles in a steel frame, connected to the switches by cable. Some still work."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Underground Passage"
     slug: underground-passage
     description: "A tiled corridor connecting the terminal to the transit hub beneath the street. The tiles are white with a green border, chipped in places, and the lights are caged in wire. Footsteps echo ahead and behind, and the rumble of trains passing overhead vibrates through the walls."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Departure Board"
     slug: departure-board
     description: "A mechanical split-flap display mounted above the concourse entrance, its letters and numbers clicking into place with each update. Half the destinations listed haven't been active routes in years. The clatter of the flaps turning is the terminal's most reliable sound."
     zone_slug: lakefront-terminal
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Seawall"
     slug: the-seawall
     description: "A massive concrete barrier running along the shoreline, its face pitted and stained by decades of wave impact. Spray crashes over the top during storms, leaving salt crusted on every surface. The walkway along the top is cracked and uneven, slick with algae where the puddles never dry."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Wave Break"
     slug: wave-break
     description: "Rows of concrete tetrapods stacked along the shore to absorb wave energy. Water surges between them, foaming white, then drains back with a deep sucking sound. The rocks beneath are green with slime, and the spray carries a cold mineral smell."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Fisherman's Walk"
     slug: fishermans-walk
     description: "A paved path along the top of the breakwall where anglers stand with long rods braced against the railing. Tackle boxes and folding chairs mark claimed spots. The wind is constant, the lake enormous, and the fish bite best at dawn when the water is still dark."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Jetty"
     slug: the-breakwall-the-jetty
     description: "A narrow stone pier extending out into the lake, waves breaking on both sides. The footing is wet and uneven, the stone blocks fitted without mortar. At the end, a rusted iron ring is set into the last block — for mooring, or for holding on."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Lighthouse Base"
     slug: lighthouse-base
     description: "A squat stone cylinder at the end of the jetty, the lighthouse that once stood on it reduced to a concrete foundation and a few embedded anchor bolts. Graffiti covers the base on the landward side. The lake side is scoured clean by water and wind."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Spray Zone"
     slug: spray-zone
     description: "The stretch of breakwall where waves hit hardest, sending sheets of spray across the walkway. Everything here is wet — the concrete, the railing, the warning signs. In winter, the spray freezes into sculptural formations on every vertical surface."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Rock Shelf"
     slug: rock-shelf
     description: "A natural limestone shelf exposed at the base of the breakwall where the concrete ends and the raw shoreline begins. Tide pools collect in the pitted surface, and small crabs scuttle between them. The rock is sharp underfoot and slippery with algae."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Tidal Pool"
     slug: tidal-pool
     description: "A shallow depression in the rock shelf, filled by wave action and left standing when the water recedes. Small fish, snails, and green threads of algae occupy the pool. The water is clear and cold, and the bottom is layered with fine sand and shell fragments."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Beacon"
     slug: the-beacon
     description: "A modern navigation marker bolted to the end of the jetty — a steel pole topped with a solar-powered light that flashes white every four seconds. The base is crusted with zebra mussels, and the pole hums faintly in the wind. Ships orient on it coming into harbor."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Storm Wall"
     slug: storm-wall
     description: "A secondary concrete wall set back from the seawall, built higher and thicker after a season of floods breached the original. The gap between the two walls is a no-man's-land of standing water, broken concrete, and rusted rebar. Warning signs are bolted at intervals."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Driftwood Beach"
     slug: driftwood-beach
     description: "A narrow strip of sand and gravel between the breakwall and the water, littered with bleached wood, plastic fragments, and tangled fishing line. The sand is coarse and gray, packed hard by wave action. Gulls pick through the debris line at the high-water mark."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Lookout"
     slug: the-breakwall-the-lookout
     description: "A raised concrete platform at the breakwall's highest point, fitted with a metal railing and a weathered bench. The view extends across the open lake — no far shore visible, just water meeting sky in a flat gray line. Wind pushes steady from the east, carrying the smell of deep water."
     zone_slug: the-breakwall
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Pier Head"
     slug: pier-head
     description: "The wide base of the pier where it meets the shore, concrete stained with fish blood and motor oil. Bollards line the edge, scarred by decades of rope and chain. A faded sign reads \"Pier 7 — Commercial Vessels Only,\" but nobody enforces it anymore."
     zone_slug: pier-7
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Bollards"
     slug: the-bollards
     description: "Cast-iron posts driven into the pier deck, each one worn smooth on top where ropes have been looped and pulled taut. Salt and rust coat them in alternating layers. A seagull stands on every third one, watching the water with territorial patience."
     zone_slug: pier-7
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cargo Hoist"
     slug: cargo-hoist
     description: "A steel boom and winch mounted on a rotating base near the pier's midpoint. The cable is frayed, the gears are stiff, and the control box hangs open, its wiring exposed. It still works — someone keeps the motor oiled."
     zone_slug: pier-7
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Fishmonger's"
     slug: fishmongers
     description: "A concrete-block building at the base of the pier with a stainless steel counter facing the walkway. Ice beds hold the day's catch, and the smell of fish and brine carries fifty yards downwind. The floor drains are always running, and the tile walls have been scrubbed to a permanent state of not-quite-clean."
     zone_slug: pier-7
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Gangway"
     slug: the-gangway
     description: "A steep metal ramp with non-skid treads descending from the pier deck to the floating docks below. The angle changes with the water level, and in low water the ramp is steep enough to make the handrails necessary. The hinges groan with every swell."
     zone_slug: pier-7
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Slip One"
     slug: slip-one
     description: "The first mooring slot off the gangway, reserved for the largest commercial vessels. The water here is deep and dark, stained with diesel sheen. Rubber fenders hang between hull and dock, compressed and cracked by years of pressure."
     zone_slug: pier-7
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Harbormaster's Office"
     slug: harbormasters-office
     description: "A second-floor room above the fishmonger's, accessible by an exterior metal staircase. Windows on three sides give a view of the entire pier and the harbor mouth beyond. Charts and tide tables are pinned to every wall, and a radio crackles with marine traffic."
     zone_slug: pier-7
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Winch"
     slug: pier-7-the-winch
     description: "A heavy drum winch bolted to the pier deck near the cargo hoist, cable wound tight in even layers. The brake lever is locked with a pin, and the motor housing is spotted with rust. When it runs, the vibration travels through the entire pier."
     zone_slug: pier-7
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Net Yard"
     slug: net-yard
     description: "An open section of pier where fishing nets are spread for mending and drying. The nets drape over wooden frames, and the ground beneath them is slick with scales and dried salt. A wooden bench holds spools of twine, shuttles, and a thermos that belongs to whoever is working."
     zone_slug: pier-7
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Piling"
     slug: the-piling
     description: "Massive timber pilings driven into the lake bed, visible at low water, green with algae and encrusted with mussels above the waterline. The wood is old — tar-soaked and salt-hardened. Between the pilings, the water is dark and deep, and things bump against the wood in the current."
     zone_slug: pier-7
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Boat Launch"
     slug: pier-7-boat-launch
     description: "A concrete ramp sloping into the water at the pier's south end, its surface ridged for traction. Trailers back down to the water's edge, and boats slide off with a scrape of fiberglass on concrete. The ramp is slippery with algae below the waterline."
     zone_slug: pier-7
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "End of the Pier"
     slug: end-of-the-pier
     description: "The final section of Pier 7, where the concrete narrows and the railing ends. Beyond this point is open water, the lake stretching out flat and gray to the horizon. The wind is strongest here, and the pier sways slightly in heavy weather, though most people don't notice until they stop walking."
     zone_slug: pier-7
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Base of the Hill"
     slug: base-of-the-hill
     description: "The neighborhood streets flatten out and then, abruptly, the ground begins to rise. A chain-link fence marks the boundary of the hill's lower slope, posted with utility company signs. The grass is unmowed, and a gravel path disappears upward through scrubby trees."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Winding Path"
     slug: winding-path
     description: "A dirt path switchbacking up the hillside, worn into the soil by decades of foot traffic. Tree roots cross the trail like cable runs, and the footing is uneven. The city noise fades with each turn, replaced by wind in the branches and the hum of something electrical above."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Gravel Trail"
     slug: gravel-trail
     description: "Loose stone crunching underfoot on a utility access road that climbs the hill's north face. Tire tracks suggest occasional vehicle use, but the weeds growing in the center say it's rare. Power line poles march upward alongside the trail, cables sagging between them."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Midway Rest"
     slug: midway-rest
     description: "A flat clearing halfway up the hill where someone placed a wooden bench years ago. The seat is weathered and carved with initials. The view through the trees shows the city grid below — rooftops, streets, the lake glinting beyond. The sound of the antenna arrays becomes audible here."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Ascent"
     slug: the-ascent
     description: "The trail steepens sharply for the final approach to the hilltop, the soil giving way to exposed rock and patchy grass. The trees thin out, and the wind picks up. Equipment housings and cable anchors appear along the trail, bolted to the rock."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Antenna Farm"
     slug: antenna-farm
     description: "A clearing at the hilltop bristling with antenna towers, satellite dishes, and relay equipment. Chain-link fences partition the site into licensed zones, each tower bearing its operator's identification plate. The electromagnetic hum is constant, and cell signal behaves erratically this close to the source."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Hilltop"
     slug: hilltop
     description: "The bare summit of Signal Hill, rocky and windswept, with the antenna farm occupying the northern half. The southern half is open ground with a 360-degree view — the lake to the east, the city sprawl in every other direction, and the industrial periphery visible to the southwest where buildings thin out and darken."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Transmission Tower"
     slug: transmission-tower
     description: "The tallest structure on the hill — a lattice steel tower rigged with broadcast antennas at multiple elevations. Red aviation lights blink at the top, visible for miles. The base is fenced and padlocked, and the tower vibrates faintly in the wind, a deep thrumming felt more than heard."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Bunker"
     slug: the-bunker
     description: "A concrete structure half-buried in the hillside below the antenna farm, its entrance a reinforced steel door set into a retaining wall. Originally built as a civil defense shelter, repurposed for telecom equipment. The walls are thick enough to muffle the wind, and the air inside smells of concrete dust and warm electronics."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Observation Post"
     slug: signal-hill-observation-post
     description: "A cleared overlook on the hill's east face with a direct sight line to the lake. A concrete pad and anchor bolts are all that remain of whatever structure once stood here. The view is unobstructed — harbor, shoreline, skyline, water — and the wind carries the faint smell of fish and diesel from the piers below."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Hillside Trail"
     slug: hillside-trail
     description: "A narrow footpath traversing the hill's south slope, running roughly level through dense brush and young trees. The trail is less maintained than the main paths — branches encroach, roots trip, and in places the path narrows to a body's width. It connects the gravel trail to the hilltop without gaining elevation too steeply."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Relay Station"
     slug: signal-hill-relay-station
     description: "A flat-roofed concrete building on the hill's western slope, housing signal relay equipment behind barred windows. A diesel generator sits in a fenced enclosure beside it, fuel line running to a buried tank. The building hums steadily, and the lights behind the windows never turn off."
     zone_slug: signal-hill
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Floor"
     slug: main-floor
     description: "High ceilings and concrete columns, the floor plan open and cavernous. The space was a warehouse once — the loading bay scars are still visible on the east wall. Now rows of steel shelving divide the floor into aisles, each one labeled with alphanumeric codes."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Reading Room"
     slug: the-reading-room
     description: "A long table under industrial pendant lights, surrounded by metal chairs with rubber feet that squeak on the concrete. Reference materials line the walls in locked glass cases. The room is quiet enough to hear the climate control system cycling on and off."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Archive Hall"
     slug: the-stacks-archive-hall
     description: "Steel shelving runs floor to ceiling in rows so tight that two people cannot pass in the same aisle. Boxes are labeled by date and category, the oldest ones at the top, yellowed and soft-cornered. The air is cool, dry, and smells faintly of old paper."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Cage"
     slug: the-cage
     description: "A chain-link enclosure within the larger building, padlocked and lit by a single overhead bulb. The contents are obscured by tarps and stacked boxes, visible only in outline. A clipboard hangs on the cage door, its sign-out sheet mostly blank."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Server Row"
     slug: server-row
     description: "A narrow aisle between two walls of rack-mounted equipment, fans whirring and LEDs blinking in arrhythmic patterns. The floor is raised to accommodate cable runs beneath, and the cold aisle blows refrigerated air at shin level. The heat aisle on the other side is warm enough to dry sweat."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Basement Level"
     slug: basement-level
     description: "Down a steel staircase with no railing, the ceiling drops and the light dims to bare bulbs on pull chains. The floor is poured concrete, slightly damp in the corners where the foundation seeps. Old building mechanicals — pipes, ducts, junction boxes — crowd the ceiling."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Loading Ramp"
     slug: loading-ramp
     description: "A sloped concrete ramp leading from the basement level to a roll-up door at grade level. The ramp is steep enough that carts need braking on the way down. Tire marks and scuff lines stripe the surface, and the roll-up door lets in a wedge of daylight when raised."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Catalog Room"
     slug: catalog-room
     description: "A small room lined with index cabinets — wooden drawers with brass pulls, each one holding cards filed in tight rows. The system is manual, cross-referenced, and the handwriting varies across decades. A desk lamp illuminates a work surface where someone has left a half-finished stack of new entries."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Annex"
     slug: the-stacks-the-annex
     description: "An addition bolted onto the main building's north side, its construction clearly newer — metal siding over a steel frame. The interior is one open room used for overflow storage, boxes stacked on pallets and shrink-wrapped. The floor is unsealed concrete that dusts underfoot."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Upper Gallery"
     slug: the-stacks-upper-gallery
     description: "A mezzanine level running along three walls of the main floor, accessible by metal stairs at either end. The railing is pipe steel, and the floor grating lets you see straight down to the main level. Additional shelving lines the gallery walls, and the lighting up here is worse."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Climate Control"
     slug: the-stacks-climate-control
     description: "A mechanical room at the building's core, packed with HVAC equipment, dehumidifiers, and monitoring gauges. The machines run continuously, maintaining the temperature and humidity required to preserve what the stacks hold. The noise inside is loud enough to make conversation difficult."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Back Stairwell"
     slug: the-stacks-back-stairwell
     description: "A concrete and steel stairwell at the building's rear, fire door at every level. The stairs are metal grate, the walls are cinder block painted gray, and the lighting is emergency-only — dim red strips along the treads. The stairwell echoes, and the fire doors seal airtight when closed."
     zone_slug: the-stacks
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Control Tower"
     slug: control-tower
     description: "A two-story brick structure overlooking the yard, its windows giving a panoramic view of every track and switch below. The interior is cramped — levers, gauges, a radio, a desk covered in clipboards. A steep iron staircase connects the floors, and the whole building vibrates when a train passes close."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Track One"
     slug: track-one
     description: "The main inbound line, rails gleaming where wheel contact keeps them polished. The ballast bed is fresh gravel, well-maintained, and the ties are creosote-soaked timber that stains the air on hot days. Signal lights at either end show green, red, or amber depending on who's asking."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Track Seven"
     slug: track-seven
     description: "A secondary siding track at the yard's eastern edge, its rails spotted with rust from irregular use. The ballast here is older, weeds pushing through in places. A single boxcar sits on the track, its door seal broken, its markings faded beyond reading."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Turntable"
     slug: the-switchyard-the-turntable
     description: "A massive rotating platform set into a concrete pit, designed to spin locomotives 180 degrees. The mechanism still turns — hydraulics whining, steel grinding on steel — but it's slow and requires two operators. The pit collects rainwater that nobody pumps out."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Coal Bunker"
     slug: coal-bunker
     description: "A concrete hopper structure, its walls stained black from decades of coal storage. Empty now, the interior dusted with fine coal particles that puff up with every footstep. The loading chutes are rusted shut, and the conveyor belt to the tracks hangs slack on its rollers."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Switch House"
     slug: switch-house
     description: "A small trackside building housing the manual switch levers for the yard's eastern section. The levers are iron, shoulder-height, connected to the track switches by cable runs buried in conduit. A kerosene heater sits in the corner for winter shifts, its chimney pipe blackened."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Roundhouse"
     slug: the-roundhouse
     description: "A curved brick building originally designed to service locomotives, its bays radiating out from the turntable like spokes. Most bays are empty now, their doors jammed or removed. The one operational bay smells of grease and diesel, its floor stained dark with decades of mechanical work."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Gravel Bed"
     slug: gravel-bed
     description: "Open ground between the tracks, covered in coarse railroad ballast. The gravel crunches loud underfoot, making quiet movement impossible. Rail ties and scrap metal are stacked in rough piles along the edges, and weeds grow in the gaps between the stones."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Signal Box"
     slug: signal-box
     description: "A small elevated cabin on stilts beside the main track, its windows giving a view up and down the line. Inside, a row of signal levers controls the lights and switches for a two-mile stretch. The floor is wood plank, the walls are thin, and the cold comes through in winter like the walls aren't there."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Maintenance Shed"
     slug: maintenance-shed
     description: "A corrugated metal building with sliding doors on rails, the interior organized around a central pit for undercarriage work. Tools hang on pegboard walls, and a welding rig sits on a wheeled cart. The concrete floor is oil-stained black and pitted from dropped equipment."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Coupling Point"
     slug: coupling-point
     description: "The section of track where cars are connected and disconnected — the bang of couplers engaging echoes across the yard. Ground-level workers move between cars with hand signals, and the air brakes hiss and release with each connection. The ground here is soaked with hydraulic fluid."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dead End Track"
     slug: dead-end-track
     description: "A spur that terminates in a concrete bumper block and a wall of earth. Three derelict freight cars sit on the track, their wheels rusted to the rails. Graffiti covers every surface, and the vegetation is reclaiming the ballast bed, grass and saplings pushing through the gravel."
     zone_slug: the-switchyard
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Loading Bay"
     slug: loading-bay
     description: "A concrete dock with refrigerated truck bays, the rubber seals around each door cracked and leaking cold air. Puddles of condensation pool on the floor, and the concrete is stained with old runoff. A clipboard on a nail tracks deliveries that stopped coming years ago."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Freezer One"
     slug: freezer-one
     description: "A walk-in freezer the size of a small warehouse, its walls coated in frost that never melts. The shelving units are empty steel racks, frost-covered and cold enough to burn bare skin. The compressor behind the wall runs in cycles, filling the room with a low mechanical throb."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Freezer Two"
     slug: freezer-two
     description: "Identical to Freezer One but colder — the thermostat has been turned down past its labeled range, and ice crystals form in the air. The light fixture is frosted over, casting a dim blue glow. Footprints in the frost on the floor suggest someone still comes in here."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Ice Room"
     slug: the-ice-room
     description: "A room where ice was manufactured in blocks, the machinery now silent but still present — molds, a brine tank, a conveyor system. The floor is permanently wet, drainage channels cut into the concrete. Icicles hang from the overhead pipes in formations that grow and break and regrow."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Hanging Racks"
     slug: hanging-racks
     description: "Rows of steel hooks on overhead rail tracks, designed to hold hanging carcasses that moved through the facility on a continuous loop. The hooks are empty now, swinging faintly in the draft from the refrigeration system. The metal rails are stained dark, and the concrete below is bleached from years of washing."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Compressor Room"
     slug: compressor-room
     description: "Industrial refrigeration compressors — three units, each the size of a truck engine — bolted to the concrete floor. Two are silent, their gauges dead. The third runs, its motor humming and its coolant lines sweating condensation. The noise is loud enough to feel in the chest."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Insulated Corridor"
     slug: insulated-corridor
     description: "A long hallway connecting the freezer units, its walls and ceiling lined with insulation panels that have yellowed and sagged. The floor is wet with condensation, and the temperature drops noticeably with every few steps deeper into the facility. Frost patterns trace the panel seams."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Walk-In"
     slug: the-walk-in
     description: "A smaller cold room off the main corridor, its heavy door fitted with an interior release handle — the kind required after the industry changed its safety codes. The shelves hold nothing, but the light works and the temperature holds steady. The walls are close, and the silence inside is absolute."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Drain Floor"
     slug: drain-floor
     description: "A wide room where the floor slopes to a central drain, the concrete scored with channels to direct runoff. The drain grate is iron, rusted but functional, and the smell rising from it is cold water and old metal. Hoses hang coiled on wall-mounted racks, their nozzles calcified."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Meat Hook Hall"
     slug: meat-hook-hall
     description: "The main processing floor — a vast room with concrete pillars and a rail system overhead, hooks still hanging at intervals. The light comes from industrial fixtures mounted high on the pillars, half of them dead. The floor is smooth concrete, sloped for drainage, scrubbed so many times it has a polish."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Staging Area"
     slug: staging-area
     description: "A room between the loading bay and the freezers where product was sorted and routed. Stainless steel tables line the walls, their surfaces dented and scratched. The floor is rubberized, buckled in places, and a hand-truck sits abandoned in the corner with a flat tire."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Roof Collapse"
     slug: roof-collapse
     description: "A section of the building where the roof gave way under the weight of accumulated ice and snow. Daylight enters through the jagged hole, illuminating the room below with unexpected brightness. Debris — insulation, roofing material, steel beams — covers the floor in a frozen heap, and icicles hang from the torn edges."
     zone_slug: cold-storage
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Intake Chamber"
     slug: intake-chamber
     description: "A cavernous concrete room below grade, water entering through grated openings in the lake-facing wall. The sound of moving water fills the space, echoing off the bare walls. Iron catwalks span the chamber above the waterline, their surfaces slick with condensation and vibration from the pumps below."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Turbine Hall"
     slug: the-turbine-hall
     description: "A double-height room housing three turbine units on reinforced concrete pads. The middle turbine still runs, its rotor spinning behind a steel shroud, the sound a deep steady drone that resonates in the bones. Oil sheen catches the overhead light, and the floor drains run continuously."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Pump Room One"
     slug: pump-room-one
     description: "A below-grade room dominated by a massive centrifugal pump, its motor the size of a car. Pipes enter and exit through the walls at multiple elevations, each one labeled with flow direction and capacity. The vibration from the pump makes standing water ripple on every flat surface."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Pump Room Two"
     slug: pump-room-two
     description: "The backup system — identical equipment to Pump Room One, but quieter. This pump runs only during peak demand or when the primary fails. The gauges read zero, the motor is cool, and the silence here is conspicuous compared to the noise next door."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Settling Tank"
     slug: settling-tank
     description: "An open-topped concrete basin where suspended solids drop out of the water column before filtration. The water surface is still and slightly murky, with a thin film of sediment collecting at the edges. Skimmer arms rotate slowly across the surface, their motors barely audible."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Valve Gallery"
     slug: valve-gallery
     description: "A corridor lined with valve wheels and handwheels of varying sizes, each controlling flow through a different section of the system. The valves are painted according to function — red for emergency shutoff, blue for main flow, yellow for bypass. The brass plates beneath each wheel are engraved with codes that predate digital labeling."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Filtration Basin"
     slug: filtration-basin
     description: "A long, shallow basin divided into lanes by concrete walls, water flowing through graded sand and gravel beds. The water enters turbid at one end and exits clear at the other. Raking mechanisms drag slowly across the surface of the filter media, their chains clinking."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Spillway"
     slug: the-spillway
     description: "A concrete chute designed to handle overflow, dropping steeply from the facility to a discharge point at the lake's edge. The spillway is dry most days, its surface stained with mineral deposits that record past high-water events. When it runs, the sound carries half a mile."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Control Panel"
     slug: control-panel
     description: "A wall-mounted panel of gauges, switches, and indicator lights monitoring every system in the station. Some gauges are original — brass-rimmed, glass-faced, needle-type — and some are digital retrofits bolted beside them. A logbook sits on the console beneath, entries made in pencil at shift changes."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Discharge Tunnel"
     slug: discharge-tunnel
     description: "A cylindrical concrete tunnel carrying treated water from the facility to the distribution system. The tunnel is large enough to walk through, and the water runs along the bottom in a steady stream. Emergency lighting marks the path at intervals, and the sound of water echoes in both directions."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Catwalk"
     slug: catwalk
     description: "A steel grate walkway spanning the intake chamber at the upper level, connecting the pump rooms to the control area. The railing is pipe steel, and the grating flexes underfoot with each step. Below, water moves through the intake channels, dark and purposeful."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Overflow Channel"
     slug: the-pumping-station-overflow-channel
     description: "A secondary discharge route that activates during flood conditions, diverting excess water around the main system. The channel is a concrete trench cut into the ground outside the building, usually dry and collecting windblown debris. Scour marks on the walls show how high the water has risen."
     zone_slug: the-pumping-station
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Corroded Alley"
     slug: corroded-alley
     description: "A narrow passage between two abandoned warehouses, the walls streaked with rust runoff from decaying steel above. The ground is broken concrete and standing water, the puddles tinged orange. Light reaches the alley floor only at midday, and the shadows smell of iron oxide and rot."
     zone_slug: rust-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Warehouse Four"
     slug: warehouse-four
     description: "A brick and corrugated metal building with half its wall panels missing, the interior visible from the street. The floor is concrete, cracked and heaved by frost cycles, and pigeon droppings coat every surface. Structural beams sag overhead, their rivets popping, and the wind moves through the gaps in the walls."
     zone_slug: rust-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Gutted Factory"
     slug: the-gutted-factory
     description: "The shell of a manufacturing plant stripped to its skeleton — steel columns, concrete floor, open sky where the roof was. Scavengers took the copper, the wiring, the mechanical equipment. What remains is too heavy to move: press foundations, crane rails, and the bolts that held everything down."
     zone_slug: rust-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Chain Link Gap"
     slug: chain-link-gap
     description: "A section of perimeter fencing where the chain link has been cut and peeled back, creating a passage wide enough to slip through sideways. The posts are still standing, the razor wire still coiled across the top, but this gap has been open long enough for a footpath to form on both sides."
     zone_slug: rust-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Broken Dock"
     slug: broken-dock
     description: "A loading dock with its concrete apron crumbling into the drainage ditch below. The roll-up door is jammed at an angle, one panel folded inward. Weeds grow in the cracks, and the dock numbers painted on the concrete are faded to ghosts."
     zone_slug: rust-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Graffiti Wall"
     slug: graffiti-wall
     description: "The windowless side of a warehouse covered in layered spray paint — tags, murals, political statements, names of the dead. The oldest layers are faded and peeling. The newest are still vivid, their paint sharp against the decaying brick. The ground below is littered with spent cans."
     zone_slug: rust-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Fire Escape"
     slug: the-fire-escape
     description: "A zigzag metal staircase bolted to the side of a derelict factory, its lowest section missing — pulled down or rusted away. The remaining flights cling to the wall, their bolts pulling free of crumbling mortar. The landing at the top gives a view over the surrounding ruins."
     zone_slug: rust-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Boarded Storefront"
     slug: boarded-storefront
     description: "A commercial building on the edge of the industrial zone, its windows covered with plywood and its door secured with a padlock and chain. The awning over the sidewalk sags under the weight of debris from the roof. A faded sign above the door reads something that was once a business name."
     zone_slug: rust-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Collapsed Roof"
     slug: rust-row-collapsed-roof
     description: "A building whose roof caved in under its own weight, the interior now a pile of beams, insulation, and roofing material open to the sky. Rain pools in the debris, and birds nest in the exposed wall cavities. The surrounding walls lean inward, held up by habit more than engineering."
     zone_slug: rust-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Scrap Metal Pile"
     slug: scrap-metal-pile
     description: "An open lot heaped with rusted steel — I-beams, pipe sections, sheet metal, cable, and unidentifiable mechanical parts. The pile shifts and settles unpredictably, and the edges are sharp enough to cut through boot leather. The ground beneath is stained rust-orange, and nothing grows."
     zone_slug: rust-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Drainage Ditch"
     slug: drainage-ditch
     description: "A concrete-lined channel running between the warehouses, carrying runoff toward the lake. The water is brown, slow-moving, and filmed with an iridescent sheen. Shopping carts and tires sit in the flow, half-submerged, and the concrete walls are cracked and undermined."
     zone_slug: rust-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Dead End"
     slug: the-dead-end
     description: "The road simply stops where a building collapsed across it, rubble filling the right-of-way. Tire tracks show where vehicles have turned around in the last open patch of pavement. Beyond the rubble, the industrial zone continues, but you can't get there from here. The RIDE coverage flickers at the edges of perception this far out."
     zone_slug: rust-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Entry Gate"
     slug: the-boneyard-entry-gate
     description: "A double gate of rusted steel pipe on wheels, one side jammed open on its track. A faded sign wired to the fence reads the name of a salvage company that no longer exists. The ground beyond the gate is packed dirt and crushed stone, worn into ruts by heavy equipment."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Crane Graveyard"
     slug: crane-graveyard
     description: "Decommissioned cranes stand in a row, their booms lowered and locked, cables hanging slack. Rust has frozen the joints, and weeds grow in the cab doorways. They cast long angular shadows across the yard, and in certain light they look like a herd of skeletal animals kneeling."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Propeller Stacks"
     slug: propeller-stacks
     description: "Ship propellers leaning against each other in stacks of three and four, their blades bent and pitted from years of use and more years of sitting in weather. Each one is taller than a person. The bronze has gone green, and the steel has gone red, and the ground beneath them has been pressed into permanent depressions."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Hull Row"
     slug: hull-row
     description: "Sections of ship hulls arranged in a line, stood on their edges like enormous steel books. The cut edges are jagged, and the exterior paint is blistered and peeling. Some still bear partial names — fragments of letters in faded white paint, identities reduced to consonants."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Cutting Yard"
     slug: the-cutting-yard
     description: "A flat expanse of bare earth where ships are dismantled with torches and saws. Scorch marks blacken the ground in overlapping circles, and metal filings glint in the dirt. The air smells of cut steel and acetylene, and the sound of angle grinders carries across the yard when work is active."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Anchor Chain"
     slug: anchor-chain
     description: "A length of anchor chain coiled in a heap, each link the size of a human head. The chain is rusted solid, the links fused together by corrosion. It sits where it was dropped years ago, and the ground beneath it has compressed into a permanent impression of iron."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Rust Field"
     slug: rust-field
     description: "An open area where smaller salvage items are laid out for sorting — gears, valves, pipe fittings, brackets — everything coated in a uniform layer of rust that makes the individual pieces hard to distinguish. The field stretches a hundred yards, and from a distance it looks like a red-brown meadow."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Dry Basin"
     slug: the-dry-basin
     description: "A concrete dry dock basin drained of water, its floor cracked and stained. The walls rise twenty feet on either side, and the gate at the far end is sealed shut. A ship's keel sits on blocks at the basin floor, its hull plating stripped away, the ribs exposed like the skeleton of something enormous."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Stripped Chassis"
     slug: stripped-chassis
     description: "A truck chassis — frame rails, axles, nothing else — sitting on flat tires in the middle of the yard. Everything removable has been removed. The frame is stamped with a manufacturer and year that put it in service before most people were born."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Cable Spool"
     slug: cable-spool
     description: "Wooden spools the size of cars, wound with steel cable of varying gauge, standing in rows. Some are full, some half-empty, the cable ends dangling. The wood is weathered gray, and the cable is surface-rusted but still sound. Forklift tracks circle the spools in packed earth."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Scrap Heap"
     slug: scrap-heap
     description: "The main accumulation pile — a mountain of mixed metal rising thirty feet, its surface a chaos of twisted steel, crushed cars, and unidentifiable industrial debris. The heap shifts in the wind, creaking and groaning as pieces settle. Rain channels have carved grooves in its flanks."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Crusher"
     slug: the-boneyard-the-crusher
     description: "A hydraulic crusher mounted on a concrete pad, its jaws open and waiting. The machine is industrial scale — it takes a car and compresses it to a cube the size of a washing machine. The hydraulic lines are thick as wrists, and the control booth beside it has armored glass."
     zone_slug: the-boneyard
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Street"
     slug: the-ward-main-street
     description: "Two lanes, parked cars on both sides, buildings shoulder to shoulder for six blocks. The storefronts are brick with painted signs — some hand-lettered, some faded beyond reading. The sidewalk is cracked, the trees are old, and everyone walking here is either going to work or coming home from it."
     zone_slug: the-ward
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Corner Bar"
     slug: corner-bar
     description: "A concrete-block building on the corner with a neon sign missing half its letters. The door sticks. Inside, the lighting is yellow, the booths are cracked vinyl, and the bartender has been here longer than anyone can remember."
     zone_slug: the-ward
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Stoop"
     slug: the-stoop
     description: "A concrete stoop in front of a row house, three steps up from the sidewalk. The railing is iron, the concrete is chipped, and the step edges are rounded from decades of use. Neighbors gather here in summer with folding chairs, and in winter the salt stains never fully wash away."
     zone_slug: the-ward
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Vacant Lot"
     slug: vacant-lot
     description: "Chain-link fence around a lot where a building used to be — the foundation is still visible under the weeds. Kids have worn a path through the gap in the fence. Broken glass and brick fragments surface after every rain, and a basketball hoop with no net stands at the far end on a leaning pole."
     zone_slug: the-ward
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Laundromat"
     slug: laundromat
     description: "Fluorescent light spilling through plate glass windows, rows of front-loading washers and dryers humming in cycles. The air is humid, heavy with detergent and heat. A folding table runs the length of the back wall, and a vending machine in the corner sells single-use soap packets."
     zone_slug: the-ward
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Neighborhood Park"
     slug: neighborhood-park
     description: "A city block of grass, a few old oaks, a playground with a rubber surface that's cracking at the edges. The basketball court has one working hoop, and the drinking fountain runs when it feels like it. Benches face the playground, and the park fills after school lets out."
     zone_slug: the-ward
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Diner"
     slug: the-ward-the-diner
     description: "Vinyl stools at a Formica counter, booths along the window with duct-taped seats. The grill is visible through a pass-through window, and the coffee is always on. The menu hasn't changed in a decade, the prices barely. Breakfast is served until closing."
     zone_slug: the-ward
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Bus Stop"
     slug: bus-stop
     description: "A metal bench under a plexiglass shelter, the route map faded beyond reading. The bench is bolted to the sidewalk, and the shelter has one cracked panel that lets the rain in. People wait here with the patience of routine, checking the time against a bus that comes when it comes."
     zone_slug: the-ward
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Row Houses"
     slug: row-houses
     description: "Brick facades in a continuous wall, each house distinguished by its front door color and the condition of its window boxes. The rooflines are uniform, the chimneys shared, and the narrow alleys between every fourth house lead to small backyards and detached garages. Some houses are pristine. Some are tired."
     zone_slug: the-ward
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Church Steps"
     slug: church-steps
     description: "Wide stone steps leading up to a double door of dark wood, the limestone facade rising above the neighboring rooftops. The steps are worn to shallow bowls in the center where generations have climbed. On Sundays the doors are open and singing carries down the block."
     zone_slug: the-ward
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Alley"
     slug: the-ward-the-alley
     description: "A narrow service alley running behind the row houses, one lane wide, paved in old brick that's heaved and cracked. Garbage cans and recycling bins line both sides, and power lines cross overhead in a tangled web. Garage doors face the alley, most of them too warped to close completely."
     zone_slug: the-ward
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Hardware Store"
     slug: hardware-store
     description: "A narrow storefront packed floor to ceiling with tools, fasteners, paint, and pipe fittings in wooden bins with handwritten labels. The owner works the register and knows where everything is without looking. The floor is wood plank, oil-darkened, and the smell is a mixture of turpentine, metal, and sawdust."
     zone_slug: the-ward
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Stockyard Gate"
     slug: stockyard-gate
     description: "A heavy timber gate on steel hinges, the entrance to the yards complex. The gateposts are concrete, stained with rust from the hardware, and the road beyond is packed earth scored with tire and hoof marks. The smell hits before the gate is fully open — livestock, hay, and something older."
     zone_slug: the-yards
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Pens"
     slug: the-pens
     description: "Pipe-rail enclosures stretching across a muddy expanse, each one large enough to hold a truck's worth of cattle. The mud is ankle-deep in wet weather, and the rails are dented and polished smooth where animals have pressed against them. Feed troughs line the far side, and water troughs drip at both ends."
     zone_slug: the-yards
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Packing House"
     slug: packing-house
     description: "A long brick building with high windows frosted opaque, its loading docks facing the rail siding. The concrete floors inside slope to drains, and the walls are tiled white to the ceiling. The building runs cold — refrigeration units hum behind the walls — and the air has a metallic, organic weight to it."
     zone_slug: the-yards
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Worker Housing"
     slug: worker-housing
     description: "Small frame houses in identical rows, built by the company a century ago and sold off piecemeal since. The paint is peeling on most, fresh on a few. Porches sag, fences lean, and the yards are small and practical — garden plots, clotheslines, dog runs. The street is narrow and unpaved past the first block."
     zone_slug: the-yards
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Tavern"
     slug: the-tavern
     description: "A two-story building at the edge of the yards, its ground floor a bar with a pressed-tin ceiling and a wooden floor worn to splinters. The upstairs rooms used to be lodging. The beer is cheap, the food is simple, and the shift-change crowd fills the place at predictable hours."
     zone_slug: the-yards
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Rail Crossing"
     slug: rail-crossing
     description: "The road dips and crosses active tracks, the crossing arms striped red and white. Warning lights flash when a train approaches, and the bells ring with a mechanical insistence that drowns out conversation. The track bed is oil-soaked gravel, and the crossing planks rattle under every tire."
     zone_slug: the-yards
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Smokehouse"
     slug: smokehouse
     description: "A squat brick building with a chimney that leans slightly south, the mortar between the bricks darkened by decades of smoke. The heavy wooden door is charred around the edges, and the interior, when open, releases a wall of hickory-scented heat. The air for a block around carries the smell."
     zone_slug: the-yards
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Union Hall"
     slug: union-hall
     description: "A two-story brick building with the local's number painted above the entrance in block letters. The meeting room upstairs has folding chairs and a podium. Bulletins and notices cover the corkboard by the door — shift schedules, grievances, a hand-drawn map to someone's retirement party."
     zone_slug: the-yards
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Scales"
     slug: the-scales
     description: "A platform scale set into the road surface, large enough for a loaded truck. The readout is housed in a small booth beside the scale, its window smudged from the inside. Drivers pull on, wait for the number, pull off. The process takes thirty seconds and repeats all day."
     zone_slug: the-yards
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Rendering Plant"
     slug: rendering-plant
     description: "A windowless building at the yards' southern edge, its exhaust stacks releasing steam that smells like nothing else. The building is set apart from its neighbors by the width of a road on all sides — a buffer that isn't nearly enough on hot days. Trucks back up to the loading dock at odd hours."
     zone_slug: the-yards
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Back Lot"
     slug: back-lot
     description: "An unpaved area behind the packing house, used for overflow parking and equipment storage. Pallets are stacked against the fence, and a forklift sits with its forks down, key in the ignition. The ground is hard-packed dirt in summer, a mud pit in spring, and frozen solid through winter."
     zone_slug: the-yards
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Bridge"
     slug: the-bridge
     description: "A steel truss bridge spanning the rail yard at the neighborhood's southern boundary, connecting The Yards to the industrial zones beyond. The deck is steel grate, and you can see the tracks below through the openings. The railing is riveted iron, and the whole structure shakes when a locomotive passes underneath."
     zone_slug: the-yards
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Root Maze"
     slug: root-maze
     description: "Arching prop roots interlock in every direction, creating a lattice that blocks straight-line travel. The water beneath is tannin-dark and knee-deep at low tide, chest-deep at high. Navigation means reading the current through the root gaps."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Prop Root"
     slug: prop-root
     description: "A single massive root system rises from the mud like architecture, buttressing a trunk that splits into a canopy twenty meters overhead. Barnacles coat the waterline in a gray crust. Crabs pick their way across the exposed surfaces at low tide."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tide Channel"
     slug: tide-channel
     description: "A narrow waterway threading between root walls, the current reversing direction twice daily. The water is murky with suspended sediment, and the bottom drops without warning from ankle-depth to over a person's head. Small fish scatter at the disturbance of each step."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Oyster Bed"
     slug: oyster-bed
     description: "Clusters of sharp-edged shells cement themselves to every submerged surface — roots, rock, each other. Walking through them means cutting whatever touches them. The bed filters the water clear in a visible ring around its perimeter."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Rookery"
     slug: the-rookery
     description: "Wading birds packed shoulder to shoulder in the upper branches, the noise continuous and deafening. Guano coats every surface below in a chalite white layer. The stench carries downwind for a quarter kilometer."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Brackish Pool"
     slug: brackish-pool
     description: "A still pool caught between root systems where fresh and salt water meet and neither wins. The surface is glassy, reflecting the canopy in dark mirror. Water moccasins hold still in the shallows, indistinguishable from submerged branches."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Mud Flat"
     slug: mud-flat
     description: "Exposed tidal bottom, the mud black and sulfurous, releasing gas in slow bubbles. Footprints fill with water immediately and stay visible for hours. The surface is slick enough to drop a person without warning."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Crab Walk"
     slug: crab-walk
     description: "Fiddler crabs by the thousands cover the mud in a shifting blanket, waving their oversized claws. They part around approaching feet and close ranks behind. The clicking of their movement is audible above the water sounds."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Snapper Hole"
     slug: snapper-hole
     description: "A deep pocket in the mud where the bottom drops away into a dark cavity. Mangrove snapper hold in the shade of the overhang, visible as silver flashes in the murk. The water here is cooler than the surrounding shallows."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Aerial Root"
     slug: aerial-root
     description: "Roots descend from branches overhead, hanging like cables before reaching the water and anchoring. They create a curtain that must be pushed through. Some are thick as a forearm, others thin as wire, all of them slick."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Mangrove Crown"
     slug: mangrove-crown
     description: "The upper canopy where branches weave a ceiling dense enough to block direct sunlight. The air is marginally cooler here. Birds and insects own this level — human access requires climbing root systems not designed for the weight."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Pelican Post"
     slug: pelican-post
     description: "A dead trunk stripped of bark, standing above the waterline, permanently occupied by brown pelicans. The wood is whitewashed with droppings and polished smooth by talons. The birds watch boat traffic with the disinterest of long tenure."
     zone_slug: the-mangrove
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Prairie"
     slug: the-prairie
     description: "Grass stretching to every horizon, broken only by the occasional tree island rising like a ship. The water beneath the grass is shin-deep and warm as blood. Sound travels flat and far across the expanse without obstruction."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Grass Wall"
     slug: grass-wall
     description: "Sawgrass growing head-high, the blade edges serrated enough to slice exposed skin on casual contact. Pushing through it is a slow, deliberate process of parting and stepping. The cut stems release a green, vegetable smell."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Airboat Trail"
     slug: airboat-trail
     description: "A corridor of flattened grass marking the passage of fan-driven boats, the stems bent but not broken. The trail fills with water and becomes invisible within hours. Following it requires reading the subtle differences in grass height."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Alligator Slide"
     slug: alligator-slide
     description: "A slick groove in the mud bank where a large reptile enters and exits the water, the vegetation worn away to bare earth. The slide is active — fresh claw marks score the mud. The water at the bottom is opaque."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Hammock Island"
     slug: hammock-island
     description: "A teardrop-shaped mound rising a meter above the waterline, dense with hardwood trees and ferns. The ground is dry and firm, rare enough out here to feel like a discovery. Spiderwebs span every gap between branches."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Strand"
     slug: the-strand
     description: "A line of cypress trees standing in shallow water, their trunks swollen at the base, knees protruding from the surface. Spanish moss hangs motionless in the heavy air. The shade beneath is deep and green."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Panther Path"
     slug: panther-path
     description: "A game trail through the hammock, the ground compressed by years of animal traffic. Tracks in the soft earth show the passage of something large and padded. The trail is narrow enough to brush both shoulders against vegetation."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Water Level"
     slug: water-level
     description: "The point where the prairie's standing water begins — a visible line where dry ground meets shallow sheet flow. The water is warm, clear over limestone, and moves south at a pace too slow to see. Stepping in means accepting wet boots for the duration."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Bird Rookery"
     slug: bird-rookery
     description: "A tree island white with nesting birds — egrets, herons, ibises stacked in colonies across every available branch. The noise is constant, a layered mix of calls and wingbeats. The water beneath is bright with dropped feathers."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fire Scar"
     slug: fire-scar
     description: "A blackened patch where a controlled burn or lightning strike swept through the grass, leaving charred stems standing in shallow water. New green shoots already push up through the ash. The regrowth will be complete within a season."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Solution Hole"
     slug: solution-hole
     description: "A circular depression in the limestone where the rock dissolved away, creating a deep pool in the shallow prairie. The water inside is dark blue and cold compared to the surrounding sheet flow. Fish gather here in visible schools."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Horizon"
     slug: sawgrass-the-horizon
     description: "Flat in every direction, the line between water and sky indistinct in the heat shimmer. Distance loses meaning without reference points. Cloud shadows cross the prairie like slow-moving stains, the only movement besides the birds."
     zone_slug: sawgrass
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Flat"
     slug: the-flat
     description: "Acres of exposed seabed at low tide, the surface a mosaic of mud, sand, and shell fragments. Heat radiates upward in visible waves. The water's edge retreats to a distant silver line and will return on its own schedule."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Shell Hash"
     slug: shell-hash
     description: "A band of crushed shell fragments deposited by storm surge, the pieces ground to the consistency of coarse gravel. Walking on it produces a dry, crunching sound. The fragments are sharp enough to wear through boot soles over distance."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Blue Crab"
     slug: blue-crab
     description: "A shallow pool alive with crabs, their blue claws raised in threat display. The water is warm enough to see the heat ripples on the surface. Stepping near the pool sends them scuttling sideways into deeper mud."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Receding Water"
     slug: receding-water
     description: "The tide pulling back across the flat, leaving behind wet sand that reflects the sky like hammered metal. Stranded organisms pulse and flex in the thin remaining water. The exposed ground steams faintly in the heat."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Drain"
     slug: the-drain
     description: "A low point in the flat where the last tidal water collects before percolating into the substrate. The mud here is soft enough to swallow a boot to the calf. Wading birds work the edges, stabbing at concentrated prey."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Fiddler Crab"
     slug: fiddler-crab
     description: "A colony of thousands occupying a section of firm mud, each crab tending a burrow entrance the diameter of a finger. The males wave their oversized claws in synchronized pulses. The ground is more hole than solid surface."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sun Bake"
     slug: sun-bake
     description: "A section of flat fully exposed to direct sun with no shade within reach. The mud has dried to a cracked mosaic, curling at the edges like broken pottery. Surface temperature is high enough to feel through boot soles."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Muck Walk"
     slug: muck-walk
     description: "Soft, anoxic mud that grabs at every step and releases with a sucking sound. Forward progress requires pulling each foot free deliberately. The smell of hydrogen sulfide rises with each disturbance of the surface."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Pool"
     slug: tidal-flat-the-pool
     description: "A tidal pool trapped behind a sand ridge, the water warming toward bath temperature. Small fish, shrimp, and anemones occupy it in a compressed ecosystem. The pool will merge with the sea in six hours and re-isolate in twelve."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Sand Dollar"
     slug: sand-dollar
     description: "A scatter of bleached sand dollar tests on the high-tide line, fragile enough to crumble between fingers. Live ones are buried just below the surface, covered in fine brown spines. The dead ones are the only white objects on the flat."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Wrack Line"
     slug: wrack-line
     description: "A band of dried seaweed, wood fragments, and plastic deposited by the last high tide. Flies work the decomposing vegetation in clouds. The line marks the water's highest recent reach like a pencil mark on a wall."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Return"
     slug: the-return
     description: "The tide coming back in, water spreading across the flat in a thin advancing sheet. The leading edge moves faster than walking pace. What was dry ground ten minutes ago is ankle-deep water now, and it is not stopping."
     zone_slug: tidal-flat
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Stairs"
     slug: the-stairs
     description: "Wooden steps climbing from the waterline to the elevated front deck, each tread bowed from years of use. The rail is a length of dock line threaded through eye bolts. Barnacles coat the lower pilings where tidal water reaches."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Front Deck"
     slug: front-deck
     description: "Weathered planking extending across the front of the structure, the boards spaced wide enough to see water moving underneath. Two chairs face the channel. The wood is gray with salt exposure and warm underfoot in the afternoon."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Hammock"
     slug: the-hammock
     description: "A rope hammock slung between two porch posts, the netting sun-bleached and stretched to the shape of its most frequent occupant. It hangs over the deck with a view of the water through the railing gaps. Mosquitoes find it at dusk."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Screen Porch"
     slug: screen-porch
     description: "A screened enclosure on the shaded side of the house, the mesh patched in several places with different grades of screen. The air moves through but the insects stay outside. A ceiling fan turns at the lowest setting, barely stirring the heat."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Kitchen"
     slug: kitchen
     description: "A narrow galley with a propane stove, a rust-stained sink, and a cooler standing in for a refrigerator. The counter is marine plywood, the edges swollen from humidity. Everything is stored in sealed containers because of the moisture and the ants."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Rain Barrel"
     slug: rain-barrel
     description: "A corrugated plastic barrel positioned under a gutter downspout, three-quarters full of brown-tinted rainwater. Mosquito netting covers the top. The water inside is the primary fresh supply when the cistern runs low."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Under the House"
     slug: under-the-house
     description: "The open space between the pilings beneath the elevated floor, tidal water moving through at high tide, mud and oyster shell exposed at low. Crab traps and miscellaneous gear hang from the joists. The shade is cool but the air is thick with salt and decay."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Dock"
     slug: the-stilthouse-the-dock
     description: "A narrow wooden pier extending from the house into deeper water, the planks flexing underfoot. Cleats and tie-off points line both edges. The end plank is worn smooth where someone sits regularly with their legs hanging over."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Bait Tank"
     slug: bait-tank
     description: "A live well built from a cut-down barrel, aerated by a small pump running off a marine battery. Shrimp and finger mullet circle inside in a slow orbit. The smell is an honest salt-and-fish that seeps into everything nearby."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Crow's Nest"
     slug: crows-nest
     description: "A small platform built atop the highest piling, reached by iron rungs hammered into the wood. The view from the top covers the surrounding channels and flats in every direction. The platform sways perceptibly in wind."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Generator Shed"
     slug: the-stilthouse-generator-shed
     description: "A plywood enclosure housing a diesel generator, the exhaust vented through a pipe in the roof. The interior is loud and hot and smells of fuel. Runtime is rationed to essentials — lights, radio, pump."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Net"
     slug: the-net
     description: "A cast net draped over the porch railing to dry, the lead line clicking against the wood in the breeze. Holes have been patched with monofilament in a tighter weave than the original mesh. Salt crystals glitter on the nylon in direct sun."
     zone_slug: the-stilthouse
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Reef"
     slug: the-reef
     description: "A submerged ridge of cemented oyster shell rising from the soft bottom, exposed at low tide as a rough gray plateau. The edges are sharp enough to cut through neoprene. The reef breaks the current and creates a lee of calmer water behind it."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Shuck Station"
     slug: shuck-station
     description: "A wooden table bolted to pilings at the water's edge, the surface scarred with thousands of knife marks. An oyster knife hangs from a lanyard. Shell fragments and liquor stain the planks in overlapping rings."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Marl Bottom"
     slug: marl-bottom
     description: "Soft calite substrate beneath a foot of warm water, the bottom a pale gray-white that reflects sunlight upward. Stingrays bury themselves here, invisible until disturbed. Every step is a calculated shuffle."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Bar"
     slug: the-bar
     description: "A shallow sandbar connecting two deeper channels, passable at low tide by foot, submerged at high tide to waist depth. Current accelerates across the bar's narrow width. Crossing requires timing the tide, not fighting it."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Poling Flat"
     slug: poling-flat
     description: "A shallow expanse of firm sand bottom, clear water barely covering the ankles. The flat extends in a broad arc, perfect depth for a push pole. Schools of bonefish tail in the shallows, their dorsals cutting the surface."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Net Haul"
     slug: net-haul
     description: "A stretch of shoreline where nets are dragged in, the bottom cleared of debris by repeated passes. Piles of bycatch — crabs, sponges, sea cucumbers — line the edge. Pelicans wait at close range for discards."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Tongs"
     slug: the-tongs
     description: "An oyster harvesting station where long-handled tongs lean against a sorting table. The handles are worn smooth from grip. Shells pile up in rough mounds, sorted by size into wire baskets."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Spat Bed"
     slug: spat-bed
     description: "A shallow area seeded with juvenile oysters attached to old shell, the bed marked with PVC poles at the corners. The young oysters are visible as tiny rough bumps on the substrate. Growth here takes years to become harvest."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Anchor Point"
     slug: anchor-point
     description: "A heavy concrete block sunk in the bottom with an iron ring set in its top, the chain running up to a surface buoy. The block has been here long enough for oysters to colonize its sides. It marks the edge of navigable water."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Sort"
     slug: the-sort
     description: "A flat-bottomed boat tied alongside a sorting platform, half-full of harvested shell. Oysters are measured against a metal gauge and either kept or tossed back. The keeper pile grows slowly. The toss-back pile splashes."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Shell Pile"
     slug: shell-pile
     description: "A mound of empty oyster shells bleaching in the sun, accumulated over seasons of harvest. The pile is head-high and growing. Crushed shell from the base washes back into the water with each tide, building new substrate."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Water Clear"
     slug: water-clear
     description: "A patch of water over an active reef where filtration has turned the murk transparent. The bottom is visible in sharp detail — shell, sand, grass, the movement of small creatures. The clarity extends for a radius of maybe twenty meters before the turbidity resumes."
     zone_slug: oyster-bank
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Tower Base"
     slug: the-everwatch-tower-base
     description: "A concrete pad at ground level, the tower's legs bolted down with rusted hardware. Stored supplies lean against the base in weatherproof containers. The surrounding vegetation has been cleared back to a ten-meter perimeter."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Climb"
     slug: the-climb
     description: "An open metal staircase spiraling up the tower's frame, each flight exposing more of the surrounding landscape. The risers are perforated steel, and the water below is visible through every step. Handrails are salt-corroded but solid."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Platform One"
     slug: the-everwatch-platform-one
     description: "The first elevated station, a metal grate floor enclosed by a waist-high railing. Equipment lockers line one side. The height is enough to see over the mangrove canopy to the water beyond."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Platform Two"
     slug: the-everwatch-platform-two
     description: "Higher than the first, exposed to full wind from every quarter. The platform sways perceptibly in gusts, the motion transmitted through the entire structure. The view now includes the curve of the coastline and open water to the horizon."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Scope"
     slug: the-scope
     description: "A mounted spotting scope bolted to the railing, its optics salt-hazed but functional. The field of view covers the primary channel approaches and the outer flats. Fingerprints and salt residue cloud the eyepiece between cleanings."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Radio Room"
     slug: radio-room
     description: "An enclosed cabin at the upper level, insulated against wind and equipped with a transceiver, a battery bank, and a logbook. The interior is hot during the day, tolerable at night. Transmission quality depends on atmospheric conditions and time of day."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Lookout"
     slug: the-everwatch-the-lookout
     description: "The highest open platform, above the radio room, nothing but air and antenna between the observer and the sky. The wind is constant and strong. The view is panoramic — water, land, sky, weather approaching from any direction."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Signal Flag"
     slug: signal-flag
     description: "A halyard rigged to a short mast at the top of the tower, signal flags snapping in the sustained wind. The flags are faded from sun exposure, colors washed toward pastel. Their messages are readable from the water approaches."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Rain Cover"
     slug: rain-cover
     description: "A corrugated roof panel angled over a section of platform, providing minimal shelter from downpours. Rain hits the metal in a roar that drowns conversation. The cover channels runoff into a collection barrel lashed to the frame."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Night Station"
     slug: night-station
     description: "The tower after dark, running lights marking the structure for water traffic. The platform lights are kept minimal — one red bulb, enough to read by, dim enough to preserve night vision. Insects orbit the light in dense spirals."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Descent"
     slug: the-everwatch-the-descent
     description: "The stairs going down, each flight revealing less sky and more canopy. The wind drops by degrees. The ground, when it arrives, feels oddly still after the tower's constant sway."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Supply Locker"
     slug: supply-locker
     description: "A steel cabinet bolted to the tower frame at the base level, the door sealed with a rubber gasket against moisture. Inside: batteries, water purification tabs, a first aid kit, flares. Everything is checked on a rotation and replaced before it expires."
     zone_slug: the-everwatch
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Door"
     slug: storm-shelter-the-door
     description: "A steel door set in a concrete frame at ground level, the hinges heavy-gauge, the latch a lever mechanism designed for operation in wind. The door opens outward against the weather. Scuff marks on the threshold show regular use."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Concrete Walls"
     slug: concrete-walls
     description: "Poured concrete, unpainted, the surface marked with the grain of the plywood forms used in construction. Moisture beads on the walls when the temperature outside changes rapidly. The walls are thick enough to muffle a direct hit."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cot Row"
     slug: cot-row
     description: "A line of military-surplus folding cots set up along one wall, each one covered with a thin pad and a sealed blanket in a plastic bag. The arrangement is efficient, not comfortable. The spacing allows for passage between them."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Generator Room"
     slug: storm-shelter-generator-room
     description: "A partitioned space housing a diesel generator on a vibration pad, the exhaust routed through the wall. The noise inside the room is punishing. Fuel storage is in a separate locker, separated by a fire wall."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Supply Stack"
     slug: supply-stack
     description: "Pallets of sealed water, canned food, and emergency rations stacked against the back wall, dated and rotated. The inventory is stenciled on a board by the door. Quantities assume a specific number of people for a specific number of days."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Radio Corner"
     slug: radio-corner
     description: "A desk with a transceiver, a battery charger, and a laminated frequency card taped to the wall. The radio is the connection to outside when the door is sealed. A log book records every transmission in and out."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Hatch"
     slug: the-hatch
     description: "A secondary exit in the ceiling, a steel plate with a wheel-lock mechanism. It opens onto the roof for post-storm assessment. The hatch is tested monthly and greased on a schedule noted in marker on the frame."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Water Storage"
     slug: water-storage
     description: "Polyethylene tanks plumbed in series along one wall, gravity-fed to a single tap. Total capacity covers the rated occupancy for seventy-two hours. The water tastes of plastic and purification chemicals."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "First Aid"
     slug: first-aid
     description: "A wall-mounted cabinet with a red cross on the door, stocked for trauma, dehydration, and environmental exposure. The contents are inventoried on a list taped inside the door. Items used are circled in pen and dated."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Map Wall"
     slug: storm-shelter-map-wall
     description: "A section of wall covered with laminated charts showing the local waterways, evacuation routes, and shelter locations. Tide tables and storm surge projections are updated seasonally. Pin holes from previous markings pepper the margins."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Vent"
     slug: storm-shelter-the-vent
     description: "An air intake duct in the ceiling with a manual damper and a filter housing. The vent provides airflow when the door is sealed, filtered against debris and rain. Closing it makes the interior bearable for about two hours before the air quality drops."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "All Clear"
     slug: all-clear
     description: "The shelter after the system passes — door opened, daylight flooding the interior, the air outside scrubbed clean and heavy with ozone. Debris covers the approach. The assessment of what remains begins with the first step outside."
     zone_slug: storm-shelter
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The On-Ramp"
     slug: the-on-ramp
     description: "A concrete transition from mainland road to the elevated causeway, the pavement rising above the surrounding marsh on packed fill. The road narrows to two lanes with no shoulder. The water begins immediately on both sides."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Mile One"
     slug: mile-one
     description: "Open water visible through the guardrail gaps, the road riding on concrete pilings above the surface. Pelicans fly at windshield height. The mainland shrinks in the rearview mirror while the destination is not yet visible ahead."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Mile Three"
     slug: mile-three
     description: "Deep enough into the crossing that land has disappeared in both directions. The water stretches to the horizon on either side. Wind hits the vehicle broadside with nothing to slow it. The isolation is sudden and complete."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Mile Seven"
     slug: mile-seven
     description: "The midpoint of the causeway, marked by a navigation tower and a channel marker. Water depth beneath the road reaches its maximum here. The bridge sways in sustained wind, the movement felt through the steering column."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Fishing Bridge"
     slug: fishing-bridge
     description: "A widened section of the causeway with a pull-off and a railing, the concrete stained with bait and fish blood. Anglers line the rail at dawn and dusk, lines disappearing into the dark water below. Tackle and coolers crowd the narrow walkway."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Drawbridge"
     slug: the-drawbridge
     description: "The movable span in the causeway, its counterweights and gears visible from the roadway. Traffic stops when the bridge opens for boat traffic, gates dropping across both lanes. The mechanical noise of the lift carries across the water."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Bait Shop"
     slug: bait-shop
     description: "A small building on pilings at the causeway's widest point, selling live bait, ice, tackle, and fuel. The interior smells of shrimp and seawater. Hand-lettered signs advertise species and prices in faded paint."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Pull-Off"
     slug: pull-off
     description: "A paved shoulder barely wide enough for a vehicle, the guardrail dented from previous misjudgments. The pull-off exists for emergencies — overheating, flat tires, the view. Standing here with traffic passing at speed is not comfortable."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Toll"
     slug: the-toll
     description: "A concrete booth straddling the roadway, the window at driver's-arm height. The booth is unmanned now, the toll collected electronically. The infrastructure remains because removing it would cost more than leaving it."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Mile Twelve"
     slug: mile-twelve
     description: "The far shore becoming visible as a green line above the water. The road descends toward it in a gentle grade. The pilings are shorter here, the water shallower, and the bottom visible through the murk. Land approaches with relief."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Pelican Rail"
     slug: pelican-rail
     description: "A section of railing where pelicans roost in a permanent colony, the concrete beneath whitewashed and corroded by guano. The birds hold their positions against traffic noise and wind, unbothered. They have been here longer than the road."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Off-Ramp"
     slug: the-off-ramp
     description: "The causeway descending back to ground level, wheels meeting solid earth after the long water crossing. Vegetation closes in on both sides. The transition from exposure to enclosure is immediate and complete."
     zone_slug: the-causeway
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Trading Floor"
     slug: trading-floor
     description: "Screens tile every surface from floor to ceiling, scrolling numbers in columns of light that move faster than the eye can track. The air hums with climate control and the low murmur of voices calibrated to convey urgency without alarm. Bodies pivot between terminals in choreographed efficiency, no one standing still for longer than a breath."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Marble Lobby"
     slug: marble-lobby
     description: "White marble veined with gray stretches from wall to wall, polished to a mirror finish that doubles the height of the already towering atrium. Footsteps echo with deliberate acoustics — every sound amplified to remind visitors they are being heard. Security stands at intervals along the walls, uniformed and expressionless."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Bull Statue"
     slug: bull-statue
     description: "A bronze bull three meters at the shoulder guards the intersection of two corridors, its surface worn bright at the horns by decades of hands reaching out in passing. The pedestal bears no plaque. Everyone who belongs here already knows what it means."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Vault"
     slug: the-exchange-the-vault
     description: "Reinforced doors set flush into the wall, their seams barely visible. The air beyond them is ten degrees cooler and carries the dry chemical scent of fire-suppression systems on standby. Even the lighting changes — dimmer, more focused, stripped of the lobby's theatrics."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Glass Office"
     slug: glass-office
     description: "Floor-to-ceiling windows on three sides offer a vertiginous view down thirty stories to the street. The desk faces inward, away from the glass — whoever sits here stopped being impressed by the height long ago. A single terminal glows on the surface, its screen angled away from the door."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Corner Office"
     slug: the-exchange-corner-office
     description: "Two glass walls meet at a right angle, framing a panorama of the harbor where it bends into open water. The furniture is minimal — dark wood, low chairs, nothing soft. This room was designed for conversations where comfort would be a disadvantage."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Boardroom"
     slug: the-boardroom
     description: "An oval table of black stone seats twenty, each chair identical, each place set with a glass of water and nothing else. The walls are paneled in something dark and sound-absorbing. Natural light enters from a single narrow window at the far end, too high to see anything but sky."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Express Elevator"
     slug: the-exchange-express-elevator
     description: "Steel doors open onto a compartment the size of a closet, lined in brushed metal. The panel shows only six floors — all above the fortieth. Acceleration presses weight into the soles for a three-second count before the doors open again onto a different kind of silence."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Coffee Cart"
     slug: the-exchange-coffee-cart
     description: "A stainless steel cart parked against the lobby wall, attended by a single person who moves with mechanical precision. The line forms without being told, ten deep at peak hours, dissolving to nothing in between. Nobody lingers after receiving their cup."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Security Checkpoint"
     slug: security-checkpoint
     description: "Turnstiles of polished steel flanked by scanners that read credentials from three meters away. The guards stand behind a curved desk of dark composite, their screens facing inward. The line moves steadily, each person admitted or diverted without a word exchanged."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Bell"
     slug: the-bell
     description: "A brass bell mounted in a glass case at the center of the main corridor, rung once each day at market open. The case is fingerprint-smudged at child height — visitors touch it for luck, or habit. The bell itself has not been physically struck in decades; the sound is piped through the building's audio system."
     zone_slug: the-exchange
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Power Lunch"
     slug: power-lunch
     description: "A restaurant occupying the northeast corner of the forty-second floor, every table positioned for a harbor view. White tablecloths, heavy silverware, no music. Conversations happen at volumes calibrated so that neighboring tables hear the cadence but not the content. ---"
     zone_slug: the-exchange
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Crosswalk"
     slug: crosswalk
     description: "Pedestrians mass at the curb in tight formation, waiting for the signal to shift. When it does, two hundred people cross in opposite directions without collision, moving through each other like rehearsed currents. The whole cycle takes eleven seconds."
     zone_slug: midtown
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Canyon Street"
     slug: canyon-street
     description: "Buildings rise sixty stories on either side, compressing the sky into a bright ribbon overhead. Wind accelerates through the gap, snapping at coats and scattering debris in spirals at the intersections. Down at street level, shadow holds until midday."
     zone_slug: midtown
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Revolving Door"
     slug: midtown-revolving-door
     description: "Brass and glass spinning in continuous motion, each compartment admitting one body at a time into the lobby beyond. The mechanism never stops — people time their entry to its rotation or get nudged aside by the next panel. Cold air and warm air trade places in the gap."
     zone_slug: midtown
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Awning"
     slug: midtown-the-awning
     description: "A striped canvas awning extends over the sidewalk, its edge dripping condensation from the climate differential between building exhaust and harbor air. Pedestrians duck under it without slowing. The shop beneath hasn't changed its signage in forty years."
     zone_slug: midtown
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Hot Dog Stand"
     slug: hot-dog-stand
     description: "A steel cart wedged between a fire hydrant and a ventilation grate, tended by someone who works without looking up. Steam rises from the surface in a continuous plume that smells of salt and grease. The line is three people deep at any hour, rain or otherwise."
     zone_slug: midtown
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Taxi Stand"
     slug: taxi-stand
     description: "A painted curb where vehicles idle bumper to bumper, their engines cycling in low hums. A dispatcher controls the queue from a post no bigger than a phone booth, waving each car forward with a gesture so practiced it's barely visible. Nobody waits more than ninety seconds."
     zone_slug: midtown
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Marquee Billboard"
     slug: marquee-billboard
     description: "A display surface covering the entire face of a twelve-story building, cycling through images so vivid they cast colored light across the street below. Pedestrians walk through shifting pools of blue and gold without looking up. The content changes every eight seconds."
     zone_slug: midtown
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Intersection"
     slug: midtown-the-intersection
     description: "Four streams of foot traffic converge where two major corridors meet, creating a vortex of bodies that somehow never quite collides. Signals cycle overhead. A traffic controller stands on a raised platform at the center, more decorative than functional — the crowd has long since learned to regulate itself."
     zone_slug: midtown
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Steam Vent"
     slug: midtown-steam-vent
     description: "A grate in the sidewalk exhales a steady column of white vapor that smells of heated metal and old water. Pedestrians split around it without breaking stride. In cold weather, the plume rises four stories before the wind shears it apart."
     zone_slug: midtown
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Newspaper Box"
     slug: newspaper-box
     description: "A row of dispensers bolted to the sidewalk, their windows showing headlines behind scratched plastic. Most are empty. One still cycles content on a small screen, its power source unknown, displaying news feeds that no one stops to read."
     zone_slug: midtown
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Express Lane"
     slug: express-lane
     description: "A narrow pedestrian corridor separated from the main sidewalk by a low rail, reserved for foot traffic moving at speed. Slower walkers who drift into it get shouldered aside without apology. The surface is worn smooth by the volume."
     zone_slug: midtown
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Tower Shadow"
     slug: midtown-tower-shadow
     description: "The northwest corner of the block sits in permanent shadow cast by the tallest building in the district. Even at midday, the temperature drops three degrees at the shadow line. Vendors on the shaded side wear heavier coats than those ten meters away in the sun. ---"
     zone_slug: midtown
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Theater Row"
     slug: theater-row
     description: "Marquees line both sides of the street for six blocks, their lights bleeding together into a continuous wash of color. The buildings behind them are old stone, their facades hidden beneath scaffolding and signage. Crowds move between venues in a slow current that thickens after dark."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Box Office"
     slug: the-box-office
     description: "A window set into the wall at street level, protected by thick glass and a brass speaking grate. The attendant sits behind a terminal, visible only from the chest up. A velvet rope channels the queue along the building's face and around the corner."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Neon Alley"
     slug: neon-alley
     description: "A narrow passage between two theaters where the neon from both sides overlaps, saturating the walls in competing color. The pavement is slick with condensation. Stage doors open onto it from both buildings, and the sound of two different orchestras bleeds through the brick."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Stage Door"
     slug: stage-door
     description: "A steel door painted black, unmarked except for a number stenciled at eye height. A single light burns above it. The alley smells of cigarette smoke and damp concrete, and the muffled thump of bass vibrates through the wall."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Lobby"
     slug: the-marquee-the-lobby
     description: "Gilt-framed mirrors multiply the crowd into an infinite regression of evening clothes and polished shoes. Crystal chandeliers throw prismatic light across a carpet so deep it swallows footsteps. The ceiling mural has darkened with age but nobody looks up — all eyes are on each other."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Orchestra Pit"
     slug: orchestra-pit
     description: "Below the stage lip, a sunken space barely wide enough for the musicians and their instruments. The conductor's podium puts eye level at the performer's knees. Sheet music is lit by individual lamps that cast the faces in sharp upward shadow. The pit smells of rosin and old wood."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Balcony Seats"
     slug: balcony-seats
     description: "Three tiers of curved seating rise above the orchestra level, each row slightly steeper than the last. The top row presses close to the ceiling, where plaster molding meets painted sky. From here, the stage is a bright rectangle far below, the performers reduced to gesture and color."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Intermission Hall"
     slug: intermission-hall
     description: "A long gallery connecting the lobby to the upper levels, lined with framed playbills from productions decades past. Crystal sconces cast warm pools along the carpet. The crowd mills between a small bar and the restrooms, their conversations pitched to carry over the ambient hum."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Marquee Sign"
     slug: the-marquee-sign
     description: "Letters three meters tall mounted on a steel frame above the entrance, each one outlined in hundreds of individual bulbs. Some flicker at slightly different intervals, giving the sign a pulse. Below it, the sidewalk glows bright enough to read by, even at midnight."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Ticket Window"
     slug: ticket-window
     description: "A brass-framed opening in the facade, no larger than a dinner plate, backed by frosted glass. The transaction happens through a shallow trough worn smooth by a century of hands passing money and paper back and forth. A small screen displays showtimes in amber text."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Side Stage"
     slug: side-stage
     description: "Black curtains partition a space barely three meters wide between the main stage and the fire exit. Props lean against the walls in careful disorder. The floor is marked with tape in six colors, each indicating a different cue. Sound from the performance comes through muffled, more felt than heard."
     zone_slug: the-marquee
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "After Party"
     slug: after-party
     description: "A rooftop terrace accessible only through the theater's back stairwell, furnished with mismatched chairs and string lights that were temporary a decade ago. The view faces east over the harbor. Bottles accumulate on every flat surface by the end of the night, and the conversations run until the sky grays. ---"
     zone_slug: the-marquee
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Great Lawn"
     slug: great-lawn
     description: "An expanse of maintained grass stretching four hundred meters between rows of trees, impossibly green for a space surrounded by concrete on all sides. People sprawl across it in loose clusters, the first open sky visible in any direction since entering the district. The towers frame it like walls around a courtyard."
     zone_slug: the-green
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Pond"
     slug: the-pond
     description: "Dark water reflecting the surrounding tree canopy and, beyond it, the tops of buildings. Ducks cut V-shaped wakes across the surface. A low stone wall rings the perimeter, worn smooth where people sit, and the water smells of algae and rain."
     zone_slug: the-green
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Bridle Path"
     slug: bridle-path
     description: "A packed-dirt trail wide enough for two horses abreast, separated from the main paths by a low fence. Hoofprints dimple the surface in overlapping patterns. The trees arch overhead, filtering light into shifting patterns on the ground. The sound of traffic drops away within twenty paces."
     zone_slug: the-green
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Bandshell"
     slug: the-bandshell
     description: "A concrete half-dome set into a hillside, its acoustic curve directing sound outward across a sloped lawn. The stage is bare concrete, cracked at the edges where tree roots push through. Metal chairs stack against the back wall. When empty, the shell amplifies the wind into a low, continuous tone."
     zone_slug: the-green
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Conservatory"
     slug: conservatory
     description: "Glass panels held in an iron frame form a Victorian structure that holds tropical heat year-round. Inside, the air is thick and wet, carrying the smell of soil and flowering plants that have no business surviving at this latitude. Condensation runs down the interior glass in steady rivulets."
     zone_slug: the-green
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Ramble"
     slug: the-ramble
     description: "Paths branch and reconnect through dense plantings that block sightlines in every direction. Within thirty seconds of entering, the surrounding city disappears — only tree canopy and birdsong, as if the park had swallowed its own borders. The trails are deliberately confusing, designed to slow the pace."
     zone_slug: the-green
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Boathouse"
     slug: boathouse
     description: "A wooden structure at the water's edge, its dock extending ten meters over the pond. Rowboats knock against each other in their slips, and the smell of varnish and lake water mixes in the still air. The interior is dim and cool, hung with life vests that haven't been moved in years."
     zone_slug: the-green
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Fountain"
     slug: the-green-the-fountain
     description: "Water arcs from a central column into a wide basin, the spray catching light and throwing tiny rainbows across the surrounding pavement. The basin rim serves as seating for dozens of people at a time. Coins glint at the bottom through green-tinged water."
     zone_slug: the-green
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Jogger's Loop"
     slug: joggers-loop
     description: "A paved circuit tracing the park's perimeter, marked at quarter-mile intervals. Runners move in a steady counter-clockwise stream, their footfalls creating a continuous rhythm against the asphalt. The path narrows where tree roots have buckled the surface, forcing single-file passage."
     zone_slug: the-green
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Meadow"
     slug: the-green-the-meadow
     description: "Tall grass and wildflowers occupy a gentle slope between two stands of trees, untended and deliberate in its wildness. Butterflies work the flower heads in erratic patterns. It's the one place in The Narrows where the ground isn't level, and the slight rise offers a rare view over the treetops to the skyline."
     zone_slug: the-green
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Stone Bridge"
     slug: stone-bridge
     description: "A single arch of gray stone spanning a narrow stream that feeds the pond. The railings are low, the stones fitted without mortar, darkened with age and spotted with lichen. Water passes underneath with barely a sound, shallow enough to see the pebbled bottom."
     zone_slug: the-green
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Park Bench"
     slug: the-green-park-bench
     description: "A wooden bench with iron armrests facing a grove of old oaks, set back from the main path where foot traffic fades to nothing. The slats are weathered pale and carved with initials layered over initials. From here, the city is just a hum behind the trees, almost ignorable. ---"
     zone_slug: the-green
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Neon Arcade"
     slug: neon-arcade
     description: "Rows of game cabinets flash in competing colors, their screens cycling attract modes to an empty room that won't fill until after midnight. The carpet is dark enough to hide everything. Somewhere in the back, past the visible machines, the layout stops making sense — too many turns for the building's footprint."
     zone_slug: neon-district
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Dance Club"
     slug: dance-club
     description: "Bass hits the chest before the eyes adjust to the dark. Strobes freeze the crowd in stop-motion snapshots — hands up, faces tilted, bodies pressed together in a mass that moves as one organism. The DJ booth sits elevated behind a wall of speakers, the operator's face lit only by the glow of their controls."
     zone_slug: neon-district
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Hologram Alley"
     slug: hologram-alley
     description: "Projected figures walk alongside the living, their edges flickering where the emitters overlap. Some are advertisements, some are art installations, some are unattributed — they simply appeared one night and no one removed them. The effect is a street where half the population isn't physically present."
     zone_slug: neon-district
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Pop-Up Gallery"
     slug: pop-up-gallery
     description: "A storefront that changes identity every seventy-two hours, its walls repainted and rehung between midnight and dawn. Tonight it's photography — harsh black and white images of harbor infrastructure. Tomorrow it could be anything. The only constant is the crowd outside, drawn by the novelty of not knowing what's inside."
     zone_slug: neon-district
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Bounce"
     slug: the-bounce
     description: "A venue with no fixed interior — the walls, floor, and ceiling are all projection surfaces that reshape the space in real time. One moment it's an infinite white void, the next a claustrophobic tunnel of color. The music synchronizes with the environment. Regulars navigate by sound; newcomers reach for walls that aren't where they appear."
     zone_slug: neon-district
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Electric Avenue"
     slug: electric-avenue
     description: "Every storefront on this block runs its signage at maximum output, creating a corridor of light so bright it eliminates shadow entirely. The pavement glows with reflected color. At street level, the effect is almost clinical — flat, shadowless, every detail visible. It feels like standing inside a screen."
     zone_slug: neon-district
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "LED Tunnel"
     slug: led-tunnel
     description: "A pedestrian underpass lined floor to ceiling with programmable light panels that pulse in slow waves of color as people walk through. The tunnel stretches forty meters, and the light patterns shift based on foot traffic density, though no one has confirmed whether this is deliberate or emergent. Sound dampens to nothing by the midpoint."
     zone_slug: neon-district
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Mirror Room"
     slug: mirror-room
     description: "Mirrored walls, floor, and ceiling fragment the room into infinite reflections. Three people become three hundred. The light sources are hidden, and the reflections make the space's actual dimensions impossible to judge. Some version of every person in the room is always watching from an angle they can't identify."
     zone_slug: neon-district
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Glow Bar"
     slug: glow-bar
     description: "The bar surface is a light panel that changes color with the temperature of each drink placed on it. The bottles behind the bartender are backlit in ultraviolet, their labels unreadable but their contents glowing in blues and greens. Conversation happens in low tones, faces underlit like campfire stories told in reverse."
     zone_slug: neon-district
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Flash"
     slug: the-flash
     description: "A small venue where the entire room — walls, bar, dance floor — strobes to white for one second every thirty, then returns to near-total darkness. Eyes never fully adjust. The regulars move through the blackout intervals from memory. First-timers freeze in place, waiting for the next pulse to show them where they are."
     zone_slug: neon-district
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Projection Wall"
     slug: projection-wall
     description: "A blank concrete wall spanning an entire city block, used as a canvas for rotating visual installations projected from the rooftop opposite. Tonight, abstract shapes morph in slow motion, casting the street below in shifting pools of amber and violet. Crowds gather on the sidewalk across the street, watching in silence."
     zone_slug: neon-district
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Black Light Lounge"
     slug: black-light-lounge
     description: "Ultraviolet fixtures strip the room of its natural palette and replace it with phosphorescent blues and purples. White clothing blazes. Teeth glow. Drinks in certain glasses emit light. The furniture is low and dark, arranged in clusters that create private spaces within the larger room. Whatever this place looks like in daylight, nobody has seen it. ---"
     zone_slug: neon-district
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Brownstone Row"
     slug: brownstone-row
     description: "Sandstone facades line both sides of the street in a continuous wall of arched windows and iron railings. The stoops are limestone, each one identical in dimension but unique in the way the stone has worn. Trees in iron grates break the sidewalk at even intervals, their canopies meeting overhead."
     zone_slug: the-heights
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Penthouse Level"
     slug: penthouse-level
     description: "The elevator opens onto a private foyer with a single door. Floor-to-ceiling glass wraps the space, offering an uninterrupted panorama of the harbor, the bridges, and the open water beyond. The ceiling is low enough to feel intimate despite the scale. Everything up here is deliberate — the quiet, the light, the distance from the street."
     zone_slug: the-heights
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Fire Escape"
     slug: the-heights-fire-escape
     description: "Iron stairs zigzag down the building's east face, bolted to brick that has stained rust-orange around every anchor point. The landings are just wide enough to stand on. Looking down through the grated steps, the alley drops away forty stories to a strip of shadow where the sun never reaches."
     zone_slug: the-heights
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Stoop"
     slug: the-heights-the-stoop
     description: "Five limestone steps rising from the sidewalk to a heavy wooden door, flanked by iron railings worn smooth by generations of hands. Neighbors occupy the steps in the evening, arranged by habit into positions that haven't changed in years. The door behind them stays propped open when the temperature allows."
     zone_slug: the-heights
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Terrace Garden"
     slug: terrace-garden
     description: "A narrow strip of cultivated green running along the top of a retaining wall, three stories above the street. Herbs and flowering plants grow in raised beds made from reclaimed stone. The gardener's tools hang from hooks on the back wall, and the soil smells of compost and recent rain."
     zone_slug: the-heights
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Window View"
     slug: window-view
     description: "A bay window on the fifth floor, deep enough to sit in, framing a view of the rooftops descending toward the harbor. The glass is old and slightly warped, bending the light into soft distortions at the edges. A radiator clicks beneath the sill, and the sash rattles when the wind shifts."
     zone_slug: the-heights
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Water Tower"
     slug: the-water-tower
     description: "A wooden tank on steel legs standing above the roofline, its planks darkened with age and streaked with mineral deposits. A maintenance ladder runs up one leg. From the catwalk at its base, the surrounding rooftops spread out in a jumble of vents, antennae, and tarred surfaces."
     zone_slug: the-heights
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Iron Railing"
     slug: iron-railing
     description: "Wrought iron running along the edge of an upper walkway, each baluster cast with a simple repeating pattern. Paint has peeled to reveal layers — black over green over red over bare metal. The railing vibrates slightly with the building's internal systems, a hum felt through the palms."
     zone_slug: the-heights
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Stone Steps"
     slug: the-heights-stone-steps
     description: "Granite stairs descending from the upper streets to the lower waterfront level, each step shallow enough for the grade and worn concave in the center. The walls on either side are damp with condensation where the temperature changes between elevations. Moss fills the joints between stones."
     zone_slug: the-heights
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Balcony"
     slug: the-heights-the-balcony
     description: "A Juliet balcony barely deep enough to stand on, its iron railing extending just past the window frame. The view is directly down to the street, close enough to hear individual conversations but too high to make out faces. Laundry occasionally hangs from the rail, snapping in the updraft."
     zone_slug: the-heights
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Upper Walk"
     slug: upper-walk
     description: "An elevated pedestrian path connecting two residential blocks across a courtyard, enclosed by glass on both sides. The walkway is narrow and the glass is tinted, creating a sense of moving through a tunnel of muted light. Below, the courtyard drops away to a communal garden that few people seem to use."
     zone_slug: the-heights
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Sky Garden"
     slug: sky-garden
     description: "A rooftop converted to green space, its perimeter walls high enough to block the wind but low enough to preserve the skyline view. Raised beds hold ornamental grasses and small trees that have been shaped by persistent harbor gusts into permanent leans. Benches face outward toward the water. ---"
     zone_slug: the-heights
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Access Door"
     slug: access-door
     description: "A steel door propped open with a cinder block, its alarm long since disabled or ignored. Beyond it, daylight hits hard after the dim stairwell. The threshold marks a transition — from the building's controlled interior to the open roof, where the wind carries the smell of tar and salt."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Tar Beach"
     slug: tar-beach
     description: "Flat black roofing material absorbing heat, soft underfoot in summer and brittle in cold. Lawn chairs and towels claim scattered territories. The surrounding buildings rise higher on all sides, creating a sheltered basin of still air. From up here, the street noise compresses into a single continuous tone."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Ledge"
     slug: the-rooftop-the-ledge
     description: "A low parapet of brick running along the roof's edge, topped with a concrete cap wide enough to sit on. The drop beyond is straight down — forty floors of glass and stone ending at a sidewalk no wider than a hallway. Wind pulls at clothing with inconsistent force."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Antenna Forest"
     slug: antenna-forest
     description: "Metal masts and crossbars cluster at the roof's highest point, their cables stretching to anchor points across the tar surface. Some carry blinking lights at their tips. The structures hum and vibrate at different frequencies, creating a layered drone that rises and falls with wind speed."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Ventilation Unit"
     slug: ventilation-unit
     description: "A housing of painted steel the size of a small room, its fan spinning behind a heavy grate. Warm air exhales from it continuously, carrying the building's interior atmosphere — cooking, cleaning chemicals, recycled breath — out into the open. The noise is a constant low roar that masks everything within five meters."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Coop"
     slug: the-coop
     description: "A wooden structure tucked against the stairwell housing, its mesh walls enclosing a space just large enough for a dozen birds. Feathers collect in the corners and blow across the roof in gusts. The door latches with a bent nail, and the interior smells of grain and dry droppings."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Solar Panel"
     slug: the-rooftop-solar-panel
     description: "Angled photovoltaic arrays mounted on aluminum frames, their surfaces tilted south and streaked with grime. The walkways between them are narrow and the cables underfoot are tripping hazards secured with weathered zip ties. A monitoring box on the wall blinks green at intervals."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Water Tank"
     slug: the-rooftop-water-tank
     description: "A cylindrical steel tank mounted on a concrete pad, its surface streaked with rust where the paint has failed. A pipe runs from its base into the rooftop, and an overflow valve on the side drips at irregular intervals. The tank makes a hollow ringing sound when the wind catches it right."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Gravel Walk"
     slug: gravel-walk
     description: "Loose stone crunches underfoot along a path worn between the stairwell door and the roof's far edge. The gravel is gray and uniform, spread over a waterproof membrane that shows through in patches where foot traffic has scattered the stone. Small weeds push up at the margins."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Parapet"
     slug: the-parapet
     description: "Brick walls rise waist-high around the roof's perimeter, their inner faces stained with decades of rain runoff. The concrete cap is cracked in places, the rebar showing through in rust-colored lines. From any point along the parapet, at least three bridges are visible spanning the harbor."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Satellite Dish"
     slug: satellite-dish
     description: "A white dish two meters across, bolted to a steel post sunk into the roof structure. Its face angles skyward, tracking something unseen. The mounting hardware is newer than the dish itself — replaced recently, the bolts still bright. A cable runs from its base to a junction box on the stairwell wall."
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Sunset View"
     slug: the-rooftop-sunset-view
     description: "The western edge of the roof, where the parapet meets a wider observation area paved in concrete. From here, the sun drops behind the skyline of the adjacent peninsula, turning the harbor water orange and black. The wind dies at this hour, and the city's hum settles into a lower register. ---"
     zone_slug: the-rooftop
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "West Anchorage"
     slug: west-anchorage
     description: "Massive stone blocks anchor the bridge cables to the peninsula bedrock, their surfaces slick with spray carried up from the water below. The anchorage building sits half-buried in the hillside, its doors rusted shut. Traffic overhead creates a continuous low vibration felt through the ground."
     zone_slug: the-span
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "East Anchorage"
     slug: east-anchorage
     description: "The bridge meets land on a platform of reinforced concrete, the cables fanning down into the stone like the roots of an inverted tree. Pedestrian access passes through a narrow gap between the anchorage wall and a chain-link fence. The sound of tires on steel decking is constant."
     zone_slug: the-span
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Cables"
     slug: the-cables
     description: "Steel cables thick as a human torso rise from the anchorages in sweeping arcs, each composed of thousands of individual wires twisted into a single mass. Up close, the surface is rough and cold, vibrating with a frequency that changes pitch in the wind. Maintenance walkways run alongside them at intervals."
     zone_slug: the-span
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Suspension Walk"
     slug: suspension-walk
     description: "A pedestrian path slung beneath the bridge deck, enclosed by chain-link on both sides. The harbor opens below through the mesh — container ships, ferry wakes, dark water moving with the current. Wind enters from every direction, and the walkway sways on cables of its own, independent of the traffic above."
     zone_slug: the-span
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Midspan"
     slug: the-span-midspan
     description: "The highest point of the bridge deck, where the road crests between the two towers. The view opens in every direction — harbor, ocean, islands, the full skyline of The Narrows spread across its peninsulas. At this height, the wind is unbroken and steady, and the deck flexes perceptibly underfoot."
     zone_slug: the-span
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Tower One"
     slug: tower-one
     description: "A stone-and-steel tower rising from the water, its base surrounded by a skirt of concrete that meets the surface at the tide line. The tower narrows as it climbs, its face studded with maintenance ladders and inspection platforms. Red lights blink at the top in a pattern visible from every point in the harbor."
     zone_slug: the-span
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Tower Two"
     slug: tower-two
     description: "The second tower stands at the span's eastern quarter, identical to its counterpart in construction but different in the way weather has marked it — the windward face paler, scoured clean, the leeward side dark with accumulation. A flock of birds nests in the cable saddle at the top."
     zone_slug: the-span
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Below Deck"
     slug: below-deck
     description: "The underside of the bridge is a grid of steel beams and cross-bracing, visible from the pedestrian walkway. Paint peels in long strips, revealing older paint beneath — layer after layer going back to bare metal. The space between the deck and the water is vast and dim, filled with the echo of traffic."
     zone_slug: the-span
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Catwalk"
     slug: the-span-the-catwalk
     description: "A narrow grated platform running along the bridge's outer edge, accessible only through locked maintenance doors. The catwalk has no railing on the water side — just a cable at waist height. The view straight down is two hundred meters of empty air to the harbor surface."
     zone_slug: the-span
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Toll Plaza"
     slug: toll-plaza
     description: "A widening of the road at the bridge's west approach, where lanes fan out through a row of automated gates. The booths are unmanned, their windows dark. Overhead signage displays lane assignments in green and red. The pavement is stained with oil in patterns that trace the most common tire paths."
     zone_slug: the-span
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Bridge View"
     slug: bridge-view
     description: "A small overlook platform built into the hillside below the west anchorage, fenced and furnished with a single bench. From here, the full span of the bridge is visible — its cables catching light, its towers framing the harbor entrance. Tour groups stop here for photographs. The bench is always occupied."
     zone_slug: the-span
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Pylon"
     slug: the-pylon
     description: "A support column rising from the water to the bridge deck, its concrete surface crusted with barnacles to the tide line and stained green above it. A ladder of corroded rungs runs up one face, ending at an inspection hatch that hasn't been opened in years. Waves slap against the base in irregular rhythms. ---"
     zone_slug: the-span
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Towpath"
     slug: towpath
     description: "A narrow stone path running along the canal's edge, worn smooth by centuries of foot traffic before the city grew over it. The water moves slowly beside it, dark and reflective. Brick warehouses line the opposite bank, their loading doors sealed, their reflections broken by the occasional ripple."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Lock Gate"
     slug: lock-gate
     description: "Heavy timber gates held in iron frames, designed to raise or lower the water level between canal sections. The mechanism is manual — a wheel mounted on the gate arm, its teeth green with algae. Water seeps through the gaps between the timbers in steady trickles that catch the light."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Sluice"
     slug: the-sluice
     description: "A controlled gap in the canal wall where water is diverted through a grated channel into the underground drainage system. The flow rate changes with the tide, and at peak current the water roars through the opening with enough force to pull debris against the grate."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Canal Boat"
     slug: canal-boat
     description: "A narrow vessel moored to iron rings set into the towpath wall, its hull painted in faded colors. The cabin windows are dark. A plank spans the gap between the boat's deck and the stone path, bowed in the middle from use. Ropes creak where they wrap around the mooring posts."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Stone Wall"
     slug: canal-walk-stone-wall
     description: "Blocks of cut granite stacked without mortar form the canal's retaining wall, their faces darkened with water stain below the high-water mark and spotted with lichen above. Ferns grow from the joints where mortar once was. The wall curves with the canal, following a line older than any building above it."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Turning Basin"
     slug: the-turning-basin
     description: "A widening of the canal where boats once reversed direction, now too silted for anything deeper than a kayak. The water is still here, almost stagnant, its surface filmed with pollen in spring and fallen leaves in autumn. Stone steps descend into the basin from three sides."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Bridge Arch"
     slug: bridge-arch
     description: "A semicircular arch of dressed stone spanning the canal, its underside blackened by exhaust and age. The towpath passes beneath it, and for a moment the sound changes — footsteps amplify, water echoes, the city muffles. Pigeons roost in the mortar gaps above, and their droppings streak the stone in white."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Waterfall Step"
     slug: waterfall-step
     description: "Where the canal drops two meters through a series of stone ledges, the water breaks into a curtain of white that fills the passage with mist and noise. The towpath narrows here, protected by an iron railing beaded with moisture. Moss coats every horizontal surface within the spray zone."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Overgrown Bank"
     slug: overgrown-bank
     description: "Vegetation has reclaimed a section of the canal's south bank where a retaining wall collapsed. Willow branches trail into the water, and ivy covers the rubble to the point where the original structure is only a suggestion beneath the green. The path detours around it through a narrow gap."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Iron Mooring"
     slug: iron-mooring
     description: "A series of mushroom-shaped bollards cast in iron, bolted to the towpath at regular intervals. Each one is worn to a polish on top where ropes have passed over it. Some still hold frayed lines tied in knots that have tightened beyond any possibility of release."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Abutment"
     slug: the-abutment
     description: "The base of a bridge where stone meets the canal wall, a massive wedge of masonry that deflects the current around it. The water runs faster here, and the sound of it hitting the stone is a continuous low slap. Graffiti marks the stone above the water line in layers."
     zone_slug: canal-walk
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Still Water"
     slug: still-water
     description: "A dead-end branch of the canal where the flow ceases entirely, the water so motionless it holds a perfect reflection of the buildings overhead. The surface is dark and glassy, broken only by the occasional ring of an insect touching down. The air here is cooler and smells of wet stone. ---"
     zone_slug: canal-walk
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Fish Market"
     slug: fish-market
     description: "Concrete stalls arranged in rows under a corrugated roof, their surfaces hosed down to a permanent wet sheen. Ice fills the display cases, and the catch sits on it in neat rows — whole fish, eyes clear, scales still bright. The air is cold and sharp with brine. Buyers and sellers negotiate in shorthand."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Lobster Trap"
     slug: lobster-trap
     description: "Wooden and wire traps stacked head-high along the dock wall, their frames salt-bleached and tangled with dried seaweed. The pile extends thirty meters along the wharf, narrowing the pedestrian path to single file. The smell is concentrated ocean — brine, shell, rot — intensifying in the heat."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Dock Three"
     slug: dock-three
     description: "A timber dock extending twenty meters over the water, its planks bowed and darkened by salt. Bollards line both edges, and ropes in various states of decay tie off to them in practiced knots. The dock shifts slightly underfoot with the swells, and creosote rises from the pilings in the afternoon heat."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Crane"
     slug: the-wharf-the-crane
     description: "A dockside crane standing four stories tall, its arm extended over the water at a fixed angle. The steel is painted in alternating stripes of red and white, both faded. The operator's cab is dark. Cables hang from the boom in slack loops, and the whole structure groans when the wind gusts off the harbor."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Cargo Net"
     slug: cargo-net
     description: "Heavy rope netting draped over a pallet of crates on the dock, its mesh knotted at each intersection with precision. The crates are unmarked wood, stacked three high and lashed to a steel frame. A hook on a cable hangs motionless above, waiting to lift the load."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Seabird"
     slug: the-seabird
     description: "A trawler moored at the far end of the wharf, its hull streaked with rust below the waterline and painted blue above it. Nets hang from the outriggers, drying in the wind. The deck is cluttered with coiled rope, bait buckets, and equipment bolted to the gunwales. Diesel fumes drift from the exhaust."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Wet Cobblestone"
     slug: wet-cobblestone
     description: "The wharf's access road is paved in cobblestones that stay perpetually wet from spray, runoff, and the hoses used to clean the fish stalls each morning. The stones are uneven and slick, and the surface reflects the overhead lights in distorted pools. Truck tires have worn two parallel tracks through the center."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Salt Air"
     slug: salt-air
     description: "An open section of the wharf where the buildings fall back and the harbor wind arrives without obstruction. The air tastes of salt and carries the sound of water against hulls, rigging against masts, engines idling. The concrete underfoot is stained white with dried spray."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Bollard"
     slug: the-bollard
     description: "A single cast-iron bollard standing at the dock's edge, its surface polished by rope friction to a dark shine. A hawser thick as an arm loops around it twice, its far end disappearing over the dock's edge to a vessel below. The bollard is anchored to the concrete with bolts the size of fists."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Shipping Container"
     slug: shipping-container
     description: "Steel boxes stacked two high along the wharf's back wall, their corrugated surfaces dented and sun-faded to pastel versions of their original colors. The containers are locked and unmarked beyond a serial number stenciled on each door. The narrow gaps between them create corridors of deep shadow."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Tide Line"
     slug: the-tide-line
     description: "A horizontal mark on the wharf pilings where wet stone meets dry, shifting twice daily with the harbor tides. Below the line, the wood is dark and crusted with barnacles. Above it, the surface is bleached and splintering. At low tide, the pilings expose three meters of encrusted wood and the smell intensifies."
     zone_slug: the-wharf
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Old Dry Dock"
     slug: old-dry-dock
     description: "A rectangular basin cut into the waterfront, its walls of fitted stone descending six meters to a floor of cracked concrete. The dock gates are jammed in the open position, and harbor water fills it to within a meter of the rim. Rust stains run down the walls from iron fittings that once held ships in place. ---"
     zone_slug: the-wharf
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Channel Marker"
     slug: the-channel-marker
     description: "A steel piling driven into the harbor floor, topped with a navigation light that blinks red at three-second intervals. The marker stands alone in open water, its base crusted with marine growth visible at low tide. Boat wakes slap against it from every direction, the impacts overlapping into a continuous percussion."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Breakwater"
     slug: breakwater
     description: "A wall of piled stone extending from the shoreline into the harbor, its surface massive and irregular — granite blocks the size of vehicles stacked without pattern. Waves hit the outer face and shatter into spray that reaches the walkway on top. The leeward side is calm, the water dark and sheltered."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Deep Berth"
     slug: deep-berth
     description: "A section of the harbor wall where the water drops to fifteen meters, reserved for the largest vessels. The bollards here are enormous — waist-high steel mushrooms sunk into concrete that is stained and cracked from the loads placed on it. The scale of everything shifts at this depth."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Tanker Slip"
     slug: tanker-slip
     description: "A long narrow channel between two concrete piers, wide enough for a single vessel. Oil stains the water surface in rainbow films that break and reform with each ripple. The piers are lined with valve connections and hose fittings, their surfaces worn by use and weather."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Foghorn"
     slug: harbor-deep-the-foghorn
     description: "A horn mounted on a concrete platform at the harbor's edge, its bell-shaped opening pointed out to sea. When it sounds, the vibration travels through the ground for a hundred meters. The horn mechanism is housed in a small shed behind it, its door locked and its walls thick enough to muffle the sound inside."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Harbor Light"
     slug: harbor-light
     description: "A squat tower of white-painted concrete standing at the end of the outer breakwater, its light rotating behind a fresnel lens that concentrates the beam into a visible line sweeping the harbor entrance. The tower's base is wet to the second window, and the access door faces landward, sheltered from the worst weather."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Submarine Pen"
     slug: submarine-pen
     description: "A reinforced concrete enclosure half-submerged at the harbor's edge, its entrance a dark rectangle opening onto deep water. The interior is cavernous and echoing, the ceiling supported by pillars thick enough to absorb a direct hit. Water slaps against the walls inside, the sound amplified by the enclosed space."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Depth"
     slug: the-depth
     description: "Open water at the harbor's center where the bottom drops away to thirty meters. The surface here moves differently — longer swells, less chop, a sense of mass in the water that the shallows don't carry. Vessels passing through leave wakes that take minutes to dissipate."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Anchor Drop"
     slug: anchor-drop
     description: "A designated anchorage where vessels wait for berth assignments, their anchor chains descending into water too deep to see the bottom. The chains emerge from the hawse pipes at steep angles, taut with current, and the hulls swing slowly on their anchors as the tide shifts."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Pilot Station"
     slug: pilot-station
     description: "A floating platform moored at the harbor entrance where pilots board incoming vessels. The station rises and falls with the swells, its deck furnished with a small shelter, a radio antenna, and a set of steps descending to the water line where a launch ties up."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Wake"
     slug: the-wake
     description: "The disturbed water behind a passing vessel, spreading in a V-pattern that reaches both shores and spends itself against the seawalls in diminishing waves. Out here the wakes of multiple vessels overlap and interfere, creating a confused chop that rocks everything afloat and settles only in the absence of traffic."
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Cold Current"
     slug: cold-current
     description: "A temperature boundary where the deep harbor water meets the warmer outflow from the river, visible as a slight color difference on the surface. The colder water is darker, clearer. Where the two meet, the surface dimples and swirls in patterns that shift with the tide. The air above it drops five degrees. ---"
     zone_slug: harbor-deep
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Pier Gate"
     slug: pier-gate
     description: "A wrought-iron arch spans the pier entrance, its scrollwork rusted and its original lettering faded to shadows in the metalwork. Foot traffic funnels through the gap between two ticket booths, neither of them staffed. Beyond the gate, the pier stretches over the water in a straight line, its railings crowded."
     zone_slug: pier-41
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Amusement Stand"
     slug: amusement-stand
     description: "A plywood booth painted in primary colors, its counter lined with prizes no one takes home. The operator runs the same game on a loop — ring toss, ball throw, the mechanics unchanged in a century. The prizes swing on hooks in the harbor breeze, and the barker's voice competes with the seagulls."
     zone_slug: pier-41
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Ferry Slip"
     slug: ferry-slip
     description: "A concrete ramp descending into the water between two timber guide walls, its surface grooved for traction. The ferry noses in with its gate already lowering, and passengers file on and off in an exchange so practiced it takes less than two minutes. Diesel exhaust lingers after departure."
     zone_slug: pier-41
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Rail"
     slug: pier-41-the-rail
     description: "A continuous iron railing running the pier's full length, its top bar worn smooth and warm from the sun and from every hand that has ever leaned against it. The view through the rails is straight down to the water, which shifts from green to black depending on the depth and the cloud cover."
     zone_slug: pier-41
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Tourist Trap"
     slug: pier-41-tourist-trap
     description: "A cluster of small shops selling identical merchandise — miniature bridges, harbor snow globes, branded clothing that no resident would wear. The displays spill onto the pier deck, narrowing the walkway. Music plays from a speaker above each door, competing genres overlapping into noise."
     zone_slug: pier-41
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Seagull Post"
     slug: seagull-post
     description: "A timber piling at the pier's edge, its flat top worn white with droppings. A gull occupies it with territorial persistence, yielding to nothing. Other birds circle and land on the nearby railing, but the post belongs to one, and the hierarchy is enforced with wing displays and noise."
     zone_slug: pier-41
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Boardwalk"
     slug: the-boardwalk
     description: "Treated planks laid perpendicular to the pier's axis, their surfaces silvered by sun and salt. The boards flex underfoot and the gaps between them show water two meters below, dark and moving. The boardwalk is wide here — room for foot traffic in both directions with space between."
     zone_slug: pier-41
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The End"
     slug: the-end
     description: "The pier terminates at a semicircular platform extending over open water, its railing curving around a view that is nothing but harbor and sky. Wind comes from every direction at once. The platform sits higher than the rest of the pier, reached by a short ramp, and feels more exposed than any point on shore."
     zone_slug: pier-41
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Fish and Chips"
     slug: fish-and-chips
     description: "A takeaway window cut into the side of a clapboard shack, its service counter a steel shelf worn to a polish. Fryers hiss behind the window, and the smell of hot oil and salt carries fifty meters downwind. Seagulls orbit at a fixed radius, experienced enough to wait for the dropped basket."
     zone_slug: pier-41
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Bench Row"
     slug: pier-41-bench-row
     description: "A line of wooden benches facing the water, each one bolted to the pier deck and spaced at precise intervals. The wood is weathered but solid, the armrests shaped by years of elbows. The view from any bench is identical — harbor, sky, the far shore — but each seat has its regulars."
     zone_slug: pier-41
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Bell Buoy"
     slug: the-bell-buoy
     description: "A navigational buoy anchored fifty meters off the pier's end, its bell clanging with each swell that rolls beneath it. The sound is irregular and metallic, carrying across the water in unpredictable bursts. The buoy itself is a conical steel shape painted red, its surface streaked with gull droppings."
     zone_slug: pier-41
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Sunset Point"
     slug: pier-41-sunset-point
     description: "The pier's western railing at its farthest extension, where the view opens past the harbor mouth to the horizon. In the hour before dark, light comes in horizontal and turns the water into hammered metal. Spectators line the rail three deep on clear evenings, cameras raised, mostly silent. ---"
     zone_slug: pier-41
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Low Tide"
     slug: low-tide
     description: "The water retreats to expose a landscape of mud, rock, and the stumps of old pilings driven into the harbor floor before the current waterfront was built. Tidal pools form in the depressions, each one a small enclosed world. The exposed flats stretch fifty meters from the seawall to the water's edge and smell of brine and decay."
     zone_slug: tidewater
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "High Tide Mark"
     slug: high-tide-mark
     description: "A horizontal stain on the seawall where the water reaches at its peak, marked by a crust of dried salt and the frayed remains of whatever the tide carried in. Below the line, the stone is dark and slick. Above it, dry and pale. The mark shifts by centimeters across the seasons."
     zone_slug: tidewater
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Barnacles"
     slug: the-barnacles
     description: "Dense clusters of barnacles encrust every surface below the high-tide line — pilings, stone, steel, anything stationary long enough to be colonized. The shells are sharp enough to cut skin, and they crackle faintly as the water recedes, thousands of small valves closing against the air."
     zone_slug: tidewater
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Seaweed Line"
     slug: seaweed-line
     description: "A ragged border of kelp and sea lettuce deposited by the last high tide, draped over rocks and dragged into ropes by the retreating water. Flies gather on it in the heat. The line traces the exact contour of the shore, recording the water's highest reach in a ribbon of green and brown."
     zone_slug: tidewater
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Rock Pool"
     slug: rock-pool
     description: "A basin the size of a bathtub carved into the stone shelf by tidal erosion, filled with clear salt water and populated by anemones, small crabs, and fish too young to survive the open harbor. The water is warmer than the surrounding tide, heated by the sun between cycles."
     zone_slug: tidewater
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Inlet"
     slug: the-inlet
     description: "A narrow cut in the shoreline where the tide pushes water inland through a gap in the rocks, creating a channel barely two meters wide. The current reverses every six hours, and the flow rate at peak tide is strong enough to pull a swimmer off their feet. The rocks on either side are polished smooth."
     zone_slug: tidewater
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Salt Marsh Edge"
     slug: salt-marsh-edge
     description: "Where the harbor gives way to a fringe of salt-tolerant grasses, their stems rising from black mud that holds bootprints indefinitely. The transition from stone to marsh happens within a few meters — solid ground softening to wet ground to standing water. Fiddler crabs disappear into holes at the sound of footsteps."
     zone_slug: tidewater
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Drift Line"
     slug: drift-line
     description: "The farthest reach of wave action, marked by a scatter of objects left by the receding water — plastic, wood, rope, shells, the occasional shoe. The debris forms a continuous border parallel to the shore, disturbed only by the next storm or the rare person who picks through it."
     zone_slug: tidewater
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Tidal Gate"
     slug: tidal-gate
     description: "A steel gate set into a concrete channel that regulates water flow between the harbor and an interior basin. The gate opens and closes with the tide cycle, its mechanism automatic and its hinges groaning with each movement. Water streams through the gaps before the gate fully opens, foaming white in the constriction."
     zone_slug: tidewater
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Shell Beach"
     slug: shell-beach
     description: "A crescent of crushed shell and sand at the base of the seawall, exposed only at low tide. The shells are fragments — mussel, oyster, clam — ground by wave action into pieces no larger than a thumbnail. The beach is ten meters wide at most, and the footing is unstable, crunching and shifting with each step."
     zone_slug: tidewater
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Estuary"
     slug: the-estuary
     description: "Where the river enters the harbor, fresh water spreading across the surface of the salt in a visible plume of lighter color. The mixing zone is turbid and busy with birds working the boundary where prey congregates. The smell shifts here — less ocean, more silt and vegetation."
     zone_slug: tidewater
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Mud Flat"
     slug: tidewater-mud-flat
     description: "At low tide, an expanse of gray mud stretches from the seawall to the water's edge, its surface pocked with worm casts and bubbling with trapped gas. The footing is treacherous — solid-looking surface giving way to knee-deep muck without warning. The smell is anaerobic, dense, and ancient. ---"
     zone_slug: tidewater
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Fort"
     slug: the-fort
     description: "Thick granite walls arranged in a star pattern, their surfaces pocked by weather and streaked with the white residue of centuries of salt spray. The structure sits on the harbor's highest point, its ramparts offering sightlines in every direction. Grass grows between the flagstones inside the walls, and the wind finds every gap."
     zone_slug: the-battery
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Cannon Row"
     slug: cannon-row
     description: "Cast-iron cannons mounted on wooden carriages line the rampart, their barrels pointed at the harbor entrance. The metal is cold to the touch in any weather, and each barrel is plugged with a wooden tampion worn gray. Informational plaques at knee height go unread."
     zone_slug: the-battery
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Rampart"
     slug: the-rampart
     description: "A raised stone walkway running along the fort's outer wall, wide enough for two people abreast. The parapet on the seaward side is chest-high, its top worn smooth. Beyond it, the harbor drops away to rocks and spray. On the landward side, the ground falls to the parade ground twelve feet below."
     zone_slug: the-battery
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Sea Wall"
     slug: sea-wall
     description: "A continuous barrier of fitted stone running from the fort to the harbor's edge, its face battered by waves that have worn the lower courses to rounded shapes. The wall is three meters thick at its base, narrowing to a walkway on top. Spray reaches the top in heavy weather."
     zone_slug: the-battery
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Battery Walk"
     slug: battery-walk
     description: "A paved promenade following the fort's perimeter, shaded by a row of old trees that lean permanently leeward. Benches face the water at regular intervals. The path surface is cracked and heaved by roots, and the iron lamp posts along it have gone dark, replaced by newer fixtures bolted to the trees."
     zone_slug: the-battery
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Battery Park"
     slug: battery-park
     description: "A wedge of green occupying the point where the fort meets the waterfront, its grass maintained to a standard that nothing else in the district matches. The park is small — two minutes to cross at a walk — but the open sky and the harbor view create a sense of space disproportionate to its size."
     zone_slug: the-battery
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Flag Pole"
     slug: flag-pole
     description: "A white steel pole rising from a concrete base at the park's highest point, its halyard slapping the shaft in a rhythm dictated by the wind. The flag at the top is large enough to be visible from the outer harbor, and its fabric is replaced before it can fade. The base is circled by a low chain."
     zone_slug: the-battery
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Harbor Overlook"
     slug: harbor-overlook
     description: "A stone platform extending from the park's edge, cantilevered over the water. Iron railings enclose three sides, and the view encompasses the full sweep of the harbor — bridges, piers, the shipping channel, the open water beyond. Coin-operated telescopes stand at intervals, their optics clouded with salt."
     zone_slug: the-battery
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Embankment"
     slug: the-embankment
     description: "A graded slope of fitted stone descending from the park level to the waterfront below, its surface interrupted by staircases at three points. The stone is dark with runoff stains and moss grows in the joints on the shaded side. At the base, the embankment meets a seawall that absorbs the tide's daily assault."
     zone_slug: the-battery
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Officer's Quarters"
     slug: officers-quarters
     description: "A two-story stone building set within the fort's walls, its windows narrow and deep-set, its roof slate. The interior is a museum now — period furniture behind velvet ropes, display cases of artifacts, walls hung with maps of a harbor that no longer matches the one outside. The floors creak with age."
     zone_slug: the-battery
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Powder Magazine"
     slug: powder-magazine
     description: "A squat windowless building of double-thick stone, half-buried in the fort's earthworks. The single door is iron, its frame set deep into the wall. Inside, the air is cool and absolutely still, the space divided by stone partitions. The ceiling is vaulted to deflect blast upward. The room smells of old stone and nothing else."
     zone_slug: the-battery
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Battlement"
     slug: the-battlement
     description: "The fort's highest point, a narrow platform atop the main tower accessible by a spiral stair worn concave at each step. The wind is constant here, strong enough to lean into. The view extends past the harbor to the open ocean, and on clear days the curve of the coastline is visible in both directions. ---"
     zone_slug: the-battery
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Tunnel Mouth"
     slug: tunnel-mouth
     description: "A concrete arch swallows the light where the street descends below grade. The transition from daylight to artificial illumination happens in five steps, each one dimmer. The air changes temperature at the threshold — cooler underground, with a faint metallic taste. Sound compresses into echoes."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Platform"
     slug: the-tunnel-the-platform
     description: "A concrete ledge running along the tunnel wall, wide enough for a crowd to stand three deep. The edge is marked with a yellow line worn to nothing at the center where the most people wait. Overhead, a display board clicks through arrival times. The air moves in pulses that precede each incoming train."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tile Wall"
     slug: tile-wall
     description: "Ceramic tiles line the tunnel walls in a pattern of white and dark green, their surface crazed with hairline cracks. Some tiles are missing, revealing the concrete beneath. The grout between them is darkened with decades of grime. Under the fluorescent lights, the tile reflects a flat, institutional glare."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Express Track"
     slug: express-track
     description: "The center pair of rails reserved for trains that pass through without stopping. Ventilation grates in the platform wall vibrate before the express arrives, and then the train itself fills the tunnel with a wall of noise and displaced air that presses clothing flat against the body. It's gone in four seconds."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Echo"
     slug: the-echo
     description: "A section of tunnel where two passages intersect, creating an acoustic anomaly that bounces sound in unpredictable directions. Conversations from one platform arrive at another, fragmented and delayed. The effect is disorienting — voices without sources, footsteps from impossible directions."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Maintenance Alcove"
     slug: maintenance-alcove
     description: "A recess cut into the tunnel wall, closed off by a steel door with no exterior handle. Behind it, the space is barely large enough for a workbench and a tool rack. Cables run along the ceiling in bundled looms. The alcove is lit by a single caged bulb, and the air inside is warmer than the tunnel."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Grate"
     slug: the-grate
     description: "A steel grate set into the platform floor, its bars thick with accumulated grime. Below it, water runs through a drainage channel that carries runoff from the entire tunnel system. The sound of flowing water is constant, and in heavy rain the volume rises until the grate itself vibrates."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Rat Run"
     slug: rat-run
     description: "A stretch of track between stations where the tunnel narrows and the maintenance walkway shrinks to a ledge barely wide enough for a sideways shuffle. The walls are close and damp, and the only light comes from service lamps mounted at twenty-meter intervals. Movement in the shadows follows its own schedule."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Emergency Phone"
     slug: emergency-phone
     description: "A blue light marks a wall-mounted phone encased in a steel box, its receiver connected by an armored cord. The instructions are printed on a card behind smudged plastic. The phone is one of dozens in the system, each one connected to a switchboard that may or may not be monitored."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Third Rail"
     slug: the-third-rail
     description: "A steel rail mounted on ceramic insulators alongside the running tracks, carrying enough voltage to kill on contact. Warning signs in red and yellow mark every access point. The rail is clean and bright where the collector shoes contact it, dark and weathered everywhere else. The air near it carries a faint ozone scent."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Signal Light"
     slug: signal-light
     description: "A cluster of colored lenses mounted on a steel post at the tunnel's curve, their sequence governing the movement of trains through the section. Red, amber, green — the pattern changes with the passage of each train, and the lenses glow with an intensity that cuts through the tunnel's permanent dusk."
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Dead Stop"
     slug: the-dead-stop
     description: "A concrete barrier at the end of a truncated track, its face scarred by buffer impacts. The rails end three meters short of it, cut and capped. Beyond the barrier, the tunnel wall is raw stone — this is where the excavation stopped, the extension never completed, the passage ending in solid rock. ---"
     zone_slug: the-tunnel
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Stairwell Down"
     slug: stairwell-down
     description: "Concrete steps descend in a tight square spiral, each flight reversing direction at a landing barely wide enough to turn. The lighting dims with each level — surface brightness giving way to caged bulbs at intervals that grow farther apart. The air thickens with moisture and the smell of old concrete."
     zone_slug: sub-level
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Basement"
     slug: the-basement
     description: "A low-ceilinged space beneath the first sub-level, its floor painted gray over concrete that has cracked and settled unevenly. Columns support the structure above at regular intervals, their surfaces wrapped in conduit and cable. The hum of building systems fills the space from every direction."
     zone_slug: sub-level
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Utility Room"
     slug: utility-room
     description: "Electrical panels line one wall, their metal doors labeled in hand-written marker that has faded to suggestions. Circuit breakers click at random intervals. The opposite wall holds water mains and gas connections, their valves tagged with wire and plastic labels. The room smells of ozone and dust."
     zone_slug: sub-level
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Steam Pipe"
     slug: steam-pipe
     description: "An insulated pipe two feet in diameter runs along the ceiling, wrapped in asbestos cloth that has yellowed and frayed at the joints. Heat radiates from it in waves visible as shimmer in the stale air. Condensation drips from the fittings into a trough that channels it to a floor drain."
     zone_slug: sub-level
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Crawlspace"
     slug: the-crawlspace
     description: "A passage too low for standing, floored in gravel over plastic sheeting. Pipes and cables run along both walls, leaving a gap barely wide enough to move through on hands and knees. The air is still and tastes of dust. Somewhere ahead, a pump cycles on and off at irregular intervals."
     zone_slug: sub-level
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Junction Box"
     slug: junction-box
     description: "A steel enclosure mounted on the wall at chest height, its cover removed and lying on the floor. Inside, cables enter from four directions and connect at a terminal block where corrosion has turned the copper green. The wiring diagram taped to the inside of the cover is illegible. Someone left a flashlight on the floor."
     zone_slug: sub-level
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Sump"
     slug: sub-level-the-sump
     description: "The lowest point of the sub-level, where a concrete pit collects water from every drain in the system. A pump activates when the water reaches a sensor mounted on the wall, churning the murky accumulation through a pipe that disappears into the ceiling. The pit is never fully empty, and the water is opaque."
     zone_slug: sub-level
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Underground Stream"
     slug: underground-stream
     description: "Water moves through a channel cut into the bedrock beneath the building foundation, following a path that predates the city above it by millennia. The stream is narrow and clear, running over smooth stone in a passage where the concrete gives way to natural rock. The sound of it is the only constant down here."
     zone_slug: sub-level
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Foundation Wall"
     slug: foundation-wall
     description: "The original stonework of the building's base, visible where later construction left it exposed. The blocks are massive — cut granite fitted without mortar, their surfaces damp with moisture that seeps through the earth behind them. The wall is colder than everything around it, and touching it is like touching the bedrock itself."
     zone_slug: sub-level
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Conduit"
     slug: the-conduit
     description: "A bundle of cables as thick as a torso, encased in a steel tray that runs along the ceiling and disappears through a hole cut in the wall. The cables branch at intervals, smaller bundles splitting off and dropping to connection points along the corridor. Labels on the tray are coded in systems nobody present can read."
     zone_slug: sub-level
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Dripping Ceiling"
     slug: dripping-ceiling
     description: "Water finds its way through the concrete overhead at a dozen points, each drip tracing a mineral stain down the wall beneath it. Plastic sheeting has been tacked up in places to divert the flow into buckets that no one empties on schedule. The sound is a continuous, arrhythmic percussion."
     zone_slug: sub-level
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Service Tunnel"
     slug: service-tunnel
     description: "A corridor connecting the sub-level to the adjacent building's infrastructure, lined with pipes and cables and lit by a string of bulbs wired in series — when one fails, the section goes dark. The tunnel is straight and long enough that the far end appears as a bright point. Air moves through it in a slow, steady draft."
     zone_slug: sub-level
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Lobby Plaza"
     slug: lobby-plaza
     description: "Polished stone stretches between two glass towers, heat rising off the surface in visible waves. A digital fountain cycles through branded animations while security cameras track foot traffic from every angle. The river is two blocks west but the climate systems keep the air dry and odorless."
     zone_slug: tower-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Glass Corridor"
     slug: glass-corridor
     description: "A skybridge connects the twin towers at the third floor, walled entirely in tinted glass. The corridor hums with filtered air and the muted click of shoes on composite flooring. Outside, the river bluffs are visible through the thermal haze, flattened to a postcard."
     zone_slug: tower-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Mezzanine"
     slug: the-mezzanine
     description: "A half-floor lounge overlooking the lobby below, furnished with low couches and ambient lighting tuned to the Cultural Zone's approved palette. Soft blues music plays from concealed speakers — algorithmically generated, close enough to the real thing that most people stopped noticing the difference. The coffee is expensive and the sightlines are designed to make everyone feel watched."
     zone_slug: tower-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "River View"
     slug: river-view
     description: "Floor-to-ceiling windows face west toward the river, the bluffs a dark line beneath the haze. On clear days the water catches light. Most days the climate systems fog the glass just enough to soften the poverty visible on the far bank."
     zone_slug: tower-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Executive Suite"
     slug: executive-suite
     description: "Thick carpet absorbs every sound. The desk faces away from the window, toward a wall of screens showing regional metrics — Cultural Zone engagement, foot traffic, consumption data. The air tastes recycled and faintly sweet, like every executive floor in every tower in every region."
     zone_slug: tower-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Parking Garage"
     slug: parking-garage
     description: "Concrete levels spiraling down into blue-white fluorescent light. The heat from outside pools at the entrance and dies two ramps in. Tire marks streak the floor in overlapping arcs. A security gate separates resident parking from visitor, the barrier arm rising and falling with mechanical indifference."
     zone_slug: tower-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Sky Lounge"
     slug: sky-lounge
     description: "The top floor of the east tower, all glass and recessed lighting. Cocktail tables ring the perimeter with views of the river and the bluffs beyond. The bartender pours with practiced efficiency while a screen behind the bar cycles through Cultural Zone programming — tonight it is a blues documentary no one is watching."
     zone_slug: tower-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Atrium"
     slug: tower-row-the-atrium
     description: "An open core between the towers, four stories of glass ceiling letting in filtered daylight. Potted trees grow in climate-controlled planters, their leaves too green for the latitude. Sound echoes off the stone — footsteps, distant conversation, the low drone of ventilation systems working overtime against the humidity."
     zone_slug: tower-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Street Level"
     slug: street-level
     description: "The base of Tower Row where glass facades meet the sidewalk. Branded awnings shade storefronts selling curated versions of regional culture — hot sauce samplers, blues compilation chips, barbecue spice kits. The heat hits immediately outside the climate barrier. Two blocks east, the neighborhood changes fast."
     zone_slug: tower-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Coffee Shop"
     slug: coffee-shop
     description: "A street-level corner unit with exposed ductwork painted matte black and a menu board in careful handwriting that changes every season. The espresso machine hisses steadily. Condensation beads on the windows where the interior cool meets the river humidity pressing in from outside."
     zone_slug: tower-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Security Desk"
     slug: security-desk
     description: "A curved console of screens and scanners positioned between the elevator bank and the front entrance. Two guards sit in ergonomic chairs, watching feeds from every floor. The desk itself is polished concrete, bolted to the floor. Badge readers flank both sides, their green lights blinking in patient rhythm."
     zone_slug: tower-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Observation Floor"
     slug: observation-floor
     description: "The highest occupied floor in Tower Row, above the Sky Lounge and below the mechanical level. Coin-operated telescopes line the windows, though most visitors just press their faces to the glass. The river bends south from here, and on the eastern bluffs the broadcast towers are visible — including one that does not appear on any GovCorp registry. ---"
     zone_slug: tower-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Exposed Brick"
     slug: exposed-brick
     description: "A renovated warehouse unit with original brick walls left intentionally bare, mortar crumbling in aesthetic patterns. Track lighting illuminates the space in warm pools. The building was a cotton warehouse a century ago, then abandoned, then converted — each layer visible if you know where to look."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Rooftop Bar"
     slug: the-rooftop-bar
     description: "String lights crisscross above a gravel-covered roof, the river visible between buildings to the west. The bar is built from reclaimed wood and corrugated tin. Heat rises from below and the drinks sweat in their glasses before the first sip."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Art Gallery"
     slug: the-loft-district-art-gallery
     description: "A ground-floor space with concrete floors and white walls, rotating installations that lean into the Cultural Zone's curated aesthetic. Tonight it is mixed-media pieces about \"River Heritage.\" The artist is from three regions over and has never seen the river."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Vintage Shop"
     slug: vintage-shop
     description: "Racks of curated clothing fill a narrow storefront, the air thick with the smell of old fabric and sandalwood candles. A turntable near the register plays vinyl — approved catalog only, but the owner has a box under the counter that is not. Tin ceiling tiles overhead, original to the building."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Craft Cocktails"
     slug: craft-cocktails
     description: "A dim bar with a fourteen-page menu describing drinks with names like \"Delta Smoke\" and \"Bluff Line Sunset.\" The bartenders wear suspenders and work with eyedroppers. The ice is hand-cut. The conversation is loud enough to cover anything said at the back tables."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Loft"
     slug: the-loft-district-the-loft
     description: "A residential unit on the top floor of a converted warehouse, exposed beams and ductwork overhead. The windows are industrial steel frames, original, letting in the amber glow of street lights. The rent is more than a family in The Bottoms earns in three months. The view is north, away from everything inconvenient."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Brunch Spot"
     slug: brunch-spot
     description: "A corner restaurant with a line out the door every weekend morning, the smell of bacon grease and chicory coffee cutting through the humidity. Ceiling fans turn slowly overhead. The menu features \"heritage recipes\" developed by an algorithm trained on Cultural Zone food data."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Converted Warehouse"
     slug: converted-warehouse
     description: "A three-story brick building mid-renovation, the ground floor gutted to open concept while upper floors still show loading-dock doors and freight hardware. Dust hangs in the light from tall windows. The developer's sign out front promises \"Authentic River Living\" in a typeface designed to look hand-painted."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "String Lights"
     slug: the-loft-district-string-lights
     description: "A pedestrian alley between two converted buildings, strung overhead with warm bulbs that cast moving shadows when the breeze pushes through. Café tables line one side. The brick walls radiate stored heat well past midnight, and the air smells like woodsmoke and jasmine from a planter someone wedged into a window ledge."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Fire Escape"
     slug: the-loft-district-fire-escape
     description: "A rusted iron staircase zigzagging up the side of a four-story warehouse, bolted into brick that has shifted enough to make the landings uneven. The metal groans underfoot. From the top landing, the river is visible between rooftops, and the lights of Prospect Row bleed orange into the humid sky."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Courtyard"
     slug: the-loft-district-the-courtyard
     description: "A shared interior space between three buildings, paved in old brick with a single magnolia tree growing from a square of exposed earth. Iron chairs cluster around small tables. The buildings block the worst of the street noise, and on still nights the tree's scent fills the courtyard thick enough to taste."
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Iron Stairs"
     slug: iron-stairs
     description: "A narrow interior stairwell with cast-iron railings worn smooth by decades of hands. The treads are original wood, creaking with each step. Light enters from a single window on each landing, thickened by dust. The building's age shows in the settling — every door frame is slightly off-square. ---"
     zone_slug: the-loft-district
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Main Drag"
     slug: the-main-drag
     description: "A four-block stretch of nightlife anchored by neon and noise. Music leaks from every doorway — approved blues, approved jazz, approved soul, all of it tuned to the Cultural Zone frequency. The sidewalks are wide enough for the weekend crowds, and the heat keeps people moving between air-conditioned interiors."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Neon Entrance"
     slug: neon-entrance
     description: "A glowing archway of layered neon tubing marks the east end of Prospect Row, cycling through blues and purples that reflect off the wet pavement below. The sign reads \"PROSPECT ROW\" in a font that suggests history without having any. Moths circle the tubes in the humid air."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Cocktail Lounge"
     slug: cocktail-lounge
     description: "Velvet booths and low amber lighting, the kind of place designed to make everyone look better than they are. A piano player works through standards in the corner, fingers moving on autopilot. The drinks are strong and the prices are high and the conversations stay at a murmur."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Live Stage"
     slug: live-stage
     description: "A raised platform at the back of a long narrow room, scuffed wood underfoot and a sound system that rattles the bottles behind the bar. The Cultural Zone programs the lineup, but the acoustics in this room do something the programming cannot account for. The walls have absorbed so much sound they almost hum on their own."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Sidewalk Patio"
     slug: sidewalk-patio
     description: "Metal tables and chairs spread across a roped-off section of sidewalk, heat lamps unnecessary in the river summer but present anyway for the aesthetic. Pedestrians flow around the perimeter. The patio faces west, and on good nights the sunset turns the river bluffs copper before the neon takes over."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Back Room"
     slug: the-back-room
     description: "Past the restrooms and through an unmarked door, a smaller room with its own bar and a handful of tables. The lighting is lower here, the music from the main room muffled to a pulse. Regulars know about it. The staff does not ask questions about the conversations held at the corner table."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Cigar Bar"
     slug: cigar-bar
     description: "Leather chairs and a ventilation system fighting a losing battle against the smoke that layers the air blue-gray. A glass humidor lines the far wall. The clientele is older, quieter, nursing bourbons and speaking in tones calibrated to carry no further than the next chair."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Late Night Kitchen"
     slug: late-night-kitchen
     description: "A walk-up window on the alley side of a Prospect Row bar, serving food from midnight until the crowd thins. The grill sends smoke into the alley, mixing with the humidity until the air tastes like charcoal and pepper. A single bulb lights the menu board, half the items crossed out by two a.m."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The VIP Booth"
     slug: the-vip-booth
     description: "A raised alcove behind a half-wall at the back of the largest bar on Prospect Row, separated from the crowd by elevation and a velvet rope that means nothing to anyone who matters. The seats face the room. The sightlines are excellent in both directions."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Jazz Corner"
     slug: jazz-corner
     description: "A basement-level room at the west end of Prospect Row, the entrance down a flight of stone steps worn concave in the center. The ceiling is low, the walls are bare brick, and the acoustics make a trio sound like a full ensemble. Condensation drips from the pipes overhead and no one cares."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Valet Stand"
     slug: valet-stand
     description: "A small podium at the curb outside the busiest block, staffed by two attendants in black shirts who take keys without small talk. The stand is lit by a single overhead lamp. Cars idle in the loading zone, engines humming against the bass frequencies leaking from the nearest club."
     zone_slug: prospect-row
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "After Hours"
     slug: after-hours
     description: "A locked door at the end of a hallway past a kitchen that closes at two. Inside, the room is small and the lighting is red and the music is whatever the DJ brought on a personal drive. No sign, no listing, no Cultural Zone programming. The crowd here knows the door code because someone trusted them with it. ---"
     zone_slug: prospect-row
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Door"
     slug: main-door
     description: "A steel door set in a corrugated metal wall, painted black, with no signage. The handle is worn bright where the paint has rubbed away. From outside, the building looks like a decommissioned freight hangar — which it was, before Ryker repurposed it. The bass from inside vibrates in the door frame."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Stage"
     slug: hackr-hangar-the-stage
     description: "A reinforced platform at the far end of the hangar, built from salvaged industrial decking. Monitor speakers line the front edge and cable runs disappear into the floor through drilled channels. The ceiling above is open steel truss, rigged with lighting that Ryker built himself from scrapped components. Every surface carries the residue of a thousand performances."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sound Booth"
     slug: sound-booth
     description: "An elevated glass-fronted room at the back of the hangar, packed with mixing boards, signal processors, and monitoring equipment. Cable bundles snake through the walls in organized runs. The glass is double-paned for isolation but still vibrates during loud sets. Ryker can see the entire stage from the chair."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Mixing Desk"
     slug: mixing-desk
     description: "A forty-channel analog board dominates the center of the sound booth, its faders worn smooth and its VU meters jumping in real time. Handwritten labels mark each channel with artist names and instrument designations. The desk predates the RIDE by decades — Ryker chose it because analog signals do not leave the digital footprint that GovCorp's monitoring systems expect."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Equipment Storage"
     slug: equipment-storage
     description: "A caged room behind the stage, stacked floor to ceiling with cases, cables, spare parts, and instruments in various states of repair. A rolling door opens to the loading area out back. The inventory is meticulous despite the apparent chaos — Ryker knows the location of every piece by memory."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Green Room"
     slug: hackr-hangar-the-green-room
     description: "A windowless room off the back hallway, furnished with a sagging couch, a mini fridge, and a table scarred by years of use. Artists wait here before sets. The walls are covered in marker tags and stickers from bands that have played the Hangar — an unauthorized history of the Fracture Network's musical output."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Recording Studio"
     slug: recording-studio
     description: "A fully isolated room built within the hangar's shell, walls packed with acoustic treatment. The monitoring setup is hybrid — analog front end feeding into hardened digital storage that never touches an external network. Work produced here is mastered, duplicated, and distributed through channels GovCorp has not yet mapped."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Broadcast Room"
     slug: broadcast-room
     description: "The nerve center of Ryker's operation, sealed behind a reinforced door. Transmission equipment lines the walls — some of it modified GovCorp hardware, some of it built from scratch. A red indicator light confirms when a broadcast is live, pushing signal through routing paths that change with every transmission. This is where The WIRE originates."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Server Rack"
     slug: server-rack
     description: "A temperature-controlled alcove behind the broadcast room, humming with processing hardware mounted in industrial racks. The servers handle signal encryption, stream routing, and the computational load of staying invisible on a network GovCorp believes it fully controls. A dedicated cooling unit keeps the air ten degrees below the rest of the building."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Bar"
     slug: hackr-hangar-the-bar
     description: "A plywood-and-steel counter along the hangar's east wall, backed by shelves of bottles and a refrigerator that shakes when the bass hits. The stools are mismatched. The drinks are cheap. The bar exists because Ryker understands that community needs a place to stand together with something in their hands."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Back Hallway"
     slug: back-hallway
     description: "A narrow corridor connecting the green room, storage, and the rear exit, lit by caged industrial fixtures. The concrete floor is painted gray and worn back to bare in the center. Cables run along the ceiling in bundled conduit. The hallway smells like sweat and solder and whatever was last cooked in the green room microwave."
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Roof Antenna"
     slug: roof-antenna
     description: "A cluster of antenna arrays mounted on the hangar's flat roof, disguised within a larger array of climate-system hardware and ventilation units. The main transmission mast is indistinguishable from a standard commercial antenna unless you know the frequency it carries. From the roof, the river is visible to the west and the lights of Tower Row glow to the north. ---"
     zone_slug: hackr-hangar
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Entrance"
     slug: blackshadez-the-entrance
     description: "A street-level door beneath a matte-black awning, flanked by two bouncers whose stillness suggests training beyond nightclub security. The neon sign overhead pulses in programmed patterns — GovCorp-approved branding for a GovCorp-approved EDM club. Bass pressure hits the chest before the door opens."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Dance Floor"
     slug: blackshadez-dance-floor
     description: "A sunken floor of polished concrete surrounded by elevated platforms, packed with bodies moving under synchronized lighting rigs. The sound system is military-grade, tuned to frequencies that make thought difficult and movement inevitable. GovCorp's monitoring arrays read the room as a standard entertainment venue. The energy is real; the context is manufactured."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "DJ Booth"
     slug: dj-booth
     description: "An elevated platform at the north end of the dance floor, enclosed in smoked plexiglass. The equipment inside is high-end — dual decks, a sixteen-channel mixer, effects processors that Dante sources through supply lines GovCorp does not audit. The DJ tonight plays what the Cultural Zone expects. The DJ on certain nights plays what the Cultural Zone cannot hear."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Bar"
     slug: blackshadez-the-bar
     description: "A long curved counter of black resin, backlit in shifting colors that match the dance floor's mood programming. The bartenders move fast and pour without measuring. Three deep on busy nights, the noise makes ordering a matter of hand signals and eye contact. The tabs run high and Dante does not extend credit."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "VIP Lounge"
     slug: vip-lounge
     description: "A roped-off section on the east platform, furnished with low couches and bottle service. The lighting is dimmer here, the music slightly attenuated by distance and design. The clientele pays for the separation. Dante uses the space to host contacts from all four factions when neutral ground is required, the cover of a nightclub making the meetings invisible."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Back Office"
     slug: back-office
     description: "Dante Russo's private space behind a locked door off the service corridor. A desk, two monitors showing security feeds, a safe bolted to the floor. The room is soundproofed well enough that the bass from the dance floor is reduced to a distant pulse. Business conducted here has nothing to do with drink orders."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Smoke Terrace"
     slug: smoke-terrace
     description: "A rooftop patio accessible through a stairwell behind the bar, open to the humid night air. Heat rises from the building below. The terrace overlooks a service alley on one side and rooftops on the other — no street-level sightlines. Smokers cluster near the railing, conversations masked by the muffled thump from below."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Loading Dock"
     slug: blackshadez-loading-dock
     description: "A roll-up door at the rear of the building, opening onto a service alley wide enough for delivery vehicles. Cases of liquor share the dock with equipment crates whose contents do not appear on any invoice. The dock is monitored by Dante's own cameras, not GovCorp's. A freight elevator connects to every level, including the one that does not officially exist."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Hidden Stairwell"
     slug: hidden-stairwell
     description: "A narrow staircase behind a wall panel in the service corridor, descending below street level. The panel blends seamlessly with the surrounding wall — finding it requires knowing the pressure point. The stairwell is concrete, unfinished, lit by battery-powered strips that operate on a closed circuit independent of the building's main power."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Underground Stage"
     slug: underground-stage
     description: "A performance space carved out of the basement level, walls lined with acoustic foam and Faraday mesh. Capacity is 100 to 150, standing room only, the ceiling low enough that the sound compresses into something physical. Bands from every faction have played this stage. The surface club above provides perfect acoustic and electronic cover for what happens down here."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Faraday Booth"
     slug: faraday-booth
     description: "One of several enclosed booths along the underground level's perimeter, each wrapped in copper mesh that blocks all wireless signal. Inside, conversations happen in complete electronic silence — no monitoring, no recording, no leakage. The booths are funded independently by all four factions, the one piece of infrastructure every corner of the Fracture Network agrees on."
     zone_slug: blackshadez
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Emergency Tunnel"
     slug: emergency-tunnel
     description: "A concrete passage leading from the underground level to an exit point two blocks north, emerging through a drainage access in a vacant lot. The tunnel is maintained but unlit — users carry their own light. Dante tests the route monthly. In the event of a raid on the surface club, the underground level can be evacuated in under four minutes. ---"
     zone_slug: blackshadez
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Front Porch"
     slug: the-juke-front-porch
     description: "A weathered wood porch with a sagging roof and two rocking chairs that have not matched since the previous decade. The screen door does not close all the way. Cicadas compete with the music bleeding from inside, and the humidity sits on everything like a second skin."
     zone_slug: the-juke
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Bar"
     slug: the-juke-the-bar
     description: "A scarred oak counter running the length of the room, its surface mapped with water rings and cigarette burns from before the ban that nobody enforces. The taps pour local and the bottles on the shelf are dusty on top. The bartender moves slow and remembers what everyone drinks."
     zone_slug: the-juke
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Dance Floor"
     slug: the-juke-dance-floor
     description: "A patch of warped hardwood between the bar and the stage, small enough that ten people fill it. The boards creak in specific places that the regulars know by feel. When the band hits a groove, the whole floor bounces and the bottles rattle on the shelves behind the bar."
     zone_slug: the-juke
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Stage"
     slug: the-juke-the-stage
     description: "A platform barely raised above the dance floor, backed by a wall covered in water-stained acoustic tile. Two monitors, a house PA held together with tape and habit, and a single spotlight that runs hot. The sound in this room is imperfect and alive in a way that no GovCorp programming has figured out how to replicate."
     zone_slug: the-juke
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Back Booth"
     slug: back-booth
     description: "A corner booth with cracked red vinyl seats and a table carved with initials going back decades. The light from the nearest fixture does not quite reach here. Conversations held in this booth stay in this booth — an arrangement enforced by custom, not technology."
     zone_slug: the-juke
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Kitchen Window"
     slug: kitchen-window
     description: "A rectangular opening in the wall between the bar and a kitchen the size of a closet, where a cook works a flat-top grill in front of a box fan. The menu is written on a whiteboard in fading marker: catfish, fried okra, hush puppies, slaw. The food is better than anything on Prospect Row and costs a tenth as much."
     zone_slug: the-juke
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Bathroom"
     slug: the-bathroom
     description: "A single-stall room with a lock that sticks and a mirror gone cloudy at the edges. The floor is concrete painted over so many times the color is geological. Graffiti covers the walls in layers — band names, phone numbers, declarations of love and grievance, some of it old enough to qualify as history."
     zone_slug: the-juke
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Parking Lot"
     slug: the-juke-parking-lot
     description: "A gravel rectangle behind the building, potholes filled with rainwater that never fully drains. Cars and trucks park at angles, headlights sometimes left on, illuminating the tree line at the lot's edge. The bass from inside carries through the walls and makes the standing water tremble."
     zone_slug: the-juke
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Side Alley"
     slug: side-alley
     description: "A narrow gap between The Juke and the next building, just wide enough for the dumpster and the AC unit that drips condensation into a permanent puddle. The wall on the Juke side vibrates with whatever is playing inside. Someone has stacked milk crates into a bench."
     zone_slug: the-juke
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Jukebox"
     slug: the-jukebox
     description: "A vintage cabinet against the east wall, its glass front glowing amber, loaded with selections that predate the Cultural Zone by generations. The mechanism clunks and whirs between songs. Half the buttons are worn smooth and some selections skip. The machine is the only thing in the building Ryker would not let the owner replace."
     zone_slug: the-juke
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Pool Table"
     slug: pool-table
     description: "A full-size table in the back room, its felt worn thin along the rail and patched in two places. The overhead light hangs from a chain and swings when someone bumps the table. Cue sticks lean against the wall in a wooden rack, most of them slightly warped. The house rules are chalked on a slate by the door."
     zone_slug: the-juke
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Back Door"
     slug: back-door
     description: "A metal door propped open with a cinder block on hot nights, opening onto the gravel lot. The doorframe is dented from years of equipment loads being angled through. Standing in the doorway, the cool of the bar fights the heat of the night, and both lose. ---"
     zone_slug: the-juke
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Bluff Trail"
     slug: bluff-trail
     description: "A packed-dirt path following the bluff's edge above the river, switchbacking down through scrub oak and exposed limestone. The trail is older than the city, worn into the rock by feet that walked it before anyone named the river. Heat rises from the stone and the air tastes like dust and cedar."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Lookout"
     slug: bluff-station-the-lookout
     description: "A cleared area at the bluff's edge where the trail widens to a flat ledge of limestone. The river spreads below, brown and slow, barges cutting lines through the current. On the far bank, the floodplain stretches flat to the horizon. The wind is stronger here, carrying the smell of water and mud and distance."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Station Platform"
     slug: station-platform
     description: "A concrete slab running along the rail line where it cuts through the bluff, exposed to weather on three sides. The platform is cracked and patched, the painted edge lines faded. A schedule board displays Slipstream arrival times — freight designations that mean nothing to anyone without the right context."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Waiting Shelter"
     slug: waiting-shelter
     description: "A metal-roofed structure on the platform with three walls and a bench, offering shade but no real protection from the humidity that presses in from the river below. The walls are aluminum, dented, covered in peeling transit authority stickers. A single overhead light attracts insects at night."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Ticket Window"
     slug: bluff-station-ticket-window
     description: "A reinforced glass panel set into the station wall, the counter beneath it worn to a polish by years of elbows. The window is staffed intermittently. The ticket system is automated, but the window remains because the building predates the automation and no one has funded the renovation to remove it."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Cliff Edge"
     slug: the-cliff-edge
     description: "The point where the bluff drops away without guardrail or warning, limestone crumbling at the lip where roots have cracked the rock. The drop is eighty feet to the river's edge. The view is unobstructed — upstream, downstream, and across to the far bank where the land flattens into delta. The wind pushes hard enough to lean into."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Switchback Path"
     slug: switchback-path
     description: "A series of tight turns cut into the bluff face, descending from the station platform toward the river. The path is partly stone steps, partly packed earth reinforced with railroad ties. Erosion has exposed roots and rocks at the turns. The descent takes ten minutes and the temperature drops as the bluff wall blocks the sun."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Observation Point"
     slug: bluff-station-observation-point
     description: "A small platform bolted to the bluff face halfway between the station and the river, accessible by a spur off the switchback path. The railing is industrial steel, rusted at the joints. The river fills the view below, close enough to hear the current working against the bank. Barge traffic passes at eye level."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Stone Steps"
     slug: bluff-station-stone-steps
     description: "A flight of limestone steps carved into the bluff where a natural seam in the rock allowed for it. The steps are uneven, some cracked, some shifted by settling. Moss grows in the joints where moisture seeps from the rock face. The stone is cool to the touch even in full summer."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Stone Landing"
     slug: stone-landing
     description: "A flat area at the base of the stone steps where the bluff meets the river's floodplain. The ground is hard-packed clay and gravel, scored by high-water marks from past floods. Driftwood collects against the bluff wall. The air here is heavy with river smell — mud, vegetation, the mineral tang of moving water."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Old Foundation"
     slug: old-foundation
     description: "The remains of a structure at the bluff's base, visible as a rectangle of cut stone half-buried in sediment. The walls are gone but the foundation footprint is clear — some kind of warehouse or landing house, predating the current city by a century or more. Weeds grow between the stones. The river has claimed the western edge."
     zone_slug: bluff-station
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Wind Ridge"
     slug: wind-ridge
     description: "The exposed top of the bluff where the trail runs closest to the edge, open to the prevailing wind off the river. Grass and scrub lay flat in the constant push of air. The wind strips the humidity away up here, and on clear days the visibility extends for miles in every direction. The station platform is visible below, and beyond it, the city. ---"
     zone_slug: bluff-station
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Dock"
     slug: the-landing-the-dock
     description: "A wooden dock extending into the river from the base of the bluff, its pilings dark with creosote and river grime. The current pushes against the upstream side, keeping the structure in constant low vibration. Rope coils and cleats line the edge. The wood is sun-bleached on top and black underneath where the water reaches."
     zone_slug: the-landing
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Cargo Hold"
     slug: cargo-hold
     description: "A low-ceilinged room built into the bluff face behind the dock, its stone walls sweating in the humidity. Crates and barrels fill the space in rough rows, the contents marked in shorthand that changes with the season. The floor is packed earth sloping toward a drain channel cut into the rock."
     zone_slug: the-landing
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Customs House"
     slug: customs-house
     description: "A stone building at the dock's landward end, one story, with barred windows and a heavy door. The interior is a single room divided by a counter, one side public, one side official. Forms and stamps and a logbook occupy the counter. The building smells of old paper and river damp, and the ceiling fan moves the air without cooling it."
     zone_slug: the-landing
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "River Steps"
     slug: river-steps
     description: "A set of stone steps descending from the dock level directly into the river, their lower treads green with algae and submerged depending on the water level. The steps are ancient — cut before the dock was built, before the customs house, before the city climbed the bluff. The current pulls at anything below the third step."
     zone_slug: the-landing
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Mooring Post"
     slug: mooring-post
     description: "A cast-iron bollard sunk into the dock's edge, its surface worn bright by decades of rope friction. The post is oversized for the current traffic — built for river commerce that no longer exists at this scale. Barnacles and river growth climb its base where the water laps during high stages."
     zone_slug: the-landing
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Plank"
     slug: the-plank
     description: "A single board gangway connecting the dock to whatever vessel is moored alongside, flexing underfoot with each step. The plank is replaced regularly — the river rots wood fast in this climate. The gap between dock and boat shows dark water moving below, carrying debris south toward the delta."
     zone_slug: the-landing
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Barge Slip"
     slug: barge-slip
     description: "A U-shaped indentation in the dock structure where flat-bottomed barges can nose in and tie off. The pilings here are reinforced with steel plate, scarred by years of contact. The slip is silted on the bottom, the water shallow and opaque. Loading equipment — a hand crane, a conveyor frame — stands idle on the dock above."
     zone_slug: the-landing
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Storage Shed"
     slug: storage-shed
     description: "A tin-roofed structure on the dock, one wall open to the river side, the other three made of corrugated metal bolted to a timber frame. Tools, rope, fuel cans, and spare parts fill the shelves and floor space. The shed radiates heat in the afternoon and the metal ticks as it cools after dark."
     zone_slug: the-landing
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Captain's Office"
     slug: captains-office
     description: "A small room above the customs house, accessible by an exterior staircase of rusted iron. The desk faces a window overlooking the dock and the river beyond. Charts cover the walls — some current, some decades old, none of them digital. A radio sits on the desk beside a logbook, both covered in a thin film of river humidity."
     zone_slug: the-landing
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Dry Goods Store"
     slug: dry-goods-store
     description: "A ground-floor commercial space near the dock, its shelves stocked with provisions for river traffic and the surrounding area. Canned goods, rope, lantern fuel, batteries, work gloves. The floors are wood plank, darkened by years of boot traffic. A bell on the door announces every entry, though the proprietor is usually already watching."
     zone_slug: the-landing
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Fish Market"
     slug: the-landing-fish-market
     description: "An open-air stall at the river end of the dock, concrete counter and a drain running to the water. The catch comes in with the morning current — catfish, drum, gar, whatever the nets pull. Ice melts in bins beneath the counter. The smell is river and fish and the iron tang of knife-work, strongest at dawn, fading by noon."
     zone_slug: the-landing
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Gangplank"
     slug: the-gangplank
     description: "A heavy timber ramp connecting the dock to the embankment at a grade steep enough to require cleats nailed into the wood. The gangplank shifts with the river level — higher in spring, lower in late summer when the water drops and the mud banks show. The wood is dark with age and river water and the grain has lifted into splinters. ---"
     zone_slug: the-landing
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Front Steps"
     slug: front-steps
     description: "Brick steps leading up to a raised porch, the mortar crumbling between courses and a wrought-iron railing listing to one side. The house sits on the high bank above a river channel, elevated against flood by design and stubborn luck. Mud dauber nests line the underside of the porch roof."
     zone_slug: channel-house
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Parlor"
     slug: channel-house-the-parlor
     description: "A front room with high ceilings and plaster walls cracked in branching patterns, the wallpaper beneath showing through in patches. The furniture is old and heavy and has not been moved in years. Light enters through tall windows facing the channel, filtered through lace curtains gone yellow at the edges."
     zone_slug: channel-house
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Channel View"
     slug: channel-view
     description: "A side porch enclosed in screens, overlooking the narrow channel where it bends around the house's lot. The water is visible through a stand of cypress, brown and slow-moving, carrying leaves and debris in lazy spirals. A ceiling fan turns overhead, stirring the air without conviction. The porch smells like screen rust and wet wood."
     zone_slug: channel-house
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Study"
     slug: channel-house-the-study
     description: "A small room off the parlor, lined floor to ceiling with shelves holding books, binders, and stacked papers. A desk sits beneath the window, its surface buried under maps and notebooks. The room is the coolest in the house, shaded by the porch on one side and the neighboring structure on the other. Dust settles on everything undisturbed."
     zone_slug: channel-house
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Upstairs Hall"
     slug: upstairs-hall
     description: "A narrow hallway connecting the upper rooms, the floorboards announcing every step with a specific creak. Framed photographs line the walls — river scenes, the house in earlier decades, faces that belong to this place. The ceiling is low enough to brush with an outstretched hand, and the heat collects here, rising from below."
     zone_slug: channel-house
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Cellar"
     slug: the-cellar
     description: "Stone walls sweating with groundwater, the floor uneven and damp. A single bulb hangs from a cord, casting hard shadows between shelves of jars and crates. The cellar predates the house above it — the stonework is older, rougher, and the air down here carries the mineral cold of the river that flows somewhere beneath the foundation."
     zone_slug: channel-house
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Back Porch"
     slug: back-porch
     description: "A screened porch off the kitchen, sagging slightly where the joists have softened. The screen has been patched in multiple places, the mesh a patchwork of different gauges. Beyond the screen, the yard slopes down to the channel through a stand of wax myrtle and palmetto. Frogs start at dusk and do not stop."
     zone_slug: channel-house
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Storm Shutters"
     slug: storm-shutters
     description: "Heavy wooden shutters hinged to the exterior window frames, currently propped open with iron hooks. The wood is weathered gray and thick enough to stop wind-driven debris. Bolt holes and brackets show where they lock down. The house has survived storms that took newer buildings, and the shutters are the reason."
     zone_slug: channel-house
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Kitchen"
     slug: the-kitchen
     description: "A large room at the back of the house, the counters worn to bare wood where knives have worked for decades. A cast-iron stove dominates one wall, its surface seasoned black. The ceiling is stained from years of cooking steam, and the window above the sink looks out onto the back porch and the channel beyond."
     zone_slug: channel-house
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Mud Room"
     slug: mud-room
     description: "A narrow room between the kitchen and the back door, its floor covered in cracked linoleum that peels at the edges. Hooks on the wall hold rain gear, nets, and hats. Boots line the baseboard, some of them caked with dried river mud. A drain in the floor handles the water that comes in on clothes and shoes and does not fully dry until morning."
     zone_slug: channel-house
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Dock"
     slug: channel-house-the-dock
     description: "A private dock extending from the channel house's lot into the water, built of cypress planks on hand-driven pilings. A flat-bottom boat ties off at the end, bumping the pilings with the current. The dock is narrow — one person wide — and the handrail is a single cable strung between posts. The planks are slick with algae where shade keeps them wet."
     zone_slug: channel-house
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Cistern Well"
     slug: cistern-well
     description: "A brick-walled cistern sunk into the ground behind the house, its mouth covered by a wooden lid weighted with a stone. The cistern collects rainwater through a gutter system running from the roof. The water inside is dark and cool and tastes of brick and leaf tannin. A hand pump bolted to the rim draws water when the house system fails. ---"
     zone_slug: channel-house
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Levee Top"
     slug: levee-top
     description: "A broad earthen ridge running parallel to the river, its grass surface mowed to a uniform height by municipal maintenance. The crest is wide enough for a vehicle and flat enough to see for miles in both directions. To the west, the river. To the east, the town. The levee is the line between the two, and everything about it says the line is negotiable."
     zone_slug: the-levee
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "River Side"
     slug: river-side
     description: "The levee's western slope descending toward the river through a band of willows and cottonwood. The grass gives way to mud as the grade steepens, and the waterline shifts daily depending on upstream conditions. Debris collects in the tree roots — plastic, driftwood, things that fell in somewhere north and ended up here."
     zone_slug: the-levee
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Town Side"
     slug: town-side
     description: "The levee's eastern slope facing the town, a gentler grade than the river side, mowed and maintained down to a drainage ditch at the base. Houses and streets begin beyond the ditch. The slope is marked by mower tracks and the occasional patch where someone has planted flowers in the public right-of-way."
     zone_slug: the-levee
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Flood Gate"
     slug: flood-gate
     description: "A steel gate set into the levee where a road crosses from town side to river side, mounted on rails and designed to close horizontally when the water rises. The gate is rust-streaked and the hydraulic mechanism is serviced once a year. A water-level gauge painted on the gate's frame marks historical flood stages in fading numbers."
     zone_slug: the-levee
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Spillway"
     slug: the-levee-the-spillway
     description: "A concrete channel cut through the levee at its lowest point, designed to direct overflow away from populated areas. The channel is dry most of the year, its floor cracked and weedy. When the river rises, water moves through here first — a controlled release that sacrifices the low ground to save the rest. Stains on the concrete walls mark past flood heights."
     zone_slug: the-levee
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Sandbag Wall"
     slug: sandbag-wall
     description: "A section of levee reinforced with stacked sandbags, some old enough to have rotted through and been replaced, others fresh from the last high-water scare. The bags form a second wall atop the earthen ridge, raising the effective height by three feet. Sand leaks from the seams and collects in drifts along the base."
     zone_slug: the-levee
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Concrete Slab"
     slug: concrete-slab
     description: "A flat section of poured concrete on the levee top, the remains of a structure that was removed — a pump house or observation post. Anchor bolts stick up from the surface, rusted and bent. The slab catches the sun all day and radiates heat well into the night. Kids from the neighborhood use it as a gathering point after dark."
     zone_slug: the-levee
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Drainage Pipe"
     slug: drainage-pipe
     description: "A corrugated metal pipe running through the levee's base, allowing rainwater from the town side to drain toward the river. The pipe is large enough to crawl through, though the grating on both ends is supposed to prevent it. The outflow end is stained with mineral deposits and the grating has been cut and repaired multiple times."
     zone_slug: the-levee
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Patrol Road"
     slug: patrol-road
     description: "A gravel road running along the levee's town-side base, maintained for inspection vehicles and flood-response access. The road is narrow, rutted, and lined on one side by the levee's grass slope and on the other by a drainage ditch. Tire tracks show regular use. At night the road is unlit, and the only sound is the river on the other side of the earthen wall."
     zone_slug: the-levee
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Break"
     slug: the-break
     description: "A section of levee where the earth has been repaired after a historical breach, the fill material a different color and density than the original construction. The grass grows differently here — thicker, more uneven, as if the soil underneath is still settling. A marker post indicates the breach date and repair year. The river is louder at this point, the bank closer."
     zone_slug: the-levee
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "High Water Mark"
     slug: high-water-mark
     description: "A painted line on a concrete retaining wall at the levee's base, marking the highest flood stage in recorded history. The line is seven feet above current ground level. Below it, successive marks record lesser floods in descending order, each with a year painted beside it. The wall is stained to the height of the most recent event — still well below the record."
     zone_slug: the-levee
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Pump House"
     slug: pump-house
     description: "A cinder-block structure at the levee's base on the town side, housing the pumps that move accumulating water over the levee and into the river during flood events. The diesel engines inside are maintained but old, and the building vibrates when they run. A gauge on the exterior wall shows the current water table level. The door is padlocked, the key held by municipal services. ---"
     zone_slug: the-levee
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Bank"
     slug: the-bank
     description: "A stretch of river bank where the water has cut into the clay, exposing layers of sediment in alternating bands of red and gray. Tree roots reach out over the undercut, exposed and tangled. The current slides past, brown and opaque, close enough to touch from the bank's lip. The soil is soft here and everything leans toward the water."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Cypress Stand"
     slug: cypress-stand
     description: "A grove of bald cypress growing in shallow water at the river's edge, their trunks swelling at the base and their knees breaking the surface in scattered clusters. Spanish moss drapes the lower branches. The light filters through the canopy in shifting patterns, and the water between the trunks is still and tannin-dark."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Mudflat"
     slug: the-mudflat
     description: "A broad expanse of exposed river bottom during low water, the mud cracked into plates and gleaming where the sun hits standing puddles. Tracks cross the surface — bird, raccoon, something larger that dragged itself back to the water. The smell is organic and dense, the kind that coats the inside of the nose."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Fishing Hole"
     slug: fishing-hole
     description: "A bend in the bank where the current slows and deepens, shaded by an overhanging sycamore. The bank here is packed hard by years of feet, and the roots of the tree form a natural seat. A length of nylon line is knotted around a branch, forgotten or deliberately left. The water is dark enough to hide whatever lives in the deep spot below."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Current"
     slug: the-current
     description: "A stretch of open water where the river narrows and the current accelerates, the surface wrinkling over submerged obstacles. Standing on the bank, the sound of moving water is continuous — a low, constant rush that absorbs other noise. Debris passes at speed: branches, leaves, the occasional unidentifiable shape tumbling in the murk."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Sandbar"
     slug: rivers-edge-sandbar
     description: "A crescent of sand deposited on the inside of a river bend, exposed at low water, submerged at high. The sand is fine-grained and littered with mussel shells and small stones polished by the current. Tracks show where herons have walked the bar's edge, fishing the shallow side. The far channel runs deep and fast."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Log Jam"
     slug: log-jam
     description: "A tangle of driftwood and tree trunks wedged against a bend in the bank, stacked by successive floods into a mass the size of a building. Water forces through the gaps, frothing white where it compresses. The logs are bleached and stripped of bark, some wedged so tight they have become structural. The jam traps everything the river carries."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Reed Bed"
     slug: reed-bed
     description: "A dense stand of river cane and cattails growing in the shallow water along the bank, tall enough to block the view and thick enough to block passage. The reeds click against each other in the wind. Red-winged blackbirds nest in the stalks, their calls sharp above the constant rustle. The water beneath is knee-deep and silted."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Curve"
     slug: rivers-edge-the-curve
     description: "The point where the river bends hard to the south, the outside bank eroding and the inside bank building up. The current swings wide here, and standing on the outer bank, the force of the water is visible in the way it pushes against the bluff. Pieces of the bank calve off during high water, trees and all."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Rope Swing"
     slug: rope-swing
     description: "A thick hemp rope knotted to a sycamore branch extending over the river, the lowest point of the arc just above the water at summer levels. The tree leans out from the bank at an angle, roots exposed on the undercut side. The rope is frayed but holds. The water beneath is deep enough — tested by every generation that has found this spot."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Water's Edge"
     slug: waters-edge
     description: "The precise line where land meets water, shifting daily with the river's mood. At this point the bank is low and flat, the transition gradual — clay to mud to shallow water to depth. Boot prints fill with water and disappear. The edge is littered with the river's leavings — sticks, feathers, plastic, the skeletal frames of leaves."
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Crawdad Rock"
     slug: crawdad-rock
     description: "A flat limestone shelf extending into the river from the bank, its surface pocked with small pools where crawfish hide beneath loose stones. The rock is warm in the sun and slick where algae grows near the water line. Kids from the surrounding areas come here to flip rocks and catch crawfish with their hands, carrying them home in buckets. ---"
     zone_slug: rivers-edge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Tight Squeeze"
     slug: tight-squeeze
     description: "A gap between two buildings where the alley narrows to shoulder width, the walls close enough to touch both at once. The air barely moves. Pipes and conduit from both buildings crowd the space overhead, dripping condensation. The passage connects two streets but feels like it connects two different eras of construction — one brick, one cinder block."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Neck Down"
     slug: neck-down
     description: "The point where a side street compresses between a retaining wall and a row of structures built too close to the road, reducing two lanes to one. Vehicles alternate passage by unspoken convention. The pavement is cracked where the retaining wall has shifted, and the gutters are permanently clogged. The buildings lean in overhead."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Chokepoint"
     slug: chokepoint
     description: "A junction where three alleys converge into a single passage barely wide enough for foot traffic. The walls are tagged with paint and the ground is uneven, patched with different materials at different times. A single fixture lights the junction from above, its cage bent and its bulb yellowed. The passage amplifies every footstep."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Side Passage"
     slug: side-passage
     description: "A narrow gap between a building's rear wall and a concrete retaining wall, running fifty feet before opening onto a parking area. The passage is unlit and the footing is broken concrete with weeds growing through the cracks. Water stains on both walls show where runoff channels during rain, and the ground stays damp for days after."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Gap"
     slug: the-gap
     description: "An open space where a building was demolished and never replaced, leaving a tooth-gap in the block. The foundation is visible through weeds and accumulated trash. Chain link surrounds the lot but has been cut in two places. The gap allows a shortcut between streets and provides sightlines that the surrounding density otherwise blocks."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Cramped Alley"
     slug: cramped-alley
     description: "A service alley behind a row of commercial buildings, barely wide enough for the dumpsters that line it. The asphalt is cracked and stained with grease and runoff. Fire escapes zigzag overhead, their shadows forming a lattice pattern on the ground. The alley smells like kitchen exhaust and rot, and the rats are bold."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "One-Way"
     slug: one-way
     description: "A single-lane passage between structures, established by use rather than planning, where foot traffic moves in the direction of whoever enters first. The walls on either side are mismatched — painted brick on one, corrugated metal on the other. A hand-lettered sign at one end reads \"ONE WAY\" in paint that has run."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Overhead Pipes"
     slug: overhead-pipes
     description: "A stretch of alley where utility pipes cross overhead in a dense cluster, some insulated, some bare, all of them sweating in the humidity. The pipes create a low ceiling that forces a slight duck. The dripping is constant, forming puddles that never dry. In winter the pipes steam. In summer the condensation falls like light rain."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Crawl"
     slug: the-bottleneck-the-crawl
     description: "A section of passage where the overhead clearance drops to four feet, requiring hands-and-knees progress through a gap between a foundation wall and a utility chase. The ground is packed dirt and the air is close. The passage is used by people who know the neighborhood well enough to know it exists, and need to move between blocks without using the street."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Tight Corner"
     slug: tight-corner
     description: "A ninety-degree turn in a narrow alley where visibility drops to zero — stepping around the corner means stepping blind. The walls are scuffed at shoulder height from years of people bracing themselves through the turn. A convex mirror, cracked and fogged, is mounted at the corner's apex in a gesture toward safety that helps no one."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Rusted Gate"
     slug: rusted-gate
     description: "A wrought-iron gate blocking a passage between buildings, its hinges orange with rust and its latch mechanism seized. The gate has not fully closed in years, wedged open at a gap just wide enough to pass through sideways. The ironwork is ornamental — scrolls and spearheads — suggesting an era when this passage was intentional rather than forgotten."
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Other Side"
     slug: the-other-side
     description: "The exit point of the Bottleneck passages, opening onto a wider street where the compressed geography finally relents. The change is immediate — light, air movement, the sound of traffic returning. The wall beside the exit is tagged with an arrow pointing back in, and beneath it, a number. The number changes periodically, and the people who use the passage know why. ---"
     zone_slug: the-bottleneck
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Still Water"
     slug: the-oxbow-still-water
     description: "A section of the old river channel cut off from the main current, the water unmoving and dark with tannin. The surface reflects the sky in perfect stillness, broken only by the occasional ring of a feeding fish or the touch of a water strider. The banks are soft and overgrown, and the air smells of standing water and leaf decay."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Cutoff"
     slug: the-cutoff
     description: "The point where the river changed course and left this channel behind, visible as a low ridge of deposited sediment separating the oxbow from the active channel. The ridge is covered in young willows and wild grass. The sound of the river is audible from the far side — a reminder that the water left but did not go far."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Old Channel"
     slug: old-channel
     description: "A stretch of the oxbow where the original channel's shape is still visible in the contour of the banks, the curve of the water, and the depth of the center line. Trees that once lined the river bank now stand well back from the reduced water level, their root systems exposed on the channel side. The place remembers its former scale."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Mud Bank"
     slug: mud-bank
     description: "A section of exposed clay bank where the oxbow's water level has dropped, leaving a shelf of drying mud scored with cracks and animal tracks. The mud is gray-brown and smells of anaerobic decay — the river bottom turned inside out. Crawfish chimneys dot the surface, their builders visible as shadows in the murky shallows."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Heron Stand"
     slug: heron-stand
     description: "A shallow area of the oxbow where a great blue heron stands motionless in knee-deep water, watching. The bird is a fixture — always present, or one indistinguishable from the last. The water around it is still, the surface broken only by the slow expansion of rings when the heron strikes. Silence is the dominant condition here."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Fallen Tree"
     slug: fallen-tree
     description: "A large cottonwood that toppled into the oxbow, its root ball torn from the softened bank and its crown submerged in the shallows. The trunk bridges water and land, bark peeling, branches breaking the surface. Turtles line the exposed wood, stacked in order of size. The tree will take years to fully dissolve into the water."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Island"
     slug: the-island
     description: "A small rise of land in the oxbow's center, formed from sediment deposited when the water still moved. The island supports a stand of willows and a thicket of buttonbush. The water surrounding it is shallow enough to wade in dry seasons, deep enough to require a boat in wet. Heron tracks circle the perimeter."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Shallow Ford"
     slug: shallow-ford
     description: "A point where the oxbow narrows and the bottom rises, allowing passage on foot with water at ankle to knee depth. The bottom is firm here — gravel over clay, unlike the surrounding mud. The ford is the only reliable crossing point, and the banks on either side are packed hard by use. Minnows scatter at each step."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Overgrown Path"
     slug: overgrown-path
     description: "A trail that once followed the oxbow's bank, now half-consumed by vegetation. Privet and honeysuckle crowd the path from both sides, forming a green tunnel in places. The footing is uneven — roots, soft ground, occasional standing water where the path dips. The trail is maintained by use alone, each passage beating back one day's growth."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Blind"
     slug: the-blind
     description: "A makeshift structure of weathered plywood and camouflage netting at the oxbow's edge, positioned where a clear sightline extends across the water. The blind was built for hunting or observation, its interior fitted with a plank bench and a narrow viewing slot. The wood smells of mildew and the netting has begun to decompose into the surrounding brush."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Lily Pad"
     slug: lily-pad
     description: "A section of the oxbow where lily pads cover the surface in overlapping green plates, their flowers white or pale yellow depending on the season. The water beneath is invisible, the pads dense enough to support the weight of frogs that sit motionless on the broadest leaves. Dragonflies patrol the surface in territorial circuits."
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Abandoned Boat"
     slug: abandoned-boat
     description: "A flat-bottom wooden boat half-sunk in the shallows, its hull rotted through on the downstream side and its interior filled with rainwater and accumulated leaves. The boat has been here long enough for algae to coat the submerged surfaces and for a small tree to root in the sediment inside the hull. The mooring rope, still tied to a bank tree, is green with mold. ---"
     zone_slug: the-oxbow
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Slog"
     slug: the-slog
     description: "A stretch of unpaved road where the surface has dissolved into a permanent slurry of mud, gravel, and standing water. Tire tracks rut the road into parallel troughs. Walking requires lifting each foot clear of suction. The air is thick with moisture and the smell of saturated earth, and every surface below the knees is uniformly brown."
     zone_slug: mudwater
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Mud Flat"
     slug: mudwater-mud-flat
     description: "An expanse of ground between structures where nothing grows and nothing drains, the surface a uniform plane of gray-brown mud baked hard on top and soft beneath. Footprints from the last rain are preserved in the crust. The flat collects everything that washes down from higher ground — silt, debris, the residue of a neighborhood that cannot maintain itself."
     zone_slug: mudwater
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Flooded Street"
     slug: flooded-street
     description: "A residential block where the street holds water year-round, the storm drains either clogged or never connected. The water ranges from ankle depth to shin depth depending on recent rainfall. Residents have placed concrete blocks and plywood sheets as stepping paths between doorways and the higher ground at the block's end."
     zone_slug: mudwater
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Stilt House"
     slug: stilt-house
     description: "A wood-frame house raised on concrete block pilings, four feet of open air between the floor joists and the ground below. The stilts are a concession to the flooding that visits this area with seasonal regularity. Beneath the house, the ground is bare dirt and standing water, and the space stores what the water cannot reach — cinder blocks, a lawn mower, a dog."
     zone_slug: mudwater
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Plank Bridge"
     slug: plank-bridge
     description: "Two boards laid across a drainage ditch, spanning the gap between a front yard and the road. The planks flex underfoot and have been replaced often enough that the current pair does not match. The ditch runs with brown water after rain and breeds mosquitoes in the standing pools between. Crossing requires balance and indifference to consequence."
     zone_slug: mudwater
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Puddle"
     slug: the-puddle
     description: "A depression in a vacant lot that holds water permanently, fed by runoff and a broken water main that municipal services has not prioritized for repair. The puddle is large enough to reflect the sky and deep enough to swallow a shoe. Mosquito larvae swirl in the shallows. The surrounding ground is spongy with saturation."
     zone_slug: mudwater
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Cattail Marsh"
     slug: cattail-marsh
     description: "A low area at Mudwater's edge where cattails and marsh grass have colonized what was once a drainage channel, filling it with a dense stand of vegetation. The water is shallow and warm, breeding frogs and insects in equal abundance. The marsh smells of decomposition and growth simultaneously, the cycle too fast to distinguish one from the other."
     zone_slug: mudwater
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Mosquito Cloud"
     slug: mosquito-cloud
     description: "An intersection where standing water and vegetation and humidity converge to create mosquito conditions that approach geological event. The insects hang in visible clouds at dawn and dusk, thick enough to inhale. Residents move fast through this area, and the few who sit outside do so behind screens or inside smoke from smoldering coils."
     zone_slug: mudwater
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Tire Rut"
     slug: tire-rut
     description: "A section of dirt road where heavy vehicles have carved ruts deep enough to trap a wheel, the grooves filled with standing water of indeterminate depth. The road has been graded once, possibly twice, in recent memory, each time degrading back to ruts within a week of the next rain. The ruts define the road more than the road defines itself."
     zone_slug: mudwater
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Culvert"
     slug: mudwater-the-culvert
     description: "A concrete pipe running beneath a road, large enough to walk through bent double, carrying the runoff that Mudwater generates toward the river. The pipe is cracked at the joints and partially blocked with silt and debris. Water trickles through in dry weather and roars through in wet. The opening at the downstream end is fringed with ferns and rusted rebar."
     zone_slug: mudwater
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Soggy Field"
     slug: soggy-field
     description: "An open lot behind a row of houses, too wet to build on and too flat to drain, existing in a permanent state of saturated uselessness. The grass grows in tufts between patches of standing water. Someone planted a garden in the higher corner; the tomato stakes lean at angles and the plants look exhausted. A tire swing hangs from the one tree, its arc passing over a puddle."
     zone_slug: mudwater
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Boot Trap"
     slug: boot-trap
     description: "A section of path where the mud is deep enough and adhesive enough to pull a boot off a foot, requiring each step to be planned and executed with both hands free. The clay here has a specific consistency — the kind that grips and holds and does not let go without a fight. Locals know the path through. Everyone else learns the hard way. ---"
     zone_slug: mudwater
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Dead End Road"
     slug: dead-end-road
     description: "A paved road that deteriorates into gravel and then into dirt before stopping at a wall of brush and scrub pine. The pavement ends abruptly, as if the crew that was laying it simply stopped and went home. Potholes transition to ruts, and the last hundred yards show no sign of recent maintenance. The turnaround at the end is worn into the weeds by vehicles backing out."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Hollow"
     slug: the-hollow
     description: "A natural depression in the land where the trees grow thicker and the light dims, shaded by a canopy of sweetgum and water oak. The air in the hollow is cooler and stiller than the surrounding area, and sound carries strangely — distant things sound close and close things sound muffled. The ground is damp even in dry weather."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Tall Grass"
     slug: cottonmouth-tall-grass
     description: "A field of uncut grass and weeds between the road and the tree line, waist-high in summer and head-high by fall. The grass hides everything — the contour of the ground, the drainage ditch, the path that someone once mowed and then stopped mowing. Something moves through the grass at dusk, parting the stalks, and it could be anything."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Abandoned Trailer"
     slug: abandoned-trailer
     description: "A single-wide mobile home set back from the road on cinder blocks, its exterior streaked with rust and mildew. The door hangs open. Inside, the carpet is warped with water damage and the ceiling panels sag where the roof leaks. Someone lived here long enough to leave curtains on the windows and a chair on the porch, and then they did not live here anymore."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Creek Crossing"
     slug: cottonmouth-creek-crossing
     description: "A low-water bridge where the road fords a creek, the concrete slab barely above the water level in dry conditions and submerged entirely after rain. The creek runs brown and fast when it runs and sits in stagnant pools when it does not. Gravel bars build up on the upstream side. A depth gauge is bolted to a post at the crossing's edge, its markings faded."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Snake Run"
     slug: snake-run
     description: "A path along the creek bank where the brush is thin enough to walk and the ground slopes toward the water. The name is descriptive and earned. The underbrush is the kind cottonmouths prefer — low, dense, near water, with cover from sun and predators. Locals walk this path in boots and daylight only, watching the ground with each step."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Burn Pile"
     slug: the-burn-pile
     description: "A clearing at the end of a dirt track where brush, lumber scraps, and household waste are burned in a ring of blackened earth. The pile is always partially rebuilt between burns, a slow accumulation of things too broken to keep and too far from pickup to dispose of properly. Ash and char mark the ground in concentric circles."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Chain Link"
     slug: chain-link
     description: "A section of fence running along a property line, the chain link sagging between posts and cut in places where foot paths have been established through the gap. The fence delineates nothing useful — both sides are equally overgrown, equally neglected. The metal is rusted to a uniform brown, indistinguishable from the dirt it is sinking into."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Dirt Pull-Off"
     slug: dirt-pull-off
     description: "A widened shoulder where the road's edge has been worn into a flat area large enough for two or three vehicles to park. The ground is packed hard from use, the perimeter defined by tire tracks and the occasional beer can. At night, headlights from the pull-off are the only illumination for a quarter mile in any direction."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Thicket"
     slug: the-thicket
     description: "A dense tangle of privet, blackberry, and Virginia creeper that has consumed a section of the roadside, growing over a fence line and swallowing whatever structure once stood behind it. The thicket is impenetrable without a blade and loud enough with insects that it provides its own sound cover. Birds nest deep inside, visible only as movement within the mass."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Old Well"
     slug: cottonmouth-old-well
     description: "A stone-walled well set in a clearing behind a collapsed outbuilding, its mouth covered with a wooden lid gone gray with weather. The well is hand-dug, older than anything else in the area, its stones fitted without mortar. Dropping a rock into the dark produces a splash after a count of three. The water may or may not be clean. Nobody tests it."
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Night Watch"
     slug: cottonmouth-night-watch
     description: "A clearing on a low rise at Cottonmouth's eastern edge where the tree line thins and the sky opens. The clearing offers sightlines down the road and into the surrounding woods. Someone has placed a camp chair and a fire ring here, used regularly, the ashes fresh. The position is chosen for visibility, and the person who sits here at night is not watching for wildlife. ---"
     zone_slug: cottonmouth
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Cracked Pavement"
     slug: cracked-pavement
     description: "A residential street where the asphalt has fractured into an irregular mosaic, the cracks filled with dirt and grass pushing through from below. The road has not been resurfaced in the lifetime of anyone living on it. Potholes deep enough to damage a wheel dot the surface, and the painted lane markings disappeared years ago."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Boarded House"
     slug: boarded-house
     description: "A wood-frame house with plywood screwed over every window and door, the boards weathered to gray and tagged with spray paint. The yard is knee-high in weeds. A porch railing has collapsed on one side, the posts rotting through at their base. The house is one of several on this block, each in a slightly different stage of the same decline."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Empty Lot"
     slug: empty-lot
     description: "A gap in the block where a structure once stood, now a rectangle of packed earth and broken concrete. The foundation outline is visible in places, and a pipe sticks up from the ground where the kitchen was. The lot collects trash blown in from the street and rainwater that pools in the lowest corner. A faded \"NO DUMPING\" sign is bolted to a stake that leans."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Corner"
     slug: the-corner
     description: "An intersection where two streets meet and a cluster of men stand in the shade of a building that used to be a store. The building's awning, still intact, provides the only shade on the block. Conversations are low and constant, the group shifting in composition but always present. The corner has its own economy, its own rules, its own memory."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Pawn Shop"
     slug: pawn-shop
     description: "A single-story commercial building with barred windows and a buzzer-entry door. The neon \"OPEN\" sign is on sixteen hours a day. Inside, glass cases hold the usual inventory — electronics, tools, jewelry, instruments. The proprietor sits behind bulletproof plexiglass and transacts through a metal tray. Everything in the cases has a story nobody tells."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Overpass"
     slug: the-bottoms-the-overpass
     description: "A concrete highway overpass spanning The Bottoms, carrying traffic that never stops here over streets that cannot attract investment. The underside is stained with water and exhaust. The pillars supporting it are tagged to a height of eight feet. The noise from above is constant — the drone of vehicles and the thump of expansion joints — and the shade beneath is the coolest spot in the neighborhood."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Storm Drain"
     slug: storm-drain
     description: "A rectangular concrete opening at the base of the overpass, large enough to stand in, channeling runoff from the highway above through a culvert that runs beneath The Bottoms. The drain is littered with debris and stinks of standing water. The echo inside amplifies every sound. After heavy rain, the drain becomes a river and the surrounding streets become its floodplain."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Dollar Store"
     slug: dollar-store
     description: "A flat-roofed commercial building with a hand-painted sign, one of the few operating businesses on the block. The fluorescent lighting inside is bright enough to hurt. The aisles are narrow and stocked with off-brand versions of everything. The cashier is behind plexiglass, the floor is linoleum, and the air conditioning struggles against the door that never fully closes."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Bus Shelter"
     slug: bus-shelter
     description: "A metal-and-plexiglass shelter at a stop where the bus runs twice an hour on a schedule that is theoretical at best. The plexiglass panels are scratched opaque and one is missing entirely. The bench inside is metal, bolted down, and designed to prevent sleeping. A route map is posted behind cracked glass, several schedule changes out of date."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Chain Link Fence"
     slug: the-bottoms-chain-link-fence
     description: "A run of chain-link separating a vacant lot from the sidewalk, its top rail bent and its fabric bulging where people have leaned against it or pushed through. Plastic bags and paper flutter in the mesh like trapped birds. The fence serves no security purpose — it simply defines a boundary that everyone ignores by walking through the gap where the gate used to be."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Weedy Sidewalk"
     slug: weedy-sidewalk
     description: "A stretch of sidewalk where the concrete has heaved and cracked, the joints colonized by grass and dandelions growing in determined lines. Sections are tilted at angles that collect rainwater. The walk passes in front of houses in various states of occupation, and the condition of each property's sidewalk section tells a story about who lives inside and what they have the capacity to maintain."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Underpass"
     slug: the-bottoms-the-underpass
     description: "A pedestrian passage beneath the highway overpass, connecting The Bottoms to the commercial strip on the other side. The passage is concrete, low-ceilinged, and lit by fixtures that work intermittently. The walls are covered in layers of graffiti old enough to be archaeological. Water seeps through the joints from above. The passage smells like concrete and urine and the faint gasoline exhaust that drifts down from the road overhead."
     zone_slug: the-bottoms
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Entry Tunnel"
     slug: entry-tunnel
     description: "A reinforced corridor cut through the foundation of an abandoned stamping plant, its walls lined with cable runs and waterproof conduit. The air changes at the threshold — temperature drops, humidity stabilizes, and the industrial noise of the surface fades to nothing behind acoustic baffling."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Voice Archive"
     slug: voice-archive
     description: "Floor-to-ceiling storage racks hold 1,847 sealed containers, each labeled with a date and a frequency range. Every container holds an unprocessed vocal sample from Ashlinn — raw recordings The Archivist pulled from GovCorp's reconditioning logs before they were scheduled for deletion."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Data Recovery"
     slug: data-recovery
     description: "Workstations line the walls, each running forensic extraction software against corrupted GovCorp storage media. The screens display fragmented data — partial behavioral modification records, truncated reconditioning sequences — slowly reassembled byte by byte from drives that were supposed to have been destroyed."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Hardware Room"
     slug: hardware-room
     description: "Salvaged server racks hum behind a wire cage, running air-gapped systems that have never touched a GovCorp network. The hardware is mismatched — different eras, different manufacturers — unified by The Archivist's modifications and connected by hand-soldered cable assemblies."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Listening Post"
     slug: listening-post
     description: "A single chair faces a mixing console in a room treated for zero reflection. The Archivist plays back recovered vocals here, isolating Ashlinn's voice from the noise of whatever GovCorp process was running when the recording was captured. The silence between playbacks is absolute."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Stacks"
     slug: the-crypt-the-stacks
     description: "Metal shelving extends into the dim interior of a windowless room, holding cataloged evidence of GovCorp's population management operations. Binders, drives, and sealed containers are organized by program name and date range, each one a record of something that was never supposed to survive."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Cold Storage"
     slug: cold-storage
     description: "A temperature-controlled vault maintains the most fragile recovered media — magnetic tapes, optical discs, and analog recordings that would degrade under normal conditions. The room stays at four degrees Celsius, and condensation forms on the outer door whenever it opens."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Processing Bay"
     slug: processing-bay
     description: "A clean room where newly recovered materials are documented, digitized, and cataloged before entering the archive. Every piece of evidence passes through this room exactly once, handled with forensic protocols that would satisfy any tribunal that might eventually convene."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Reading Room"
     slug: the-crypt-the-reading-room
     description: "A quiet space with a single terminal where recovered documents can be reviewed in full. Behavioral modification program directives, reconditioning schedules, population management memos — the bureaucratic language of atrocity laid out in standard GovCorp formatting."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Evidence Locker"
     slug: evidence-locker
     description: "A reinforced room with a biometric lock containing the original physical media from the most significant recoveries. Chain-of-custody documentation tracks every access, because The Archivist understands that evidence without provenance is just data."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Sanctum"
     slug: the-sanctum
     description: "The Archivist's private workspace at the facility's deepest point, shielded and sound-isolated beyond any operational necessity. The walls are bare except for a single photograph that no one else has been close enough to identify. This is where decisions about the archive are made."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Emergency Wipe"
     slug: emergency-wipe
     description: "A dead-man system wired to the facility's storage infrastructure, designed to destroy everything if the Crypt is compromised. The activation panel is unlocked and the procedure is documented — The Archivist has accepted that preserving the evidence matters less than preventing GovCorp from recapturing it."
     zone_slug: the-crypt
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Line Start"
     slug: line-start
     description: "The beginning of a production line that once built three thousand vehicles a day, now silent except for wind moving through broken clerestory windows. Conveyor framework still runs the length of the building, its rollers seized with rust."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Chassis"
     slug: the-chassis
     description: "A station where bare frames were once lowered onto the line from overhead carriers. The carriers still hang from their track, swaying slightly when the wind gusts, their hooks empty and oxidized to a uniform brown."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Body Drop"
     slug: body-drop
     description: "The point where vehicle bodies were married to chassis on the line below, a two-story drop executed by automated systems. The alignment pins on the floor are still set to the last model year produced, frozen in position like the hands of a stopped clock."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Paint Booth"
     slug: paint-booth
     description: "An enclosed chamber where robotic arms once applied twelve coats of finish in ninety seconds. The nozzles are clogged with dried pigment, and the booth walls are layered with overspray in the final production color — a metallic gray that GovCorp later adopted for its fleet vehicles."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Trim Station"
     slug: trim-station
     description: "A section of line where interiors were installed — seats, dashboards, wiring harnesses. Bins along the wall still hold miscounted inventory from the last shift: plastic trim pieces, foam gaskets, clips in cellophane bags yellowed by time."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Robot Arm"
     slug: the-robot-arm
     description: "A six-axis welding robot stands locked in its last position, arm extended, torch pointed at a spot-weld that was never completed. The teach pendant hangs from its cable nearby, its screen dark, its program frozen mid-cycle."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Quality Gate"
     slug: quality-gate
     description: "An inspection station where finished vehicles were checked against specification before leaving the line. The light banks overhead still work when power reaches this section of the plant, flooding the empty bay with the flat white light of a standard that no longer applies."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Final Assembly"
     slug: final-assembly
     description: "The last station on the line where fluids were added, systems tested, and keys placed in the ignition. A clipboard hangs from a hook on the wall, its pages fused together by moisture, the final quality checklist of the final vehicle permanently unreadable."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Test Track"
     slug: test-track
     description: "A short oval of cracked asphalt behind the plant where finished vehicles were driven through acceleration and braking checks. Weeds push through the surface at every joint, and the painted lane markings have faded to suggestions."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Break Room"
     slug: break-room
     description: "A windowless interior room with bolted-down tables and a bank of vending machines, all empty. The clock on the wall stopped at 3:47, and someone left a jacket on the back of a chair that has been there long enough to become part of the furniture."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Whistle"
     slug: the-whistle
     description: "A steam whistle mounted on the plant's roof that once marked shift changes for workers across the district. The whistle is intact but the boiler that powered it was scrapped decades ago, leaving the horn as a mute monument to a schedule no one keeps."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Line End"
     slug: line-end
     description: "The production line terminates at a loading dock where finished vehicles were driven onto transport carriers. The dock doors are jammed at different heights — one fully open, two partially closed — and the loading ramp descends to a rail spur overgrown with scrub trees."
     zone_slug: the-assembly-line
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Near Side"
     slug: near-side
     description: "The approach to the border crossing from the south, where the road narrows from four lanes to two and concrete barriers funnel traffic toward the inspection booths. The pavement is scarred with tire marks from decades of vehicles braking too late."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Bridge"
     slug: the-crossing-the-bridge
     description: "A steel-deck bridge spans the narrow waterway connecting the two great lakes, its structural members riveted in a pattern that dates its construction to an era when permanence was a design goal. The deck plates rattle under any weight, and the sound carries across the water."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Tunnel"
     slug: the-tunnel
     description: "A subaqueous passage running beneath the strait as an alternative to the bridge above. The tile walls weep moisture at the seams, and the ventilation system pushes air through the tube with enough force to create a constant low moan."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Checkpoint"
     slug: checkpoint
     description: "A canopied lane where vehicles stop for document verification and scan. The booth operators work behind ballistic glass, and the overhead lights are bright enough to eliminate shadows — every face that passes through is fully illuminated and recorded."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Free Zone"
     slug: free-zone
     description: "A narrow strip of duty-free commerce between the two inspection stations, selling liquor and tobacco from buildings that look temporary but have been here for fifty years. The prices are posted in two currencies that no longer exist."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Wait"
     slug: the-wait
     description: "A queue of vehicles stretching back from the checkpoint, engines idling in a haze of exhaust. Wait times are displayed on a digital sign that updates with bureaucratic indifference, and the drivers sit with windows up, faces lit by dashboard screens."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Inspection Point"
     slug: the-crossing-inspection-point
     description: "A secondary screening area where selected vehicles are diverted for closer examination. The concrete pad is stained with leaked fluids from a thousand nervous border crossings, and the inspection mirrors on poles lean against the barrier when not in use."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The River"
     slug: the-river
     description: "The narrow strait itself, visible from the bridge and the shoreline approaches. The current runs fast between the two lakes, carrying water that is colder and darker than either body it connects, and the surface churns where the channel bottom rises."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Between"
     slug: between
     description: "The midpoint of the crossing where jurisdiction is ambiguous and the water below belongs to both sides and neither. The bridge deck is marked with a painted line that has been repainted so many times the stripe is a ridge of dried paint."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Booth"
     slug: the-crossing-the-booth
     description: "A single inspection booth at the crossing's narrowest point, staffed by an officer whose routine has calcified into a script. The booth's interior is visible through smudged glass — a stool, a screen, a microphone, and a button that raises or lowers the gate."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "ID Scan"
     slug: id-scan
     description: "A biometric station where travelers present identification to a sensor array. The equipment is newer than the infrastructure around it — GovCorp hardware mounted on pre-GovCorp concrete — and the scan takes slightly longer than the display says it should."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Far Side"
     slug: the-crossing-far-side
     description: "The road opens back to four lanes beyond the final inspection point, and the character of the buildings changes immediately. The architecture shifts, the signage shifts, and the air carries a different mix of industrial particulate — the other side of the strait."
     zone_slug: the-crossing
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Smokestack"
     slug: the-smokestack
     description: "A brick chimney rises sixty meters from the ruins of a smelting operation, its top edge crumbling but its base still solid. The stack has become a landmark visible from both sides of the strait, a reference point in a landscape where most vertical structures have been demolished or collapsed."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Loading Dock"
     slug: iron-mile-loading-dock
     description: "A concrete platform at truck-bed height runs along the side of a windowless building, its rubber bumpers cracked and peeling. The overhead door is frozen half-open, revealing a dark interior where pallets of something unidentifiable sit under a layer of pigeon droppings."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Rail Spur"
     slug: the-rail-spur
     description: "A single track branches off the main line and runs between two factory buildings before terminating in a bumper block overgrown with weeds. The rails are still in gauge but the ties have rotted, and the ballast has settled into the mud beneath."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Foundry Door"
     slug: foundry-door
     description: "A pair of steel doors tall enough to admit a rail car stand at the entrance to a foundry building, one door hanging from its upper hinge, the other wedged shut by debris. The threshold is worn down to bare steel by decades of heavy traffic."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Grinder"
     slug: the-grinder
     description: "A grinding station inside a metalworking shop where sparks once arced across the room in continuous streams. The grinding wheels are still mounted on their shafts, stone surfaces glazed smooth, and the floor around each station is indented from the operator's stance."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Sheet Metal"
     slug: sheet-metal
     description: "A fabrication bay filled with press brakes and shears, their blades locked in position by rust and time. Sheets of steel lean against the walls in varying stages of corrosion — some still showing layout marks in soapstone, measurements for parts that were never cut."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Press"
     slug: the-press
     description: "A hydraulic stamping press stands at the center of a concrete floor stained with decades of hydraulic fluid. The press bed weighs forty tons and the ram above it another thirty, held in its upper position by a mechanism that maintenance logs suggest was last inspected before GovCorp existed."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Tool and Die"
     slug: tool-and-die
     description: "A precision workshop where the molds and dies for the production floor were machined. The workbenches are granite-topped for flatness, and the micrometers and gauge blocks in the wall cabinet are still in their cases, protected from the corrosion that has claimed everything else."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Break Hall"
     slug: break-hall
     description: "A cafeteria-style room where three shifts of workers once ate in rotation, its long tables bolted to the floor in rows. The kitchen equipment was stripped for scrap years ago, but the serving line's stainless steel counter resists decay with industrial stubbornness."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Yard"
     slug: the-yard
     description: "An open lot between factory buildings where raw materials were staged before entering the production process. Rail ties, pipe sections, and plate steel sit in rusting stacks, slowly merging with the ground beneath them as oxidation and gravity do their work."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Chain Hoist"
     slug: chain-hoist
     description: "A manual chain hoist hangs from an I-beam trolley in a machine shop doorway, its chain pooled on the floor in a heap of rust-welded links. The hoist was rated for five tons, its capacity stamped into the housing in raised letters still legible under the corrosion."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Clock Tower"
     slug: clock-tower
     description: "A square tower rises from the factory complex's main building, its four clock faces frozen at different times — 6:12, 6:14, 6:15, and blank where the mechanism fell through. The tower served as the district's timekeeper when the plants ran, and its silence now measures a different kind of interval."
     zone_slug: iron-mile
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Loading Bay"
     slug: the-forge-loading-bay
     description: "A freight door opens onto a concrete apron stained with machine oil and boot prints. Pallets of raw materials sit under tarps, inventoried in Cipher's shorthand that no one else can read. The bay connects the dead industrial world outside to something living inside."
     zone_slug: the-forge
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Anvil"
     slug: the-anvil
     description: "A two-hundred-kilo anvil sits bolted to a hardwood stump, its face polished bright from daily use. Hammer marks ring the edges where Cipher tests alloy hardness by sound alone. The floor around it is swept clean — the only clean floor in the entire Works."
     zone_slug: the-forge
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Workbench One"
     slug: workbench-one
     description: "Soldering stations and magnification rigs line a steel bench scarred by decades of prior use. Circuit boards in various stages of assembly sit clamped under articulated lamps. A handwritten sign reads LABEL YOUR WORK OR LOSE IT."
     zone_slug: the-forge
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Workbench Two"
     slug: workbench-two
     description: "This bench handles the heavier fabrication — metal housings, antenna assemblies, shielded enclosures. A drill press and bench grinder anchor one end, vises and clamps the other. The ventilation here runs louder than anywhere else in the Forge."
     zone_slug: the-forge
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "The Quench Tank"
     slug: the-quench-tank
     description: "A long trough of dark water sits against the far wall, its surface filmed with oil and carbon. Finished metalwork goes in hot and comes out hardened, the hiss audible from two rooms away. Temperature markings on the wall track cooling rates in grease pencil."
     zone_slug: the-forge
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Furnace Room"
     slug: furnace-room
     description: "The coal-fired furnace dominates the back wall, its brick face cracked and repatched across generations. Cipher keeps it running at temperatures precise enough for metallurgical work, feeding it from a coal bin that never seems to empty. Heat radiates in waves that distort the air."
     zone_slug: the-forge
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Testing Lab"
     slug: testing-lab
     description: "Shielded from the rest of the workshop by lead-lined walls, this room houses Cipher's signal testing equipment. Oscilloscopes, spectrum analyzers, and custom-built frequency scanners crowd a central table. Every device the Forge produces passes through here before it leaves."
     zone_slug: the-forge
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Blueprint Wall"
     slug: blueprint-wall
     description: "One entire wall is covered in technical drawings, schematics, and hand-annotated diagrams pinned in overlapping layers. The oldest drawings are yellowed and brittle, their specs still referenced for legacy hardware. Red thread connects related designs in a pattern only Cipher follows."
     zone_slug: the-forge
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Tool Rack"
     slug: tool-rack
     description: "Pegboard walls hold hand tools organized with obsessive precision — each outline traced so every missing tool is immediately visible. Specialty instruments for electronics work hang alongside blacksmithing hammers and tongs. Nothing leaves this wall without being signed out."
     zone_slug: the-forge
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Cipher's Desk"
     slug: ciphers-desk
     description: "A battered metal desk wedged into a corner, stacked with notebooks filled with encrypted annotations. A single lamp illuminates whatever Cipher is working on, casting the rest of the desk in shadow. The chair is an old truck seat bolted to a swivel base."
     zone_slug: the-forge
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Clean Room"
     slug: the-clean-room
     description: "Plastic sheeting seals this section off from the forge dust and coal particulate that pervade everything else. Anti-static mats cover the floor and workbenches where the most sensitive electronics are assembled. Positive air pressure keeps contamination out through a salvaged HVAC filter."
     zone_slug: the-forge
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Secure Storage"
     slug: the-forge-secure-storage
     description: "A vault door salvaged from a demolished bank seals this room from the rest of the Forge. Inside, finished devices await distribution — transmitters, signal scramblers, encrypted communication rigs. Cipher keeps the only key, and the inventory exists nowhere in writing."
     zone_slug: the-forge
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Blast Furnace"
     slug: blast-furnace
     description: "The furnace towers three stories, its exterior riveted steel plate stained orange with oxidation. Cold air whistles through cracks in the charging bell at the top. It has not held fire in living memory, but the refractory lining still smells of iron when the humidity rises."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Casting Floor"
     slug: casting-floor
     description: "Sand covers the floor in a thick layer, pocked with the impressions of molds long since broken apart. Overhead cranes hang motionless on rusted tracks, their hooks dangling at odd angles. Spilled metal has cooled in silver rivers across the concrete beneath the sand."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Sand Mold"
     slug: sand-mold
     description: "Wooden flask frames lean against the walls, packed with green sand shaped into hollow negatives. The craft of sand casting is taught here as heritage, a Cultural Zone ritual stripped of any economic purpose. The molds are made, admired, and broken apart again."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Ladle"
     slug: the-ladle
     description: "A massive refractory-lined ladle hangs from a gantry crane, tipped at an angle that suggests its last pour. Dried slag clings to its lip in frozen drips. The chain and gear mechanism that controlled the pour is seized solid with rust."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Slag Tap"
     slug: slag-tap
     description: "A channel cut into the furnace base leads to a slag pit where vitrified waste was once drained during active smelting. The glass-like slag has built up in jagged formations over decades. Greenish and sharp-edged, it catches light from gaps in the roof."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Cooling Bay"
     slug: cooling-bay
     description: "Long rows of casting racks stand in open air where finished pours once cooled to handling temperature. Wind moves through freely here — one wall is entirely missing, collapsed outward into a rubble field. Pigeons roost in the overhead beams."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Pattern Shop"
     slug: pattern-shop
     description: "Wooden patterns for every casting the foundry ever produced line shelves from floor to ceiling. Each one is a mirror image of something that once existed in metal — gears, housings, valve bodies, machine parts. The wood is dark with age and handling, smooth as bone."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Cupola"
     slug: the-cupola
     description: "A smaller vertical furnace used for melting iron stands in its own alcove, its stack punching through the roof. Coke and limestone residue crust the charging door. The cupola could theoretically be restarted, but no one has tried in forty years."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Pouring Line"
     slug: pouring-line
     description: "A conveyor of steel rollers runs the length of the building, designed to move filled molds from the furnace to the cooling bay. Half the rollers are missing or locked solid. The line ends at a wall that was built after the foundry closed, sealing off the next building."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Core Room"
     slug: core-room
     description: "Sand cores shaped on wooden mandrels fill the racks here, each one designed to create a hollow space inside a casting. The finest detail work in the foundry happened in this room. Now the cores sit as sculpture, too fragile to move and too precise to discard."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Runner"
     slug: the-runner
     description: "A narrow channel cut into the casting floor where molten metal once flowed from the furnace to the molds. The runner is glazed with a permanent layer of iron oxide, its surface cracked like dried mud. Footprints in the surrounding sand are preserved from the last shift."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Quality Check"
     slug: quality-check
     description: "A steel inspection table sits under fluorescent fixtures, most of them dead. Calipers, micrometers, and gauge blocks remain in a glass-fronted cabinet, tools too precise for the rough environment. Rejection tags still hang from a wire, each one marking a flaw in something that no longer exists."
     zone_slug: the-foundry
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Main Street"
     slug: mill-town-main-street
     description: "A two-lane road runs through what was once a company town, its asphalt patched and repaired so many times the surface is more tar than stone. Brick storefronts line both sides, their awnings faded to the same indeterminate gray. The Cultural Zone keeps the streetlights burning and the sidewalks swept."
     zone_slug: mill-town
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Mill Gate"
     slug: the-mill-gate
     description: "Iron gates stand permanently open on stone pillars, marking the entrance to the mill complex beyond. The company name has been chiseled off the arch, but the shadow of the letters remains in cleaner stone. Workers walked through here for three generations before the gates lost their purpose."
     zone_slug: mill-town
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Company Housing"
     slug: company-housing
     description: "Rows of identical frame houses line streets named after numbers, their porches sagging at the same angle. The company built them, the company owned them, and when the company left, the Cultural Zone rebranded them as heritage housing. Paint peels in long strips that curl like bark."
     zone_slug: mill-town
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Church"
     slug: mill-town-the-church
     description: "A stone church anchors the corner of Main and Second, its steeple the tallest structure in Mill Town. The bell still rings on Sundays, operated by a timer installed when the last bellringer died. Stained glass windows depict scenes of labor — men at furnaces, women at looms."
     zone_slug: mill-town
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Company Store"
     slug: mill-town-company-store
     description: "The original general store where workers spent company scrip stands preserved as a Cultural Zone museum piece. Shelves are stocked with replica goods behind glass. The prices are still marked in scrip, a currency that expired before anyone alive was born."
     zone_slug: mill-town
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Slag Pile"
     slug: the-slag-pile
     description: "Behind the mill, a ridge of industrial waste rises thirty meters above the surrounding terrain. Purple-black and vitrified, the slag has been colonized by scrub brush that grows in sickly yellows. Rain channels have carved gullies down its face that glow faintly at night with leached minerals."
     zone_slug: mill-town
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Recreation Hall"
     slug: recreation-hall
     description: "A clapboard building with a dance floor, a stage, and a bar that served three-two beer during the mill's operating years. The Cultural Zone hosts dances and community events here, keeping the rituals alive without the economy that created them. The floor still bounces underfoot."
     zone_slug: mill-town
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The School"
     slug: the-school
     description: "A two-room schoolhouse with desks bolted to the floor in rows of six. Blackboards still show chalk marks from lessons about mill safety and the company's contribution to the community. The bell above the door is green with verdigris. Children attend school elsewhere now."
     zone_slug: mill-town
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Water Tower"
     slug: mill-town-water-tower
     description: "A steel tank on lattice legs stands above the town, its sides streaked with rust that runs in vertical lines like old blood. The tank is empty — water comes from the regional supply now. The tower serves only as a landmark, visible from every street in Mill Town."
     zone_slug: mill-town
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "The Tracks"
     slug: the-tracks
     description: "Rail lines run along the edge of town, their ties rotting and their spikes working loose from the ballast. Ore cars sit rusted to the rails in a permanent train going nowhere. Weeds grow between the ties in thick green lines that map the railroad's path through town."
     zone_slug: mill-town
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Picket Fence"
     slug: picket-fence
     description: "White picket fences line the yards of company housing, maintained by residents who repaint them every spring as the Cultural Zone prescribes. The uniformity is aggressive — every picket the same height, every gate the same latch. It looks like a memory of something that never quite existed."
     zone_slug: mill-town
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The Memorial"
     slug: the-memorial
     description: "A granite monument lists the names of workers killed in mill accidents across seven decades of operation. The stone is well-maintained, the names still legible, fresh flowers placed weekly by the Cultural Zone heritage committee. The list fills all four sides of the monument."
     zone_slug: mill-town
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Base"
     slug: slag-heap-the-base
     description: "The heap begins at the edge of the old foundry lot, its base spreading wide across what was once a loading area. The ground here is hard-packed waste mixed with gravel, hostile to anything organic. A chain-link fence with a faded warning sign marks the perimeter, but the gate hangs open."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "The Slope"
     slug: the-slope
     description: "Loose slag shifts underfoot on the ascent, chunks of vitrified waste clinking against each other like broken glass. The angle is steep enough to require hands in places. Nothing grows on the exposed face — the chemistry of the slag kills roots on contact."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Hot Spot"
     slug: hot-spot
     description: "Decades-old chemical reactions still generate heat in pockets beneath the surface. Steam vents from cracks in the slag on cold mornings, and the ground here is warm to the touch year-round. Locals know which spots to avoid after a worker broke through a thin crust in 2098."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Runoff Channel"
     slug: runoff-channel
     description: "Rainwater filtering through the heap runs in an orange-brown stream down a channel cut into the slag. The water carries dissolved metals that stain everything it touches. Nothing lives in the channel — no algae, no insects, no moss on the rocks."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Glass Crust"
     slug: glass-crust
     description: "Near the top, the slag has fused into a smooth, glassy surface that reflects the sky in dark greens and purples. Walking on it sounds like stepping on a frozen lake. Cracks web the surface in patterns that look deliberate but follow nothing except fracture mechanics."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Peak"
     slug: slag-heap-the-peak
     description: "The summit of the heap offers a panoramic view of the river valley and the mill ruins below. Wind scours the top clean of loose material, leaving only the heaviest slag. On clear days the view extends to the next town, its own slag heap visible as a dark ridge on the horizon."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Toxic Pool"
     slug: toxic-pool
     description: "Rainwater collects in a depression near the top, forming a still pool with an oily sheen of dissolved heavy metals. The water is the wrong color — too blue, too saturated, almost luminous. Nothing drinks from it. The pool never dries completely, even in summer."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Rust Layer"
     slug: rust-layer
     description: "A stratum of iron-rich waste runs through the heap like a geological formation, its exposed face bright orange against the darker slag above and below. The rust weeps in wet weather, staining the slope in streaks that look like the heap is bleeding. It smells of iron filings."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "The Dig"
     slug: slag-heap-the-dig
     description: "Someone has excavated a trench into the side of the heap, exposing layers of waste from different eras of the foundry's operation. Each layer is a different color and composition, banded like sedimentary rock but entirely artificial. The dig appears academic but has no posted attribution."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Scrap Pile"
     slug: scrap-pile
     description: "Metal fragments too contaminated to recycle were dumped here alongside the slag, their shapes barely recognizable under layers of corrosion. Rebar, pipe fittings, failed castings, and unidentifiable machine parts form a low mound. Rust has welded many pieces into a single mass."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "Coal Dust"
     slug: coal-dust
     description: "A section of the heap where coal ash was dumped is black and powdery, distinct from the hard slag around it. The dust shifts in wind, forming small drifts against the harder surfaces. Walking through it raises a dark cloud that settles on clothing and skin."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "The View"
     slug: slag-heap-the-view
     description: "The far side of the heap overlooks the river, its surface a patchwork of slag colors running down to the tree line. From here, the full scale of industrial waste becomes visible — the heap extends further than it appears from the base. The river below runs clear, indifferent to the ruin above it."
     zone_slug: slag-heap
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "The Chamber"
     slug: the-crucible-the-chamber
     description: "A cylindrical room lined with refractory brick, built to contain temperatures that could melt steel. The bricks are cracked and discolored in bands that mark the hottest zones. The air inside holds a mineral smell that decades of disuse have not erased."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Heat Shield"
     slug: heat-shield
     description: "Insulating panels line the approach to the melting vessel, their surfaces bubbled and warped from radiant heat exposure. Some panels have been replaced with newer material that does not quite match. The temperature differential between this side and the chamber side is palpable."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "Firing Port"
     slug: firing-port
     description: "A small reinforced opening in the chamber wall allowed operators to observe the melt without entering the heat zone. The glass is gone from the viewport, replaced by a steel plate welded shut. Scorch marks radiate from the port in a starburst pattern."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "The Melt"
     slug: the-melt
     description: "The crucible itself sits at the center of the chamber — a ceramic vessel large enough to stand in, its interior glazed with residue from its last pour. Metal froze in the bottom when the furnace was shut down for the final time. The surface is cratered and iridescent."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Temperature Gauge"
     slug: temperature-gauge
     description: "An analog gauge the size of a dinner plate is mounted to the wall, its needle pegged at zero. The dial is calibrated to temperatures that would incinerate organic material. The gauge face is yellowed behind cracked glass, its markings still precise and legible."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "Brick Lining"
     slug: brick-lining
     description: "The inner wall of the crucible chamber reveals its construction — layers of firebrick laid in interlocking patterns designed to expand uniformly under heat. Some bricks have been pushed inward by thermal stress, giving the wall an uneven, breathing quality. Mortar dust coats the floor."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "The Pour"
     slug: the-pour
     description: "A channel slopes from the base of the crucible to the casting floor, its refractory surface glazed smooth by the passage of molten metal. The pour channel narrows at the exit point, designed to control flow rate. Dried metal droplets bead along its edges like frozen sweat."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "Fume Hood"
     slug: fume-hood
     description: "Industrial ventilation hoods hang above the crucible, their ductwork running to extractors on the roof. The hoods are stained dark with metallic condensate that dripped back down over years of operation. Filters packed with particulate block most of the remaining ductwork."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Ash Pit"
     slug: ash-pit
     description: "Below the firing grate, a pit collects the ash and clinker from decades of combustion. The pit is deep and partially full, its contents compacted into layers of white, gray, and black. A rusted rake leans against the wall, its handle worn smooth by use."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Control Panel"
     slug: the-crucible-control-panel
     description: "A bank of switches, dials, and indicator lights covers one wall, connected to systems that no longer function. Labels in faded industrial stencil identify blowers, dampers, fuel feeds, and emergency shutoffs. Someone has taped a handwritten note to the panel: DO NOT ENERGIZE."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Glow"
     slug: the-glow
     description: "In the deepest part of the chamber, residual minerals in the brick emit a faint luminescence visible only in complete darkness. The glow is chemical, not thermal — phosphorescent compounds deposited over decades of high-temperature operation. It pulses with no detectable rhythm."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Cooling Floor"
     slug: cooling-floor
     description: "Beyond the pour channel, a broad concrete floor was designed to receive hot castings and let them cool in open air. Circular stains mark where ingots sat for hours, their heat gradually surrendering to the floor. The concrete is permanently discolored in overlapping rings."
     zone_slug: the-crucible
     room_type: standard
-    map_x: 3
-    map_y: 2
 
   - name: "Switch Tower"
     slug: switch-tower
     description: "A two-story brick tower overlooking the yard, its upper floor lined with windows on all four sides. The mechanical lever frame that controlled the switches is still intact, each lever labeled with a track number. The tower smells of grease and cold iron."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 0
-    map_y: 0
 
   - name: "Track Bed"
     slug: track-bed
     description: "Parallel rails stretch across a gravel bed, their steel surfaces brown with surface rust except where wheel flanges kept them polished. The ballast between ties is packed with decades of coal dust, oil drips, and iron filings. Drainage is poor — puddles sit in the low spots."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 1
-    map_y: 0
 
   - name: "The Hump"
     slug: the-hump
     description: "An artificial hill built to use gravity for sorting railcars — cars pushed over the hump rolled down into classification tracks at controlled speeds. The grade is gentle but precise, engineered to a specific angle. Weeds have softened the gravel shoulders but not the rails."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 2
-    map_y: 0
 
   - name: "Classification Yard"
     slug: classification-yard
     description: "Dozens of tracks fan out from the hump in a pattern designed to sort cars by destination. Most tracks hold a few abandoned cars coupled together, their wheels rusted to the rails. Switch points between tracks are frozen in their last position."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 3
-    map_y: 0
 
   - name: "Locomotive Shed"
     slug: locomotive-shed
     description: "A long building with tracks running through it, open at both ends, where engines were serviced and stored. The inspection pits are filled with oily water. Overhead, chain hoists and jib cranes hang from rails bolted to the roof beams. Tool cabinets line the walls, most of them empty."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 0
-    map_y: 1
 
   - name: "The Turntable"
     slug: the-railyard-the-turntable
     description: "A rotating platform set in a circular pit, designed to reverse locomotives or direct them to radial tracks. The turntable is locked in position, its mechanism seized. The pit has partially filled with rainwater and debris, creating a shallow pool around the platform's edge."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 1
-    map_y: 1
 
   - name: "Coal Depot"
     slug: coal-depot
     description: "Concrete bunkers once held coal for fueling steam locomotives, their walls stained black permanently. The bunkers are empty now, their floors cracked and heaved by frost. A conveyor structure spans overhead, its belt rotted away to expose the roller frame."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 2
-    map_y: 1
 
   - name: "The Caboose"
     slug: the-caboose
     description: "A single caboose sits on a siding at the edge of the yard, its red paint faded to a dull pink. The cupola windows are intact but clouded. Inside, the crew quarters are stripped to bare wood — bunks, desk, and stove removed, leaving only bolt holes in the floor."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 3
-    map_y: 1
 
   - name: "Signal Post"
     slug: signal-post
     description: "A semaphore signal stands at the yard throat, its arm fixed in the stop position. The post is painted in alternating bands of faded red and white. The signal lamp housing is empty, its lens missing. Wires that once connected it to the switch tower hang slack along the trackside."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 0
-    map_y: 2
 
   - name: "Repair Bay"
     slug: repair-bay
     description: "A covered area with heavy overhead cranes and rail-level access pits for working underneath rolling stock. Tools sized for railcar maintenance hang from wall-mounted boards — wrenches as long as a forearm, sledgehammers, pry bars. Grease stains map years of wheel bearing work."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 1
-    map_y: 2
 
   - name: "The Buffer"
     slug: the-buffer
     description: "A heavy steel bumper mounted at the end of a stub track, designed to stop any car that rolled past its intended stopping point. The buffer is dented from impacts, its spring mechanism compressed permanently. Rust has welded its mounting bolts to the rail."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 2
-    map_y: 2
 
   - name: "Dead End Spur"
     slug: dead-end-spur
     description: "The last track in the yard ends abruptly where the ballast gives way to bare earth and scrub growth. A derail device sits on the rail, its flag faded to white. Beyond the end of track, the ground drops away toward the river in a steep, eroded bank."
     zone_slug: the-railyard
     room_type: standard
-    map_x: 3
-    map_y: 2
 

--- a/db/migrate/20260506141300_add_map_position_to_grid_zones.rb
+++ b/db/migrate/20260506141300_add_map_position_to_grid_zones.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMapPositionToGridZones < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_zones, :map_x, :integer
+    add_column :grid_zones, :map_y, :integer
+  end
+end

--- a/db/migrate/20260506165402_drop_map_coordinates_from_grid_rooms_and_zones.rb
+++ b/db/migrate/20260506165402_drop_map_coordinates_from_grid_rooms_and_zones.rb
@@ -1,0 +1,9 @@
+class DropMapCoordinatesFromGridRoomsAndZones < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :grid_rooms, :map_x, :integer
+    remove_column :grid_rooms, :map_y, :integer
+    remove_column :grid_rooms, :map_z, :integer, default: 0, null: false
+    remove_column :grid_zones, :map_x, :integer
+    remove_column :grid_zones, :map_y, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_02_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -626,9 +626,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_02_200000) do
     t.text "description"
     t.integer "grid_zone_id", null: false
     t.boolean "locked", default: false, null: false
-    t.integer "map_x"
-    t.integer "map_y"
-    t.integer "map_z", default: 0, null: false
     t.integer "min_clearance", default: 0, null: false
     t.string "name"
     t.integer "owner_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -816,10 +816,7 @@ namespace :data do
         description: attrs["description"],
         grid_zone: zone,
         room_type: attrs["room_type"],
-        min_clearance: attrs["min_clearance"] || 0,
-        map_x: attrs["map_x"],
-        map_y: attrs["map_y"],
-        map_z: attrs["map_z"] || 0
+        min_clearance: attrs["min_clearance"] || 0
       )
       room.save!
       created += 1

--- a/spec/controllers/admin/grid_map_editor_controller_spec.rb
+++ b/spec/controllers/admin/grid_map_editor_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
   let(:admin_hackr) { create(:grid_hackr, :admin) }
   let(:region) { create(:grid_region) }
   let(:zone) { create(:grid_zone, grid_region: region) }
-  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", room_type: "hub", map_x: 0, map_y: 0) }
-  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", room_type: "transit", map_x: 1, map_y: 0) }
+  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", room_type: "hub") }
+  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", room_type: "transit") }
 
   before { session[:grid_hackr_id] = admin_hackr.id }
 
@@ -44,23 +44,27 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
       expect(json["zone"]["name"]).to eq(zone.name)
     end
 
-    it "includes room positions" do
+    it "computes BFS positions from exit topology" do
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+
       get :data, params: {zone_id: zone.id}, format: :json
       json = response.parsed_body
       hub = json["rooms"].find { |r| r["name"] == "Hub Alpha" }
+      transit = json["rooms"].find { |r| r["name"] == "Transit Beta" }
       expect(hub["map_x"]).to eq(0)
       expect(hub["map_y"]).to eq(0)
-      expect(hub["position_source"]).to eq("stored")
+      expect(transit["map_x"]).to eq(1) # east = +1 x
+      expect(transit["map_y"]).to eq(0)
     end
 
-    it "computes BFS positions for rooms without stored coords" do
-      room_no_coords = create(:grid_room, grid_zone: zone, name: "Unplaced Room")
-      create(:grid_exit, from_room: room1, to_room: room_no_coords, direction: "east")
+    it "computes z-levels from up/down exits" do
+      room_above = create(:grid_room, grid_zone: zone, name: "Upper Room")
+      create(:grid_exit, from_room: room1, to_room: room_above, direction: "up")
 
-      get :data, params: {zone_id: zone.id}, format: :json
+      get :data, params: {zone_id: zone.id, all_z: true}, format: :json
       json = response.parsed_body
-      unplaced = json["rooms"].find { |r| r["name"] == "Unplaced Room" }
-      expect(unplaced["position_source"]).to eq("computed")
+      upper = json["rooms"].find { |r| r["name"] == "Upper Room" }
+      expect(upper["map_z"]).to eq(1)
     end
 
     it "includes exits" do
@@ -98,25 +102,52 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
     end
   end
 
+  describe "GET #region_data" do
+    it "returns JSON with zones and rooms" do
+      room1
+      room2
+      create(:grid_exit, from_room: room1, to_room: room2, direction: "east")
+
+      get :region_data, params: {region_id: region.id}, format: :json
+      json = response.parsed_body
+      expect(json["zones"].length).to eq(1)
+      expect(json["rooms"].length).to eq(2)
+      expect(json["region"]["id"]).to eq(region.id)
+    end
+
+    it "separates zones connected by cross-zone exits" do
+      zone2 = create(:grid_zone, grid_region: region)
+      room_z2 = create(:grid_room, grid_zone: zone2, name: "Zone2 Room", room_type: "hub")
+      room1 # ensure room1 exists
+      create(:grid_exit, from_room: room1, to_room: room_z2, direction: "east")
+
+      get :region_data, params: {region_id: region.id}, format: :json
+      json = response.parsed_body
+      zone_positions = json["zones"].map { |z| [z["id"], [z["map_x"], z["map_y"]]] }.to_h
+      # Connected zones should have different positions
+      expect(zone_positions[zone.id]).not_to eq(zone_positions[zone2.id])
+    end
+  end
+
   describe "POST #create_room" do
-    it "creates a room at specified position" do
+    it "creates a room in the zone" do
       expect {
         post :create_room, params: {
           name: "New Room", slug: "new-room", room_type: "transit",
-          grid_zone_id: zone.id, map_x: 3, map_y: 2, min_clearance: 0
+          grid_zone_id: zone.id, min_clearance: 0
         }, format: :json
       }.to change(GridRoom, :count).by(1)
 
       json = response.parsed_body
       expect(json["success"]).to be true
       room = GridRoom.last
-      expect(room.map_x).to eq(3)
-      expect(room.map_y).to eq(2)
+      expect(room.name).to eq("New Room")
+      expect(room.grid_zone_id).to eq(zone.id)
     end
 
     it "returns errors for invalid room" do
       post :create_room, params: {
-        name: "", slug: "", grid_zone_id: zone.id, map_x: 0, map_y: 0, min_clearance: 0
+        name: "", slug: "", grid_zone_id: zone.id, min_clearance: 0
       }, format: :json
       json = response.parsed_body
       expect(json["success"]).to be false
@@ -131,14 +162,6 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
       expect(json["success"]).to be true
       expect(room1.reload.name).to eq("Renamed Hub")
       expect(room1.min_clearance).to eq(5)
-    end
-
-    it "updates position" do
-      patch :update_room, params: {id: room1.id, map_x: 10, map_y: 5}, format: :json
-      json = response.parsed_body
-      expect(json["success"]).to be true
-      expect(room1.reload.map_x).to eq(10)
-      expect(room1.reload.map_y).to eq(5)
     end
 
     it "returns errors for invalid updates" do
@@ -397,25 +420,6 @@ RSpec.describe Admin::GridMapEditorController, type: :controller do
       delete :destroy_encounter, params: {id: encounter.id}, format: :json
       json = response.parsed_body
       expect(json["success"]).to be false
-    end
-  end
-
-  describe "POST #auto_layout" do
-    it "computes and saves BFS positions" do
-      room_a = create(:grid_room, grid_zone: zone, name: "A", map_x: nil, map_y: nil, room_type: "hub")
-      room_b = create(:grid_room, grid_zone: zone, name: "B", map_x: nil, map_y: nil)
-      create(:grid_exit, from_room: room_a, to_room: room_b, direction: "east")
-
-      post :auto_layout, params: {zone_id: zone.id}, format: :json
-      json = response.parsed_body
-      expect(json["success"]).to be true
-      expect(json["updated"]).to eq(2)
-
-      room_a.reload
-      room_b.reload
-      expect(room_a.map_x).not_to be_nil
-      expect(room_b.map_x).not_to be_nil
-      expect(room_b.map_x).to eq(room_a.map_x + 1) # east = +1 x
     end
   end
 

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -6,9 +6,6 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
-#  map_x               :integer
-#  map_y               :integer
-#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string           default("standard"), not null

--- a/spec/models/grid_room_spec.rb
+++ b/spec/models/grid_room_spec.rb
@@ -6,9 +6,6 @@
 #  id                  :integer          not null, primary key
 #  description         :text
 #  locked              :boolean          default(FALSE), not null
-#  map_x               :integer
-#  map_y               :integer
-#  map_z               :integer          default(0), not null
 #  min_clearance       :integer          default(0), not null
 #  name                :string
 #  room_type           :string           default("standard"), not null

--- a/spec/services/grid/world_exporter_spec.rb
+++ b/spec/services/grid/world_exporter_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Grid::WorldExporter do
   let(:region) { create(:grid_region) }
   let(:zone) { create(:grid_zone, grid_region: region) }
-  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", slug: "hub-alpha", room_type: "hub", map_x: 0, map_y: 0) }
-  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", slug: "transit-beta", room_type: "transit", map_x: 1, map_y: 0) }
+  let(:room1) { create(:grid_room, grid_zone: zone, name: "Hub Alpha", slug: "hub-alpha", room_type: "hub") }
+  let(:room2) { create(:grid_room, grid_zone: zone, name: "Transit Beta", slug: "transit-beta", room_type: "transit") }
 
   describe "#export_all" do
     it "writes YAML files to the target directory" do
@@ -40,25 +40,15 @@ RSpec.describe Grid::WorldExporter do
       end
     end
 
-    it "exports map_x and map_y for rooms with stored coordinates" do
+    it "does not export map coordinates" do
       room1
       Dir.mktmpdir do |dir|
         described_class.new.export_all(dir: dir)
         data = YAML.load_file(File.join(dir, "rooms.yml"))
         exported = data["rooms"].find { |r| r["slug"] == room1.slug }
-        expect(exported["map_x"]).to eq(0)
-        expect(exported["map_y"]).to eq(0)
-      end
-    end
-
-    it "omits map_x/map_y for rooms without stored coordinates" do
-      room = create(:grid_room, grid_zone: zone, map_x: nil, map_y: nil)
-      Dir.mktmpdir do |dir|
-        described_class.new.export_all(dir: dir)
-        data = YAML.load_file(File.join(dir, "rooms.yml"))
-        exported = data["rooms"].find { |r| r["slug"] == room.slug }
         expect(exported).not_to have_key("map_x")
         expect(exported).not_to have_key("map_y")
+        expect(exported).not_to have_key("map_z")
       end
     end
 


### PR DESCRIPTION
  Drop stored map_x/map_y/map_z from grid_rooms and map_x/map_y from
  grid_zones. All positions now computed on the fly via BFS from exit
  topology — exits are the single source of truth for layout.

  Positioning refactor:
  - Room positions: BFS from exits, seeded from hub/special/transit rooms
  - Room z-levels: computed by walking up/down exits from z=0 seed
  - Zone positions: BFS over cross-zone exits with bbox-aware spacing
  - Disconnected zone clusters: each component gets its own BFS pass, clusters stack vertically (fixes twisted rendering for unconnected zones)
  - All drag (room + zone) is now ephemeral/session-only
  - "Auto Layout" replaced with "Reset Layout" (reloads from server)

  Performance fixes:
  - Pre-index all lookups with group_by/index_by (O(1) vs O(n²))
  - Extract shared room/exit/ghost JSON builders (DRY region_data + data)
  - 2.5D pan updates viewBox directly instead of full SVG re-render
  - Zone filter scoped to data cells only (no longer matches button text)

  UX improvements:
  - Map editor page constrained to viewport height (no vertical scroll)
  - Zone↔Region scope toggle centers on current zone
  - Region scope button remembers current zone for centering
  - Mob form combobox formId fix (remove broken submit guard)

  Removed: 3 routes (zone position update, both auto-layout endpoints),
  map coordinates from world export YAML and seed rake task.