### PR TITLE
[TPG] Transit System: Slipstream (Inter-Regional) + local transit

### DIFF
--- a/app/controllers/admin/grid_slipstream_routes_controller.rb
+++ b/app/controllers/admin/grid_slipstream_routes_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class Admin::GridSlipstreamRoutesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridSlipstreamRoute, find_by: :slug, children: [:grid_slipstream_legs]
+
+  before_action :set_route, only: %i[show edit update destroy]
+  before_action :load_selects, only: %i[new edit create update]
+
+  def index
+    @routes = GridSlipstreamRoute.includes(:origin_region, :destination_region).ordered
+  end
+
+  def show
+    @legs = @route.grid_slipstream_legs.order(:position)
+  end
+
+  def new
+    @route = GridSlipstreamRoute.new(
+      min_clearance: 15,
+      base_heat_cost: 10,
+      detection_risk_base: 15,
+      active: true,
+      position: (GridSlipstreamRoute.maximum(:position) || 0) + 1
+    )
+  end
+
+  def create
+    @route = GridSlipstreamRoute.new(route_params)
+    if @route.save
+      set_flash_success("Slipstream route '#{@route.name}' created.")
+      redirect_to edit_admin_grid_slipstream_route_path(@route)
+    else
+      flash.now[:error] = @route.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @legs = @route.grid_slipstream_legs.order(:position)
+  end
+
+  def update
+    @route.assign_attributes(route_params)
+    unless parse_json_fields!
+      flash.now[:error] = @route.errors.full_messages.join(", ")
+      @legs = @route.grid_slipstream_legs.order(:position)
+      load_selects
+      return render :edit, status: :unprocessable_entity
+    end
+
+    if @route.save
+      set_flash_success("Slipstream route '#{@route.name}' updated.")
+      redirect_to edit_admin_grid_slipstream_route_path(@route)
+    else
+      flash.now[:error] = @route.errors.full_messages.join(", ")
+      @legs = @route.grid_slipstream_legs.order(:position)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @route.name
+    if @route.grid_transit_journeys.exists?
+      flash[:error] = "Cannot delete '#{name}' — journeys reference this route."
+    else
+      @route.destroy!
+      set_flash_success("Slipstream route '#{name}' deleted.")
+    end
+    redirect_to admin_grid_slipstream_routes_path
+  end
+
+  private
+
+  def set_route
+    @route = GridSlipstreamRoute.find_by!(slug: params[:id])
+  end
+
+  def load_selects
+    @regions = GridRegion.order(:name)
+    @rooms = GridRoom.includes(:grid_zone).order(:name)
+    @breach_templates = GridBreachTemplate.published.ordered
+  end
+
+  def route_params
+    params.require(:grid_slipstream_route).permit(
+      :slug, :name, :origin_region_id, :destination_region_id,
+      :origin_room_id, :destination_room_id,
+      :min_clearance, :base_heat_cost, :detection_risk_base,
+      :active, :description, :position
+    )
+  end
+
+  def parse_json_fields!
+    true
+  end
+end

--- a/app/controllers/admin/grid_transit_journeys_controller.rb
+++ b/app/controllers/admin/grid_transit_journeys_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Admin::GridTransitJourneysController < Admin::ApplicationController
+  include Admin::DevToolsGate
+
+  def index
+    @journeys = GridTransitJourney.includes(:grid_hackr, :grid_transit_route, :grid_slipstream_route)
+      .order(created_at: :desc)
+      .limit(100)
+
+    if params[:state].present?
+      @journeys = @journeys.where(state: params[:state])
+    end
+    if params[:journey_type].present?
+      @journeys = @journeys.where(journey_type: params[:journey_type])
+    end
+  end
+
+  def show
+    @journey = GridTransitJourney.includes(
+      :grid_hackr, :grid_transit_route, :grid_slipstream_route,
+      :current_stop, :current_leg, :origin_room, :destination_room
+    ).find(params[:id])
+  end
+
+  def force_abandon
+    require_dev_tools!
+    journey = GridTransitJourney.find(params[:id])
+    if journey.active?
+      journey.update!(state: "abandoned", ended_at: Time.current)
+      hackr = journey.grid_hackr
+      hackr.update!(current_room: journey.origin_room) if journey.origin_room
+      set_flash_success("Journey ##{journey.id} force-abandoned.")
+    else
+      flash[:error] = "Journey is not active (state: #{journey.state})."
+    end
+    redirect_to admin_grid_transit_journey_path(journey)
+  end
+end

--- a/app/controllers/admin/grid_transit_routes_controller.rb
+++ b/app/controllers/admin/grid_transit_routes_controller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+class Admin::GridTransitRoutesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridTransitRoute, find_by: :slug, children: [:grid_transit_stops]
+
+  before_action :set_route, only: %i[show edit update destroy add_stop remove_stop]
+  before_action :load_selects, only: %i[new edit create update add_stop]
+
+  def index
+    @routes = GridTransitRoute.includes(:grid_transit_type, :grid_region, :grid_transit_stops).ordered
+  end
+
+  def show
+    @stops = @route.grid_transit_stops.includes(:grid_room).order(:position)
+  end
+
+  def new
+    @route = GridTransitRoute.new(active: true, position: (GridTransitRoute.maximum(:position) || 0) + 1)
+  end
+
+  def create
+    @route = GridTransitRoute.new(route_params)
+    if @route.save
+      set_flash_success("Transit route '#{@route.name}' created.")
+      redirect_to edit_admin_grid_transit_route_path(@route)
+    else
+      flash.now[:error] = @route.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @stops = @route.grid_transit_stops.includes(:grid_room).order(:position)
+  end
+
+  def update
+    if @route.update(route_params)
+      set_flash_success("Transit route '#{@route.name}' updated.")
+      redirect_to edit_admin_grid_transit_route_path(@route)
+    else
+      flash.now[:error] = @route.errors.full_messages.join(", ")
+      @stops = @route.grid_transit_stops.includes(:grid_room).order(:position)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def add_stop
+    next_pos = (@route.grid_transit_stops.maximum(:position) || -1) + 1
+    stop = @route.grid_transit_stops.new(stop_params.merge(position: next_pos))
+    if stop.save
+      set_flash_success("Stop '#{stop.display_name}' added at position #{stop.position}.")
+    else
+      flash[:error] = stop.errors.full_messages.join(", ")
+    end
+    redirect_to edit_admin_grid_transit_route_path(@route)
+  end
+
+  def remove_stop
+    stop = @route.grid_transit_stops.find(params[:stop_id])
+    name = stop.display_name
+    stop.destroy!
+    set_flash_success("Stop '#{name}' removed.")
+    redirect_to edit_admin_grid_transit_route_path(@route)
+  end
+
+  def destroy
+    name = @route.name
+    if @route.grid_transit_journeys.exists?
+      flash[:error] = "Cannot delete '#{name}' — journeys reference this route."
+    else
+      @route.destroy!
+      set_flash_success("Transit route '#{name}' deleted.")
+    end
+    redirect_to admin_grid_transit_routes_path
+  end
+
+  private
+
+  def set_route
+    @route = GridTransitRoute.find_by!(slug: params[:id])
+  end
+
+  def load_selects
+    @transit_types = GridTransitType.ordered
+    @regions = GridRegion.order(:name)
+    # For stop management: transit rooms scoped to route's region
+    @region_rooms = if @route&.persisted? && @route.grid_region_id
+      GridRoom.where(room_type: "transit")
+        .joins(:grid_zone).where(grid_zones: {grid_region_id: @route.grid_region_id})
+        .includes(:grid_zone).order(:name)
+    else
+      GridRoom.none
+    end
+  end
+
+  def route_params
+    params.require(:grid_transit_route).permit(
+      :slug, :name, :grid_transit_type_id, :grid_region_id,
+      :loop_route, :active, :description, :position
+    )
+  end
+
+  def stop_params
+    params.require(:grid_transit_stop).permit(:grid_room_id, :label, :is_terminus)
+  end
+end

--- a/app/controllers/admin/grid_transit_types_controller.rb
+++ b/app/controllers/admin/grid_transit_types_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Admin::GridTransitTypesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridTransitType, find_by: :slug
+
+  before_action :set_transit_type, only: %i[edit update destroy]
+
+  def index
+    @transit_types = GridTransitType.ordered
+  end
+
+  def new
+    @transit_type = GridTransitType.new(
+      category: "public",
+      base_fare: 0,
+      min_clearance: 0,
+      published: false,
+      position: (GridTransitType.maximum(:position) || 0) + 1
+    )
+  end
+
+  def create
+    @transit_type = GridTransitType.new(transit_type_params)
+    if @transit_type.save
+      set_flash_success("Transit type '#{@transit_type.name}' created.")
+      redirect_to edit_admin_grid_transit_type_path(@transit_type)
+    else
+      flash.now[:error] = @transit_type.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @transit_type.update(transit_type_params)
+      set_flash_success("Transit type '#{@transit_type.name}' updated.")
+      redirect_to edit_admin_grid_transit_type_path(@transit_type)
+    else
+      flash.now[:error] = @transit_type.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @transit_type.name
+    if @transit_type.grid_transit_routes.exists?
+      flash[:error] = "Cannot delete '#{name}' — transit routes reference this type."
+    else
+      @transit_type.destroy!
+      set_flash_success("Transit type '#{name}' deleted.")
+    end
+    redirect_to admin_grid_transit_types_path
+  end
+
+  private
+
+  def set_transit_type
+    @transit_type = GridTransitType.find_by!(slug: params[:id])
+  end
+
+  def transit_type_params
+    params.require(:grid_transit_type).permit(
+      :slug, :name, :category, :description, :icon_key,
+      :base_fare, :min_clearance, :published, :position
+    )
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,7 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action :require_admin_api, only: [:debit]
 
@@ -191,6 +191,43 @@ class Api::GridController < ApplicationController
       },
       software: loaded.map { |s| software_item_json(s) },
       inventory_software: inventory_sw.map { |s| software_item_json(s) }
+    }
+  end
+
+  # GET /api/grid/transit - Transit map and route browser data
+  def transit_index
+    room = current_hackr.current_room
+    region = room&.grid_zone&.grid_region
+
+    active_journey = current_hackr.active_journey
+
+    local_routes = if region
+      Grid::LocalTransitService.routes_at_room(room: room, hackr: current_hackr)
+    else
+      []
+    end
+
+    slip_routes = if region
+      Grid::SlipstreamService.routes_from(region: region, hackr: current_hackr)
+    else
+      GridSlipstreamRoute.none
+    end
+
+    region_assignments = GridRegionTransitAssignment
+      .includes(:grid_region, :grid_transit_type)
+      .order(:position)
+
+    render json: {
+      slipstream_heat: current_hackr.slipstream_heat,
+      slipstream_heat_tier: current_hackr.slipstream_heat_tier,
+      current_region: region ? {slug: region.slug, name: region.name} : nil,
+      current_journey: active_journey ? transit_journey_json(active_journey) : nil,
+      local_routes: local_routes.map { |r| transit_route_json(r) },
+      slipstream_routes: slip_routes.map { |r| slipstream_route_json(r) },
+      region_assignments: region_assignments.group_by { |a| a.grid_region.slug }
+        .transform_values { |assignments|
+          assignments.map { |a| {slug: a.grid_transit_type.slug, name: a.grid_transit_type.name, category: a.grid_transit_type.category} }
+        }
     }
   end
 
@@ -699,6 +736,46 @@ class Api::GridController < ApplicationController
       target_types: props["target_types"],
       level: (props["level"] || 1).to_i,
       loaded: item.deck_id.present?
+    }
+  end
+
+  def transit_journey_json(journey)
+    {
+      id: journey.id,
+      journey_type: journey.journey_type,
+      state: journey.state,
+      legs_completed: journey.legs_completed,
+      total_legs: journey.total_legs,
+      pending_fork: journey.pending_fork,
+      breach_mid_journey: journey.breach_mid_journey,
+      started_at: journey.started_at&.iso8601,
+      route_name: journey.slipstream? ? journey.grid_slipstream_route&.name : journey.grid_transit_route&.name,
+      current_stop: journey.current_stop ? {position: journey.current_stop.position, name: journey.current_stop.display_name} : nil,
+      current_leg: journey.current_leg ? {position: journey.current_leg.position, name: journey.current_leg.name} : nil
+    }
+  end
+
+  def transit_route_json(route)
+    {
+      slug: route.slug,
+      name: route.name,
+      transit_type: {slug: route.grid_transit_type.slug, name: route.grid_transit_type.name, category: route.grid_transit_type.category, base_fare: route.grid_transit_type.base_fare, icon_key: route.grid_transit_type.icon_key},
+      region: {slug: route.grid_region.slug, name: route.grid_region.name},
+      loop_route: route.loop_route,
+      stop_count: route.grid_transit_stops.size,
+      stops: route.grid_transit_stops.map { |s| {position: s.position, name: s.display_name, room_slug: s.grid_room.slug, is_terminus: s.is_terminus} }
+    }
+  end
+
+  def slipstream_route_json(route)
+    {
+      slug: route.slug,
+      name: route.name,
+      origin_region: {slug: route.origin_region.slug, name: route.origin_region.name},
+      destination_region: {slug: route.destination_region.slug, name: route.destination_region.name},
+      min_clearance: route.min_clearance,
+      leg_count: route.grid_slipstream_legs.size,
+      legs: route.grid_slipstream_legs.map { |l| {position: l.position, name: l.name, has_forks: l.has_forks?} }
     }
   end
 

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -30,6 +30,7 @@ const MissionsPage = lazy(() => import('~/components/pages/grid/MissionsPage'))
 const SchematicsPage = lazy(() => import('~/components/pages/grid/SchematicsPage'))
 const LoadoutPage = lazy(() => import('~/components/pages/grid/LoadoutPage'))
 const DeckPage = lazy(() => import('~/components/pages/grid/DeckPage'))
+const TransitPage = lazy(() => import('~/components/pages/grid/TransitPage'))
 const GridLoginPage = lazy(() => import('~/components/pages/grid/GridLoginPage').then(m => ({ default: m.GridLoginPage })))
 const GridRegisterPage = lazy(() => import('~/components/pages/grid/GridRegisterPage').then(m => ({ default: m.GridRegisterPage })))
 const GridVerifyPage = lazy(() => import('~/components/pages/grid/GridVerifyPage').then(m => ({ default: m.GridVerifyPage })))
@@ -111,6 +112,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/schematics" element={<ProtectedRoute><SchematicsPage /></ProtectedRoute>} />
           <Route path="/loadout" element={<ProtectedRoute><LoadoutPage /></ProtectedRoute>} />
           <Route path="/deck" element={<ProtectedRoute><DeckPage /></ProtectedRoute>} />
+          <Route path="/transit" element={<ProtectedRoute><TransitPage /></ProtectedRoute>} />
           <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
           <Route path="/grid/login" element={<GridLoginPage />} />
           <Route path="/grid/register" element={<GridRegisterPage />} />

--- a/app/javascript/components/pages/grid/TransitPage.tsx
+++ b/app/javascript/components/pages/grid/TransitPage.tsx
@@ -66,13 +66,13 @@ const HEAT_COLORS: Record<string, string> = {
   cold: '#34d399',
   warm: '#fbbf24',
   hot: '#f97316',
-  burning: '#ef4444',
+  burning: '#ef4444'
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
   public: '#34d399',
   private: '#fbbf24',
-  slipstream: '#a78bfa',
+  slipstream: '#a78bfa'
 }
 
 const TransitPage: React.FC = () => {
@@ -123,7 +123,7 @@ const TransitPage: React.FC = () => {
   const tabs: { key: TabKey; label: string }[] = [
     { key: 'local', label: 'Local Transit' },
     { key: 'slipstream', label: 'Slipstream' },
-    { key: 'network', label: 'Region Network' },
+    { key: 'network', label: 'Region Network' }
   ]
 
   return (
@@ -155,7 +155,7 @@ const TransitPage: React.FC = () => {
                 padding: '8px 20px',
                 fontFamily: 'monospace',
                 cursor: 'pointer',
-                fontSize: '0.9em',
+                fontSize: '0.9em'
               }}
             >
               {tab.label}

--- a/app/javascript/components/pages/grid/TransitPage.tsx
+++ b/app/javascript/components/pages/grid/TransitPage.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from 'react'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { LoadingSpinner } from '~/components/shared/LoadingSpinner'
+import { apiJson } from '~/utils/apiClient'
+
+interface TransitType {
+  slug: string
+  name: string
+  category: string
+  base_fare: number
+  icon_key: string | null
+}
+
+interface TransitStop {
+  position: number
+  name: string
+  room_slug: string
+  is_terminus: boolean
+}
+
+interface TransitRoute {
+  slug: string
+  name: string
+  transit_type: TransitType
+  region: { slug: string; name: string }
+  loop_route: boolean
+  stop_count: number
+  stops: TransitStop[]
+}
+
+interface SlipstreamLeg {
+  position: number
+  name: string
+  has_forks: boolean
+}
+
+interface SlipstreamRoute {
+  slug: string
+  name: string
+  origin_region: { slug: string; name: string }
+  destination_region: { slug: string; name: string }
+  min_clearance: number
+  leg_count: number
+  legs: SlipstreamLeg[]
+}
+
+interface RegionAssignment {
+  slug: string
+  name: string
+  category: string
+}
+
+interface TransitResponse {
+  slipstream_heat: number
+  slipstream_heat_tier: string
+  current_region: { slug: string; name: string } | null
+  current_journey: object | null
+  local_routes: TransitRoute[]
+  slipstream_routes: SlipstreamRoute[]
+  region_assignments: Record<string, RegionAssignment[]>
+}
+
+type TabKey = 'local' | 'slipstream' | 'network'
+
+const HEAT_COLORS: Record<string, string> = {
+  cold: '#34d399',
+  warm: '#fbbf24',
+  hot: '#f97316',
+  burning: '#ef4444',
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  public: '#34d399',
+  private: '#fbbf24',
+  slipstream: '#a78bfa',
+}
+
+const TransitPage: React.FC = () => {
+  const [data, setData] = useState<TransitResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<TabKey>('local')
+  const [expandedRoutes, setExpandedRoutes] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    apiJson<TransitResponse>('/api/grid/transit')
+      .then(json => { setData(json); setLoading(false) })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : 'Failed to load transit data')
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto' }}>
+          <LoadingSpinner message="Loading transit map..." color="cyan-255-text" size="large" />
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <DefaultLayout>
+        <div style={{ maxWidth: 1100, margin: '30px auto', padding: 40, textAlign: 'center', color: '#f87171' }}>
+          {error || 'Failed to load transit data'}
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  const toggleRoute = (slug: string) => {
+    setExpandedRoutes(prev => {
+      const next = new Set(prev)
+      if (next.has(slug)) next.delete(slug)
+      else next.add(slug)
+      return next
+    })
+  }
+
+  const tabs: { key: TabKey; label: string }[] = [
+    { key: 'local', label: 'Local Transit' },
+    { key: 'slipstream', label: 'Slipstream' },
+    { key: 'network', label: 'Region Network' },
+  ]
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: 1100, margin: '30px auto', padding: '0 20px' }}>
+        {/* Header */}
+        <div style={{ borderBottom: '2px solid #a78bfa', paddingBottom: 15, marginBottom: 20 }}>
+          <h1 style={{ color: '#22d3ee', fontFamily: 'monospace', margin: 0, fontSize: '1.4em' }}>
+            TRANSIT SYSTEM
+          </h1>
+          {data.current_region && (
+            <span style={{ color: '#9ca3af', fontFamily: 'monospace' }}>
+              Current region: <span style={{ color: '#a78bfa' }}>{data.current_region.name}</span>
+            </span>
+          )}
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: 0, marginBottom: 20 }}>
+          {tabs.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              style={{
+                background: activeTab === tab.key ? '#1a1a2e' : 'transparent',
+                color: activeTab === tab.key ? '#22d3ee' : '#6b7280',
+                border: `1px solid ${activeTab === tab.key ? '#22d3ee' : '#333'}`,
+                borderBottom: activeTab === tab.key ? '1px solid #1a1a2e' : '1px solid #333',
+                padding: '8px 20px',
+                fontFamily: 'monospace',
+                cursor: 'pointer',
+                fontSize: '0.9em',
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab Content */}
+        {activeTab === 'local' && <LocalTransitTab routes={data.local_routes} expandedRoutes={expandedRoutes} toggleRoute={toggleRoute} />}
+        {activeTab === 'slipstream' && <SlipstreamTab routes={data.slipstream_routes} heat={data.slipstream_heat} heatTier={data.slipstream_heat_tier} />}
+        {activeTab === 'network' && <NetworkTab assignments={data.region_assignments} />}
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const LocalTransitTab: React.FC<{
+  routes: TransitRoute[]
+  expandedRoutes: Set<string>
+  toggleRoute: (slug: string) => void
+}> = ({ routes, expandedRoutes, toggleRoute }) => {
+  if (routes.length === 0) {
+    return <div style={{ color: '#6b7280', fontFamily: 'monospace', padding: 20 }}>No transit routes available from your current location.</div>
+  }
+
+  const grouped = routes.reduce<Record<string, TransitRoute[]>>((acc, r) => {
+    const key = `${r.transit_type.name} (${r.transit_type.category})`
+    if (!acc[key]) acc[key] = []
+    acc[key].push(r)
+    return acc
+  }, {})
+
+  return (
+    <div>
+      {Object.entries(grouped).map(([typeName, typeRoutes]) => (
+        <div key={typeName} style={{ marginBottom: 20 }}>
+          <h3 style={{ color: CATEGORY_COLORS[typeRoutes[0].transit_type.category] || '#9ca3af', fontFamily: 'monospace', margin: '0 0 10px 0' }}>
+            [{typeRoutes[0].transit_type.icon_key || 'TRANSIT'}] {typeName}
+          </h3>
+          {typeRoutes.map(route => (
+            <div key={route.slug} style={{ border: '1px solid #333', marginBottom: 8, background: '#0a0a0a' }}>
+              <div
+                onClick={() => toggleRoute(route.slug)}
+                style={{ padding: '10px 15px', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+              >
+                <div>
+                  <span style={{ color: '#22d3ee', fontFamily: 'monospace', fontWeight: 'bold' }}>{route.name}</span>
+                  <span style={{ color: '#6b7280', fontFamily: 'monospace', marginLeft: 10 }}>
+                    {route.stop_count} stops {route.loop_route ? '(loop)' : ''} | {route.transit_type.base_fare} CRED
+                  </span>
+                </div>
+                <span style={{ color: '#6b7280' }}>{expandedRoutes.has(route.slug) ? '[-]' : '[+]'}</span>
+              </div>
+              {expandedRoutes.has(route.slug) && (
+                <div style={{ padding: '0 15px 15px', borderTop: '1px solid #222' }}>
+                  {route.stops.map((stop, i) => (
+                    <div key={i} style={{ padding: '4px 0', fontFamily: 'monospace', color: stop.is_terminus ? '#fbbf24' : '#9ca3af' }}>
+                      {stop.is_terminus ? '◆' : '·'} {stop.name}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const SlipstreamTab: React.FC<{
+  routes: SlipstreamRoute[]
+  heat: number
+  heatTier: string
+}> = ({ routes, heat, heatTier }) => {
+  return (
+    <div>
+      {/* Heat indicator */}
+      <div style={{ padding: '10px 15px', border: '1px solid #333', marginBottom: 20, background: '#0a0a0a', fontFamily: 'monospace' }}>
+        <span style={{ color: '#9ca3af' }}>Corridor Heat: </span>
+        <span style={{ color: HEAT_COLORS[heatTier] || '#9ca3af', fontWeight: 'bold' }}>
+          {heat}/100 ({heatTier})
+        </span>
+        <div style={{ marginTop: 8, height: 4, background: '#222', borderRadius: 2 }}>
+          <div style={{ width: `${heat}%`, height: '100%', background: HEAT_COLORS[heatTier] || '#9ca3af', borderRadius: 2, transition: 'width 0.3s' }} />
+        </div>
+      </div>
+
+      {routes.length === 0 ? (
+        <div style={{ color: '#6b7280', fontFamily: 'monospace', padding: 20 }}>No Slipstream corridors available from your current region.</div>
+      ) : (
+        routes.map(route => (
+          <div key={route.slug} style={{ border: '1px solid #a78bfa33', padding: 15, marginBottom: 10, background: '#0a0a0a' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+              <span style={{ color: '#a78bfa', fontFamily: 'monospace', fontWeight: 'bold' }}>[SLIP] {route.name}</span>
+              <span style={{ color: '#6b7280', fontFamily: 'monospace', fontSize: '0.85em' }}>CL{route.min_clearance}+</span>
+            </div>
+            <div style={{ color: '#9ca3af', fontFamily: 'monospace', fontSize: '0.9em' }}>
+              {route.origin_region.name} <span style={{ color: '#a78bfa' }}>→</span> {route.destination_region.name}
+              <span style={{ color: '#6b7280', marginLeft: 15 }}>{route.leg_count} legs</span>
+            </div>
+            {route.legs.length > 0 && (
+              <div style={{ marginTop: 10, paddingLeft: 10, borderLeft: '2px solid #a78bfa33' }}>
+                {route.legs.map(leg => (
+                  <div key={leg.position} style={{ padding: '3px 0', fontFamily: 'monospace', color: '#6b7280', fontSize: '0.85em' }}>
+                    Leg {leg.position}: {leg.name} {leg.has_forks && <span style={{ color: '#fbbf24' }}>[FORK]</span>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+
+const NetworkTab: React.FC<{
+  assignments: Record<string, RegionAssignment[]>
+}> = ({ assignments }) => {
+  const regions = Object.entries(assignments).sort(([a], [b]) => a.localeCompare(b))
+
+  return (
+    <div>
+      <p style={{ color: '#6b7280', fontFamily: 'monospace', marginBottom: 20 }}>
+        Transit types available per region across THE PULSE GRID.
+      </p>
+      {regions.length === 0 ? (
+        <div style={{ color: '#6b7280', fontFamily: 'monospace' }}>No transit assignments configured.</div>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 }}>
+          {regions.map(([regionSlug, types]) => (
+            <div key={regionSlug} style={{ border: '1px solid #333', padding: 12, background: '#0a0a0a' }}>
+              <div style={{ color: '#a78bfa', fontFamily: 'monospace', fontWeight: 'bold', marginBottom: 8 }}>
+                {regionSlug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()).replace(/^The /, 'The ')}
+              </div>
+              {types.map(t => (
+                <div key={t.slug} style={{ padding: '2px 0', fontFamily: 'monospace', fontSize: '0.85em' }}>
+                  <span style={{ color: CATEGORY_COLORS[t.category] || '#9ca3af' }}>
+                    {t.category === 'public' ? '■' : '◇'}
+                  </span>{' '}
+                  <span style={{ color: '#d0d0d0' }}>{t.name}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TransitPage

--- a/app/models/concerns/grid_hackr/transit.rb
+++ b/app/models/concerns/grid_hackr/transit.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module GridHackr::Transit
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :grid_transit_journeys, dependent: :destroy
+  end
+
+  def in_transit?
+    grid_transit_journeys.where(state: "active").exists?
+  end
+
+  def active_journey
+    grid_transit_journeys.where(state: "active")
+      .includes(:grid_slipstream_route, :current_leg,
+        :grid_transit_route, :current_stop)
+      .first
+  end
+
+  # Read current slipstream heat with lazy decay applied.
+  # Decay: 1 point per minute since last update.
+  # NOTE: This has a DB write side-effect — decayed value is persisted on read
+  # to avoid recalculating on every access. This means API GET endpoints that
+  # call slipstream_heat are not purely read-only.
+  def slipstream_heat
+    raw = stat("slipstream_heat").to_i
+    last_at = stat("slipstream_heat_last_at").to_i
+    return raw if last_at.zero? || raw.zero?
+
+    elapsed_minutes = ((Time.current.to_i - last_at) / 60.0).floor
+    return raw if elapsed_minutes <= 0
+
+    decayed = [raw - elapsed_minutes, 0].max
+    if decayed < raw
+      set_stat!("slipstream_heat", decayed)
+      set_stat!("slipstream_heat_last_at", Time.current.to_i) if decayed > 0
+    end
+    decayed
+  end
+
+  def slipstream_heat_tier
+    heat = slipstream_heat
+    case heat
+    when 0..9 then :cold
+    when 10..40 then :warm
+    when 41..70 then :hot
+    else :burning
+    end
+  end
+
+  def add_slipstream_heat!(amount)
+    current = slipstream_heat # triggers decay first
+    new_level = [current + amount, 100].min
+    set_stat!("slipstream_heat", new_level)
+    set_stat!("slipstream_heat_last_at", Time.current.to_i)
+    new_level
+  end
+end

--- a/app/models/grid_achievement.rb
+++ b/app/models/grid_achievement.rb
@@ -74,6 +74,11 @@ class GridAchievement < ApplicationRecord
     breaches_completed_count
     protocols_dismantled
     data_extracted
+    local_transit_completed
+    slipstream_completed
+    transits_completed_count
+    slipstreams_completed_count
+    regions_visited_count
   ].freeze
 
   CATEGORIES = %w[grid music social meta progression].freeze
@@ -97,6 +102,9 @@ class GridAchievement < ApplicationRecord
     breaches_completed_count
     protocols_dismantled
     data_extracted
+    transits_completed_count
+    slipstreams_completed_count
+    regions_visited_count
   ].freeze
 
   has_many :grid_hackr_achievements, dependent: :destroy

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -39,6 +39,7 @@ class GridHackr < ApplicationRecord
   include GridHackr::Stats
   include GridHackr::Loadout
   include GridHackr::Breach
+  include GridHackr::Transit
 
   has_paper_trail ignore: %i[
     password_digest api_token_digest last_activity_at stats

--- a/app/models/grid_region_transit_assignment.rb
+++ b/app/models/grid_region_transit_assignment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class GridRegionTransitAssignment < ApplicationRecord
+  belongs_to :grid_region
+  belongs_to :grid_transit_type
+
+  validates :grid_region_id, uniqueness: {scope: :grid_transit_type_id}
+  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+end

--- a/app/models/grid_slipstream_leg.rb
+++ b/app/models/grid_slipstream_leg.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class GridSlipstreamLeg < ApplicationRecord
+  belongs_to :grid_slipstream_route
+
+  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 1},
+    uniqueness: {scope: :grid_slipstream_route_id}
+  validates :name, presence: true
+
+  def option_keys = (fork_options || []).map { |o| o["key"] }
+
+  def option_for(key) = (fork_options || []).find { |o| o["key"] == key }
+
+  def has_forks? = fork_options.present? && fork_options.any?
+end

--- a/app/models/grid_slipstream_route.rb
+++ b/app/models/grid_slipstream_route.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class GridSlipstreamRoute < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :origin_region, class_name: "GridRegion"
+  belongs_to :destination_region, class_name: "GridRegion"
+  belongs_to :origin_room, class_name: "GridRoom"
+  belongs_to :destination_room, class_name: "GridRoom"
+  has_many :grid_slipstream_legs, -> { order(:position) }, dependent: :destroy
+  has_many :grid_transit_journeys, dependent: :restrict_with_error
+
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+
+  def to_param = slug
+  validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :base_heat_cost, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :detection_risk_base, numericality: {only_integer: true, in: 0..100}
+  validate :regions_must_differ
+
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(:position, :name) }
+  scope :accessible_by, ->(hackr) { active.where("min_clearance <= ?", hackr.stat("clearance")) }
+
+  def leg_count = grid_slipstream_legs.size
+
+  def legs_in_order = grid_slipstream_legs.order(:position).to_a
+
+  def first_leg = grid_slipstream_legs.order(:position).first
+
+  def next_leg_after(leg)
+    grid_slipstream_legs.where("position > ?", leg.position).order(:position).first
+  end
+
+  private
+
+  def regions_must_differ
+    if origin_region_id.present? && origin_region_id == destination_region_id
+      errors.add(:destination_region, "must differ from origin region")
+    end
+  end
+end

--- a/app/models/grid_transit_journey.rb
+++ b/app/models/grid_transit_journey.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class GridTransitJourney < ApplicationRecord
+  JOURNEY_TYPES = %w[slipstream local_public local_private].freeze
+  STATES = %w[active completed abandoned ejected].freeze
+
+  belongs_to :grid_hackr
+  belongs_to :origin_room, class_name: "GridRoom", optional: true
+  belongs_to :destination_room, class_name: "GridRoom", optional: true
+
+  # Slipstream associations
+  belongs_to :grid_slipstream_route, optional: true
+  belongs_to :current_leg, class_name: "GridSlipstreamLeg", optional: true
+
+  # Local transit associations
+  belongs_to :grid_transit_route, optional: true
+  belongs_to :current_stop, class_name: "GridTransitStop", optional: true
+
+  validates :journey_type, inclusion: {in: JOURNEY_TYPES}
+  validates :state, inclusion: {in: STATES}
+
+  scope :active, -> { where(state: "active") }
+
+  def active? = state == "active"
+  def slipstream? = journey_type == "slipstream"
+  def local_public? = journey_type == "local_public"
+  def local_private? = journey_type == "local_private"
+  def local? = local_public? || local_private?
+  def awaiting_fork? = pending_fork?
+
+  def total_legs
+    grid_slipstream_route&.leg_count || 0
+  end
+
+  def chosen_forks
+    meta&.dig("chosen_forks") || {}
+  end
+end

--- a/app/models/grid_transit_route.rb
+++ b/app/models/grid_transit_route.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class GridTransitRoute < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :grid_transit_type
+  belongs_to :grid_region
+  has_many :grid_transit_stops, -> { order(:position) }, dependent: :destroy
+  has_many :grid_transit_journeys, dependent: :restrict_with_error
+
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+
+  def to_param = slug
+
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(:position, :name) }
+  scope :for_region, ->(region) { where(grid_region: region) }
+
+  def stop_count = grid_transit_stops.size
+
+  def stop_at_position(pos)
+    grid_transit_stops.find_by(position: pos)
+  end
+
+  def stop_for_room(room)
+    grid_transit_stops.find_by(grid_room_id: room.id)
+  end
+
+  def next_stop_after(stop)
+    stops = grid_transit_stops.order(:position).to_a
+    idx = stops.index { |s| s.id == stop.id }
+    return nil if idx.nil?
+    if idx + 1 < stops.size
+      stops[idx + 1]
+    elsif loop_route
+      stops.first
+    end
+  end
+end

--- a/app/models/grid_transit_stop.rb
+++ b/app/models/grid_transit_stop.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class GridTransitStop < ApplicationRecord
+  belongs_to :grid_transit_route
+  belongs_to :grid_room
+
+  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0},
+    uniqueness: {scope: :grid_transit_route_id}
+
+  def display_name
+    label.presence || grid_room.name
+  end
+end

--- a/app/models/grid_transit_type.rb
+++ b/app/models/grid_transit_type.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class GridTransitType < ApplicationRecord
+  has_paper_trail
+
+  CATEGORIES = %w[public private slipstream].freeze
+
+  has_many :grid_region_transit_assignments, dependent: :destroy
+  has_many :grid_regions, through: :grid_region_transit_assignments
+  has_many :grid_transit_routes, dependent: :restrict_with_error
+
+  validates :slug, presence: true, uniqueness: true
+  validates :name, presence: true
+
+  def to_param = slug
+  validates :category, inclusion: {in: CATEGORIES}
+  validates :base_fare, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(:position, :name) }
+
+  def public_route? = category == "public"
+  def private_point? = category == "private"
+  def slipstream? = category == "slipstream"
+end

--- a/app/services/grid/achievement_checker.rb
+++ b/app/services/grid/achievement_checker.rb
@@ -120,6 +120,12 @@ module Grid
         derive(@hackr.stat("protocols_dismantled_count").to_i, data[:count].to_i)
       when "data_extracted"
         derive(@hackr.stat("data_extracted_count").to_i, data[:count].to_i)
+      when "transits_completed_count"
+        derive(@hackr.stat("local_transit_trips_count").to_i, data[:count].to_i)
+      when "slipstreams_completed_count"
+        derive(@hackr.stat("slipstream_trips_count").to_i, data[:count].to_i)
+      when "regions_visited_count"
+        derive(@hackr.stat("regions_visited_count").to_i, data[:count].to_i)
       end
     end
 
@@ -317,6 +323,10 @@ module Grid
         return data[:item_name].blank? || data[:item_name].to_s.downcase == context[:item_name].to_s.downcase
       when "breach_completed"
         return data[:template_slug].blank? || data[:template_slug].to_s == context[:template_slug].to_s
+      when "local_transit_completed"
+        return data[:transit_type_slug].blank? || data[:transit_type_slug].to_s == context[:transit_type_slug].to_s
+      when "slipstream_completed"
+        return data[:route_slug].blank? || data[:route_slug].to_s == context[:route_slug].to_s
       when "manual"
         return false
       end

--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -3,8 +3,8 @@
 module Grid
   class BreachActionService
     ExecResult = Data.define(:hit, :damage_dealt, :program_name, :target_position,
-      :protocol_destroyed, :battery_consumed, :all_destroyed, :exploit, :fragment)
-    AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action)
+      :protocol_destroyed, :battery_consumed, :all_destroyed, :exploit, :fragment, :debuff_hint)
+    AnalyzeResult = Data.define(:target_position, :level_reached, :info_revealed, :bonus_action, :debuff_hint)
     RerouteResult = Data.define(:target_position, :protocol_type_label)
     UseItemResult = Data.define(:item_name, :effect_output, :emergency_jackout)
     InterfaceResult = Data.define(:gate_id, :correct, :gate_state, :attempts_remaining, :all_solved, :all_failed, :feedback)
@@ -173,7 +173,8 @@ module Grid
         battery_consumed: battery_cost,
         all_destroyed: all_destroyed,
         exploit: is_exploit,
-        fragment: fragment_extracted
+        fragment: fragment_extracted,
+        debuff_hint: energy_debuff_hint
       )
     end
 
@@ -203,7 +204,8 @@ module Grid
             target_position: target_position,
             level_reached: current_level,
             info_revealed: "Already fully analyzed.",
-            bonus_action: false
+            bonus_action: false,
+            debuff_hint: nil
           )
         end
 
@@ -263,7 +265,8 @@ module Grid
         target_position: target_position,
         level_reached: level_reached,
         info_revealed: info_revealed,
-        bonus_action: bonus_action
+        bonus_action: bonus_action,
+        debuff_hint: psyche_debuff_hint
       )
     end
 
@@ -714,6 +717,36 @@ module Grid
         0.75
       else
         0.50
+      end
+    end
+
+    # Debuff hint for exec output — tells the player why damage is reduced/zero
+    def energy_debuff_hint
+      energy = @hackr.stat("energy")
+      max_energy = @hackr.effective_max("energy")
+      return "ENERGY depleted — damage output disabled." if energy <= 0
+      ratio = energy.to_f / max_energy
+      if ratio < 0.10
+        "Low ENERGY — damage reduced to 50%."
+      elsif ratio < 0.25
+        "Low ENERGY — damage reduced to 75%."
+      elsif ratio < 0.50
+        "Low ENERGY — damage reduced to 90%."
+      end
+    end
+
+    # Debuff hint for analyze output — tells the player intel may be unreliable
+    def psyche_debuff_hint
+      psyche = @hackr.stat("psyche")
+      max_psyche = @hackr.effective_max("psyche")
+      return "PSYCHE depleted — intel unreliable." if psyche <= 0
+      ratio = psyche.to_f / max_psyche
+      if ratio < 0.10
+        "Low PSYCHE — high chance of false intel."
+      elsif ratio < 0.25
+        "Low PSYCHE — intel may be unreliable."
+      elsif ratio < 0.50
+        "Low PSYCHE — slight chance of false intel."
       end
     end
 

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -73,8 +73,10 @@ module Grid
         damage_color = result.protocol_destroyed ? "#34d399" : "#22d3ee"
         output << "<span style='color: #{damage_color};'>#{h(result.program_name)} → Protocol [#{result.target_position + 1}]: #{result.damage_dealt} damage#{" — DESTROYED" if result.protocol_destroyed}</span>"
         output << "<span style='color: #6b7280;'>Battery: -#{result.battery_consumed}</span>"
+        output << "<span style='color: #fbbf24;'>  ▸ #{h(result.debuff_hint)}</span>" if result.debuff_hint
       else
         output << "<span style='color: #9ca3af;'>#{h(result.program_name)} → Protocol [#{result.target_position + 1}]: no effect.</span>"
+        output << "<span style='color: #f87171;'>  ▸ #{h(result.debuff_hint)}</span>" if result.debuff_hint
       end
 
       # Fragment extraction notification
@@ -146,6 +148,7 @@ module Grid
 
       output = []
       output << "<span style='color: #22d3ee;'>ANALYZE → Protocol [#{result.target_position + 1}]: #{h(result.info_revealed)}</span>"
+      output << "<span style='color: #fbbf24;'>  ▸ #{h(result.debuff_hint)}</span>" if result.debuff_hint
       output << "<span style='color: #34d399;'>  ▸ Bonus action!</span>" if result.bonus_action
 
       # Check if round should end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -234,11 +234,21 @@ module Grid
         end
       end
 
-      # Local transit indicator — show routes that stop at this room
+      # Local transit indicator — show public routes that stop at this room
       local_routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
       if local_routes.any?
         output << ""
         output << Grid::TransitRenderer.render_available_routes(local_routes, hackr)
+      end
+
+      # Private transit indicator — show hailable types + destinations when in a transit room
+      private_types = Grid::LocalTransitService.private_types_at_room(room: room, hackr: hackr)
+      if private_types.any?
+        destinations = Grid::LocalTransitService.private_destinations(room: room)
+        if destinations.any?
+          output << ""
+          output << Grid::TransitRenderer.render_private_types(private_types, destinations, room)
+        end
       end
 
       output << ""
@@ -938,14 +948,6 @@ module Grid
       route = routes.find { |r| r.slug == route_slug }
       return "<span style='color: #f87171;'>Route '#{h(route_slug)}' not available here. Type <span style='color: #22d3ee;'>transit</span> to see routes.</span>" unless route
 
-      type = route.grid_transit_type
-
-      if type.private_point?
-        # Private: need destination — "board taxi-car <destination>"
-        # For now, show available stops
-        return "<span style='color: #fbbf24;'>Private transit requires a destination. Use <span style='color: #22d3ee;'>hail #{h(route_slug)} &lt;stop-name&gt;</span>.</span>"
-      end
-
       result = Grid::LocalTransitService.board!(hackr: hackr, route: route)
       result.display
     rescue Grid::LocalTransitService::AlreadyInJourney
@@ -960,49 +962,45 @@ module Grid
       return "<span style='color: #fbbf24;'>Hail what? e.g. <span style='color: #22d3ee;'>hail taxi-car &lt;destination&gt;</span></span>" unless args&.any?
 
       room = hackr.current_room
-      routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
+      private_types = Grid::LocalTransitService.private_types_at_room(room: room, hackr: hackr)
 
-      # First arg is route slug, rest is destination name
-      route_slug = args.first
+      # First arg is type slug, rest is destination name
+      type_slug = args.first
       dest_name = args[1..]&.join(" ")
 
-      route = routes.find { |r| r.slug == route_slug }
-      unless route
-        return "<span style='color: #f87171;'>'#{h(route_slug)}' not available here. Type <span style='color: #22d3ee;'>transit</span> to see options.</span>"
+      transit_type = private_types.find { |t| t.slug == type_slug }
+      unless transit_type
+        return "<span style='color: #f87171;'>'#{h(type_slug)}' not available here. Type <span style='color: #22d3ee;'>look</span> to see options.</span>"
       end
 
-      unless route.grid_transit_type.private_point?
-        return "<span style='color: #9ca3af;'>Use <span style='color: #22d3ee;'>board #{h(route_slug)}</span> for public transit.</span>"
-      end
+      destinations = Grid::LocalTransitService.private_destinations(room: room)
 
       unless dest_name.present?
-        # Show available destinations
-        stops = route.grid_transit_stops.includes(:grid_room).order(:position)
-        lines = ["<span style='color: #fbbf24;'>Available destinations:</span>"]
-        stops.each do |s|
-          next if s.grid_room_id == room.id
-          lines << "  <span style='color: #22d3ee;'>hail #{h(route_slug)} #{h(s.display_name.downcase)}</span>"
+        lines = ["<span style='color: #fbbf24;'>Available destinations for #{h(transit_type.name)}:</span>"]
+        destinations.each do |d|
+          lines << "  <span style='color: #22d3ee;'>hail #{h(type_slug)} #{h(d.name.downcase)}</span> <span style='color: #6b7280;'>(#{h(d.grid_zone.name)})</span>"
         end
         return lines.join("\n")
       end
 
-      # Find destination stop by name match
-      stops = route.grid_transit_stops.includes(:grid_room).to_a
-      dest_stop = stops.find { |s| s.display_name.downcase == dest_name.downcase }
-      dest_stop ||= stops.find { |s| s.display_name.downcase.include?(dest_name.downcase) }
+      # Find destination room by name match
+      dest_room = destinations.find { |d| d.name.downcase == dest_name.downcase }
+      dest_room ||= destinations.find { |d| d.name.downcase.include?(dest_name.downcase) }
 
-      unless dest_stop
-        return "<span style='color: #f87171;'>Destination '#{h(dest_name)}' not found on this route.</span>"
+      unless dest_room
+        return "<span style='color: #f87171;'>Destination '#{h(dest_name)}' not found in this region.</span>"
       end
 
-      result = Grid::LocalTransitService.board!(hackr: hackr, route: route, destination_stop: dest_stop)
+      result = Grid::LocalTransitService.board_private!(hackr: hackr, transit_type: transit_type, destination_room: dest_room)
       result.display
     rescue Grid::LocalTransitService::AlreadyInJourney
       "<span style='color: #f87171;'>Already in transit.</span>"
     rescue Grid::LocalTransitService::InsufficientFunds
       "<span style='color: #f87171;'>Insufficient CRED for fare.</span>"
     rescue Grid::LocalTransitService::AlreadyAtDestination
-      "<span style='color: #f87171;'>You're already at that stop.</span>"
+      "<span style='color: #f87171;'>You're already there.</span>"
+    rescue Grid::LocalTransitService::NotAtTransitStop
+      "<span style='color: #f87171;'>You must be at a transit location to hail private transport.</span>"
     end
 
     def slipstream_command(args)

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -25,8 +25,14 @@ module Grid
       end
 
       # Captured mode: restricted command set in GovCorp facility
+      # (Checked before transit — a captured hackr's journey is effectively frozen)
       if Grid::ContainmentService.captured?(hackr)
         return Grid::CapturedCommandParser.new(hackr, input, self).execute
+      end
+
+      # Transit mode: restricted command set while in transit
+      if (active_journey = hackr.active_journey)
+        return Grid::TransitCommandParser.new(hackr, input, active_journey, self).execute
       end
 
       # Split input but preserve case in arguments
@@ -152,6 +158,14 @@ module Grid
         go_command("out")
       when "home"
         go_command("home")
+      when "transit", "tr"
+        transit_command
+      when "board"
+        board_command(args)
+      when "slipstream", "slip"
+        slipstream_command(args)
+      when "hail"
+        hail_command(args)
       when "help", "?"
         help_command
       when "who"
@@ -206,6 +220,25 @@ module Grid
           end
           output << "<span style='color: #6b7280;'>  Type 'breach &lt;name or #&gt;' to initiate.</span>"
         end
+      end
+
+      # Slipstream access indicator — show destinations available from this room
+      slip_routes = GridSlipstreamRoute.active
+        .where(origin_room: room)
+        .includes(:destination_region)
+      if slip_routes.any?
+        output << ""
+        output << "<span style='color: #a78bfa; font-weight: bold;'>[ SLIPSTREAM ACCESS ]</span>"
+        slip_routes.each do |sr|
+          output << "  <span style='color: #a78bfa;'>→ #{h(sr.destination_region.name)}</span> <span style='color: #6b7280;'>(CL#{sr.min_clearance}+, #{sr.leg_count} legs)</span> <span style='color: #a78bfa;'>slipstream #{h(sr.slug)}</span>"
+        end
+      end
+
+      # Local transit indicator — show routes that stop at this room
+      local_routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
+      if local_routes.any?
+        output << ""
+        output << Grid::TransitRenderer.render_available_routes(local_routes, hackr)
       end
 
       output << ""
@@ -888,6 +921,120 @@ module Grid
       status.reason ? h(status.reason) : nil
     end
 
+    def transit_command
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere.</span>" unless room
+
+      routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
+      Grid::TransitRenderer.render_available_routes(routes, hackr)
+    end
+
+    def board_command(args)
+      route_slug = args&.join("-")
+      return "<span style='color: #fbbf24;'>Board what? Specify a route slug. Type <span style='color: #22d3ee;'>transit</span> to see available routes.</span>" unless route_slug.present?
+
+      room = hackr.current_room
+      routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
+      route = routes.find { |r| r.slug == route_slug }
+      return "<span style='color: #f87171;'>Route '#{h(route_slug)}' not available here. Type <span style='color: #22d3ee;'>transit</span> to see routes.</span>" unless route
+
+      type = route.grid_transit_type
+
+      if type.private_point?
+        # Private: need destination — "board taxi-car <destination>"
+        # For now, show available stops
+        return "<span style='color: #fbbf24;'>Private transit requires a destination. Use <span style='color: #22d3ee;'>hail #{h(route_slug)} &lt;stop-name&gt;</span>.</span>"
+      end
+
+      result = Grid::LocalTransitService.board!(hackr: hackr, route: route)
+      result.display
+    rescue Grid::LocalTransitService::AlreadyInJourney
+      "<span style='color: #f87171;'>Already in transit.</span>"
+    rescue Grid::LocalTransitService::InsufficientFunds
+      "<span style='color: #f87171;'>Insufficient CRED for fare.</span>"
+    rescue Grid::LocalTransitService::RouteNotAtStop
+      "<span style='color: #f87171;'>This route doesn't stop here.</span>"
+    end
+
+    def hail_command(args)
+      return "<span style='color: #fbbf24;'>Hail what? e.g. <span style='color: #22d3ee;'>hail taxi-car &lt;destination&gt;</span></span>" unless args&.any?
+
+      room = hackr.current_room
+      routes = Grid::LocalTransitService.routes_at_room(room: room, hackr: hackr)
+
+      # First arg is route slug, rest is destination name
+      route_slug = args.first
+      dest_name = args[1..]&.join(" ")
+
+      route = routes.find { |r| r.slug == route_slug }
+      unless route
+        return "<span style='color: #f87171;'>'#{h(route_slug)}' not available here. Type <span style='color: #22d3ee;'>transit</span> to see options.</span>"
+      end
+
+      unless route.grid_transit_type.private_point?
+        return "<span style='color: #9ca3af;'>Use <span style='color: #22d3ee;'>board #{h(route_slug)}</span> for public transit.</span>"
+      end
+
+      unless dest_name.present?
+        # Show available destinations
+        stops = route.grid_transit_stops.includes(:grid_room).order(:position)
+        lines = ["<span style='color: #fbbf24;'>Available destinations:</span>"]
+        stops.each do |s|
+          next if s.grid_room_id == room.id
+          lines << "  <span style='color: #22d3ee;'>hail #{h(route_slug)} #{h(s.display_name.downcase)}</span>"
+        end
+        return lines.join("\n")
+      end
+
+      # Find destination stop by name match
+      stops = route.grid_transit_stops.includes(:grid_room).to_a
+      dest_stop = stops.find { |s| s.display_name.downcase == dest_name.downcase }
+      dest_stop ||= stops.find { |s| s.display_name.downcase.include?(dest_name.downcase) }
+
+      unless dest_stop
+        return "<span style='color: #f87171;'>Destination '#{h(dest_name)}' not found on this route.</span>"
+      end
+
+      result = Grid::LocalTransitService.board!(hackr: hackr, route: route, destination_stop: dest_stop)
+      result.display
+    rescue Grid::LocalTransitService::AlreadyInJourney
+      "<span style='color: #f87171;'>Already in transit.</span>"
+    rescue Grid::LocalTransitService::InsufficientFunds
+      "<span style='color: #f87171;'>Insufficient CRED for fare.</span>"
+    rescue Grid::LocalTransitService::AlreadyAtDestination
+      "<span style='color: #f87171;'>You're already at that stop.</span>"
+    end
+
+    def slipstream_command(args)
+      region = hackr.current_room&.grid_zone&.grid_region
+      return "<span style='color: #f87171;'>You are nowhere.</span>" unless region
+
+      if hackr.stat("clearance").to_i < Grid::SlipstreamService::MIN_CLEARANCE
+        return "<span style='color: #f87171;'>Slipstream access requires Clearance #{Grid::SlipstreamService::MIN_CLEARANCE}+.</span>"
+      end
+
+      routes = Grid::SlipstreamService.routes_from(region: region, hackr: hackr)
+
+      if args&.any?
+        route_slug = args.join("-")
+        route = routes.find { |r| r.slug == route_slug }
+        return "<span style='color: #f87171;'>Slipstream route '#{h(route_slug)}' not found.</span>" unless route
+
+        result = Grid::SlipstreamService.board!(hackr: hackr, route: route)
+        return result.display
+      end
+
+      Grid::TransitRenderer.render_slipstream_routes(routes, hackr)
+    rescue Grid::SlipstreamService::AlreadyInJourney
+      "<span style='color: #f87171;'>Already in transit.</span>"
+    rescue Grid::SlipstreamService::ClearanceRequired
+      "<span style='color: #f87171;'>Clearance too low for this route.</span>"
+    rescue Grid::SlipstreamService::NotAtBoardingPoint
+      "<span style='color: #f87171;'>You must be at the Slipstream access point to board.</span>"
+    rescue Grid::SlipstreamService::CorridorLockedOut
+      "<span style='color: #f87171;'>This corridor is locked out — GovCorp flagged the route. Wait for the heat to clear.</span>"
+    end
+
     def help_command
       <<~HELP
         <span style='color: #22d3ee; font-weight: bold;'>Available Commands:</span>
@@ -913,6 +1060,12 @@ module Grid
           <span style='color: #34d399;'>equip &lt;item&gt;, wear</span>         - Equip a gear item
           <span style='color: #34d399;'>unequip &lt;item|slot&gt;, remove</span> - Remove equipped gear
           <span style='color: #34d399;'>loadout, lo</span>                - View your current loadout
+
+        <span style='color: #fbbf24;'>Transit:</span>
+          <span style='color: #34d399;'>transit, tr</span>                - View transit routes at current location
+          <span style='color: #34d399;'>board &lt;route&gt;</span>              - Board public transit route
+          <span style='color: #34d399;'>hail &lt;type&gt; &lt;dest&gt;</span>         - Hail private transport to destination
+          <span style='color: #34d399;'>slipstream, slip</span>           - View/initiate inter-region Slipstream corridors
 
         <span style='color: #fbbf24;'>DECK &amp; BREACH:</span>
           <span style='color: #34d399;'>deck, dk</span>                   - View equipped DECK status

--- a/app/services/grid/local_transit_service.rb
+++ b/app/services/grid/local_transit_service.rb
@@ -36,6 +36,35 @@ module Grid
       new(hackr).status
     end
 
+    # Private transit types available at this room (route-free, region-wide)
+    def self.private_types_at_room(room:, hackr:)
+      return [] unless room.room_type == "transit"
+      region = room.grid_zone&.grid_region
+      return [] unless region
+
+      GridRegionTransitAssignment
+        .where(grid_region: region)
+        .includes(:grid_transit_type)
+        .map(&:grid_transit_type)
+        .select { |t| t.private_point? && t.published? && hackr.stat("clearance").to_i >= t.min_clearance }
+    end
+
+    # All transit rooms in the same region as the given room (for private destinations)
+    def self.private_destinations(room:)
+      region = room.grid_zone&.grid_region
+      return [] unless region
+
+      GridRoom.where(room_type: "transit")
+        .joins(:grid_zone).where(grid_zones: {grid_region_id: region.id})
+        .where.not(id: room.id)
+        .includes(:grid_zone)
+        .order(:name)
+    end
+
+    def self.board_private!(hackr:, transit_type:, destination_room:)
+      new(hackr).board_private!(transit_type, destination_room)
+    end
+
     def self.routes_at_room(room:, hackr:)
       region = room.grid_zone&.grid_region
       return [] unless region
@@ -60,9 +89,10 @@ module Grid
 
       type = route.grid_transit_type
 
-      # Private: require destination
+      # Private: require destination on the same route
       if type.private_point?
         raise DestinationNotOnRoute unless destination_stop
+        raise DestinationNotOnRoute unless destination_stop.grid_transit_route_id == route.id
         raise AlreadyAtDestination if destination_stop.id == boarding_stop.id
       end
 
@@ -100,6 +130,40 @@ module Grid
       end
     end
 
+    # Route-free private transit — hackr picks any transit room in the region
+    def board_private!(transit_type, destination_room)
+      room = @hackr.current_room
+      raise NotAtTransitStop unless room.room_type == "transit"
+      raise AlreadyAtDestination if destination_room.id == room.id
+
+      fare = transit_type.base_fare
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        raise AlreadyInJourney if @hackr.active_journey
+
+        if fare > 0
+          cache = @hackr.default_cache
+          raise InsufficientFunds unless cache && cache.balance >= fare
+          Grid::TransactionService.burn!(from_cache: cache, amount: fare, memo: "#{transit_type.name} fare")
+        end
+
+        journey = GridTransitJourney.create!(
+          grid_hackr: @hackr,
+          journey_type: "local_private",
+          state: "active",
+          origin_room: room,
+          destination_room: destination_room,
+          fare_paid: fare,
+          started_at: Time.current,
+          meta: {"transit_type_slug" => transit_type.slug}
+        )
+
+        display = Grid::TransitRenderer.render_private_board(journey, transit_type, destination_room)
+        BoardResult.new(journey: journey, route: nil, current_stop: nil, fare_charged: fare, display: display)
+      end
+    end
+
     def wait!
       journey = @hackr.active_journey
       raise NotInJourney unless journey&.active? && journey.local?
@@ -112,14 +176,12 @@ module Grid
 
         # Private transit: single wait → arrive directly at destination
         if journey.local_private?
-          dest_stop = route.grid_transit_stops.find_by(grid_room_id: journey.destination_room_id)
-          dest_room = dest_stop&.grid_room || journey.destination_room
+          dest_room = journey.destination_room
           if dest_room
-            journey.update!(current_stop: dest_stop) if dest_stop
             move_hackr_to_room!(dest_room)
             complete_journey!(journey)
-            display = Grid::TransitRenderer.render_wait(journey, dest_stop || current, true, route)
-            return WaitResult.new(journey: journey.reload, current_stop: dest_stop || current, arrived: true, display: display)
+            display = Grid::TransitRenderer.render_private_arrival(journey, dest_room)
+            return WaitResult.new(journey: journey.reload, current_stop: nil, arrived: true, display: display)
           end
         end
 

--- a/app/services/grid/local_transit_service.rb
+++ b/app/services/grid/local_transit_service.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+module Grid
+  class LocalTransitService
+    BoardResult = Data.define(:journey, :route, :current_stop, :fare_charged, :display)
+    WaitResult = Data.define(:journey, :current_stop, :arrived, :display)
+    DisembarkResult = Data.define(:journey, :room, :display)
+    AbandonResult = Data.define(:journey, :display)
+    StatusResult = Data.define(:journey, :display)
+
+    class NotAtTransitStop < StandardError; end
+    class RouteNotAtStop < StandardError; end
+    class AlreadyInJourney < StandardError; end
+    class InsufficientFunds < StandardError; end
+    class DestinationNotOnRoute < StandardError; end
+    class AlreadyAtDestination < StandardError; end
+    class NotInJourney < StandardError; end
+
+    def self.board!(hackr:, route:, destination_stop: nil)
+      new(hackr).board!(route, destination_stop)
+    end
+
+    def self.wait!(hackr:)
+      new(hackr).wait!
+    end
+
+    def self.disembark!(hackr:)
+      new(hackr).disembark!
+    end
+
+    def self.abandon!(hackr:)
+      new(hackr).abandon!
+    end
+
+    def self.status(hackr:)
+      new(hackr).status
+    end
+
+    def self.routes_at_room(room:, hackr:)
+      region = room.grid_zone&.grid_region
+      return [] unless region
+
+      GridTransitRoute.active
+        .joins(:grid_transit_stops)
+        .where(grid_transit_stops: {grid_room_id: room.id})
+        .where(grid_region: region)
+        .includes(:grid_transit_type, :grid_region, grid_transit_stops: :grid_room)
+        .distinct
+        .select { |r| r.grid_transit_type.published? && hackr.stat("clearance").to_i >= r.grid_transit_type.min_clearance }
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def board!(route, destination_stop = nil)
+      room = @hackr.current_room
+      boarding_stop = route.stop_for_room(room)
+      raise RouteNotAtStop unless boarding_stop
+
+      type = route.grid_transit_type
+
+      # Private: require destination
+      if type.private_point?
+        raise DestinationNotOnRoute unless destination_stop
+        raise AlreadyAtDestination if destination_stop.id == boarding_stop.id
+      end
+
+      fare = compute_fare(route, boarding_stop, destination_stop)
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        raise AlreadyInJourney if @hackr.active_journey
+
+        # Check balance and deduct fare inside transaction
+        if fare > 0
+          cache = @hackr.default_cache
+          raise InsufficientFunds unless cache && cache.balance >= fare
+          Grid::TransactionService.burn!(from_cache: cache, amount: fare, memo: "Transit fare: #{route.name}")
+        end
+
+        journey_type = type.private_point? ? "local_private" : "local_public"
+        dest_room = destination_stop&.grid_room
+
+        journey = GridTransitJourney.create!(
+          grid_hackr: @hackr,
+          journey_type: journey_type,
+          state: "active",
+          origin_room: room,
+          destination_room: dest_room,
+          grid_transit_route: route,
+          current_stop: boarding_stop,
+          fare_paid: fare,
+          started_at: Time.current,
+          meta: {}
+        )
+
+        display = Grid::TransitRenderer.render_board(journey, route, boarding_stop)
+        BoardResult.new(journey: journey, route: route, current_stop: boarding_stop, fare_charged: fare, display: display)
+      end
+    end
+
+    def wait!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.local?
+
+      route = journey.grid_transit_route
+      current = journey.current_stop
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+
+        # Private transit: single wait → arrive directly at destination
+        if journey.local_private?
+          dest_stop = route.grid_transit_stops.find_by(grid_room_id: journey.destination_room_id)
+          dest_room = dest_stop&.grid_room || journey.destination_room
+          if dest_room
+            journey.update!(current_stop: dest_stop) if dest_stop
+            move_hackr_to_room!(dest_room)
+            complete_journey!(journey)
+            display = Grid::TransitRenderer.render_wait(journey, dest_stop || current, true, route)
+            return WaitResult.new(journey: journey.reload, current_stop: dest_stop || current, arrived: true, display: display)
+          end
+        end
+
+        next_stop = route.next_stop_after(current)
+
+        unless next_stop
+          # End of line (non-loop) — auto-disembark at current stop
+          complete_journey!(journey)
+          display = Grid::TransitRenderer.render_end_of_line(journey, current)
+          return WaitResult.new(journey: journey.reload, current_stop: current, arrived: true, display: display)
+        end
+
+        journey.update!(current_stop: next_stop)
+        move_hackr_to_room!(next_stop.grid_room)
+
+        arrived = journey.destination_room_id.present? && next_stop.grid_room_id == journey.destination_room_id
+        complete_journey!(journey) if arrived
+
+        display = Grid::TransitRenderer.render_wait(journey, next_stop, arrived, route)
+        WaitResult.new(journey: journey.reload, current_stop: next_stop, arrived: arrived, display: display)
+      end
+    end
+
+    def disembark!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.local?
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        room = journey.current_stop.grid_room
+        complete_journey!(journey)
+        display = Grid::TransitRenderer.render_disembark(journey, room)
+        DisembarkResult.new(journey: journey.reload, room: room, display: display)
+      end
+    end
+
+    def abandon!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.local?
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        # Return to origin room
+        @hackr.update!(current_room: journey.origin_room) if journey.origin_room
+        journey.update!(state: "abandoned", ended_at: Time.current)
+        display = Grid::TransitRenderer.render_abandon(journey)
+        AbandonResult.new(journey: journey.reload, display: display)
+      end
+    end
+
+    def status
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.local?
+      display = Grid::TransitRenderer.render_local_status(journey)
+      StatusResult.new(journey: journey, display: display)
+    end
+
+    private
+
+    def compute_fare(route, boarding_stop, destination_stop)
+      type = route.grid_transit_type
+      if type.private_point? && destination_stop
+        stops = route.grid_transit_stops.order(:position).to_a
+        board_idx = stops.index { |s| s.id == boarding_stop.id } || 0
+        dest_idx = stops.index { |s| s.id == destination_stop.id } || 0
+        distance = (dest_idx - board_idx).abs
+        type.base_fare * [distance, 1].max
+      else
+        type.base_fare
+      end
+    end
+
+    # Move hackr to room, tracking zone boundary crossings for BREACH ejection
+    def move_hackr_to_room!(room)
+      old_room = @hackr.current_room
+      if old_room && old_room.grid_zone_id != room.grid_zone_id
+        @hackr.update!(current_room: room, zone_entry_room_id: old_room.id)
+      else
+        @hackr.update!(current_room: room)
+      end
+    end
+
+    def complete_journey!(journey)
+      journey.update!(state: "completed", ended_at: Time.current)
+      increment_transit_stats!
+    end
+
+    def increment_transit_stats!
+      count = @hackr.stat("local_transit_trips_count").to_i + 1
+      @hackr.set_stat!("local_transit_trips_count", count)
+    end
+  end
+end

--- a/app/services/grid/slipstream_service.rb
+++ b/app/services/grid/slipstream_service.rb
@@ -1,0 +1,398 @@
+# frozen_string_literal: true
+
+module Grid
+  class SlipstreamService
+    BoardResult = Data.define(:journey, :route, :first_leg, :display)
+    ForkResult = Data.define(:journey, :leg, :chosen_option, :display)
+    AdvanceResult = Data.define(:journey, :leg, :completed, :breach_triggered, :display)
+    ArrivalResult = Data.define(:journey, :destination_room, :heat_applied, :display)
+    AbandonResult = Data.define(:journey, :display)
+    ResumeResult = Data.define(:journey, :continued, :display)
+    StatusResult = Data.define(:journey, :display)
+
+    class NotAtBoardingPoint < StandardError; end
+    class AlreadyInJourney < StandardError; end
+    class ClearanceRequired < StandardError; end
+    class NotInJourney < StandardError; end
+    class NotAwaitingFork < StandardError; end
+    class AwaitingFork < StandardError; end
+    class InvalidForkKey < StandardError; end
+    class CorridorLockedOut < StandardError; end
+
+    MIN_CLEARANCE = 15
+
+    def self.board!(hackr:, route:)
+      new(hackr).board!(route)
+    end
+
+    def self.choose_fork!(hackr:, fork_key:)
+      new(hackr).choose_fork!(fork_key)
+    end
+
+    def self.advance_leg!(hackr:)
+      new(hackr).advance_leg!
+    end
+
+    def self.abandon!(hackr:)
+      new(hackr).abandon!
+    end
+
+    def self.status(hackr:)
+      new(hackr).status
+    end
+
+    def self.handle_breach_resume!(hackr:)
+      new(hackr).handle_breach_resume!
+    end
+
+    def self.routes_from(region:, hackr:)
+      GridSlipstreamRoute.accessible_by(hackr)
+        .where(origin_region: region)
+        .includes(:origin_region, :destination_region, :origin_room, :destination_room, :grid_slipstream_legs)
+        .ordered
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def board!(route)
+      raise ClearanceRequired if @hackr.stat("clearance").to_i < route.min_clearance
+      raise NotAtBoardingPoint unless @hackr.current_room_id == route.origin_room_id
+
+      first_leg = route.first_leg
+      raise StandardError, "Route has no legs" unless first_leg
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+        raise AlreadyInJourney if @hackr.active_journey
+        raise CorridorLockedOut if corridor_locked_out?(route)
+
+        journey = GridTransitJourney.create!(
+          grid_hackr: @hackr,
+          journey_type: "slipstream",
+          state: "active",
+          origin_room: @hackr.current_room,
+          grid_slipstream_route: route,
+          current_leg: first_leg,
+          pending_fork: first_leg.has_forks?,
+          started_at: Time.current,
+          meta: {"chosen_forks" => {}}
+        )
+
+        display = Grid::TransitRenderer.render_slipstream_board(journey, route, first_leg)
+        BoardResult.new(journey: journey, route: route, first_leg: first_leg, display: display)
+      end
+    end
+
+    def choose_fork!(fork_key)
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.slipstream?
+      raise NotAwaitingFork unless journey.awaiting_fork?
+
+      leg = journey.current_leg
+      # Case-insensitive match — keys are stored uppercase but input may be lowercase
+      fork_key = leg.option_keys.find { |k| k.casecmp?(fork_key) } || fork_key
+      raise InvalidForkKey unless leg.option_keys.include?(fork_key)
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        forks = journey.chosen_forks.merge(leg.position.to_s => fork_key)
+        journey.update!(
+          pending_fork: false,
+          meta: journey.meta.merge("chosen_forks" => forks, "current_fork" => fork_key)
+        )
+
+        option = leg.option_for(fork_key)
+        display = Grid::TransitRenderer.render_fork_chosen(journey, leg, option)
+        ForkResult.new(journey: journey.reload, leg: leg, chosen_option: option, display: display)
+      end
+    end
+
+    def advance_leg!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.slipstream?
+      raise AwaitingFork if journey.awaiting_fork?
+
+      route = journey.grid_slipstream_route
+      current_leg = journey.current_leg
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        @hackr.lock!
+
+        # Detection roll BEFORE heat increment — failed legs don't accumulate heat
+        detection = detection_check!(journey, current_leg, route)
+
+        if detection == :breach
+          # Real BREACH started — freeze journey until resolved
+          last_breach = @hackr.grid_hackr_breaches.order(created_at: :desc).first
+          journey.update!(
+            breach_mid_journey: true,
+            meta: journey.meta.merge("triggering_breach_id" => last_breach&.id)
+          )
+          display = Grid::TransitRenderer.render_slipstream_breach(journey, current_leg)
+          return AdvanceResult.new(journey: journey.reload, leg: current_leg, completed: false,
+            breach_triggered: true, display: display)
+        end
+
+        if detection == :penalty
+          # Detected but no BREACH (no deck / fried deck) — penalty applied, replay leg
+          journey.update!(
+            pending_fork: current_leg.has_forks?,
+            meta: journey.meta.except("current_fork")
+          )
+          display = Grid::TransitRenderer.render_slipstream_penalty(journey, current_leg)
+          return AdvanceResult.new(journey: journey.reload, leg: current_leg, completed: false,
+            breach_triggered: false, display: display)
+        end
+
+        # Accumulate heat only on successful leg traversal
+        heat_per_leg = (route.base_heat_cost.to_f / route.leg_count).ceil
+        journey.update!(heat_accumulated: journey.heat_accumulated + heat_per_leg)
+
+        # Advance to next leg
+        next_leg = route.next_leg_after(current_leg)
+
+        if next_leg
+          journey.update!(
+            current_leg: next_leg,
+            legs_completed: journey.legs_completed + 1,
+            pending_fork: next_leg.has_forks?,
+            meta: journey.meta.except("current_fork")
+          )
+          display = Grid::TransitRenderer.render_leg_advanced(journey, next_leg)
+          AdvanceResult.new(journey: journey.reload, leg: next_leg, completed: false,
+            breach_triggered: false, display: display)
+        else
+          # Final leg complete — arrive
+          arrive!(journey, route)
+          display = Grid::TransitRenderer.render_slipstream_arrival(journey, route)
+          AdvanceResult.new(journey: journey.reload, leg: current_leg, completed: true,
+            breach_triggered: false, display: display)
+        end
+      end
+    end
+
+    def abandon!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.slipstream?
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        @hackr.update!(current_room: journey.origin_room) if journey.origin_room
+        journey.update!(state: "abandoned", ended_at: Time.current)
+        display = Grid::TransitRenderer.render_slipstream_abandon(journey)
+        AbandonResult.new(journey: journey.reload, display: display)
+      end
+    end
+
+    def handle_breach_resume!
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.slipstream? && journey.breach_mid_journey?
+
+      # Check the specific breach that triggered during this journey
+      triggering_id = journey.meta["triggering_breach_id"]
+      last_breach = if triggering_id
+        @hackr.grid_hackr_breaches.find_by(id: triggering_id)
+      else
+        @hackr.grid_hackr_breaches.order(updated_at: :desc).first
+      end
+      breach_state = last_breach&.state
+
+      ActiveRecord::Base.transaction do
+        journey.lock!
+        @hackr.lock!
+
+        case breach_state
+        when "success"
+          # Survived — continue journey with extra heat
+          @hackr.add_slipstream_heat!(5)
+          journey.update!(breach_mid_journey: false)
+          display = Grid::TransitRenderer.render_breach_survived(journey)
+          ResumeResult.new(journey: journey.reload, continued: true, display: display)
+        when "failure"
+          # Failed — severity depends on heat
+          heat = @hackr.slipstream_heat
+          if heat >= 71
+            eject!(journey, :fatal)
+          elsif heat >= 41
+            eject!(journey, :severe)
+          else
+            # Light — replay current leg with increased heat
+            @hackr.add_slipstream_heat!(10)
+            journey.update!(
+              breach_mid_journey: false,
+              pending_fork: journey.current_leg&.has_forks? || false,
+              meta: journey.meta.except("current_fork")
+            )
+            display = Grid::TransitRenderer.render_breach_failed_replay(journey)
+            ResumeResult.new(journey: journey.reload, continued: true, display: display)
+          end
+        when "jacked_out"
+          # Jackout — treat as light failure
+          @hackr.add_slipstream_heat!(8)
+          journey.update!(
+            breach_mid_journey: false,
+            pending_fork: journey.current_leg&.has_forks? || false,
+            meta: journey.meta.except("current_fork")
+          )
+          display = Grid::TransitRenderer.render_breach_jackout_resume(journey)
+          ResumeResult.new(journey: journey.reload, continued: true, display: display)
+        else
+          # Unknown state — just clear the flag
+          journey.update!(breach_mid_journey: false)
+          ResumeResult.new(journey: journey, continued: true,
+            display: "<span style='color: #9ca3af;'>Slipstream transit resumed.</span>")
+        end
+      end
+    end
+
+    def status
+      journey = @hackr.active_journey
+      raise NotInJourney unless journey&.active? && journey.slipstream?
+      display = Grid::TransitRenderer.render_slipstream_status(journey, @hackr)
+      StatusResult.new(journey: journey, display: display)
+    end
+
+    private
+
+    # Returns :none, :penalty (detected but no BREACH — no deck/fried), or :breach
+    def detection_check!(journey, leg, route)
+      heat = @hackr.slipstream_heat
+      fork_key = journey.meta["current_fork"]
+      risk_modifier = fork_key ? (leg.option_for(fork_key)&.dig("risk_modifier").to_i) : 0
+
+      base_chance = route.detection_risk_base / 100.0
+      heat_bonus = heat * 0.003 # each heat point adds 0.3%
+      fork_bonus = risk_modifier / 100.0
+
+      total_chance = [base_chance + heat_bonus + fork_bonus, 0.0].max
+      total_chance = [total_chance, 0.95].min # cap at 95%
+
+      return :none unless rand < total_chance
+
+      # Find a breach template for slipstream encounters
+      template_slug = leg.breach_template_slug
+      template = if template_slug.present?
+        GridBreachTemplate.published.find_by(slug: template_slug)
+      end
+
+      # Fallback: find any ambient template at CL15+
+      template ||= GridBreachTemplate.published.ambient
+        .where("min_clearance <= ?", @hackr.stat("clearance").to_i)
+        .sample
+
+      return :none unless template
+
+      deck = @hackr.equipped_deck
+      unless deck
+        apply_no_deck_penalty!(journey)
+        return :penalty
+      end
+
+      if deck.deck_fried?
+        apply_no_deck_penalty!(journey)
+        return :penalty
+      end
+
+      Grid::BreachService.start_ambient!(hackr: @hackr, template: template)
+      :breach
+    rescue Grid::BreachService::AlreadyInBreach
+      :none
+    end
+
+    def apply_corridor_lockout!(journey, duration)
+      route = journey.grid_slipstream_route
+      return unless route
+      lockout_until = Time.current.to_i + duration
+      @hackr.set_stat!("slip_lockout_#{route.slug}", lockout_until)
+    end
+
+    def corridor_locked_out?(route)
+      lockout_until = @hackr.stat("slip_lockout_#{route.slug}").to_i
+      lockout_until > 0 && Time.current.to_i < lockout_until
+    end
+
+    def corridor_lockout_remaining(route)
+      lockout_until = @hackr.stat("slip_lockout_#{route.slug}").to_i
+      return 0 if lockout_until <= 0
+      remaining = lockout_until - Time.current.to_i
+      [remaining, 0].max
+    end
+
+    def apply_no_deck_penalty!(journey)
+      drain_vital_floored!("energy", -20)
+      drain_vital_floored!("psyche", -20)
+      @hackr.add_slipstream_heat!(15)
+    end
+
+    # Drain a vital but floor at 1 — transit can't kill you
+    def drain_vital_floored!(vital, amount)
+      current = @hackr.stat(vital).to_i
+      clamped = [amount, -(current - 1)].max # ensure result >= 1
+      @hackr.adjust_vital!(vital, clamped) if clamped < 0
+    end
+
+    def arrive!(journey, route)
+      # Track zone boundary for BREACH ejection targeting
+      old_room = @hackr.current_room
+      dest = route.destination_room
+      if old_room && old_room.grid_zone_id != dest.grid_zone_id
+        @hackr.update!(current_room: dest, zone_entry_room_id: old_room.id)
+      else
+        @hackr.update!(current_room: dest)
+      end
+      @hackr.add_slipstream_heat!(journey.heat_accumulated)
+      journey.update!(
+        state: "completed",
+        ended_at: Time.current,
+        legs_completed: journey.legs_completed + 1,
+        destination_room: route.destination_room
+      )
+      increment_slipstream_stats!(route)
+    end
+
+    CORRIDOR_LOCKOUT_SEVERE = 5.minutes.to_i
+    CORRIDOR_LOCKOUT_FATAL = 10.minutes.to_i
+
+    def eject!(journey, severity)
+      origin = journey.origin_room
+      @hackr.update!(current_room: origin) if origin
+
+      case severity
+      when :severe
+        drain_vital_floored!("energy", -30)
+        drain_vital_floored!("psyche", -30)
+        drain_vital_floored!("health", -15)
+        @hackr.add_slipstream_heat!(journey.heat_accumulated + 20)
+        apply_corridor_lockout!(journey, CORRIDOR_LOCKOUT_SEVERE)
+      when :fatal
+        drain_vital_floored!("energy", -40)
+        drain_vital_floored!("psyche", -40)
+        drain_vital_floored!("health", -30)
+        @hackr.add_slipstream_heat!(journey.heat_accumulated + 35)
+        apply_corridor_lockout!(journey, CORRIDOR_LOCKOUT_FATAL)
+      end
+
+      journey.update!(state: "ejected", ended_at: Time.current)
+
+      display = Grid::TransitRenderer.render_slipstream_ejection(journey, severity)
+      ResumeResult.new(journey: journey.reload, continued: false, display: display)
+    end
+
+    def increment_slipstream_stats!(route)
+      count = @hackr.stat("slipstream_trips_count").to_i + 1
+      @hackr.set_stat!("slipstream_trips_count", count)
+
+      # Track visited regions
+      visited = @hackr.stat("visited_region_ids") || []
+      dest_id = route.destination_region_id
+      unless visited.include?(dest_id)
+        visited += [dest_id]
+        @hackr.set_stat!("visited_region_ids", visited)
+        @hackr.set_stat!("regions_visited_count", visited.size)
+      end
+    end
+  end
+end

--- a/app/services/grid/transit_command_parser.rb
+++ b/app/services/grid/transit_command_parser.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+module Grid
+  class TransitCommandParser
+    # Commands delegated to main parser while in transit
+    PASSTHROUGH_COMMANDS = %w[
+      look l stat stats st inventory inv i help ? who clear cls cl
+      say examine ex x
+    ].freeze
+
+    attr_reader :hackr, :input, :journey, :parser
+
+    def initialize(hackr, input, journey, parser)
+      @hackr = hackr
+      @input = input.to_s.strip
+      @journey = journey
+      @parser = parser
+    end
+
+    def execute
+      return {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", event: nil} if input.empty?
+
+      # Handle breach-just-resumed for slipstream
+      if journey.slipstream? && journey.breach_mid_journey? && !hackr.in_breach?
+        resume_result = Grid::SlipstreamService.handle_breach_resume!(hackr: hackr)
+        @journey = hackr.active_journey
+
+        unless resume_result.continued
+          # Ejected — show ejection + look at new room
+          output = resume_result.display + "\n" + parser.send(:look_command)
+          return {output: output, event: nil}
+        end
+
+        # Journey continues — show resume message, then fall through to process current command
+        # If journey ended (completed/ejected), no active journey anymore
+        unless @journey&.active?
+          return {output: resume_result.display + "\n" + parser.send(:look_command), event: nil}
+        end
+
+        # Prepend resume display to whatever command result follows
+        @resume_prefix = resume_result.display + "\n"
+      end
+
+      parts = input.split
+      command = parts.first&.downcase
+      args = parts[1..]
+
+      result = dispatch_transit_command(command, args)
+      result = result.is_a?(Hash) ? result : {output: result, event: nil}
+
+      # Prepend resume message if applicable
+      if @resume_prefix
+        result[:output] = @resume_prefix + result[:output].to_s
+      end
+
+      result
+    end
+
+    private
+
+    def dispatch_transit_command(command, args)
+      case command
+      # Universal transit commands
+      when "wait", "w", "w8", "ride"
+        wait_command
+      when "disembark", "off"
+        disembark_command
+      when "abandon", "abort"
+        abandon_command
+      when "transit", "tr", "ts", "status"
+        transit_status_command
+
+      # Slipstream-specific
+      when "choose", "ch"
+        choose_command(args&.first)
+      when "advance", "adv"
+        advance_command
+
+      # Passthrough to main parser
+      when *PASSTHROUGH_COMMANDS
+        parser.send(:dispatch_command, command, args)
+
+      else
+        transit_blocked_message(command)
+      end
+    end
+
+    def wait_command
+      if journey.slipstream?
+        # For slipstream, 'wait' is an alias for 'advance'
+        return advance_command
+      end
+
+      result = Grid::LocalTransitService.wait!(hackr: hackr)
+      output = result.display
+
+      if result.arrived
+        notifications = fire_transit_hooks
+        output = append_notifications(output, notifications)
+        output += "\n" + parser.send(:look_command)
+      end
+
+      {output: output, event: nil}
+    rescue Grid::LocalTransitService::NotInJourney
+      "<span style='color: #f87171;'>Not currently in transit.</span>"
+    end
+
+    def disembark_command
+      unless journey.local?
+        return "<span style='color: #f87171;'>Cannot disembark from Slipstream. Use <span style='color: #a78bfa;'>abandon</span> to abort.</span>"
+      end
+
+      result = Grid::LocalTransitService.disembark!(hackr: hackr)
+      notifications = fire_transit_hooks
+      output = result.display
+      output = append_notifications(output, notifications)
+      output += "\n" + parser.send(:look_command)
+      {output: output, event: nil}
+    rescue Grid::LocalTransitService::NotInJourney
+      "<span style='color: #f87171;'>Not currently in transit.</span>"
+    end
+
+    def abandon_command
+      result = if journey.slipstream?
+        Grid::SlipstreamService.abandon!(hackr: hackr)
+      else
+        Grid::LocalTransitService.abandon!(hackr: hackr)
+      end
+      output = result.display + "\n" + parser.send(:look_command)
+      {output: output, event: nil}
+    rescue Grid::SlipstreamService::NotInJourney, Grid::LocalTransitService::NotInJourney
+      "<span style='color: #f87171;'>Not currently in transit.</span>"
+    end
+
+    def transit_status_command
+      result = if journey.slipstream?
+        Grid::SlipstreamService.status(hackr: hackr)
+      else
+        Grid::LocalTransitService.status(hackr: hackr)
+      end
+      {output: result.display, event: nil}
+    rescue Grid::SlipstreamService::NotInJourney, Grid::LocalTransitService::NotInJourney
+      "<span style='color: #f87171;'>Not currently in transit.</span>"
+    end
+
+    def choose_command(fork_key)
+      unless journey.slipstream?
+        return "<span style='color: #9ca3af;'>Fork choices are only available on Slipstream routes.</span>"
+      end
+      unless fork_key
+        return "<span style='color: #fbbf24;'>Specify a fork: choose &lt;key&gt;</span>"
+      end
+
+      result = Grid::SlipstreamService.choose_fork!(hackr: hackr, fork_key: fork_key)
+      {output: result.display, event: nil}
+    rescue Grid::SlipstreamService::NotAwaitingFork
+      "<span style='color: #9ca3af;'>No fork choice pending at this leg.</span>"
+    rescue Grid::SlipstreamService::InvalidForkKey
+      "<span style='color: #f87171;'>Unknown fork: '#{h(fork_key)}'. Type <span style='color: #a78bfa;'>status</span> to see options.</span>"
+    end
+
+    def advance_command
+      unless journey.slipstream?
+        return "<span style='color: #9ca3af;'>Advance is for Slipstream transit. Use <span style='color: #22d3ee;'>wait</span> for local transit.</span>"
+      end
+
+      if journey.awaiting_fork?
+        leg = journey.current_leg
+        return Grid::TransitRenderer.render_leg_prompt(leg, journey.legs_completed + 1, journey.total_legs)
+      end
+
+      result = Grid::SlipstreamService.advance_leg!(hackr: hackr)
+
+      if result.completed
+        notifications = fire_slipstream_hooks
+        output = append_notifications(result.display, notifications)
+        output += "\n" + parser.send(:look_command)
+        return {output: output, event: nil}
+      end
+
+      {output: result.display, event: nil}
+    rescue Grid::SlipstreamService::NotInJourney
+      "<span style='color: #f87171;'>Not in Slipstream transit.</span>"
+    end
+
+    def fire_transit_hooks
+      notifications = []
+      type_slug = journey.grid_transit_route&.grid_transit_type&.slug
+      notifications += achievement_checker.check(:local_transit_completed, transit_type_slug: type_slug)
+      notifications += achievement_checker.check(:transits_completed_count)
+      notifications += mission_progressor.record(:complete_transit, transit_type_slug: type_slug)
+      notifications
+    end
+
+    def fire_slipstream_hooks
+      notifications = []
+      route_slug = journey.grid_slipstream_route&.slug
+      region_slug = journey.grid_slipstream_route&.destination_region&.slug
+      notifications += achievement_checker.check(:slipstream_completed, route_slug: route_slug)
+      notifications += achievement_checker.check(:slipstreams_completed_count)
+      notifications += achievement_checker.check(:regions_visited_count)
+      notifications += mission_progressor.record(:complete_slipstream, route_slug: route_slug)
+      notifications += mission_progressor.record(:reach_region, region_slug: region_slug)
+      notifications
+    end
+
+    def transit_blocked_message(command)
+      "<span style='color: #f87171;'>In transit — '#{h(command)}' unavailable. Type <span style='color: #22d3ee;'>help</span> for transit commands.</span>"
+    end
+
+    def append_notifications(output, notifications)
+      return output if notifications.empty?
+      output + "\n" + notifications.join("\n")
+    end
+
+    def h(text) = ERB::Util.html_escape(text.to_s)
+    def achievement_checker = @achievement_checker ||= Grid::AchievementChecker.new(hackr)
+    def mission_progressor = @mission_progressor ||= Grid::MissionProgressor.new(hackr)
+  end
+end

--- a/app/services/grid/transit_renderer.rb
+++ b/app/services/grid/transit_renderer.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+module Grid
+  class TransitRenderer
+    class << self
+      # === Local Transit ===
+
+      def render_board(journey, route, stop)
+        type = route.grid_transit_type
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #22d3ee; font-weight: bold;'>#{icon(type)} BOARDING: #{h(route.name)}</span>"
+        lines << separator
+        if journey.local_private?
+          dest = journey.destination_room
+          lines << "<span style='color: #9ca3af;'>Destination: #{h(dest&.name || "unknown")}</span>"
+          lines << "<span style='color: #9ca3af;'>Fare: #{journey.fare_paid} CRED</span>"
+          lines << ""
+          lines << "<span style='color: #6b7280;'>Type <span style='color: #22d3ee;'>wait</span> to travel. <span style='color: #22d3ee;'>abandon</span> to cancel.</span>"
+        else
+          lines << "<span style='color: #9ca3af;'>Boarded at: #{h(stop.display_name)}</span>"
+          lines << "<span style='color: #9ca3af;'>Fare: #{journey.fare_paid} CRED</span>"
+          lines << ""
+          lines << render_route_stops(route, stop)
+          lines << ""
+          lines << "<span style='color: #6b7280;'>Type <span style='color: #22d3ee;'>wait</span> to ride to next stop. <span style='color: #22d3ee;'>disembark</span> to exit.</span>"
+        end
+        lines.join("\n")
+      end
+
+      def render_wait(journey, stop, arrived, route)
+        type = route.grid_transit_type
+        lines = []
+        lines << ""
+        if arrived
+          lines << "<span style='color: #34d399; font-weight: bold;'>#{icon(type)} ARRIVED: #{h(stop.display_name)}</span>"
+          lines << "<span style='color: #9ca3af;'>You have reached your destination.</span>"
+        else
+          lines << "<span style='color: #9ca3af;'>#{icon(type)} Now at:</span> <span style='color: #22d3ee; font-weight: bold;'>#{h(stop.display_name)}</span>"
+          remaining = remaining_stops(route, stop)
+          lines << "<span style='color: #6b7280;'>#{remaining} stop(s) remaining.</span>" if remaining > 0
+          lines << ""
+          lines << "<span style='color: #6b7280;'>Type <span style='color: #22d3ee;'>wait</span> to continue. <span style='color: #22d3ee;'>disembark</span> to exit here.</span>"
+        end
+        lines.join("\n")
+      end
+
+      def render_end_of_line(journey, stop)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #fbbf24; font-weight: bold;'>END OF LINE</span>"
+        lines << "<span style='color: #9ca3af;'>Final stop: #{h(stop.display_name)}. You have been disembarked.</span>"
+        lines.join("\n")
+      end
+
+      def render_disembark(journey, room)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #34d399;'>You disembark at #{h(room.name)}.</span>"
+        lines.join("\n")
+      end
+
+      def render_abandon(journey)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>Transit abandoned. Returned to #{h(journey.origin_room&.name || "origin")}.</span>"
+        lines.join("\n")
+      end
+
+      def render_local_status(journey)
+        route = journey.grid_transit_route
+        type = route.grid_transit_type
+        stop = journey.current_stop
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #22d3ee; font-weight: bold;'>#{icon(type)} IN TRANSIT: #{h(route.name)}</span>"
+        lines << separator
+        lines << "<span style='color: #9ca3af;'>Current stop: #{h(stop&.display_name || "unknown")}</span>"
+        if journey.local_private?
+          lines << "<span style='color: #9ca3af;'>Destination: #{h(journey.destination_room&.name || "unknown")}</span>"
+        else
+          remaining = remaining_stops(route, stop)
+          lines << "<span style='color: #6b7280;'>#{remaining} stop(s) to end of line.</span>"
+        end
+        lines << "<span style='color: #9ca3af;'>Fare paid: #{journey.fare_paid} CRED</span>"
+        lines.join("\n")
+      end
+
+      # === Slipstream ===
+
+      def render_slipstream_board(journey, route, first_leg)
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #a78bfa; font-weight: bold;'>[SLIP] SLIPSTREAM INITIATED</span>"
+        lines << separator
+        lines << "<span style='color: #9ca3af;'>Route: #{h(route.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>Origin: #{h(route.origin_region.name)} → Destination: #{h(route.destination_region.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>Legs: #{route.leg_count}</span>"
+        lines << ""
+        lines << render_leg_prompt(first_leg, 1, route.leg_count)
+        lines.join("\n")
+      end
+
+      def render_fork_chosen(journey, leg, option)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #a78bfa;'>Path chosen: <span style='font-weight: bold;'>#{h(option["label"])}</span></span>"
+        lines << "<span style='color: #6b7280;'>#{h(option["description"])}</span>"
+        lines << ""
+        lines << "<span style='color: #6b7280;'>Type <span style='color: #a78bfa;'>advance</span> to traverse this leg.</span>"
+        lines.join("\n")
+      end
+
+      def render_leg_advanced(journey, next_leg)
+        route = journey.grid_slipstream_route
+        lines = []
+        lines << ""
+        lines << "<span style='color: #34d399;'>Leg #{journey.legs_completed} cleared. No detection.</span>"
+        lines << ""
+        lines << render_leg_prompt(next_leg, journey.legs_completed + 1, route.leg_count)
+        lines.join("\n")
+      end
+
+      def render_slipstream_breach(journey, leg)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #ef4444; font-weight: bold;'>\u26a0 SLIPSTREAM DETECTION — BREACH TRIGGERED</span>"
+        lines << "<span style='color: #f87171;'>GovCorp surveillance has flagged anomalous traffic on this corridor.</span>"
+        lines << "<span style='color: #f87171;'>Resolve the BREACH to continue transit.</span>"
+        lines.join("\n")
+      end
+
+      def render_slipstream_penalty(journey, leg)
+        route = journey.grid_slipstream_route
+        lines = []
+        lines << ""
+        lines << "<span style='color: #ef4444; font-weight: bold;'>\u26a0 SLIPSTREAM DETECTION — SCAN INTERCEPTED</span>"
+        lines << "<span style='color: #f87171;'>GovCorp surveillance flagged anomalous traffic. Without a functional DECK, you absorb the hit raw.</span>"
+        lines << "<span style='color: #f87171;'>ENERGY -20 | PSYCHE -20 | Heat increased.</span>"
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>Must replay current leg. Equip a DECK to survive future scans.</span>"
+        lines << ""
+        lines << render_leg_prompt(leg, journey.legs_completed + 1, route.leg_count)
+        lines.join("\n")
+      end
+
+      def render_slipstream_arrival(journey, route)
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #34d399; font-weight: bold;'>[SLIP] SLIPSTREAM TRANSIT COMPLETE</span>"
+        lines << separator
+        lines << "<span style='color: #9ca3af;'>Arrived: #{h(route.destination_region.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>Legs traversed: #{journey.legs_completed}</span>"
+        heat = journey.grid_hackr.slipstream_heat
+        lines << "<span style='color: #{heat_color(heat)};'>Corridor heat: #{heat}/100</span>"
+        lines.join("\n")
+      end
+
+      def render_slipstream_abandon(journey)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>[SLIP] Slipstream transit abandoned. Returned to origin.</span>"
+        lines.join("\n")
+      end
+
+      def render_slipstream_ejection(journey, severity)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #ef4444; font-weight: bold;'>[SLIP] EJECTED FROM SLIPSTREAM</span>"
+        case severity
+        when :severe
+          lines << "<span style='color: #f87171;'>Heavy detection. ENERGY -30 | PSYCHE -30 | HEALTH -15</span>"
+          lines << "<span style='color: #f87171;'>Returned to origin region. Corridor locked out for 5 minutes.</span>"
+        when :fatal
+          lines << "<span style='color: #ef4444;'>Critical detection — corridor burned.</span>"
+          lines << "<span style='color: #f87171;'>ENERGY -40 | PSYCHE -40 | HEALTH -30</span>"
+          lines << "<span style='color: #f87171;'>Returned to origin region. Corridor locked out for 10 minutes.</span>"
+        end
+        lines.join("\n")
+      end
+
+      def render_breach_survived(journey)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #34d399;'>[SLIP] BREACH resolved. Slipstream transit resumed.</span>"
+        lines << "<span style='color: #fbbf24;'>Corridor heat increased from detection event.</span>"
+        lines << ""
+        leg = journey.current_leg
+        if leg
+          route = journey.grid_slipstream_route
+          lines << render_leg_prompt(leg, journey.legs_completed + 1, route.leg_count)
+        end
+        lines.join("\n")
+      end
+
+      def render_breach_failed_replay(journey)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>[SLIP] BREACH failed. Must replay current leg.</span>"
+        lines << "<span style='color: #f87171;'>Corridor heat rising.</span>"
+        lines << ""
+        leg = journey.current_leg
+        if leg
+          route = journey.grid_slipstream_route
+          lines << render_leg_prompt(leg, journey.legs_completed + 1, route.leg_count)
+        end
+        lines.join("\n")
+      end
+
+      def render_breach_jackout_resume(journey)
+        lines = []
+        lines << ""
+        lines << "<span style='color: #fbbf24;'>[SLIP] Jacked out of BREACH. Transit continues — heat increased.</span>"
+        lines << ""
+        leg = journey.current_leg
+        if leg
+          route = journey.grid_slipstream_route
+          lines << render_leg_prompt(leg, journey.legs_completed + 1, route.leg_count)
+        end
+        lines.join("\n")
+      end
+
+      def render_slipstream_status(journey, hackr)
+        route = journey.grid_slipstream_route
+        leg = journey.current_leg
+        heat = hackr.slipstream_heat
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #a78bfa; font-weight: bold;'>[SLIP] SLIPSTREAM STATUS</span>"
+        lines << separator
+        lines << "<span style='color: #9ca3af;'>Route: #{h(route.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>#{h(route.origin_region.name)} → #{h(route.destination_region.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>Progress: #{journey.legs_completed}/#{route.leg_count} legs</span>"
+        lines << "<span style='color: #9ca3af;'>Current: #{h(leg&.name || "unknown")}</span>"
+        lines << "<span style='color: #{heat_color(heat)};'>Corridor heat: #{heat}/100 (#{hackr.slipstream_heat_tier})</span>"
+        if journey.awaiting_fork?
+          lines << ""
+          lines << "<span style='color: #fbbf24;'>FORK DECISION PENDING — choose a path.</span>"
+        elsif journey.breach_mid_journey?
+          lines << ""
+          lines << "<span style='color: #ef4444;'>BREACH IN PROGRESS — resolve before continuing.</span>"
+        end
+        lines.join("\n")
+      end
+
+      # === Shared Helpers ===
+
+      def render_available_routes(routes, hackr)
+        return "<span style='color: #9ca3af;'>No transit available from this location.</span>" if routes.empty?
+
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #22d3ee; font-weight: bold;'>TRANSIT ROUTES</span>"
+        lines << separator
+
+        routes.group_by { |r| r.grid_transit_type }.each do |type, type_routes|
+          lines << "<span style='color: #a78bfa;'>#{icon(type)} #{h(type.name)} (#{type.category})</span>"
+          type_routes.each do |route|
+            fare_text = (type.base_fare > 0) ? " — #{type.base_fare} CRED" : ""
+            stop_count = route.grid_transit_stops.size
+            lines << "  <span style='color: #22d3ee;'>board #{h(route.slug)}</span>  <span style='color: #9ca3af;'>#{h(route.name)} (#{stop_count} stops#{fare_text})</span>"
+          end
+          lines << ""
+        end
+        lines.join("\n")
+      end
+
+      def render_slipstream_routes(routes, hackr)
+        return "<span style='color: #9ca3af;'>No Slipstream routes available from this region.</span>" if routes.empty?
+
+        heat = hackr.slipstream_heat
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #a78bfa; font-weight: bold;'>[SLIP] SLIPSTREAM CORRIDORS</span>"
+        lines << separator
+        lines << "<span style='color: #{heat_color(heat)};'>Current heat: #{heat}/100 (#{hackr.slipstream_heat_tier})</span>"
+        lines << ""
+
+        routes.each do |route|
+          legs = route.leg_count
+          room_name = route.origin_room&.name || "unknown"
+          zone_name = route.origin_room&.grid_zone&.name || "unknown"
+          lockout_until = hackr.stat("slip_lockout_#{route.slug}").to_i
+          locked = lockout_until > 0 && Time.current.to_i < lockout_until
+          if locked
+            remaining = ((lockout_until - Time.current.to_i) / 60.0).ceil
+            lines << "  <span style='color: #6b7280;'>slipstream #{h(route.slug)}</span>  <span style='color: #f87171;'>→ #{h(route.destination_region.name)} [LOCKED OUT — #{remaining}m remaining]</span>"
+          else
+            lines << "  <span style='color: #a78bfa;'>slipstream #{h(route.slug)}</span>  <span style='color: #9ca3af;'>→ #{h(route.destination_region.name)} (#{legs} legs, CL#{route.min_clearance}+)</span>"
+          end
+          lines << "    <span style='color: #6b7280;'>Board at: #{h(room_name)} (#{h(zone_name)})</span>"
+        end
+        lines << ""
+        lines << "<span style='color: #6b7280;'>Use <span style='color: #a78bfa;'>slipstream &lt;slug&gt;</span> at the access point to initiate transit.</span>"
+        lines.join("\n")
+      end
+
+      def render_leg_prompt(leg, leg_number, total_legs)
+        lines = []
+        lines << "<span style='color: #a78bfa; font-weight: bold;'>LEG #{leg_number}/#{total_legs}: #{h(leg.name)}</span>"
+        lines << "<span style='color: #6b7280;'>#{h(leg.description)}</span>" if leg.description.present?
+        lines << ""
+        if leg.has_forks?
+          lines << "<span style='color: #fbbf24;'>Choose your path:</span>"
+          leg.fork_options.each do |opt|
+            risk = opt["risk_modifier"].to_i
+            risk_label = if risk < 0
+              "<span style='color: #34d399;'>low risk</span>"
+            elsif risk > 10
+              "<span style='color: #ef4444;'>high risk</span>"
+            else
+              "<span style='color: #fbbf24;'>moderate risk</span>"
+            end
+            lines << "  <span style='color: #a78bfa;'>choose #{h(opt["key"])}</span>  <span style='color: #9ca3af;'>#{h(opt["label"])} — #{h(opt["description"])} (#{risk_label})</span>"
+          end
+        else
+          lines << "<span style='color: #6b7280;'>Type <span style='color: #a78bfa;'>advance</span> to traverse this leg.</span>"
+        end
+        lines.join("\n")
+      end
+
+      private
+
+      def h(text) = ERB::Util.html_escape(text.to_s)
+
+      def separator
+        "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      end
+
+      def icon(type)
+        type.icon_key.present? ? "[#{type.icon_key.upcase}]" : "[TRANSIT]"
+      end
+
+      def render_route_stops(route, current_stop)
+        stops = route.grid_transit_stops.order(:position).to_a
+        stops.map { |s|
+          marker = (s.id == current_stop.id) ? "►" : "·"
+          color = (s.id == current_stop.id) ? "#22d3ee" : "#6b7280"
+          "<span style='color: #{color};'>  #{marker} #{h(s.display_name)}</span>"
+        }.join("\n")
+      end
+
+      def remaining_stops(route, current_stop)
+        stops = route.grid_transit_stops.order(:position).to_a
+        idx = stops.index { |s| s.id == current_stop.id }
+        return 0 unless idx
+        stops.size - idx - 1
+      end
+
+      def heat_color(heat)
+        case heat
+        when 0..9 then "#34d399"
+        when 10..40 then "#fbbf24"
+        when 41..70 then "#f97316"
+        else "#ef4444"
+        end
+      end
+    end
+  end
+end

--- a/app/services/grid/transit_renderer.rb
+++ b/app/services/grid/transit_renderer.rb
@@ -88,6 +88,50 @@ module Grid
         lines.join("\n")
       end
 
+      # === Private Transit (route-free) ===
+
+      def render_private_board(journey, transit_type, destination_room)
+        lines = []
+        lines << ""
+        lines << separator
+        lines << "<span style='color: #fbbf24; font-weight: bold;'>[#{h(transit_type.icon_key || "PRIVATE")}] #{h(transit_type.name).upcase}</span>"
+        lines << separator
+        lines << "<span style='color: #9ca3af;'>Destination: <span style='color: #22d3ee; font-weight: bold;'>#{h(destination_room.name)}</span> (#{h(destination_room.grid_zone.name)})</span>"
+        lines << "<span style='color: #9ca3af;'>Fare: #{journey.fare_paid} CRED</span>"
+        lines << ""
+        lines << "<span style='color: #6b7280;'>Type <span style='color: #22d3ee;'>wait</span> to travel. <span style='color: #22d3ee;'>abandon</span> to cancel.</span>"
+        lines.join("\n")
+      end
+
+      def render_private_arrival(journey, room)
+        lines = []
+        lines << ""
+        type_slug = journey.meta&.dig("transit_type_slug")
+        type = type_slug ? GridTransitType.find_by(slug: type_slug) : nil
+        icon = type&.icon_key || "PRIVATE"
+        lines << "<span style='color: #34d399; font-weight: bold;'>[#{h(icon)}] ARRIVED: #{h(room.name)}</span>"
+        lines << "<span style='color: #9ca3af;'>#{h(room.grid_zone.name)}</span>"
+        lines.join("\n")
+      end
+
+      def render_private_types(types, destinations, room)
+        lines = []
+        lines << "<span style='color: #fbbf24; font-weight: bold;'>[ PRIVATE TRANSIT ]</span>"
+        types.each do |t|
+          lines << "  <span style='color: #fbbf24;'>[#{h(t.icon_key || "PRIVATE")}]</span> <span style='color: #d0d0d0;'>#{h(t.name)}</span> <span style='color: #6b7280;'>— #{t.base_fare} CRED</span>"
+        end
+        lines << "<span style='color: #6b7280;'>  Destinations:</span>"
+        destinations.each do |d|
+          lines << "    <span style='color: #9ca3af;'>#{h(d.name)}</span> <span style='color: #6b7280;'>(#{h(d.grid_zone.name)})</span>"
+        end
+        type_example = types.first
+        dest_example = destinations.first
+        if type_example && dest_example
+          lines << "<span style='color: #6b7280;'>  Use: <span style='color: #22d3ee;'>hail #{h(type_example.slug)} #{h(dest_example.name.downcase)}</span></span>"
+        end
+        lines.join("\n")
+      end
+
       # === Slipstream ===
 
       def render_slipstream_board(journey, route, first_leg)

--- a/app/views/admin/grid_slipstream_routes/_form.html.erb
+++ b/app/views/admin/grid_slipstream_routes/_form.html.erb
@@ -1,0 +1,79 @@
+<%= form_with model: [:admin, route], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: ROUTE INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if route.errors[:name].any? %>
+        <br><small class="red-255-text"><%= route.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">e.g. lakeshore-to-arch</small>
+      <% if route.errors[:slug].any? %>
+        <br><small class="red-255-text"><%= route.errors[:slug].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :origin_region_id, "ORIGIN REGION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :origin_region_id, @regions.map { |r| [r.name, r.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+    <div>
+      <%= f.label :destination_region_id, "DESTINATION REGION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :destination_region_id, @regions.map { |r| [r.name, r.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :origin_room_id, "ORIGIN ROOM (boarding point)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :origin_room_id, @rooms.map { |r| ["#{r.name} (#{r.grid_zone.name})", r.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+    <div>
+      <%= f.label :destination_room_id, "DESTINATION ROOM (arrival point)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :destination_room_id, @rooms.map { |r| ["#{r.name} (#{r.grid_zone.name})", r.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: RISK CONFIG ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0, max: 99 %>
+    </div>
+    <div>
+      <%= f.label :base_heat_cost, "BASE HEAT COST", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :base_heat_cost, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0, max: 100 %>
+    </div>
+    <div>
+      <%= f.label :detection_risk_base, "DETECTION RISK %", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :detection_risk_base, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0, max: 100 %>
+    </div>
+    <div>
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0 %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :active, "ACTIVE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.check_box :active, style: "margin-top: 5px;" %>
+  </div>
+
+  <div style="margin-top: 25px;">
+    <%= f.submit route.new_record? ? "Create Slipstream Route" : "Update Slipstream Route", class: "tui-button green-168", style: "padding: 8px 20px;" %>
+    <%= link_to "Cancel", admin_grid_slipstream_routes_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_slipstream_routes/edit.html.erb
+++ b/app/views/admin/grid_slipstream_routes/edit.html.erb
@@ -1,0 +1,44 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/slipstream_routes/<%= @route.slug %> :: EDIT SLIPSTREAM ROUTE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", route: @route %>
+
+      <% if @legs&.any? %>
+        <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: LEGS (<%= @legs.size %>) ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Pos</th>
+                <th style="text-align: left;">Name</th>
+                <th style="text-align: center;">Forks</th>
+                <th style="text-align: left;">Breach Template</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @legs.each do |leg| %>
+                <tr>
+                  <td style="text-align: center;"><%= leg.position %></td>
+                  <td><%= leg.name %></td>
+                  <td style="text-align: center;"><%= leg.fork_options&.size || 0 %></td>
+                  <td style="color: #6b7280;"><%= leg.breach_template_slug.presence || "&mdash;".html_safe %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_slipstream_routes/index.html.erb
+++ b/app/views/admin/grid_slipstream_routes/index.html.erb
@@ -1,0 +1,67 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/slipstream_routes :: SLIPSTREAM ROUTES</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Slipstream Route", new_admin_grid_slipstream_route_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 900px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Origin</th>
+              <th style="text-align: center;">&rarr;</th>
+              <th style="text-align: left;">Destination</th>
+              <th style="text-align: center;">Legs</th>
+              <th style="text-align: center;">CL</th>
+              <th style="text-align: center;">Heat</th>
+              <th style="text-align: center;">Risk%</th>
+              <th style="text-align: center;">Active</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @routes.each do |r| %>
+              <tr>
+                <td><%= r.name %></td>
+                <td style="color: #a78bfa;"><%= r.origin_region.name %></td>
+                <td style="text-align: center; color: #6b7280;">&rarr;</td>
+                <td style="color: #a78bfa;"><%= r.destination_region.name %></td>
+                <td style="text-align: center;"><%= r.grid_slipstream_legs.length %></td>
+                <td style="text-align: center;"><%= r.min_clearance %></td>
+                <td style="text-align: center;"><%= r.base_heat_cost %></td>
+                <td style="text-align: center;"><%= r.detection_risk_base %>%</td>
+                <td style="text-align: center;">
+                  <% if r.active? %>
+                    <span class="green-255-text">&#10003;</span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_slipstream_route_path(r), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_slipstream_route_path(r), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_slipstream_route_path(r), data: { turbo_method: :delete, turbo_confirm: "Delete route '#{r.name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_slipstream_routes/new.html.erb
+++ b/app/views/admin/grid_slipstream_routes/new.html.erb
@@ -1,0 +1,13 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/slipstream_routes/new :: NEW SLIPSTREAM ROUTE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", route: @route %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_slipstream_routes/show.html.erb
+++ b/app/views/admin/grid_slipstream_routes/show.html.erb
@@ -1,0 +1,32 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/slipstream_routes/<%= @route.slug %> :: SLIPSTREAM ROUTE</legend>
+    <div style="padding: 20px;">
+      <p><strong>Name:</strong> <%= @route.name %></p>
+      <p><strong>Origin:</strong> <%= @route.origin_region.name %> &rarr; <strong>Destination:</strong> <%= @route.destination_region.name %></p>
+      <p><strong>Clearance:</strong> CL<%= @route.min_clearance %>+</p>
+      <p><strong>Heat Cost:</strong> <%= @route.base_heat_cost %> | <strong>Detection:</strong> <%= @route.detection_risk_base %>%</p>
+
+      <% if @legs.any? %>
+        <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: LEGS ::]</h3>
+        <% @legs.each do |leg| %>
+          <div style="border: 1px solid #333; padding: 10px; margin: 5px 0;">
+            <strong>Leg <%= leg.position %>:</strong> <%= leg.name %>
+            <% if leg.has_forks? %>
+              <div style="margin-left: 20px; color: #9ca3af;">
+                <% leg.fork_options.each do |opt| %>
+                  <div>[<%= opt["key"] %>] <%= opt["label"] %> (risk: <%= opt["risk_modifier"] %>)</div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <div style="margin-top: 20px;">
+        <%= link_to "Edit", edit_admin_grid_slipstream_route_path(@route), class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "Back", admin_grid_slipstream_routes_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_journeys/index.html.erb
+++ b/app/views/admin/grid_transit_journeys/index.html.erb
@@ -1,0 +1,74 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_journeys :: TRANSIT JOURNEYS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= form_with url: admin_grid_transit_journeys_path, method: :get, local: true, style: "margin-bottom: 20px;" do %>
+        <div style="display: flex; gap: 15px; align-items: center; flex-wrap: wrap;">
+          <%= select_tag :state, options_for_select([["All States", ""], ["active", "active"], ["completed", "completed"], ["abandoned", "abandoned"], ["ejected", "ejected"]], params[:state]), class: "tui-input", style: "font-family: monospace;", onchange: "this.form.submit()" %>
+          <%= select_tag :journey_type, options_for_select([["All Types", ""], ["slipstream", "slipstream"], ["local_public", "local_public"], ["local_private", "local_private"]], params[:journey_type]), class: "tui-input", style: "font-family: monospace;", onchange: "this.form.submit()" %>
+          <% if params[:state].present? || params[:journey_type].present? %>
+            <%= link_to "Clear", admin_grid_transit_journeys_path, class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 900px;">
+          <thead>
+            <tr>
+              <th style="text-align: center;">ID</th>
+              <th style="text-align: left;">Hackr</th>
+              <th style="text-align: center;">Type</th>
+              <th style="text-align: left;">Route</th>
+              <th style="text-align: center;">State</th>
+              <th style="text-align: center;">Started</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @journeys.each do |j| %>
+              <tr>
+                <td style="text-align: center;"><%= j.id %></td>
+                <td><%= j.grid_hackr.hackr_alias %></td>
+                <td style="text-align: center;">
+                  <% color = j.slipstream? ? "#a78bfa" : "#22d3ee" %>
+                  <span style="color: <%= color %>;"><%= j.journey_type.upcase %></span>
+                </td>
+                <td>
+                  <% if j.slipstream? %>
+                    <%= j.grid_slipstream_route&.name || "—" %>
+                  <% else %>
+                    <%= j.grid_transit_route&.name || "—" %>
+                  <% end %>
+                </td>
+                <td style="text-align: center;">
+                  <% state_color = case j.state; when "active" then "#34d399"; when "completed" then "#6b7280"; when "abandoned" then "#fbbf24"; else "#f87171"; end %>
+                  <span style="color: <%= state_color %>;"><%= j.state.upcase %></span>
+                </td>
+                <td style="text-align: center; color: #6b7280;"><%= j.started_at&.strftime("%Y-%m-%d %H:%M") %></td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "View", admin_grid_transit_journey_path(j), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <% if j.active? && dev_tools_enabled? %>
+                    <%= link_to "Abandon", force_abandon_admin_grid_transit_journey_path(j), data: { turbo_method: :post, turbo_confirm: "Force-abandon journey ##{j.id}?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_journeys/show.html.erb
+++ b/app/views/admin/grid_transit_journeys/show.html.erb
@@ -1,0 +1,47 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_journeys/<%= @journey.id %> :: TRANSIT JOURNEY</legend>
+    <div style="padding: 20px;">
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div>
+          <h3 class="cyan-255-text" style="margin: 0 0 15px 0;">[:: JOURNEY ::]</h3>
+          <p><strong>Hackr:</strong> <span style="color: #a78bfa;"><%= @journey.grid_hackr.hackr_alias %></span></p>
+          <p><strong>Type:</strong> <%= @journey.journey_type %></p>
+          <% state_color = case @journey.state; when "active" then "#34d399"; when "completed" then "#6b7280"; when "abandoned" then "#fbbf24"; else "#f87171"; end %>
+          <p><strong>State:</strong> <span style="color: <%= state_color %>;"><%= @journey.state.upcase %></span></p>
+          <p><strong>Started:</strong> <%= @journey.started_at&.strftime("%Y-%m-%d %H:%M:%S") %></p>
+          <p><strong>Ended:</strong> <%= @journey.ended_at&.strftime("%Y-%m-%d %H:%M:%S") || "—" %></p>
+        </div>
+        <div>
+          <h3 class="cyan-255-text" style="margin: 0 0 15px 0;">[:: DETAILS ::]</h3>
+          <p><strong>Origin:</strong> <%= @journey.origin_room&.name || "—" %></p>
+          <p><strong>Destination:</strong> <%= @journey.destination_room&.name || "—" %></p>
+          <% if @journey.slipstream? %>
+            <p><strong>Route:</strong> <%= @journey.grid_slipstream_route&.name || "—" %></p>
+            <p><strong>Current Leg:</strong> <%= @journey.current_leg&.name || "—" %></p>
+            <p><strong>Legs Completed:</strong> <%= @journey.legs_completed %> / <%= @journey.total_legs %></p>
+            <p><strong>Heat Accumulated:</strong> <%= @journey.heat_accumulated %></p>
+            <p><strong>Pending Fork:</strong> <%= @journey.pending_fork? ? "Yes" : "No" %></p>
+            <p><strong>Breach Mid-Journey:</strong> <%= @journey.breach_mid_journey? ? "Yes" : "No" %></p>
+          <% else %>
+            <p><strong>Route:</strong> <%= @journey.grid_transit_route&.name || "—" %></p>
+            <p><strong>Current Stop:</strong> <%= @journey.current_stop&.display_name || "—" %></p>
+            <p><strong>Fare Paid:</strong> <%= @journey.fare_paid %> CRED</p>
+          <% end %>
+        </div>
+      </div>
+
+      <% if @journey.meta.present? && @journey.meta != {} %>
+        <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: META ::]</h3>
+        <pre style="background: #111; padding: 10px; overflow-x: auto; color: #9ca3af;"><%= JSON.pretty_generate(@journey.meta) %></pre>
+      <% end %>
+
+      <div style="margin-top: 20px;">
+        <% if @journey.active? && dev_tools_enabled? %>
+          <%= link_to "Force Abandon", force_abandon_admin_grid_transit_journey_path(@journey), data: { turbo_method: :post, turbo_confirm: "Force-abandon this journey?" }, class: "tui-button red-168", style: "padding: 8px 20px;" %>
+        <% end %>
+        <%= link_to "Back", admin_grid_transit_journeys_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_routes/_form.html.erb
+++ b/app/views/admin/grid_transit_routes/_form.html.erb
@@ -1,0 +1,57 @@
+<%= form_with model: [:admin, route], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: ROUTE INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if route.errors[:name].any? %>
+        <br><small class="red-255-text"><%= route.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">lowercase letters, numbers, hyphens only</small>
+      <% if route.errors[:slug].any? %>
+        <br><small class="red-255-text"><%= route.errors[:slug].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :grid_transit_type_id, "TRANSIT TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_transit_type_id, @transit_types.map { |t| ["#{t.name} (#{t.category})", t.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+    <div>
+      <%= f.label :grid_region_id, "REGION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :grid_region_id, @regions.map { |r| [r.name, r.id] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0 %>
+    </div>
+    <div>
+      <%= f.label :loop_route, "LOOP ROUTE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.check_box :loop_route, style: "margin-top: 5px;" %>
+    </div>
+    <div>
+      <%= f.label :active, "ACTIVE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.check_box :active, style: "margin-top: 5px;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 25px;">
+    <%= f.submit route.new_record? ? "Create Route" : "Update Route", class: "tui-button green-168", style: "padding: 8px 20px;" %>
+    <%= link_to "Cancel", admin_grid_transit_routes_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_transit_routes/edit.html.erb
+++ b/app/views/admin/grid_transit_routes/edit.html.erb
@@ -1,0 +1,104 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_routes/<%= @route.slug %> :: EDIT TRANSIT ROUTE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", route: @route %>
+
+      <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: STOPS (<%= @stops&.size || 0 %>) ::]</h3>
+
+      <% if @stops&.any? %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Pos</th>
+                <th style="text-align: left;">Label</th>
+                <th style="text-align: left;">Room</th>
+                <th style="text-align: left;">Zone</th>
+                <th style="text-align: center;">Terminus</th>
+                <th style="text-align: right;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @stops.each do |s| %>
+                <tr>
+                  <td style="text-align: center;"><%= s.position %></td>
+                  <td><%= s.label.presence || "&mdash;".html_safe %></td>
+                  <td style="color: #22d3ee;"><%= s.grid_room.name %></td>
+                  <td style="color: #6b7280;"><%= s.grid_room.grid_zone.name %></td>
+                  <td style="text-align: center;">
+                    <% if s.is_terminus? %>
+                      <span class="green-255-text">&#10003;</span>
+                    <% else %>
+                      <span style="color: #6b7280;">&mdash;</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: right;">
+                    <%= link_to "Remove", remove_stop_admin_grid_transit_route_path(@route, stop_id: s.id), data: { turbo_method: :delete, turbo_confirm: "Remove stop '#{s.display_name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+
+      <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: ADD STOP ::]</h3>
+      <%= render "admin/shared/combobox" %>
+      <%= form_with url: add_stop_admin_grid_transit_route_path(@route), method: :post, local: true, id: "add-stop-form" do |f| %>
+        <div style="display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 15px; align-items: end;">
+          <div>
+            <%= label_tag :stop_room, "ROOM", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+            <input type="hidden" name="grid_transit_stop[grid_room_id]" id="stop-room-hidden" value="">
+            <div class="admin-combobox">
+              <input type="text" id="stop-room-input" class="admin-combobox-input" autocomplete="off" placeholder="Type to search transit rooms...">
+              <div id="stop-room-dropdown" class="admin-combobox-dropdown"></div>
+            </div>
+          </div>
+          <div>
+            <%= label_tag :grid_transit_stop_label, "LABEL (optional)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+            <%= text_field_tag "grid_transit_stop[label]", nil, class: "tui-input", style: "width: 100%; font-family: monospace;", placeholder: "Override name" %>
+          </div>
+          <div>
+            <%= label_tag :grid_transit_stop_is_terminus, "TERMINUS", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+            <%= check_box_tag "grid_transit_stop[is_terminus]", "1", false, style: "margin-top: 5px;" %>
+          </div>
+          <div>
+            <%= submit_tag "Add Stop", class: "tui-button green-168", style: "padding: 8px 20px;" %>
+          </div>
+        </div>
+      <% end %>
+      <script nonce="<%= content_security_policy_nonce %>">
+        (function() {
+          var rooms = <%= raw @region_rooms.map { |r| { id: r.id, name: r.name, zone_name: r.grid_zone.name } }.to_json %>;
+          AdminCombobox.init({
+            inputId: 'stop-room-input',
+            hiddenId: 'stop-room-hidden',
+            dropdownId: 'stop-room-dropdown',
+            items: rooms,
+            getSearchText: function(r) { return (r.name + ' ' + r.zone_name).toLowerCase(); },
+            getGroupKey: function(r) { return r.zone_name; },
+            renderOption: function(r, e) {
+              return '<span class="cb-name">' + e(r.name) + '</span>';
+            },
+            getId: function(r) { return String(r.id); },
+            getLabel: function(r) { return r.zone_name + ' / ' + r.name; },
+            emptyText: 'No transit rooms in this region',
+            selectedText: 'Room selected',
+            formId: 'add-stop-form'
+          });
+        })();
+      </script>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_routes/index.html.erb
+++ b/app/views/admin/grid_transit_routes/index.html.erb
@@ -1,0 +1,69 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_routes :: TRANSIT ROUTES</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Route", new_admin_grid_transit_route_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 900px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: left;">Type</th>
+              <th style="text-align: left;">Region</th>
+              <th style="text-align: center;">Stops</th>
+              <th style="text-align: center;">Loop</th>
+              <th style="text-align: center;">Active</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @routes.each do |r| %>
+              <tr>
+                <td><%= r.name %></td>
+                <td style="color: #6b7280;"><%= r.slug %></td>
+                <td style="color: #22d3ee;"><%= r.grid_transit_type.name %></td>
+                <td style="color: #a78bfa;"><%= r.grid_region.name %></td>
+                <td style="text-align: center;"><%= r.grid_transit_stops.length %></td>
+                <td style="text-align: center;">
+                  <% if r.loop_route? %>
+                    <span class="green-255-text">&#10003;</span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: center;">
+                  <% if r.active? %>
+                    <span class="green-255-text">&#10003;</span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_transit_route_path(r), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_transit_route_path(r), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_transit_route_path(r), data: { turbo_method: :delete, turbo_confirm: "Delete route '#{r.name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_routes/new.html.erb
+++ b/app/views/admin/grid_transit_routes/new.html.erb
@@ -1,0 +1,13 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_routes/new :: NEW TRANSIT ROUTE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", route: @route %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_routes/show.html.erb
+++ b/app/views/admin/grid_transit_routes/show.html.erb
@@ -1,0 +1,42 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_routes/<%= @route.slug %> :: TRANSIT ROUTE</legend>
+    <div style="padding: 20px;">
+      <p><strong>Name:</strong> <%= @route.name %></p>
+      <p><strong>Type:</strong> <%= @route.grid_transit_type.name %></p>
+      <p><strong>Region:</strong> <%= @route.grid_region.name %></p>
+      <p><strong>Stops:</strong> <%= @stops.size %></p>
+
+      <% if @stops.any? %>
+        <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: STOPS ::]</h3>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Pos</th>
+                <th style="text-align: left;">Label</th>
+                <th style="text-align: left;">Room</th>
+                <th style="text-align: center;">Terminus</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @stops.each do |s| %>
+                <tr>
+                  <td style="text-align: center;"><%= s.position %></td>
+                  <td><%= s.display_name %></td>
+                  <td style="color: #22d3ee;"><%= s.grid_room.name %></td>
+                  <td style="text-align: center;"><%= s.is_terminus? ? "Yes" : "" %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 20px;">
+        <%= link_to "Edit", edit_admin_grid_transit_route_path(@route), class: "tui-button green-168", style: "padding: 8px 20px;" %>
+        <%= link_to "Back", admin_grid_transit_routes_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_types/_form.html.erb
+++ b/app/views/admin/grid_transit_types/_form.html.erb
@@ -1,0 +1,62 @@
+<%= form_with model: [:admin, transit_type], local: true do |f| %>
+  <h3 class="cyan-255-text" style="margin: 20px 0 15px 0;">[:: TYPE INFO ::]</h3>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+    <div>
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <% if transit_type.errors[:name].any? %>
+        <br><small class="red-255-text"><%= transit_type.errors[:name].join(", ") %></small>
+      <% end %>
+    </div>
+    <div>
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">lowercase letters, numbers, hyphens only</small>
+      <% if transit_type.errors[:slug].any? %>
+        <br><small class="red-255-text"><%= transit_type.errors[:slug].join(", ") %></small>
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 15px;">
+    <%= f.label :description, "DESCRIPTION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.text_area :description, class: "tui-input", style: "width: 100%; font-family: monospace; height: 80px;" %>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :category, "CATEGORY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.select :category, GridTransitType::CATEGORIES.map { |c| [c.upcase, c] }, {}, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+    </div>
+    <div>
+      <%= f.label :base_fare, "BASE FARE (CRED)", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :base_fare, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0 %>
+    </div>
+    <div>
+      <%= f.label :min_clearance, "MIN CLEARANCE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :min_clearance, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0, max: 99 %>
+    </div>
+    <div>
+      <%= f.label :icon_key, "ICON KEY", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.text_field :icon_key, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+      <small style="color: #888;">e.g. TRAIN, BUS, TAXI</small>
+    </div>
+  </div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 15px;">
+    <div>
+      <%= f.label :position, "POSITION", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; font-family: monospace;", min: 0 %>
+    </div>
+    <div>
+      <%= f.label :published, "PUBLISHED", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+      <%= f.check_box :published, style: "margin-top: 5px;" %>
+    </div>
+  </div>
+
+  <div style="margin-top: 25px;">
+    <%= f.submit transit_type.new_record? ? "Create Transit Type" : "Update Transit Type", class: "tui-button green-168", style: "padding: 8px 20px;" %>
+    <%= link_to "Cancel", admin_grid_transit_types_path, class: "tui-button", style: "padding: 8px 20px; margin-left: 10px;" %>
+  </div>
+<% end %>

--- a/app/views/admin/grid_transit_types/edit.html.erb
+++ b/app/views/admin/grid_transit_types/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_types/<%= @transit_type.slug %> :: EDIT TRANSIT TYPE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", transit_type: @transit_type %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_types/index.html.erb
+++ b/app/views/admin/grid_transit_types/index.html.erb
@@ -1,0 +1,67 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_types :: TRANSIT TYPES</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Transit Type", new_admin_grid_transit_type_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 800px;">
+          <thead>
+            <tr>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Slug</th>
+              <th style="text-align: center;">Category</th>
+              <th style="text-align: center;">Fare</th>
+              <th style="text-align: center;">CL</th>
+              <th style="text-align: center;">Icon</th>
+              <th style="text-align: center;">Published</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @transit_types.each do |t| %>
+              <tr>
+                <td><%= t.name %></td>
+                <td style="color: #6b7280;"><%= t.slug %></td>
+                <td style="text-align: center;">
+                  <% color = case t.category; when "public" then "#34d399"; when "private" then "#fbbf24"; else "#a78bfa"; end %>
+                  <span style="color: <%= color %>;"><%= t.category.upcase %></span>
+                </td>
+                <td style="text-align: center;"><%= t.base_fare %></td>
+                <td style="text-align: center;"><%= t.min_clearance %></td>
+                <td style="text-align: center; color: #6b7280;"><%= t.icon_key %></td>
+                <td style="text-align: center;">
+                  <% if t.published? %>
+                    <span class="green-255-text">&#10003;</span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_transit_type_path(t), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_transit_type_path(t), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_transit_type_path(t), data: { turbo_method: :delete, turbo_confirm: "Delete transit type '#{t.name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_transit_types/new.html.erb
+++ b/app/views/admin/grid_transit_types/new.html.erb
@@ -1,0 +1,13 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/transit_types/new :: NEW TRANSIT TYPE</legend>
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+      <%= render "form", transit_type: @transit_type %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -92,6 +92,10 @@
           <%= link_to "Schematics", admin_grid_schematics_path, class: "green-168-text" %>
           <%= link_to "Breach Templates", admin_grid_breach_templates_path, class: "green-168-text" %>
           <%= link_to "Breach Encounters", admin_grid_breach_encounters_path, class: "green-168-text" %>
+          <%= link_to "Transit Types", admin_grid_transit_types_path, class: "green-168-text" %>
+          <%= link_to "Transit Routes", admin_grid_transit_routes_path, class: "green-168-text" %>
+          <%= link_to "Slipstream", admin_grid_slipstream_routes_path, class: "green-168-text" %>
+          <%= link_to "Journeys", admin_grid_transit_journeys_path, class: "green-168-text" %>
           <%= link_to "Mission Arcs", admin_grid_mission_arcs_path, class: "green-168-text" %>
           <%= link_to "Factions", admin_grid_factions_path, class: "green-168-text" %>
           <%= link_to "Regions", admin_grid_regions_path, class: "green-168-text" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
   get "loadout", to: "pages#spa_root", as: :loadout
   get "gear", to: redirect("/loadout")
   get "deck", to: "pages#spa_root", as: :deck_page
+  get "transit", to: "pages#spa_root", as: :transit_page
 
   # Codex (wiki) routes - SPA
   scope "codex" do
@@ -170,6 +171,7 @@ Rails.application.routes.draw do
     get "grid/schematics", to: "grid#schematics_index"
     get "grid/loadout", to: "grid#loadout_index"
     get "grid/deck", to: "grid#deck_index"
+    get "grid/transit", to: "grid#transit_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
     get "grid/verify/:token", to: "grid#verify_token"
@@ -487,6 +489,30 @@ Rails.application.routes.draw do
     resources :grid_breach_encounters, except: [:show] do
       member do
         get :history
+      end
+    end
+
+    # Transit system
+    resources :grid_transit_types, except: [:show] do
+      member do
+        get :history
+      end
+    end
+    resources :grid_transit_routes do
+      member do
+        get :history
+        post :add_stop
+        delete :remove_stop
+      end
+    end
+    resources :grid_slipstream_routes do
+      member do
+        get :history
+      end
+    end
+    resources :grid_transit_journeys, only: %i[index show] do
+      member do
+        post :force_abandon
       end
     end
 

--- a/data/world/achievements.yml
+++ b/data/world/achievements.yml
@@ -819,3 +819,90 @@ achievements:
       count: 50
     xp_reward: 500
     cred_reward: 50
+
+  # Transit Achievements
+  - slug: first_ride
+    name: "First Ride"
+    description: "Completed your first local transit trip."
+    badge_icon: "TRN"
+    category: grid
+    trigger_type: local_transit_completed
+    trigger_data: {}
+    xp_reward: 50
+    cred_reward: 5
+
+  - slug: frequent_rider
+    name: "Frequent Rider"
+    description: "Completed 10 local transit trips."
+    badge_icon: "TRN"
+    category: grid
+    trigger_type: transits_completed_count
+    trigger_data:
+      count: 10
+    xp_reward: 150
+    cred_reward: 15
+
+  - slug: commuter
+    name: "Commuter"
+    description: "Completed 50 local transit trips."
+    badge_icon: "TRN"
+    category: grid
+    trigger_type: transits_completed_count
+    trigger_data:
+      count: 50
+    xp_reward: 300
+    cred_reward: 30
+
+  - slug: first_slipstream
+    name: "Ghost in the Machine"
+    description: "Completed your first Slipstream transit."
+    badge_icon: "SLP"
+    category: grid
+    trigger_type: slipstream_completed
+    trigger_data: {}
+    xp_reward: 200
+    cred_reward: 20
+
+  - slug: corridor_runner
+    name: "Corridor Runner"
+    description: "Completed 5 Slipstream transits."
+    badge_icon: "SLP"
+    category: grid
+    trigger_type: slipstreams_completed_count
+    trigger_data:
+      count: 5
+    xp_reward: 300
+    cred_reward: 30
+
+  - slug: first_step_larger_world
+    name: "First Step into a Larger World"
+    description: "Visited 2 different regions via Slipstream."
+    badge_icon: "MAP"
+    category: grid
+    trigger_type: regions_visited_count
+    trigger_data:
+      count: 2
+    xp_reward: 150
+    cred_reward: 10
+
+  - slug: well_travelled
+    name: "Well-Travelled"
+    description: "Visited 8 or more regions via Slipstream."
+    badge_icon: "MAP"
+    category: grid
+    trigger_type: regions_visited_count
+    trigger_data:
+      count: 8
+    xp_reward: 500
+    cred_reward: 50
+
+  - slug: continental
+    name: "Continental"
+    description: "Visited every region in THE PULSE GRID via Slipstream."
+    badge_icon: "MAP"
+    category: grid
+    trigger_type: regions_visited_count
+    trigger_data:
+      count: 16
+    xp_reward: 1000
+    cred_reward: 100

--- a/data/world/region_transit_assignments.yml
+++ b/data/world/region_transit_assignments.yml
@@ -1,0 +1,96 @@
+# Region Transit Assignments
+# Maps which transit types are available in each region (0-4 per region)
+# Based on geographic flavor and real-world city analogs
+
+region_transit_assignments:
+  # The Lakeshore (Chicago) — 4 types
+  - region_slug: the-lakeshore
+    transit_type_slugs:
+      - elevated-traincar
+      - underground-rail
+      - water-taxi
+      - taxi-car
+
+  # The Riverlands (Memphis) — 3 types
+  - region_slug: the-riverlands
+    transit_type_slugs:
+      - metro-bus
+      - trolley-streetcar
+      - taxi-car
+
+  # The Narrows (NYC) — 3 types
+  - region_slug: the-narrows
+    transit_type_slugs:
+      - underground-rail
+      - taxi-car
+      - water-taxi
+
+  # The Basin (LA) — 1 type (private only)
+  - region_slug: the-basin
+    transit_type_slugs:
+      - private-car
+
+  # The Gate (SF) — 2 types
+  - region_slug: the-gate
+    transit_type_slugs:
+      - trolley-streetcar
+      - water-taxi
+
+  # The Front (Denver) — 2 types
+  - region_slug: the-front
+    transit_type_slugs:
+      - all-terrain-transport
+      - taxi-car
+
+  # The Straits (Detroit) — 1 type
+  - region_slug: the-straits
+    transit_type_slugs:
+      - electric-rail-bus
+
+  # The Bend (NOLA) — 3 types
+  - region_slug: the-bend
+    transit_type_slugs:
+      - trolley-streetcar
+      - airboat
+      - taxi-car
+
+  # The Canopy (PNW) — 3 types
+  - region_slug: the-canopy
+    transit_type_slugs:
+      - electric-rail-bus
+      - water-taxi
+      - taxi-car
+
+  # The Flats (Houston) — 2 types
+  - region_slug: the-flats
+    transit_type_slugs:
+      - metro-bus
+      - taxi-car
+
+  # The Marshes (Florida) — 1 type (private only)
+  - region_slug: the-marshes
+    transit_type_slugs:
+      - airboat
+
+  # The Works (Pittsburgh) — 2 types
+  - region_slug: the-works
+    transit_type_slugs:
+      - electric-rail-bus
+      - taxi-car
+
+  # The Badlands (Dakotas) — 0 types (walk or Slipstream)
+
+  # The Canyon (Grand Canyon) — 1 type
+  - region_slug: the-canyon
+    transit_type_slugs:
+      - all-terrain-transport
+
+  # The Hollows (Appalachia) — 1 type
+  - region_slug: the-hollows
+    transit_type_slugs:
+      - all-terrain-transport
+
+  # The Arch (St. Louis) — 1 type (private only, premium in deadzone)
+  - region_slug: the-arch
+    transit_type_slugs:
+      - private-car

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -11232,3 +11232,331 @@ rooms:
     zone_slug: the-railyard
     room_type: standard
 
+  # ══════════════════════════════════════════════════════
+  # SLIPSTREAM ACCESS POINTS
+  # Service hatches, maintenance platforms, and freight loading bays
+  # located near Grid facilities. CL15+ required to board.
+  # ══════════════════════════════════════════════════════
+
+  # --- THE LAKESHORE (lakefront-terminal) ---
+  - name: "Slipstream Gate South"
+    slug: lakeshore-slip-south
+    description: "A service hatch behind the Lakefront Terminal's boiler room, concealed beneath a maintenance platform that hasn't appeared on any GovCorp schematic in decades. The air smells of heated steel and old grease. A freight elevator descends into corridors that officially do not exist."
+    zone_slug: lakefront-terminal
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: lakeshore-slip-east
+    description: "An access point behind the terminal's eastern loading dock, where automated freight containers stack three high. The Fracture Network cut a passage between two container bays — from the outside it looks like a gap in the shipping schedule."
+    zone_slug: lakefront-terminal
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: lakeshore-slip-west
+    description: "The western service corridor terminates at a freight elevator shaft that GovCorp's maintenance logs show as 'permanently decommissioned.' The Fracture Network disagrees. A concealed hatch opens onto rails that stretch west into the dark."
+    zone_slug: lakefront-terminal
+    room_type: transit
+
+  # --- THE ARCH (warehouse-row) ---
+  - name: "Slipstream Gate North"
+    slug: arch-slip-north
+    description: "Behind a loading dock on Warehouse Row, a false wall swings open on counterweighted hinges. The RIDE deadzone extends this far — GovCorp's sensors are blind here. The corridor beyond hums with freight rail that the Network has been riding for years without detection."
+    zone_slug: warehouse-row
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: arch-slip-south
+    description: "A basement access beneath the oldest warehouse on the row. Brick walls give way to poured concrete, then to steel-reinforced tunnels that predate the Consolidation. The deadzone makes this the safest boarding point on the continent."
+    zone_slug: warehouse-row
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: arch-slip-east
+    description: "The eastern dock's drainage system connects to an older tunnel network that runs beneath the riverbank. Water drips from overhead, but the rails are dry and maintained. The deadzone interference fades as the corridor extends eastward."
+    zone_slug: warehouse-row
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: arch-slip-west
+    description: "A service tunnel behind the western warehouse wall, marked with faded Fracture Network chalk signs. The air is cool and still — the deadzone suppresses even the ambient electromagnetic hum that GovCorp infrastructure usually generates."
+    zone_slug: warehouse-row
+    room_type: transit
+
+  # --- THE RIVERLANDS (bluff-station) ---
+  - name: "Slipstream Gate North"
+    slug: riverlands-slip-north
+    description: "Below the Bluff Station platform, a maintenance access leads to service tunnels carved into the limestone bluff. The arrival board above still shows Slipstream corridor status if you know which numbers to read."
+    zone_slug: bluff-station
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: riverlands-slip-south
+    description: "A freight loading bay at the base of the bluff, where river barges once transferred cargo to rail. The Fracture Network converted the transfer machinery into a concealed Slipstream boarding platform. The river smell is constant."
+    zone_slug: bluff-station
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: riverlands-slip-east
+    description: "An access point behind the station's eastern retaining wall, where the limestone has been cut to accommodate a service passage. The route heads into the foothills — mountain air replaces river humidity within the first hundred meters."
+    zone_slug: bluff-station
+    room_type: transit
+
+  # --- THE BEND (pump-station) ---
+  - name: "Slipstream Gate North"
+    slug: bend-slip-north
+    description: "The pump station's deepest level, below the flood control machinery. Water pressure regulators mask the vibration of freight rail running beneath the levee system. Everything is damp. The rails lead upriver."
+    zone_slug: pump-station
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: bend-slip-east
+    description: "An access hatch in the pump station's eastern drainage gallery. The corridor runs alongside municipal water infrastructure — the constant flow of pumped water creates enough noise and vibration to mask transit signatures from GovCorp sensors."
+    zone_slug: pump-station
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: bend-slip-west
+    description: "The western pump gallery connects to a freight corridor that follows the gulf coast. Salt corrosion on the walls tells you how close the sea is. The rails are maintained but the walls are not."
+    zone_slug: pump-station
+    room_type: transit
+
+  # --- THE MARSHES (the-causeway) ---
+  - name: "Slipstream Gate West"
+    slug: marshes-slip-west
+    description: "Below the causeway's central support pylon, a service access descends to corridors that run along the road's foundation piles. The ground is uncertain — concrete and steel driven into swamp muck that shifts with the tides."
+    zone_slug: the-causeway
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: marshes-slip-north
+    description: "An access point beneath the causeway's northern abutment, where the road meets solid ground. The corridor heads inland through mangrove root systems that GovCorp's infrastructure planners never bothered to map."
+    zone_slug: the-causeway
+    room_type: transit
+
+  # --- THE FLATS (the-pipeline) ---
+  - name: "Slipstream Gate East"
+    slug: flats-slip-east
+    description: "An access hatch inside a pipeline junction facility, camouflaged among the valves and regulators of the petrochemical infrastructure. The corridor follows oil pipelines east — industrial camouflage at its finest."
+    zone_slug: the-pipeline
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: flats-slip-north
+    description: "The pipeline's northern terminus connects to freight infrastructure that runs straight north across the plains. Nothing but flat prairie above and steel below. The longest and most exposed corridors on the Slipstream network."
+    zone_slug: the-pipeline
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: flats-slip-west
+    description: "A service access in the pipeline's western junction, where petrochemical freight meets desert logistics. The corridor heads toward red rock country, trading humidity for dry heat."
+    zone_slug: the-pipeline
+    room_type: transit
+
+  # --- THE CANYON (the-rim) ---
+  - name: "Slipstream Gate East"
+    slug: canyon-slip-east
+    description: "A concealed access point at the rim's eastern edge, where cable tramway machinery provides cover for the service hatch beneath. The corridor runs along the canyon rim before descending into the rock."
+    zone_slug: the-rim
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: canyon-slip-north
+    description: "Behind a geological survey station on the northern rim. The rock walls of the access corridor show layers of geological time — red sandstone, limestone, shale. GovCorp's signal fails at depth; the Network rides that failure."
+    zone_slug: the-rim
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: canyon-slip-west
+    description: "The western rim access drops into a corridor carved through Kaibab limestone. Desert wind howls at the entrance but the corridor is dead still. The rails lead toward the coast through some of the driest country on the continent."
+    zone_slug: the-rim
+    room_type: transit
+
+  # --- THE BASIN (the-channel) ---
+  - name: "Slipstream Gate East"
+    slug: basin-slip-east
+    description: "A service access beneath the concrete channel's eastern bank, hidden among flood control infrastructure that Los Angeles stopped needing when GovCorp engineered the weather. The corridor smells like sun-baked concrete and machine oil."
+    zone_slug: the-channel
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: basin-slip-north
+    description: "The channel's northern terminus connects to coastal freight infrastructure. Approaching GovCorp's entertainment capital from the north means approaching the most surveilled region on the continent. The Fracture Network moves carefully here."
+    zone_slug: the-channel
+    room_type: transit
+
+  # --- THE GATE (drydock) ---
+  - name: "Slipstream Gate South"
+    slug: gate-slip-south
+    description: "Deep in the drydock's sub-basement, behind decommissioned ship repair machinery. The bay's fog helps — moisture in the air attenuates sensor arrays. The corridor south follows undersea cable routes along the coast."
+    zone_slug: drydock
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: gate-slip-north
+    description: "A service tunnel beneath the drydock's northern seawall, where tidal engineering infrastructure masks the entrance. The corridor runs through old-growth forest roots and volcanic rock — natural RIDE attenuation all the way north."
+    zone_slug: drydock
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: gate-slip-east
+    description: "The drydock's eastern access connects to freight tunnels that bore straight through the Sierra. The longest single-leg corridor on the western Slipstream network — mountain rock shields the entire crossing."
+    zone_slug: drydock
+    room_type: transit
+
+  # --- THE CANOPY (the-waterfront) ---
+  - name: "Slipstream Gate South"
+    slug: canopy-slip-south
+    description: "Below the waterfront's ferry terminal, an access leads to corridors that run beneath the river. The persistent rain above creates ground-level noise that helps mask transit vibrations from the surface sensor grid."
+    zone_slug: the-waterfront
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: canopy-slip-east
+    description: "A service hatch behind the waterfront's cargo handling facility, concealed by stacked shipping containers. The corridor heads east through volcanic mountain passes — lava tubes that the Fracture Network discovered decades before GovCorp mapped the region."
+    zone_slug: the-waterfront
+    room_type: transit
+
+  # --- THE BADLANDS (the-outpost) ---
+  - name: "Slipstream Gate East"
+    slug: badlands-slip-east
+    description: "An access point beneath the outpost's supply depot, where monthly freight deliveries provide cover for Slipstream operations. Out here, GovCorp barely monitors — there's nobody to watch. The corridor heads east across a thousand miles of nothing."
+    zone_slug: the-outpost
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: badlands-slip-west
+    description: "A service tunnel behind the outpost's western perimeter, dug into eroded rock. The corridor follows old highway infrastructure west toward the mountain passes. Wind from the surface whistles through ventilation grates."
+    zone_slug: the-outpost
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: badlands-slip-south
+    description: "The outpost's southernmost access point, where the high plains begin their descent toward the Front Range. Coverage is thin in both directions — the Badlands' emptiness extends its protection into the first leg of transit."
+    zone_slug: the-outpost
+    room_type: transit
+
+  # --- THE FRONT (snow-station) ---
+  - name: "Slipstream Gate East"
+    slug: front-slip-east
+    description: "Beneath the snow station's gondola machinery, a service corridor drops into the mountain. The altitude makes GovCorp's sensors struggle with false positives — thin air carries signals strangely."
+    zone_slug: snow-station
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: front-slip-south
+    description: "A maintenance tunnel behind the station's southern platform, descending through switchback corridors into freight infrastructure that runs south across the high plains. The corridor is cold year-round."
+    zone_slug: snow-station
+    room_type: transit
+
+  - name: "Slipstream Gate South (Canyon)"
+    slug: front-slip-south-canyon
+    description: "A second southern access point on the station's lower level, routing through a different tunnel system toward the desert and canyon country. The air transitions from mountain cold to desert dry within the first leg."
+    zone_slug: snow-station
+    room_type: transit
+
+  - name: "Slipstream Gate West"
+    slug: front-slip-west
+    description: "The station's western service corridor bores into the mountain range itself. The Fracture Network spent years carving this route — it crosses the Continental Divide underground, following mining infrastructure that predates the Consolidation."
+    zone_slug: snow-station
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: front-slip-north
+    description: "Behind the warming hut at the station's northern edge, a hatch opens onto a corridor that descends through the foothills toward the open plains. The coverage thins as you head north — the Badlands' emptiness is an asset."
+    zone_slug: snow-station
+    room_type: transit
+
+  # --- THE STRAITS (the-crossing) ---
+  - name: "Slipstream Gate West"
+    slug: straits-slip-west
+    description: "Below the bridge crossing's western abutment, a service corridor runs alongside old automotive supply tunnels. The strait's industrial history left infrastructure that GovCorp repurposed but never fully audited."
+    zone_slug: the-crossing
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: straits-slip-south
+    description: "An access point beneath the crossing's southern checkpoint, where the tunnel system connects to rail infrastructure running south through the lake country toward the steel valleys."
+    zone_slug: the-crossing
+    room_type: transit
+
+  - name: "Slipstream Gate East"
+    slug: straits-slip-east
+    description: "The crossing's eastern tunnel extension, built for automotive traffic that never materialized. The Fracture Network uses the overbuilt infrastructure — four lanes of tunnel for a single rail track, with plenty of room to disappear."
+    zone_slug: the-crossing
+    room_type: transit
+
+  # --- THE WORKS (the-railyard) ---
+  - name: "Slipstream Gate West"
+    slug: works-slip-west
+    description: "Deep in the railyard's switching complex, a spur track leads to a dead-end tunnel that isn't dead-end at all. The coal dust in the air has been there for a century. The freight traffic provides perfect acoustic camouflage."
+    zone_slug: the-railyard
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: works-slip-north
+    description: "An access beneath the railyard's northern signal tower, where the switching control room provides visual cover for the hatch below. The corridor follows old ore transport routes toward the lake country."
+    zone_slug: the-railyard
+    room_type: transit
+
+  - name: "Slipstream Gate Northwest"
+    slug: works-slip-northwest
+    description: "A service corridor behind the railyard's westernmost engine house, routing through mountain tunnels toward the harbor city. Century-old railroad bores through the Alleghenies — the oldest infrastructure on the Slipstream network."
+    zone_slug: the-railyard
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: works-slip-south
+    description: "Below the railyard's coal bunker, where the loading mechanism's vibrations mask transit activity. The corridor follows the river south into the mountain hollows — coal country rail that nobody audits anymore."
+    zone_slug: the-railyard
+    room_type: transit
+
+  # --- THE HOLLOWS (coal-run) ---
+  - name: "Slipstream Gate West"
+    slug: hollows-slip-west
+    description: "An old mine entrance behind the coal processing facility, shored up with timber that the Fracture Network reinforced with stolen GovCorp structural alloy. The corridor follows creek beds westward toward the river country."
+    zone_slug: coal-run
+    room_type: transit
+
+  - name: "Slipstream Gate North"
+    slug: hollows-slip-north
+    description: "A service tunnel beneath the rail siding at Coal Run, where the narrow-gauge track connects to standard gauge infrastructure. The corridor climbs through mountain passes toward the harbor city. Signal dies in the hollows."
+    zone_slug: coal-run
+    room_type: transit
+
+  - name: "Slipstream Gate North (Works)"
+    slug: hollows-slip-north-works
+    description: "A second northern access at Coal Run's upper switchback, routing through a different tunnel system toward the steel valleys. The coal dust and ore residue in the walls are indistinguishable from the railyard's own contamination."
+    zone_slug: coal-run
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: hollows-slip-south
+    description: "The deepest access point in Coal Run, below the old mine's third level. The corridor descends through the piedmont toward the coastal wetlands. Mountain cool gives way to subtropical humidity within two legs."
+    zone_slug: coal-run
+    room_type: transit
+
+  # --- THE NARROWS (sub-level) ---
+  - name: "Slipstream Gate West"
+    slug: narrows-slip-west
+    description: "In the sub-level's deepest utility corridor, behind a bank of transformers that the Fracture Network rerouted around. The most heavily surveilled boarding point on the continent — operatives use it only when the alternatives are worse."
+    zone_slug: sub-level
+    room_type: transit
+
+  - name: "Slipstream Gate West (Straits)"
+    slug: narrows-slip-west-straits
+    description: "A secondary western access point in the sub-level's drainage system, routing through old transit tunnels toward the lake country. Separate from the main western gate to allow parallel corridor usage without heat overlap."
+    zone_slug: sub-level
+    room_type: transit
+
+  - name: "Slipstream Gate Southwest"
+    slug: narrows-slip-southwest
+    description: "A concealed access beneath the sub-level's ventilation system, routing southwest through mountain tunnels toward the steel valleys. The Fracture Network built this gate specifically to bypass the main western corridor's surveillance load."
+    zone_slug: sub-level
+    room_type: transit
+
+  - name: "Slipstream Gate South"
+    slug: narrows-slip-south
+    description: "The sub-level's southern access, behind a decommissioned signal relay station. The corridor follows old rail infrastructure south through the Appalachian gaps into the mountain hollows. RIDE saturation drops fast once you clear the harbor district."
+    zone_slug: sub-level
+    room_type: transit
+

--- a/data/world/slipstream_routes.yml
+++ b/data/world/slipstream_routes.yml
@@ -1,0 +1,1716 @@
+# Slipstream Routes — Inter-Region Transit Corridors
+# Each route is directional (A→B and B→A are separate rows).
+# Legs define the fork-choice journey. Each leg has 2-3 fork options.
+# Nearest-neighbor connectivity only — cross-country requires multiple hops.
+#
+# NOTE: origin_room_slug and destination_room_slug must reference existing
+# transit rooms. These will be created when transit infrastructure rooms
+# are seeded. Until then, routes remain seedable but not boardable.
+
+slipstream_routes:
+  # === LAKESHORE CONNECTIONS ===
+  # Lakeshore → Arch (South)
+  - slug: lakeshore-to-arch
+    name: "Lakeshore → Arch Conduit"
+    origin_region_slug: the-lakeshore
+    destination_region_slug: the-arch
+    origin_room_slug: lakeshore-slip-south
+    destination_room_slug: arch-slip-north
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Service corridor following old freight rail under the plains."
+    legs:
+      - position: 1
+        name: "Sub-Lake Junction"
+        description: "The corridor passes beneath the lake bed. Three paths diverge."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Drainage Tunnel"
+            description: "Tight, damp, heavily shielded from scans."
+            risk_modifier: -5
+          - key: B
+            label: "Freight Bypass"
+            description: "Standard cargo route. Moderate traffic."
+            risk_modifier: 5
+          - key: C
+            label: "Express Trunk"
+            description: "High-speed main line. Exposed to patrol sweeps."
+            risk_modifier: 15
+      - position: 2
+        name: "Prairie Relay"
+        description: "Signal relay under the flatlands. Brief exposure window."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Arch Approach"
+        description: "Final stretch into the RIDE deadzone. Interference helps."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Deadzone Edge"
+            description: "Skirt the interference boundary. Safer but longer."
+            risk_modifier: -8
+          - key: B
+            label: "Direct Insert"
+            description: "Straight through. Fast but briefly visible."
+            risk_modifier: 10
+
+  # Arch → Lakeshore (North)
+  - slug: arch-to-lakeshore
+    name: "Arch → Lakeshore Conduit"
+    origin_region_slug: the-arch
+    destination_region_slug: the-lakeshore
+    origin_room_slug: arch-slip-north
+    destination_room_slug: lakeshore-slip-south
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Return corridor from the deadzone to the lakefront."
+    legs:
+      - position: 1
+        name: "Deadzone Exit"
+        description: "Leaving the interference field. Scanners wake up."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Gradual Ascent"
+            description: "Slow rise out of the deadzone. Lower profile."
+            risk_modifier: -5
+          - key: B
+            label: "Quick Break"
+            description: "Fast exit. One burst of exposure."
+            risk_modifier: 10
+      - position: 2
+        name: "Prairie Crossing"
+        description: "Open corridor under farmland."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Lakefront Approach"
+        description: "Industrial tunnels under the lakeshore periphery."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Service Duct"
+            description: "Narrow maintenance access. Slow, hidden."
+            risk_modifier: -8
+          - key: B
+            label: "Cargo Spur"
+            description: "Main freight line. Mixed traffic cover."
+            risk_modifier: 5
+
+  # Lakeshore → Straits (East)
+  - slug: lakeshore-to-straits
+    name: "Lakeshore → Straits Conduit"
+    origin_region_slug: the-lakeshore
+    destination_region_slug: the-straits
+    origin_room_slug: lakeshore-slip-east
+    destination_room_slug: straits-slip-west
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "Lakefront corridor following old automotive supply routes."
+    legs:
+      - position: 1
+        name: "Lakeshore Tunnel"
+        description: "Under the industrial waterfront."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Water Main"
+            description: "Follow the municipal water infrastructure. Cold, dark, safe."
+            risk_modifier: -5
+          - key: B
+            label: "Rail Bed"
+            description: "Old passenger rail corridor. Faster."
+            risk_modifier: 8
+      - position: 2
+        name: "Straits Approach"
+        description: "Industrial ruins provide cover for the final approach."
+        breach_template_slug: null
+        fork_options: []
+
+  # Straits → Lakeshore (West)
+  - slug: straits-to-lakeshore
+    name: "Straits → Lakeshore Conduit"
+    origin_region_slug: the-straits
+    destination_region_slug: the-lakeshore
+    origin_room_slug: straits-slip-west
+    destination_room_slug: lakeshore-slip-east
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "Return route through lakefront industrial tunnels."
+    legs:
+      - position: 1
+        name: "Assembly Line Exit"
+        description: "Through abandoned manufacturing corridors."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Paint Shop Tunnel"
+            description: "Chemical residue masks heat signatures."
+            risk_modifier: -5
+          - key: B
+            label: "Conveyor Shaft"
+            description: "Wider, faster, exposed."
+            risk_modifier: 8
+      - position: 2
+        name: "Lakefront Insert"
+        description: "Merge into lakeshore freight traffic."
+        breach_template_slug: null
+        fork_options: []
+
+  # Lakeshore → Badlands (West)
+  - slug: lakeshore-to-badlands
+    name: "Lakeshore → Badlands Conduit"
+    origin_region_slug: the-lakeshore
+    destination_region_slug: the-badlands
+    origin_room_slug: lakeshore-slip-west
+    destination_room_slug: badlands-slip-east
+    min_clearance: 15
+    base_heat_cost: 15
+    detection_risk_base: 8
+    active: true
+    description: "Long-haul corridor across the plains. Low risk but high heat from distance."
+    legs:
+      - position: 1
+        name: "Western Outskirts"
+        description: "Urban infrastructure gives way to grain corridor freight."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Grain Silo Route"
+            description: "Follow agricultural freight. Slow, invisible."
+            risk_modifier: -8
+          - key: B
+            label: "Interstate Underpass"
+            description: "Direct routing. Exposed at junctions."
+            risk_modifier: 10
+      - position: 2
+        name: "Great Plains Crossing"
+        description: "Nothing but emptiness above and steel below."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Badlands Descent"
+        description: "The terrain drops. Coverage thins."
+        breach_template_slug: null
+        fork_options: []
+
+  # Badlands → Lakeshore (East)
+  - slug: badlands-to-lakeshore
+    name: "Badlands → Lakeshore Conduit"
+    origin_region_slug: the-badlands
+    destination_region_slug: the-lakeshore
+    origin_room_slug: badlands-slip-east
+    destination_room_slug: lakeshore-slip-west
+    min_clearance: 15
+    base_heat_cost: 15
+    detection_risk_base: 8
+    active: true
+    description: "Long return corridor from the high plains to the lakefront."
+    legs:
+      - position: 1
+        name: "Badlands Ascent"
+        description: "Climbing out of eroded rock. Thin coverage."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Plains Transit"
+        description: "Flat, featureless, automated freight."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Wind Farm Corridor"
+            description: "Electromagnetic interference from turbines. Good cover."
+            risk_modifier: -5
+          - key: B
+            label: "Direct Line"
+            description: "Fastest path. Clean scans."
+            risk_modifier: 8
+      - position: 3
+        name: "Urban Approach"
+        description: "Re-entering the lakefront sprawl."
+        breach_template_slug: null
+        fork_options: []
+
+  # === ARCH CONNECTIONS ===
+  # Arch → Riverlands (South)
+  - slug: arch-to-riverlands
+    name: "Arch → Riverlands Conduit"
+    origin_region_slug: the-arch
+    destination_region_slug: the-riverlands
+    origin_room_slug: arch-slip-south
+    destination_room_slug: riverlands-slip-north
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "River corridor following the great waterway south."
+    legs:
+      - position: 1
+        name: "River Bluff Descent"
+        description: "Down from the confluence into river country."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Barge Channel"
+            description: "Under the river freight lanes."
+            risk_modifier: -5
+          - key: B
+            label: "Bluff Tunnel"
+            description: "Through the limestone. Direct."
+            risk_modifier: 8
+      - position: 2
+        name: "Riverlands Approach"
+        description: "Delta country. Humid, close."
+        breach_template_slug: null
+        fork_options: []
+
+  # Riverlands → Arch (North)
+  - slug: riverlands-to-arch
+    name: "Riverlands → Arch Conduit"
+    origin_region_slug: the-riverlands
+    destination_region_slug: the-arch
+    origin_room_slug: riverlands-slip-north
+    destination_room_slug: arch-slip-south
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "Upriver corridor to the confluence."
+    legs:
+      - position: 1
+        name: "River Ascent"
+        description: "Climbing the river gradient toward the arch."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Levee Underpass"
+            description: "Follow flood infrastructure. Narrow."
+            risk_modifier: -5
+          - key: B
+            label: "River Bed Channel"
+            description: "Deeper, wider, exposed at bridges."
+            risk_modifier: 8
+      - position: 2
+        name: "Confluence Insert"
+        description: "The deadzone interference begins to help."
+        breach_template_slug: null
+        fork_options: []
+
+  # Arch → Works (East)
+  - slug: arch-to-works
+    name: "Arch → Works Conduit"
+    origin_region_slug: the-arch
+    destination_region_slug: the-works
+    origin_room_slug: arch-slip-east
+    destination_room_slug: works-slip-west
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Industrial corridor connecting the confluence to the steel valleys."
+    legs:
+      - position: 1
+        name: "Eastern Departure"
+        description: "Leaving the deadzone. Sensors come alive."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Coal Seam Route"
+            description: "Follow the old coal freight. Deep, dirty, hidden."
+            risk_modifier: -8
+          - key: B
+            label: "River Valley Express"
+            description: "Main corridor. Fast, monitored."
+            risk_modifier: 12
+      - position: 2
+        name: "Steel Valley Approach"
+        description: "Industrial ruins line the corridor."
+        breach_template_slug: null
+        fork_options: []
+
+  # Works → Arch (West)
+  - slug: works-to-arch
+    name: "Works → Arch Conduit"
+    origin_region_slug: the-works
+    destination_region_slug: the-arch
+    origin_room_slug: works-slip-west
+    destination_room_slug: arch-slip-east
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Return through the industrial corridor to the deadzone."
+    legs:
+      - position: 1
+        name: "Foundry Exit"
+        description: "Through the skeletal remains of steel production."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Slag Tunnel"
+            description: "Hot, toxic, invisible to thermal scans."
+            risk_modifier: -8
+          - key: B
+            label: "Rail Mainline"
+            description: "Former passenger route. Clean, exposed."
+            risk_modifier: 12
+      - position: 2
+        name: "Deadzone Insert"
+        description: "Relief as the interference field takes hold."
+        breach_template_slug: null
+        fork_options: []
+
+  # Arch → Front (West)
+  - slug: arch-to-front
+    name: "Arch → Front Conduit"
+    origin_region_slug: the-arch
+    destination_region_slug: the-front
+    origin_room_slug: arch-slip-west
+    destination_room_slug: front-slip-east
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "Long corridor across the plains to the mountains."
+    legs:
+      - position: 1
+        name: "Westward Departure"
+        description: "Out of the deadzone into open country."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Cattle Route"
+            description: "Follow agricultural freight lanes. Slow."
+            risk_modifier: -5
+          - key: B
+            label: "Interstate Corridor"
+            description: "Main infrastructure. Faster, watched."
+            risk_modifier: 10
+      - position: 2
+        name: "High Plains Transit"
+        description: "Altitude climbing. Air thinning."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Mountain Approach"
+        description: "The Front Range rises. Terrain disrupts scans."
+        breach_template_slug: null
+        fork_options: []
+
+  # Front → Arch (East)
+  - slug: front-to-arch
+    name: "Front → Arch Conduit"
+    origin_region_slug: the-front
+    destination_region_slug: the-arch
+    origin_room_slug: front-slip-east
+    destination_room_slug: arch-slip-west
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "Downhill run from the mountains to the confluence deadzone."
+    legs:
+      - position: 1
+        name: "Mountain Departure"
+        description: "Descending the front range."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Plains Run"
+        description: "Flat, fast, nothing to hide behind."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Storm Drain Network"
+            description: "Tornado country infrastructure. Intermittent cover."
+            risk_modifier: -3
+          - key: B
+            label: "Freight Express"
+            description: "Direct automated freight. Fast."
+            risk_modifier: 8
+      - position: 3
+        name: "Deadzone Insert"
+        description: "Sweet relief of the interference field."
+        breach_template_slug: null
+        fork_options: []
+
+  # === RIVERLANDS CONNECTIONS ===
+  # Riverlands → Bend (South)
+  - slug: riverlands-to-bend
+    name: "Riverlands → Bend Conduit"
+    origin_region_slug: the-riverlands
+    destination_region_slug: the-bend
+    origin_room_slug: riverlands-slip-south
+    destination_room_slug: bend-slip-north
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 12
+    active: true
+    description: "Downriver to where the great river meets the sea."
+    legs:
+      - position: 1
+        name: "River Descent"
+        description: "Following the current south."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Bayou Channel"
+            description: "Waterlogged side channel. Sensors struggle."
+            risk_modifier: -8
+          - key: B
+            label: "Main River Bed"
+            description: "Center channel. Faster current, more traffic."
+            risk_modifier: 10
+      - position: 2
+        name: "Bend Approach"
+        description: "Below sea level. Everything is damp."
+        breach_template_slug: null
+        fork_options: []
+
+  # Bend → Riverlands (North)
+  - slug: bend-to-riverlands
+    name: "Bend → Riverlands Conduit"
+    origin_region_slug: the-bend
+    destination_region_slug: the-riverlands
+    origin_room_slug: bend-slip-north
+    destination_room_slug: riverlands-slip-south
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 12
+    active: true
+    description: "Upriver from the delta to the bluffs."
+    legs:
+      - position: 1
+        name: "Delta Exit"
+        description: "Fighting the current north."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Cistern Route"
+            description: "Through flood management infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Channel Direct"
+            description: "Against the main current. Strain on systems."
+            risk_modifier: 8
+      - position: 2
+        name: "Bluff Ascent"
+        description: "Climbing to higher ground."
+        breach_template_slug: null
+        fork_options: []
+
+  # Riverlands → Hollows (East)
+  - slug: riverlands-to-hollows
+    name: "Riverlands → Hollows Conduit"
+    origin_region_slug: the-riverlands
+    destination_region_slug: the-hollows
+    origin_room_slug: riverlands-slip-east
+    destination_room_slug: hollows-slip-west
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "Mountain corridor through old coal country."
+    legs:
+      - position: 1
+        name: "Foothills Entry"
+        description: "Terrain begins to fold. Signal weakens."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mine Shaft Route"
+            description: "Through abandoned coal mines. Dangerous but dark."
+            risk_modifier: -8
+          - key: B
+            label: "Ridge Runner"
+            description: "Follow the ridgeline. Exposed at gaps."
+            risk_modifier: 10
+      - position: 2
+        name: "Hollows Insert"
+        description: "Deep in the valleys. Mist and silence."
+        breach_template_slug: null
+        fork_options: []
+
+  # Hollows → Riverlands (West)
+  - slug: hollows-to-riverlands
+    name: "Hollows → Riverlands Conduit"
+    origin_region_slug: the-hollows
+    destination_region_slug: the-riverlands
+    origin_room_slug: hollows-slip-west
+    destination_room_slug: riverlands-slip-east
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "Out of the mountains to the river bluffs."
+    legs:
+      - position: 1
+        name: "Valley Exit"
+        description: "Climbing out of the hollows."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Creek Bed"
+            description: "Follow the water down. Natural cover."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Tunnel"
+            description: "Through old interstate infrastructure."
+            risk_modifier: 8
+      - position: 2
+        name: "Riverlands Approach"
+        description: "Terrain flattening. River smell."
+        breach_template_slug: null
+        fork_options: []
+
+  # === REMAINING CONNECTIONS (abbreviated legs for space) ===
+
+  # Bend → Marshes (East)
+  - slug: bend-to-marshes
+    name: "Bend → Marshes Conduit"
+    origin_region_slug: the-bend
+    destination_region_slug: the-marshes
+    origin_room_slug: bend-slip-east
+    destination_room_slug: marshes-slip-west
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 14
+    active: true
+    description: "Gulf coast corridor through wetlands."
+    legs:
+      - position: 1
+        name: "Coastal Run"
+        description: "Along the gulf. Salt air corrodes everything."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Causeway Underpass"
+            description: "Below the bridges. Tidal interference."
+            risk_modifier: -5
+          - key: B
+            label: "Coastal Express"
+            description: "Above-grade freight. Fast, exposed."
+            risk_modifier: 12
+      - position: 2
+        name: "Marshes Insert"
+        description: "Where the land stops being land."
+        breach_template_slug: null
+        fork_options: []
+
+  # Marshes → Bend (West)
+  - slug: marshes-to-bend
+    name: "Marshes → Bend Conduit"
+    origin_region_slug: the-marshes
+    destination_region_slug: the-bend
+    origin_room_slug: marshes-slip-west
+    destination_room_slug: bend-slip-east
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 14
+    active: true
+    description: "Back through the gulf coast to the river bend."
+    legs:
+      - position: 1
+        name: "Swamp Exit"
+        description: "Solid ground is a relative concept here."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mangrove Channel"
+            description: "Through root systems. Barely passable."
+            risk_modifier: -8
+          - key: B
+            label: "Highway Corridor"
+            description: "Elevated above the swamp. Visible."
+            risk_modifier: 10
+      - position: 2
+        name: "Bend Approach"
+        description: "Back to the delta."
+        breach_template_slug: null
+        fork_options: []
+
+  # Bend → Flats (West)
+  - slug: bend-to-flats
+    name: "Bend → Flats Conduit"
+    origin_region_slug: the-bend
+    destination_region_slug: the-flats
+    origin_room_slug: bend-slip-west
+    destination_room_slug: flats-slip-east
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "Gulf coast corridor west to the sprawl."
+    legs:
+      - position: 1
+        name: "Bayou Crossing"
+        description: "Through the bayou infrastructure."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Pipeline Route"
+            description: "Follow the oil infrastructure. Industrial camouflage."
+            risk_modifier: -5
+          - key: B
+            label: "Coastal Highway"
+            description: "Straight shot. Monitored."
+            risk_modifier: 8
+      - position: 2
+        name: "Flats Approach"
+        description: "Everything flattens. Nowhere to hide."
+        breach_template_slug: null
+        fork_options: []
+
+  # Flats → Bend (East)
+  - slug: flats-to-bend
+    name: "Flats → Bend Conduit"
+    origin_region_slug: the-flats
+    destination_region_slug: the-bend
+    origin_room_slug: flats-slip-east
+    destination_room_slug: bend-slip-west
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "East along the gulf to the river bend."
+    legs:
+      - position: 1
+        name: "Prairie Exit"
+        description: "Leaving the flat sprawl."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Refinery Corridor"
+            description: "Through petrochemical infrastructure. Good cover."
+            risk_modifier: -5
+          - key: B
+            label: "Gulf Freeway"
+            description: "Direct route. Total coverage."
+            risk_modifier: 10
+      - position: 2
+        name: "Delta Insert"
+        description: "Into the river country."
+        breach_template_slug: null
+        fork_options: []
+
+  # Flats → Front (North)
+  - slug: flats-to-front
+    name: "Flats → Front Conduit"
+    origin_region_slug: the-flats
+    destination_region_slug: the-front
+    origin_room_slug: flats-slip-north
+    destination_room_slug: front-slip-south
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "Long haul north from the gulf to the mountains."
+    legs:
+      - position: 1
+        name: "Plains Ascent"
+        description: "Gradual climb. Altitude increasing."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Wind Farm Corridor"
+            description: "EM interference from turbine arrays."
+            risk_modifier: -5
+          - key: B
+            label: "Interstate Trunk"
+            description: "Main infrastructure. Straight, fast."
+            risk_modifier: 8
+      - position: 2
+        name: "High Country"
+        description: "Thin air, thin coverage."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Front Range Insert"
+        description: "Mountains rise. Terrain is your friend."
+        breach_template_slug: null
+        fork_options: []
+
+  # Front → Flats (South)
+  - slug: front-to-flats
+    name: "Front → Flats Conduit"
+    origin_region_slug: the-front
+    destination_region_slug: the-flats
+    origin_room_slug: front-slip-south
+    destination_room_slug: flats-slip-north
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "Downhill run from the mountains to the gulf sprawl."
+    legs:
+      - position: 1
+        name: "Mountain Descent"
+        description: "Dropping altitude fast."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Plains Crossing"
+        description: "Flat and exposed."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Agricultural Corridor"
+            description: "Among the grain freight. Slow but hidden."
+            risk_modifier: -5
+          - key: B
+            label: "Freight Express"
+            description: "Priority cargo lane. Fast."
+            risk_modifier: 8
+      - position: 3
+        name: "Sprawl Insert"
+        description: "Urban infrastructure returns."
+        breach_template_slug: null
+        fork_options: []
+
+  # Flats → Canyon (West)
+  - slug: flats-to-canyon
+    name: "Flats → Canyon Conduit"
+    origin_region_slug: the-flats
+    destination_region_slug: the-canyon
+    origin_room_slug: flats-slip-west
+    destination_room_slug: canyon-slip-east
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 8
+    active: true
+    description: "West through desert to the canyon rim."
+    legs:
+      - position: 1
+        name: "Desert Crossing"
+        description: "Nothing but heat and rock."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Aquifer Route"
+            description: "Follow the water table. Deep and cool."
+            risk_modifier: -8
+          - key: B
+            label: "Surface Run"
+            description: "Above-grade freight. Exposed but fast."
+            risk_modifier: 10
+      - position: 2
+        name: "Canyon Rim"
+        description: "The ground drops away. Signal falters at depth."
+        breach_template_slug: null
+        fork_options: []
+
+  # Canyon → Flats (East)
+  - slug: canyon-to-flats
+    name: "Canyon → Flats Conduit"
+    origin_region_slug: the-canyon
+    destination_region_slug: the-flats
+    origin_room_slug: canyon-slip-east
+    destination_room_slug: flats-slip-west
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 8
+    active: true
+    description: "Out of the canyon into the flat sprawl."
+    legs:
+      - position: 1
+        name: "Rim Ascent"
+        description: "Climbing out of the canyon."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Desert Transit"
+        description: "East through the badlands."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Pipeline Route"
+            description: "Along old oil infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Underpass"
+            description: "Interstate infrastructure. Monitored."
+            risk_modifier: 8
+
+  # Canyon → Front (North)
+  - slug: canyon-to-front
+    name: "Canyon → Front Conduit"
+    origin_region_slug: the-canyon
+    destination_region_slug: the-front
+    origin_room_slug: canyon-slip-north
+    destination_room_slug: front-slip-south
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 8
+    active: true
+    description: "North through desert to the mountain front."
+    legs:
+      - position: 1
+        name: "Plateau Crossing"
+        description: "High desert. Thin air, thin coverage."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mesa Route"
+            description: "Wind through rock formations. Natural cover."
+            risk_modifier: -8
+          - key: B
+            label: "Valley Floor"
+            description: "Straight shot. No cover."
+            risk_modifier: 10
+      - position: 2
+        name: "Front Range Insert"
+        description: "Mountains ahead."
+        breach_template_slug: null
+        fork_options: []
+
+  # Front → Canyon (South — intentionally same as Flats South target slot, uses different room)
+  - slug: front-to-canyon
+    name: "Front → Canyon Conduit"
+    origin_region_slug: the-front
+    destination_region_slug: the-canyon
+    origin_room_slug: front-slip-south-canyon
+    destination_room_slug: canyon-slip-north
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 8
+    active: true
+    description: "South through high desert to the canyon rim."
+    legs:
+      - position: 1
+        name: "High Desert"
+        description: "Descending from the mountains into red rock."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Arroyo Route"
+            description: "Dry river beds. Flash flood risk, scanner shade."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Corridor"
+            description: "Main route. Well-maintained, well-monitored."
+            risk_modifier: 8
+      - position: 2
+        name: "Rim Approach"
+        description: "The canyon opens below."
+        breach_template_slug: null
+        fork_options: []
+
+  # Canyon → Basin (West)
+  - slug: canyon-to-basin
+    name: "Canyon → Basin Conduit"
+    origin_region_slug: the-canyon
+    destination_region_slug: the-basin
+    origin_room_slug: canyon-slip-west
+    destination_room_slug: basin-slip-east
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 15
+    active: true
+    description: "West through desert to GovCorp's entertainment capital. Heavy monitoring."
+    legs:
+      - position: 1
+        name: "Desert Crossing"
+        description: "Mojave. Nothing lives here on purpose."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Solar Farm Corridor"
+            description: "Heat shimmer masks thermal signatures."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Express"
+            description: "Interstate freight. GovCorp territory."
+            risk_modifier: 15
+      - position: 2
+        name: "Basin Perimeter"
+        description: "Approaching Ground Zero. Maximum surveillance."
+        breach_template_slug: null
+        fork_options: []
+
+  # Basin → Canyon (East)
+  - slug: basin-to-canyon
+    name: "Basin → Canyon Conduit"
+    origin_region_slug: the-basin
+    destination_region_slug: the-canyon
+    origin_room_slug: basin-slip-east
+    destination_room_slug: canyon-slip-west
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 15
+    active: true
+    description: "East through desert away from GovCorp's core."
+    legs:
+      - position: 1
+        name: "Basin Exit"
+        description: "Leaving the most surveilled region on the continent."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Aqueduct Route"
+            description: "Follow water infrastructure. Low-priority scans."
+            risk_modifier: -5
+          - key: B
+            label: "Freight Direct"
+            description: "Cargo mainline. Fastest exit."
+            risk_modifier: 12
+      - position: 2
+        name: "Desert Relief"
+        description: "Coverage drops as you enter the wasteland."
+        breach_template_slug: null
+        fork_options: []
+
+  # Basin → Gate (North)
+  - slug: basin-to-gate
+    name: "Basin → Gate Conduit"
+    origin_region_slug: the-basin
+    destination_region_slug: the-gate
+    origin_room_slug: basin-slip-north
+    destination_room_slug: gate-slip-south
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 14
+    active: true
+    description: "Coast corridor north to the innovation hub."
+    legs:
+      - position: 1
+        name: "Coastal Highway"
+        description: "Along the coast. Beautiful and monitored."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Submarine Cable Route"
+            description: "Follow undersea fiber infrastructure."
+            risk_modifier: -8
+          - key: B
+            label: "Surface Express"
+            description: "Coastal rail. Fast, exposed."
+            risk_modifier: 10
+      - position: 2
+        name: "Gate Approach"
+        description: "Research-grade RIDE infrastructure ahead."
+        breach_template_slug: null
+        fork_options: []
+
+  # Gate → Basin (South)
+  - slug: gate-to-basin
+    name: "Gate → Basin Conduit"
+    origin_region_slug: the-gate
+    destination_region_slug: the-basin
+    origin_room_slug: gate-slip-south
+    destination_room_slug: basin-slip-north
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 14
+    active: true
+    description: "South along the coast to GovCorp's entertainment capital."
+    legs:
+      - position: 1
+        name: "Bay Exit"
+        description: "Leaving the research hub."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Kelp Farm Route"
+            description: "Through aquaculture infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Coast Rail"
+            description: "Main passenger corridor. Fast."
+            risk_modifier: 10
+      - position: 2
+        name: "Basin Insert"
+        description: "Welcome to GovCorp central."
+        breach_template_slug: null
+        fork_options: []
+
+  # Gate → Canopy (North)
+  - slug: gate-to-canopy
+    name: "Gate → Canopy Conduit"
+    origin_region_slug: the-gate
+    destination_region_slug: the-canopy
+    origin_room_slug: gate-slip-north
+    destination_room_slug: canopy-slip-south
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "North through old-growth forest to the canopy."
+    legs:
+      - position: 1
+        name: "Redwood Corridor"
+        description: "The trees do half the work. Natural signal attenuation."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Root Network"
+            description: "Follow the root systems. Biomass shields everything."
+            risk_modifier: -10
+          - key: B
+            label: "Timber Route"
+            description: "Logging infrastructure. Cleared paths."
+            risk_modifier: 5
+      - position: 2
+        name: "Canopy Insert"
+        description: "Under the evergreen canopy. Rain starts."
+        breach_template_slug: null
+        fork_options: []
+
+  # Canopy → Gate (South)
+  - slug: canopy-to-gate
+    name: "Canopy → Gate Conduit"
+    origin_region_slug: the-canopy
+    destination_region_slug: the-gate
+    origin_room_slug: canopy-slip-south
+    destination_room_slug: gate-slip-north
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "South through the forest to the bay."
+    legs:
+      - position: 1
+        name: "Forest Descent"
+        description: "Out of the canopy. Rain lessening."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Watershed Route"
+            description: "Follow the rivers south."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Tunnel"
+            description: "Interstate infrastructure through the mountains."
+            risk_modifier: 8
+      - position: 2
+        name: "Bay Approach"
+        description: "Research RIDE infrastructure intensifying."
+        breach_template_slug: null
+        fork_options: []
+
+  # Gate → Front (East)
+  - slug: gate-to-front
+    name: "Gate → Front Conduit"
+    origin_region_slug: the-gate
+    destination_region_slug: the-front
+    origin_room_slug: gate-slip-east
+    destination_room_slug: front-slip-west
+    min_clearance: 15
+    base_heat_cost: 14
+    detection_risk_base: 10
+    active: true
+    description: "East across the Sierra and Great Basin to the Front Range."
+    legs:
+      - position: 1
+        name: "Mountain Pass"
+        description: "Through the Sierra. Altitude disrupts scans."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Donner Route"
+            description: "Historic pass. Narrow, slow, shielded."
+            risk_modifier: -8
+          - key: B
+            label: "Freight Tunnel"
+            description: "Modern bore. Wide, fast, monitored."
+            risk_modifier: 10
+      - position: 2
+        name: "Basin Crossing"
+        description: "Salt flats and emptiness."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Front Range Insert"
+        description: "Mountains rise again. Almost there."
+        breach_template_slug: null
+        fork_options: []
+
+  # Front → Gate (West)
+  - slug: front-to-gate
+    name: "Front → Gate Conduit"
+    origin_region_slug: the-front
+    destination_region_slug: the-gate
+    origin_room_slug: front-slip-west
+    destination_room_slug: gate-slip-east
+    min_clearance: 15
+    base_heat_cost: 14
+    detection_risk_base: 10
+    active: true
+    description: "West across the Great Basin and Sierra to the bay."
+    legs:
+      - position: 1
+        name: "Western Descent"
+        description: "Down from the Front Range."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Salt Flat Transit"
+        description: "Flat, bright, nothing to see. Or be seen."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mine Corridor"
+            description: "Through lithium extraction infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Highway Express"
+            description: "Straight shot. No cover."
+            risk_modifier: 10
+      - position: 3
+        name: "Sierra Crossing"
+        description: "Through the mountains to the bay."
+        breach_template_slug: null
+        fork_options: []
+
+  # Canopy → Badlands (East)
+  - slug: canopy-to-badlands
+    name: "Canopy → Badlands Conduit"
+    origin_region_slug: the-canopy
+    destination_region_slug: the-badlands
+    origin_room_slug: canopy-slip-east
+    destination_room_slug: badlands-slip-west
+    min_clearance: 15
+    base_heat_cost: 14
+    detection_risk_base: 8
+    active: true
+    description: "East through mountain passes to the high plains."
+    legs:
+      - position: 1
+        name: "Cascade Exit"
+        description: "Through volcanic mountain passes."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Lava Tube"
+            description: "Natural volcanic tunnels. Ancient, stable."
+            risk_modifier: -10
+          - key: B
+            label: "Pass Road"
+            description: "Mountain highway infrastructure."
+            risk_modifier: 8
+      - position: 2
+        name: "Columbia Plateau"
+        description: "Basalt flatlands. Sparse."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Badlands Approach"
+        description: "Everything erodes. Including coverage."
+        breach_template_slug: null
+        fork_options: []
+
+  # Badlands → Canopy (West)
+  - slug: badlands-to-canopy
+    name: "Badlands → Canopy Conduit"
+    origin_region_slug: the-badlands
+    destination_region_slug: the-canopy
+    origin_room_slug: badlands-slip-west
+    destination_room_slug: canopy-slip-east
+    min_clearance: 15
+    base_heat_cost: 14
+    detection_risk_base: 8
+    active: true
+    description: "West through the passes to the evergreen canopy."
+    legs:
+      - position: 1
+        name: "Badlands Exit"
+        description: "Leaving the eroded rock."
+        breach_template_slug: null
+        fork_options: []
+      - position: 2
+        name: "Plateau Crossing"
+        description: "Basalt country."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "River Gorge"
+            description: "Through deep canyon infrastructure."
+            risk_modifier: -8
+          - key: B
+            label: "Freight Line"
+            description: "Agricultural freight. Grain cover."
+            risk_modifier: 5
+      - position: 3
+        name: "Canopy Insert"
+        description: "Rain and trees. Blessed interference."
+        breach_template_slug: null
+        fork_options: []
+
+  # Badlands → Front (South)
+  - slug: badlands-to-front
+    name: "Badlands → Front Conduit"
+    origin_region_slug: the-badlands
+    destination_region_slug: the-front
+    origin_room_slug: badlands-slip-south
+    destination_room_slug: front-slip-north
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 8
+    active: true
+    description: "South from the high plains to the mountain front."
+    legs:
+      - position: 1
+        name: "Plains Descent"
+        description: "South through cattle country."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Ranch Route"
+            description: "Through livestock infrastructure. Low priority."
+            risk_modifier: -5
+          - key: B
+            label: "Highway South"
+            description: "Direct. Monitored at state boundaries."
+            risk_modifier: 8
+      - position: 2
+        name: "Front Range Insert"
+        description: "Mountains ahead. Denver sprawl."
+        breach_template_slug: null
+        fork_options: []
+
+  # Front → Badlands (North)
+  - slug: front-to-badlands
+    name: "Front → Badlands Conduit"
+    origin_region_slug: the-front
+    destination_region_slug: the-badlands
+    origin_room_slug: front-slip-north
+    destination_room_slug: badlands-slip-south
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 8
+    active: true
+    description: "North from the mountains to the high plains."
+    legs:
+      - position: 1
+        name: "Mountain Exit"
+        description: "North through the foothills."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mining Access"
+            description: "Through abandoned mine infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Interstate North"
+            description: "Direct highway corridor."
+            risk_modifier: 8
+      - position: 2
+        name: "Badlands Insert"
+        description: "Coverage drops. Sky opens."
+        breach_template_slug: null
+        fork_options: []
+
+  # === EASTERN SEABOARD CONNECTIONS ===
+
+  # Straits → Works (South)
+  - slug: straits-to-works
+    name: "Straits → Works Conduit"
+    origin_region_slug: the-straits
+    destination_region_slug: the-works
+    origin_room_slug: straits-slip-south
+    destination_room_slug: works-slip-north
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 12
+    active: true
+    description: "South through industrial lake country to the steel valleys."
+    legs:
+      - position: 1
+        name: "Lake Shore Run"
+        description: "Along the southern lake."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Steel Mill Corridor"
+            description: "Through decommissioned mills. Residual heat masks signatures."
+            risk_modifier: -8
+          - key: B
+            label: "Freeway Underpass"
+            description: "Interstate infrastructure. Maintained."
+            risk_modifier: 10
+      - position: 2
+        name: "River Valley Insert"
+        description: "Into the steel country."
+        breach_template_slug: null
+        fork_options: []
+
+  # Works → Straits (North)
+  - slug: works-to-straits
+    name: "Works → Straits Conduit"
+    origin_region_slug: the-works
+    destination_region_slug: the-straits
+    origin_room_slug: works-slip-north
+    destination_room_slug: straits-slip-south
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 12
+    active: true
+    description: "North from the river valleys to the lake strait."
+    legs:
+      - position: 1
+        name: "Valley Exit"
+        description: "Out of the river valleys."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Ore Car Route"
+            description: "Old ore transport. Slow, buried."
+            risk_modifier: -5
+          - key: B
+            label: "Turnpike Tunnel"
+            description: "Modern infrastructure. Toll cameras."
+            risk_modifier: 10
+      - position: 2
+        name: "Straits Insert"
+        description: "Industrial waterfront ahead."
+        breach_template_slug: null
+        fork_options: []
+
+  # Straits → Narrows (East)
+  - slug: straits-to-narrows
+    name: "Straits → Narrows Conduit"
+    origin_region_slug: the-straits
+    destination_region_slug: the-narrows
+    origin_room_slug: straits-slip-east
+    destination_room_slug: narrows-slip-west
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 14
+    active: true
+    description: "East through the northeast corridor to the most surveilled city on the continent."
+    legs:
+      - position: 1
+        name: "Great Lakes Exit"
+        description: "Leaving the lake country."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Canal Route"
+            description: "Follow the old canal infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Northeast Corridor"
+            description: "High-speed rail infrastructure. Maximum surveillance."
+            risk_modifier: 15
+      - position: 2
+        name: "Mountain Pass"
+        description: "Through the Appalachian gaps."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Narrows Approach"
+        description: "RIDE saturation increasing. Maximum density."
+        breach_template_slug: null
+        fork_options: []
+
+  # Narrows → Straits (West)
+  - slug: narrows-to-straits
+    name: "Narrows → Straits Conduit"
+    origin_region_slug: the-narrows
+    destination_region_slug: the-straits
+    origin_room_slug: narrows-slip-west-straits
+    destination_room_slug: straits-slip-east
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 14
+    active: true
+    description: "West from the harbor city through the northeast corridor."
+    legs:
+      - position: 1
+        name: "Harbor Exit"
+        description: "Escaping the most surveilled location on the continent."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Subway Extension"
+            description: "Through abandoned subway tunnels. Dark, old."
+            risk_modifier: -8
+          - key: B
+            label: "Amtrak Corridor"
+            description: "Main passenger rail. Fast, observed."
+            risk_modifier: 12
+      - position: 2
+        name: "Appalachian Crossing"
+        description: "Mountain country. Coverage fading."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Straits Insert"
+        description: "Industrial lake country ahead."
+        breach_template_slug: null
+        fork_options: []
+
+  # Works → Narrows (Northwest from Works perspective)
+  - slug: works-to-narrows
+    name: "Works → Narrows Conduit"
+    origin_region_slug: the-works
+    destination_region_slug: the-narrows
+    origin_room_slug: works-slip-northwest
+    destination_room_slug: narrows-slip-southwest
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Northeast through the mountains to the harbor city."
+    legs:
+      - position: 1
+        name: "Allegheny Crossing"
+        description: "Through the old mountain corridors."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Railroad Tunnel"
+            description: "Century-old bore through the mountains."
+            risk_modifier: -5
+          - key: B
+            label: "Turnpike Route"
+            description: "Modern highway infrastructure."
+            risk_modifier: 10
+      - position: 2
+        name: "Narrows Insert"
+        description: "Urban density increasing. RIDE saturation rising."
+        breach_template_slug: null
+        fork_options: []
+
+  # Narrows → Works (Southwest)
+  - slug: narrows-to-works
+    name: "Narrows → Works Conduit"
+    origin_region_slug: the-narrows
+    destination_region_slug: the-works
+    origin_room_slug: narrows-slip-southwest
+    destination_room_slug: works-slip-northwest
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 12
+    active: true
+    description: "Southwest through the mountains to the steel valleys."
+    legs:
+      - position: 1
+        name: "Metro Exit"
+        description: "Out of the dense urban core."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "PATH Tunnel"
+            description: "Through old trans-river tunnel infrastructure."
+            risk_modifier: -8
+          - key: B
+            label: "Interstate Express"
+            description: "Highway infrastructure. Direct."
+            risk_modifier: 10
+      - position: 2
+        name: "Steel Valley Insert"
+        description: "River valleys and foundry ruins."
+        breach_template_slug: null
+        fork_options: []
+
+  # Hollows → Narrows (North)
+  - slug: hollows-to-narrows
+    name: "Hollows → Narrows Conduit"
+    origin_region_slug: the-hollows
+    destination_region_slug: the-narrows
+    origin_room_slug: hollows-slip-north
+    destination_room_slug: narrows-slip-south
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "North through the mountains to the harbor city."
+    legs:
+      - position: 1
+        name: "Mountain Exit"
+        description: "Out of the hollows. Coverage slowly returning."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Coal Corridor"
+            description: "Old coal transport routes. Deep, dark."
+            risk_modifier: -8
+          - key: B
+            label: "Valley Highway"
+            description: "Modern infrastructure through gaps."
+            risk_modifier: 8
+      - position: 2
+        name: "Coastal Approach"
+        description: "The harbor city ahead. Maximum RIDE density."
+        breach_template_slug: null
+        fork_options: []
+
+  # Narrows → Hollows (South)
+  - slug: narrows-to-hollows
+    name: "Narrows → Hollows Conduit"
+    origin_region_slug: the-narrows
+    destination_region_slug: the-hollows
+    origin_room_slug: narrows-slip-south
+    destination_room_slug: hollows-slip-north
+    min_clearance: 15
+    base_heat_cost: 10
+    detection_risk_base: 10
+    active: true
+    description: "South from the harbor into the mountain hollows."
+    legs:
+      - position: 1
+        name: "Urban Exit"
+        description: "Leaving the most surveilled city on the continent."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Sewer Infrastructure"
+            description: "Through the century-old drainage system."
+            risk_modifier: -10
+          - key: B
+            label: "Rail Corridor"
+            description: "Main line south. Fast, watched."
+            risk_modifier: 10
+      - position: 2
+        name: "Hollows Insert"
+        description: "Mountains folding around you. Signal dying."
+        breach_template_slug: null
+        fork_options: []
+
+  # Hollows → Marshes (South)
+  - slug: hollows-to-marshes
+    name: "Hollows → Marshes Conduit"
+    origin_region_slug: the-hollows
+    destination_region_slug: the-marshes
+    origin_room_slug: hollows-slip-south
+    destination_room_slug: marshes-slip-north
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "South from the mountains through the piedmont to the wetlands."
+    legs:
+      - position: 1
+        name: "Piedmont Descent"
+        description: "Mountains give way to rolling hills."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Creek Route"
+            description: "Follow the waterways. Natural cover."
+            risk_modifier: -5
+          - key: B
+            label: "Interstate South"
+            description: "Direct highway corridor."
+            risk_modifier: 8
+      - position: 2
+        name: "Coastal Plain"
+        description: "Flat, subtropical, humid."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Marshes Insert"
+        description: "The ground becomes uncertain."
+        breach_template_slug: null
+        fork_options: []
+
+  # Marshes → Hollows (North)
+  - slug: marshes-to-hollows
+    name: "Marshes → Hollows Conduit"
+    origin_region_slug: the-marshes
+    destination_region_slug: the-hollows
+    origin_room_slug: marshes-slip-north
+    destination_room_slug: hollows-slip-south
+    min_clearance: 15
+    base_heat_cost: 12
+    detection_risk_base: 10
+    active: true
+    description: "North from the wetlands through the piedmont to the mountain hollows."
+    legs:
+      - position: 1
+        name: "Swamp Exit"
+        description: "Finding solid ground."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Cypress Route"
+            description: "Through the cypress swamp infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Highway North"
+            description: "Interstate corridor. Fast."
+            risk_modifier: 8
+      - position: 2
+        name: "Piedmont Ascent"
+        description: "Climbing into the hills."
+        breach_template_slug: null
+        fork_options: []
+      - position: 3
+        name: "Hollows Insert"
+        description: "Mountains closing in. Signal dying."
+        breach_template_slug: null
+        fork_options: []
+
+  # Works → Hollows (South)
+  - slug: works-to-hollows
+    name: "Works → Hollows Conduit"
+    origin_region_slug: the-works
+    destination_region_slug: the-hollows
+    origin_room_slug: works-slip-south
+    destination_room_slug: hollows-slip-north-works
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "South from the steel valleys into the mountain hollows."
+    legs:
+      - position: 1
+        name: "Valley Descent"
+        description: "Following the river south."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "River Barge Route"
+            description: "Follow the barge infrastructure."
+            risk_modifier: -5
+          - key: B
+            label: "Rail Direct"
+            description: "Coal country rail. Industrial traffic."
+            risk_modifier: 8
+      - position: 2
+        name: "Hollows Insert"
+        description: "Into the deep valleys."
+        breach_template_slug: null
+        fork_options: []
+
+  # Hollows → Works (North — toward Works specifically)
+  - slug: hollows-to-works
+    name: "Hollows → Works Conduit"
+    origin_region_slug: the-hollows
+    destination_region_slug: the-works
+    origin_room_slug: hollows-slip-north-works
+    destination_room_slug: works-slip-south
+    min_clearance: 15
+    base_heat_cost: 8
+    detection_risk_base: 10
+    active: true
+    description: "North from the hollows to the steel valleys."
+    legs:
+      - position: 1
+        name: "Mountain Ascent"
+        description: "Climbing toward the river valleys."
+        breach_template_slug: null
+        fork_options:
+          - key: A
+            label: "Mine Cart Route"
+            description: "Through old mining infrastructure."
+            risk_modifier: -8
+          - key: B
+            label: "Highway Tunnel"
+            description: "Modern bore through the mountains."
+            risk_modifier: 8
+      - position: 2
+        name: "Works Insert"
+        description: "Steel country ahead."
+        breach_template_slug: null
+        fork_options: []

--- a/data/world/transit_types.yml
+++ b/data/world/transit_types.yml
@@ -1,0 +1,115 @@
+# Transit Type Definitions
+# Category: "public" (route-based, multiple stops, cheap)
+#           "private" (point-to-point, 1 wait cycle, expensive)
+#           "slipstream" (inter-region, leg-by-leg with fork choices)
+
+transit_types:
+  - slug: elevated-traincar
+    name: "Elevated Traincar"
+    category: public
+    description: "High-speed rail running on elevated tracks above the urban grid. Frequent stops, open platform access."
+    icon_key: TRAIN
+    base_fare: 5
+    min_clearance: 0
+    published: true
+    position: 1
+
+  - slug: underground-rail
+    name: "Underground Rail"
+    category: public
+    description: "Deep-bore tunnel rail system beneath the city substrate. Fast, reliable, claustrophobic."
+    icon_key: RAIL
+    base_fare: 5
+    min_clearance: 0
+    published: true
+    position: 2
+
+  - slug: metro-bus
+    name: "Metro Bus"
+    category: public
+    description: "Surface-level bus routes threading through the urban grid. Slow but everywhere."
+    icon_key: BUS
+    base_fare: 3
+    min_clearance: 0
+    published: true
+    position: 3
+
+  - slug: electric-rail-bus
+    name: "Electric Rail Bus"
+    category: public
+    description: "Overhead-wire electric buses running fixed rail-like routes. Quiet, efficient, practical."
+    icon_key: ERAIL
+    base_fare: 4
+    min_clearance: 0
+    published: true
+    position: 4
+
+  - slug: trolley-streetcar
+    name: "Trolley / Streetcar"
+    category: public
+    description: "Heritage streetcars rattling along embedded tracks. Slow, scenic, beloved."
+    icon_key: TRAM
+    base_fare: 2
+    min_clearance: 0
+    published: true
+    position: 5
+
+  - slug: all-terrain-transport
+    name: "All-Terrain Transport"
+    category: public
+    description: "Rugged vehicles built for rough terrain — switchback crawlers, gondola shuttles, mountain buses."
+    icon_key: ATT
+    base_fare: 8
+    min_clearance: 5
+    published: true
+    position: 6
+
+  - slug: taxi-car
+    name: "Taxi Car"
+    category: private
+    description: "Standard car-for-hire service. Pick your destination, pay the fare, arrive in one stop."
+    icon_key: TAXI
+    base_fare: 20
+    min_clearance: 0
+    published: true
+    position: 7
+
+  - slug: private-car
+    name: "Private Car"
+    category: private
+    description: "Black car service for high-rolling districts. Premium fare, no questions asked."
+    icon_key: CAR
+    base_fare: 35
+    min_clearance: 0
+    published: true
+    position: 8
+
+  - slug: water-taxi
+    name: "Water Taxi"
+    category: private
+    description: "Charter boat service across harbors, rivers, and lakefronts. Wind in your hair, if you have any."
+    icon_key: BOAT
+    base_fare: 25
+    min_clearance: 0
+    published: true
+    position: 9
+
+  - slug: airboat
+    name: "Airboat"
+    category: private
+    description: "Fan-powered flat-bottom craft for swamps and wetlands. Loud, fast, the only thing that moves out here."
+    icon_key: AIR
+    base_fare: 40
+    min_clearance: 0
+    published: true
+    position: 10
+
+  - slug: slipstream
+    name: "Slipstream"
+    category: slipstream
+    description: "Inter-region covert transit through GovCorp's freight and maintenance rail. Leg-by-leg with fork decisions. CL15 minimum."
+    icon_key: SLIP
+    base_fare: 0
+    min_clearance: 15
+    published: true
+    position: 11

--- a/db/migrate/20260506200000_create_grid_transit_tables.rb
+++ b/db/migrate/20260506200000_create_grid_transit_tables.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+class CreateGridTransitTables < ActiveRecord::Migration[8.0]
+  def change
+    # Transit type definitions (10 vehicle/mode types + slipstream)
+    create_table :grid_transit_types do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.string :category, null: false # "public", "private", "slipstream"
+      t.text :description
+      t.string :icon_key
+      t.integer :base_fare, null: false, default: 0
+      t.integer :min_clearance, null: false, default: 0
+      t.boolean :published, null: false, default: false
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_transit_types, :slug, unique: true
+    add_index :grid_transit_types, :category
+
+    # Which transit types are available in each region (0-4 per region)
+    create_table :grid_region_transit_assignments do |t|
+      t.references :grid_region, null: false, foreign_key: {on_delete: :cascade}
+      t.references :grid_transit_type, null: false, foreign_key: {on_delete: :cascade}
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_region_transit_assignments, [:grid_region_id, :grid_transit_type_id],
+      unique: true, name: "index_region_transit_assignments_unique"
+
+    # Local transit routes (public route lines within a region)
+    create_table :grid_transit_routes do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.references :grid_transit_type, null: false, foreign_key: {on_delete: :restrict}
+      t.references :grid_region, null: false, foreign_key: {on_delete: :restrict}
+      t.boolean :loop_route, null: false, default: false
+      t.boolean :active, null: false, default: true
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_transit_routes, :slug, unique: true
+    add_index :grid_transit_routes, :active
+
+    # Ordered stops on a local transit route
+    create_table :grid_transit_stops do |t|
+      t.references :grid_transit_route, null: false, foreign_key: {on_delete: :cascade}
+      t.references :grid_room, null: false, foreign_key: {on_delete: :restrict}
+      t.integer :position, null: false
+      t.string :label
+      t.boolean :is_terminus, null: false, default: false
+      t.timestamps
+    end
+    add_index :grid_transit_stops, [:grid_transit_route_id, :position],
+      unique: true, name: "index_transit_stops_route_position"
+
+    # Inter-region slipstream route definitions
+    create_table :grid_slipstream_routes do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.references :origin_region, null: false, foreign_key: {to_table: :grid_regions, on_delete: :restrict}
+      t.references :destination_region, null: false, foreign_key: {to_table: :grid_regions, on_delete: :restrict}
+      t.references :origin_room, null: false, foreign_key: {to_table: :grid_rooms, on_delete: :restrict}
+      t.references :destination_room, null: false, foreign_key: {to_table: :grid_rooms, on_delete: :restrict}
+      t.integer :min_clearance, null: false, default: 15
+      t.integer :base_heat_cost, null: false, default: 10
+      t.integer :detection_risk_base, null: false, default: 15
+      t.boolean :active, null: false, default: true
+      t.text :description
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_slipstream_routes, :slug, unique: true
+    add_index :grid_slipstream_routes, [:origin_region_id, :destination_region_id],
+      unique: true, name: "index_slipstream_routes_origin_dest"
+
+    # Ordered legs of a slipstream route (each with fork choices)
+    create_table :grid_slipstream_legs do |t|
+      t.references :grid_slipstream_route, null: false, foreign_key: {on_delete: :cascade}
+      t.integer :position, null: false
+      t.string :name, null: false
+      t.text :description
+      t.json :fork_options, null: false, default: []
+      t.string :breach_template_slug
+      t.timestamps
+    end
+    add_index :grid_slipstream_legs, [:grid_slipstream_route_id, :position],
+      unique: true, name: "index_slipstream_legs_route_position"
+
+    # Unified journey tracker (one active per hackr)
+    create_table :grid_transit_journeys do |t|
+      t.references :grid_hackr, null: false, foreign_key: {on_delete: :cascade}
+      t.string :journey_type, null: false # "slipstream", "local_public", "local_private"
+      t.string :state, null: false, default: "active"
+
+      # Shared fields
+      t.references :origin_room, foreign_key: {to_table: :grid_rooms, on_delete: :nullify}
+      t.references :destination_room, foreign_key: {to_table: :grid_rooms, on_delete: :nullify}
+      t.datetime :started_at, null: false
+
+      # Slipstream fields
+      t.references :grid_slipstream_route, foreign_key: {on_delete: :nullify}
+      t.references :current_leg, foreign_key: {to_table: :grid_slipstream_legs, on_delete: :nullify}
+      t.integer :legs_completed, null: false, default: 0
+      t.boolean :pending_fork, null: false, default: false
+      t.integer :heat_accumulated, null: false, default: 0
+      t.boolean :breach_mid_journey, null: false, default: false
+
+      # Local transit fields
+      t.references :grid_transit_route, foreign_key: {on_delete: :nullify}
+      t.references :current_stop, foreign_key: {to_table: :grid_transit_stops, on_delete: :nullify}
+      t.integer :fare_paid, null: false, default: 0
+
+      # Metadata
+      t.json :meta, null: false, default: {}
+      t.datetime :ended_at
+
+      t.timestamps
+    end
+    add_index :grid_transit_journeys, :state
+    add_index :grid_transit_journeys, :grid_hackr_id,
+      unique: true, where: "state = 'active'",
+      name: "index_transit_journeys_one_active_per_hackr"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -570,6 +570,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
     t.json "vendor_config"
   end
 
+  create_table "grid_region_transit_assignments", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_region_id", null: false
+    t.integer "grid_transit_type_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_region_id", "grid_transit_type_id"], name: "index_region_transit_assignments_unique", unique: true
+    t.index ["grid_region_id"], name: "index_grid_region_transit_assignments_on_grid_region_id"
+    t.index ["grid_transit_type_id"], name: "index_grid_region_transit_assignments_on_grid_transit_type_id"
+  end
+
   create_table "grid_regions", force: :cascade do |t|
     t.integer "cell_block_room_id"
     t.integer "containment_room_id"
@@ -718,6 +729,42 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
     t.index ["grid_shop_listing_id"], name: "index_grid_shop_transactions_on_grid_shop_listing_id"
   end
 
+  create_table "grid_slipstream_legs", force: :cascade do |t|
+    t.string "breach_template_slug"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.json "fork_options", default: [], null: false
+    t.integer "grid_slipstream_route_id", null: false
+    t.string "name", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_slipstream_route_id", "position"], name: "index_slipstream_legs_route_position", unique: true
+    t.index ["grid_slipstream_route_id"], name: "index_grid_slipstream_legs_on_grid_slipstream_route_id"
+  end
+
+  create_table "grid_slipstream_routes", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.integer "base_heat_cost", default: 10, null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "destination_region_id", null: false
+    t.integer "destination_room_id", null: false
+    t.integer "detection_risk_base", default: 15, null: false
+    t.integer "min_clearance", default: 15, null: false
+    t.string "name", null: false
+    t.integer "origin_region_id", null: false
+    t.integer "origin_room_id", null: false
+    t.integer "position", default: 0, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["destination_region_id"], name: "index_grid_slipstream_routes_on_destination_region_id"
+    t.index ["destination_room_id"], name: "index_grid_slipstream_routes_on_destination_room_id"
+    t.index ["origin_region_id", "destination_region_id"], name: "index_slipstream_routes_origin_dest", unique: true
+    t.index ["origin_region_id"], name: "index_grid_slipstream_routes_on_origin_region_id"
+    t.index ["origin_room_id"], name: "index_grid_slipstream_routes_on_origin_room_id"
+    t.index ["slug"], name: "index_grid_slipstream_routes_on_slug", unique: true
+  end
+
   create_table "grid_transactions", force: :cascade do |t|
     t.integer "amount", null: false
     t.datetime "created_at", null: false
@@ -732,6 +779,83 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
     t.index ["to_cache_id"], name: "index_grid_transactions_on_to_cache_id"
     t.index ["tx_hash"], name: "index_grid_transactions_on_tx_hash", unique: true
     t.index ["tx_type"], name: "index_grid_transactions_on_tx_type"
+  end
+
+  create_table "grid_transit_journeys", force: :cascade do |t|
+    t.boolean "breach_mid_journey", default: false, null: false
+    t.datetime "created_at", null: false
+    t.integer "current_leg_id"
+    t.integer "current_stop_id"
+    t.integer "destination_room_id"
+    t.datetime "ended_at"
+    t.integer "fare_paid", default: 0, null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "grid_slipstream_route_id"
+    t.integer "grid_transit_route_id"
+    t.integer "heat_accumulated", default: 0, null: false
+    t.string "journey_type", null: false
+    t.integer "legs_completed", default: 0, null: false
+    t.json "meta", default: {}, null: false
+    t.integer "origin_room_id"
+    t.boolean "pending_fork", default: false, null: false
+    t.datetime "started_at", null: false
+    t.string "state", default: "active", null: false
+    t.datetime "updated_at", null: false
+    t.index ["current_leg_id"], name: "index_grid_transit_journeys_on_current_leg_id"
+    t.index ["current_stop_id"], name: "index_grid_transit_journeys_on_current_stop_id"
+    t.index ["destination_room_id"], name: "index_grid_transit_journeys_on_destination_room_id"
+    t.index ["grid_hackr_id"], name: "index_grid_transit_journeys_on_grid_hackr_id"
+    t.index ["grid_hackr_id"], name: "index_transit_journeys_one_active_per_hackr", unique: true, where: "state = 'active'"
+    t.index ["grid_slipstream_route_id"], name: "index_grid_transit_journeys_on_grid_slipstream_route_id"
+    t.index ["grid_transit_route_id"], name: "index_grid_transit_journeys_on_grid_transit_route_id"
+    t.index ["origin_room_id"], name: "index_grid_transit_journeys_on_origin_room_id"
+    t.index ["state"], name: "index_grid_transit_journeys_on_state"
+  end
+
+  create_table "grid_transit_routes", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "grid_region_id", null: false
+    t.integer "grid_transit_type_id", null: false
+    t.boolean "loop_route", default: false, null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_grid_transit_routes_on_active"
+    t.index ["grid_region_id"], name: "index_grid_transit_routes_on_grid_region_id"
+    t.index ["grid_transit_type_id"], name: "index_grid_transit_routes_on_grid_transit_type_id"
+    t.index ["slug"], name: "index_grid_transit_routes_on_slug", unique: true
+  end
+
+  create_table "grid_transit_stops", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_room_id", null: false
+    t.integer "grid_transit_route_id", null: false
+    t.boolean "is_terminus", default: false, null: false
+    t.string "label"
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_room_id"], name: "index_grid_transit_stops_on_grid_room_id"
+    t.index ["grid_transit_route_id", "position"], name: "index_transit_stops_route_position", unique: true
+    t.index ["grid_transit_route_id"], name: "index_grid_transit_stops_on_grid_transit_route_id"
+  end
+
+  create_table "grid_transit_types", force: :cascade do |t|
+    t.integer "base_fare", default: 0, null: false
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "icon_key"
+    t.integer "min_clearance", default: 0, null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.boolean "published", default: false, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_grid_transit_types_on_category"
+    t.index ["slug"], name: "index_grid_transit_types_on_slug", unique: true
   end
 
   create_table "grid_uplink_presences", force: :cascade do |t|
@@ -1272,6 +1396,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
   add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
+  add_foreign_key "grid_region_transit_assignments", "grid_regions", on_delete: :cascade
+  add_foreign_key "grid_region_transit_assignments", "grid_transit_types", on_delete: :cascade
   add_foreign_key "grid_regions", "grid_rooms", column: "cell_block_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "containment_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "facility_bribe_exit_room_id", on_delete: :nullify
@@ -1288,6 +1414,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_165402) do
   add_foreign_key "grid_schematics", "grid_item_definitions", column: "output_definition_id"
   add_foreign_key "grid_shop_listings", "grid_item_definitions"
   add_foreign_key "grid_shop_listings", "grid_mobs"
+  add_foreign_key "grid_slipstream_legs", "grid_slipstream_routes", on_delete: :cascade
+  add_foreign_key "grid_slipstream_routes", "grid_regions", column: "destination_region_id", on_delete: :restrict
+  add_foreign_key "grid_slipstream_routes", "grid_regions", column: "origin_region_id", on_delete: :restrict
+  add_foreign_key "grid_slipstream_routes", "grid_rooms", column: "destination_room_id", on_delete: :restrict
+  add_foreign_key "grid_slipstream_routes", "grid_rooms", column: "origin_room_id", on_delete: :restrict
+  add_foreign_key "grid_transit_journeys", "grid_hackrs", on_delete: :cascade
+  add_foreign_key "grid_transit_journeys", "grid_rooms", column: "destination_room_id", on_delete: :nullify
+  add_foreign_key "grid_transit_journeys", "grid_rooms", column: "origin_room_id", on_delete: :nullify
+  add_foreign_key "grid_transit_journeys", "grid_slipstream_legs", column: "current_leg_id", on_delete: :nullify
+  add_foreign_key "grid_transit_journeys", "grid_slipstream_routes", on_delete: :nullify
+  add_foreign_key "grid_transit_journeys", "grid_transit_routes", on_delete: :nullify
+  add_foreign_key "grid_transit_journeys", "grid_transit_stops", column: "current_stop_id", on_delete: :nullify
+  add_foreign_key "grid_transit_routes", "grid_regions", on_delete: :restrict
+  add_foreign_key "grid_transit_routes", "grid_transit_types", on_delete: :restrict
+  add_foreign_key "grid_transit_stops", "grid_rooms", on_delete: :restrict
+  add_foreign_key "grid_transit_stops", "grid_transit_routes", on_delete: :cascade
   add_foreign_key "grid_verification_tokens", "grid_hackrs"
   add_foreign_key "grid_zones", "grid_regions"
   add_foreign_key "grid_zones", "zone_playlists", column: "ambient_playlist_id"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -206,7 +206,7 @@ namespace :data do
   desc "Load world data (factions, regions, zones, rooms, etc.)"
   task world: :environment do
     guard_world_seed!
-    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities].each do |t|
+    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities transit_types region_transit_assignments slipstream_routes].each do |t|
       Rake::Task["data:#{t}"].invoke
     end
   end
@@ -1278,6 +1278,135 @@ namespace :data do
     end
 
     puts "PAC Facilities: #{zones_created} zones, #{rooms_created} rooms, #{exits_created} exits, #{mobs_created} mobs, #{encounters_created} encounters"
+  end
+
+  desc "Load transit types from YAML"
+  task transit_types: :environment do
+    guard_world_seed!
+    puts "\n--- Loading Transit Types ---"
+    yaml_file = Rails.root.join("data", "world", "transit_types.yml")
+    next unless File.exist?(yaml_file)
+
+    data = YAML.load_file(yaml_file)
+    created = 0
+
+    data["transit_types"].each do |attrs|
+      type = GridTransitType.find_or_initialize_by(slug: attrs["slug"])
+      next unless type.new_record?
+      type.assign_attributes(attrs.except("slug"))
+      type.save!
+      created += 1
+      puts "  ✓ #{type.name} (#{type.category})"
+    end
+
+    puts "Transit Types: #{created} created, #{GridTransitType.count} total"
+  end
+
+  desc "Load region transit assignments from YAML"
+  task region_transit_assignments: :environment do
+    guard_world_seed!
+    puts "\n--- Loading Region Transit Assignments ---"
+    yaml_file = Rails.root.join("data", "world", "region_transit_assignments.yml")
+    next unless File.exist?(yaml_file)
+
+    data = YAML.load_file(yaml_file)
+    type_map = GridTransitType.all.index_by(&:slug)
+    region_map = GridRegion.all.index_by(&:slug)
+    created = 0
+
+    data["region_transit_assignments"].each do |entry|
+      region = region_map[entry["region_slug"]]
+      unless region
+        puts "  ✗ Region not found: #{entry["region_slug"]}"
+        next
+      end
+
+      (entry["transit_type_slugs"] || []).each_with_index do |type_slug, idx|
+        type = type_map[type_slug]
+        unless type
+          puts "  ✗ Transit type not found: #{type_slug}"
+          next
+        end
+
+        assignment = GridRegionTransitAssignment.find_or_initialize_by(
+          grid_region: region, grid_transit_type: type
+        )
+        next unless assignment.new_record?
+        assignment.position = idx
+        assignment.save!
+        created += 1
+      end
+    end
+
+    puts "Region Transit Assignments: #{created} created, #{GridRegionTransitAssignment.count} total"
+  end
+
+  desc "Load slipstream routes and legs from YAML"
+  task slipstream_routes: :environment do
+    guard_world_seed!
+    puts "\n--- Loading Slipstream Routes ---"
+    yaml_file = Rails.root.join("data", "world", "slipstream_routes.yml")
+    next unless File.exist?(yaml_file)
+
+    data = YAML.load_file(yaml_file)
+    region_map = GridRegion.all.index_by(&:slug)
+    room_map = GridRoom.all.index_by(&:slug)
+    created = 0
+    legs_created = 0
+
+    data["slipstream_routes"].each do |attrs|
+      route = GridSlipstreamRoute.find_or_initialize_by(slug: attrs["slug"])
+      next unless route.new_record?
+
+      origin_region = region_map[attrs["origin_region_slug"]]
+      dest_region = region_map[attrs["destination_region_slug"]]
+      origin_room = room_map[attrs["origin_room_slug"]]
+      dest_room = room_map[attrs["destination_room_slug"]]
+
+      unless origin_region && dest_region
+        puts "  ✗ Region not found for #{attrs["slug"]}"
+        next
+      end
+
+      # Skip if rooms don't exist yet — route will be seedable once rooms are created
+      unless origin_room && dest_room
+        puts "  ⚠ Rooms not found for #{attrs["slug"]} — skipping (seed rooms first)"
+        next
+      end
+
+      route.assign_attributes(
+        name: attrs["name"],
+        origin_region: origin_region,
+        destination_region: dest_region,
+        origin_room: origin_room,
+        destination_room: dest_room,
+        min_clearance: attrs["min_clearance"] || 15,
+        base_heat_cost: attrs["base_heat_cost"] || 10,
+        detection_risk_base: attrs["detection_risk_base"] || 15,
+        active: attrs["active"] != false,
+        description: attrs["description"],
+        position: attrs["position"] || 0
+      )
+      route.save!
+      created += 1
+
+      (attrs["legs"] || []).each do |leg_attrs|
+        leg = route.grid_slipstream_legs.find_or_initialize_by(position: leg_attrs["position"])
+        next unless leg.new_record?
+        leg.assign_attributes(
+          name: leg_attrs["name"],
+          description: leg_attrs["description"],
+          fork_options: leg_attrs["fork_options"] || [],
+          breach_template_slug: leg_attrs["breach_template_slug"]
+        )
+        leg.save!
+        legs_created += 1
+      end
+
+      puts "  ✓ #{route.name} (#{route.grid_slipstream_legs.count} legs)"
+    end
+
+    puts "Slipstream Routes: #{created} created (#{legs_created} legs), #{GridSlipstreamRoute.count} total"
   end
 
   desc "Sync existing grid_items with their current definitions"

--- a/spec/factories/grid_transit.rb
+++ b/spec/factories/grid_transit.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :grid_transit_type do
+    sequence(:slug) { |n| "transit-type-#{n}" }
+    sequence(:name) { |n| "Transit Type #{n}" }
+    category { "public" }
+    base_fare { 5 }
+    min_clearance { 0 }
+    published { true }
+    position { 0 }
+
+    trait :public_type do
+      category { "public" }
+      base_fare { 5 }
+    end
+
+    trait :private_type do
+      category { "private" }
+      base_fare { 20 }
+    end
+
+    trait :slipstream_type do
+      category { "slipstream" }
+      base_fare { 0 }
+      min_clearance { 15 }
+      slug { "slipstream" }
+      name { "Slipstream" }
+    end
+  end
+
+  factory :grid_transit_route do
+    sequence(:slug) { |n| "transit-route-#{n}" }
+    sequence(:name) { |n| "Transit Route #{n}" }
+    association :grid_transit_type
+    association :grid_region
+    active { true }
+    position { 0 }
+  end
+
+  factory :grid_transit_stop do
+    association :grid_transit_route
+    association :grid_room
+    sequence(:position) { |n| n }
+    is_terminus { false }
+  end
+
+  factory :grid_slipstream_route do
+    sequence(:slug) { |n| "slip-route-#{n}" }
+    sequence(:name) { |n| "Slipstream Route #{n}" }
+    association :origin_region, factory: :grid_region
+    association :destination_region, factory: :grid_region
+    association :origin_room, factory: :grid_room
+    association :destination_room, factory: :grid_room
+    min_clearance { 15 }
+    base_heat_cost { 10 }
+    detection_risk_base { 15 }
+    active { true }
+    position { 0 }
+  end
+
+  factory :grid_slipstream_leg do
+    association :grid_slipstream_route
+    sequence(:position) { |n| n }
+    sequence(:name) { |n| "Leg #{n}" }
+    description { "A corridor junction." }
+    fork_options do
+      [
+        {"key" => "A", "label" => "Maintenance Corridor", "risk_modifier" => -5, "description" => "Low risk, slow."},
+        {"key" => "B", "label" => "Freight Car", "risk_modifier" => 10, "description" => "High risk, fast."}
+      ]
+    end
+  end
+end

--- a/spec/factories/grid_transit.rb
+++ b/spec/factories/grid_transit.rb
@@ -45,6 +45,12 @@ FactoryBot.define do
     is_terminus { false }
   end
 
+  factory :grid_region_transit_assignment do
+    association :grid_region
+    association :grid_transit_type
+    position { 0 }
+  end
+
   factory :grid_slipstream_route do
     sequence(:slug) { |n| "slip-route-#{n}" }
     sequence(:name) { |n| "Slipstream Route #{n}" }

--- a/spec/services/grid/local_transit_service_spec.rb
+++ b/spec/services/grid/local_transit_service_spec.rb
@@ -136,44 +136,72 @@ RSpec.describe Grid::LocalTransitService do
     end
   end
 
-  describe "private transit" do
+  describe "private transit (route-free)" do
     let(:private_type) { create(:grid_transit_type, :private_type) }
-    let(:private_route) do
-      create(:grid_transit_route, grid_transit_type: private_type, grid_region: region).tap do |r|
-        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0)
-        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
-        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_c, position: 2)
-      end
-    end
+    let!(:assignment) { create(:grid_region_transit_assignment, grid_region: region, grid_transit_type: private_type) }
 
-    it "boards with destination and arrives in single wait" do
-      dest_stop = private_route.grid_transit_stops.find_by(position: 2)
-      result = described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
+    it "boards with destination room and arrives in single wait" do
+      result = described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_c)
       expect(result.journey.journey_type).to eq("local_private")
+      expect(result.journey.destination_room).to eq(room_c)
+      expect(result.fare_charged).to eq(private_type.base_fare)
 
       wait_result = described_class.wait!(hackr: hackr)
       expect(wait_result.arrived).to be true
       expect(hackr.reload.current_room).to eq(room_c)
     end
 
-    it "raises DestinationNotOnRoute without destination" do
-      expect {
-        described_class.board!(hackr: hackr, route: private_route)
-      }.to raise_error(Grid::LocalTransitService::DestinationNotOnRoute)
+    it "charges flat base fare" do
+      result = described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_c)
+      expect(result.fare_charged).to eq(private_type.base_fare)
     end
 
-    it "raises AlreadyAtDestination when destination is current stop" do
-      dest_stop = private_route.grid_transit_stops.find_by(position: 0)
+    it "raises AlreadyAtDestination when destination is current room" do
       expect {
-        described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
+        described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_a)
       }.to raise_error(Grid::LocalTransitService::AlreadyAtDestination)
     end
 
-    it "scales fare by distance" do
-      dest_stop = private_route.grid_transit_stops.find_by(position: 2)
-      result = described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
-      # Distance is 2 stops, fare = base_fare * max(distance, 1)
-      expect(result.fare_charged).to eq(private_type.base_fare * 2)
+    it "raises NotAtTransitStop when not in a transit room" do
+      standard_room = create(:grid_room, :standard, grid_zone: zone)
+      hackr.update!(current_room: standard_room)
+      expect {
+        described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_a)
+      }.to raise_error(Grid::LocalTransitService::NotAtTransitStop)
+    end
+
+    it "raises InsufficientFunds when hackr cannot afford fare" do
+      Grid::TransactionService.burn!(from_cache: cache, amount: 1000, memo: "drain")
+      expect {
+        described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_c)
+      }.to raise_error(Grid::LocalTransitService::InsufficientFunds)
+    end
+  end
+
+  describe ".private_types_at_room" do
+    let(:private_type) { create(:grid_transit_type, :private_type) }
+    let!(:assignment) { create(:grid_region_transit_assignment, grid_region: region, grid_transit_type: private_type) }
+
+    it "returns private types for transit rooms in the region" do
+      results = described_class.private_types_at_room(room: room_a, hackr: hackr)
+      expect(results).to include(private_type)
+    end
+
+    it "returns empty for non-transit rooms" do
+      standard_room = create(:grid_room, :standard, grid_zone: zone)
+      results = described_class.private_types_at_room(room: standard_room, hackr: hackr)
+      expect(results).to be_empty
+    end
+  end
+
+  describe ".private_destinations" do
+    it "returns other transit rooms in the region" do
+      # Force room creation before query
+      room_b
+      room_c
+      results = described_class.private_destinations(room: room_a)
+      expect(results.map(&:id)).to include(room_b.id, room_c.id)
+      expect(results.map(&:id)).not_to include(room_a.id)
     end
   end
 

--- a/spec/services/grid/local_transit_service_spec.rb
+++ b/spec/services/grid/local_transit_service_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::LocalTransitService do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room_a) { create(:grid_room, grid_zone: zone, name: "Stop A") }
+  let(:room_b) { create(:grid_room, grid_zone: zone, name: "Stop B") }
+  let(:room_c) { create(:grid_room, grid_zone: zone, name: "Stop C") }
+  let(:hackr) { create(:grid_hackr, current_room: room_a) }
+
+  let(:transit_type) { create(:grid_transit_type, :public_type) }
+  let(:route) do
+    create(:grid_transit_route, grid_transit_type: transit_type, grid_region: region).tap do |r|
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0, is_terminus: true)
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_c, position: 2, is_terminus: true)
+    end
+  end
+
+  let!(:burn_cache) { create(:grid_cache, :burn) }
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  before do
+    fund_cache(cache, 1000)
+  end
+
+  describe ".board!" do
+    it "creates an active journey for public transit" do
+      result = described_class.board!(hackr: hackr, route: route)
+
+      expect(result.journey).to be_a(GridTransitJourney)
+      expect(result.journey.state).to eq("active")
+      expect(result.journey.journey_type).to eq("local_public")
+      expect(result.journey.current_stop.grid_room).to eq(room_a)
+      expect(result.fare_charged).to eq(transit_type.base_fare)
+      expect(result.display).to include("BOARDING")
+    end
+
+    it "deducts fare from hackr cache" do
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to change { hackr.default_cache.reload.balance }.by(-transit_type.base_fare)
+    end
+
+    it "raises AlreadyInJourney when hackr has active journey" do
+      described_class.board!(hackr: hackr, route: route)
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::LocalTransitService::AlreadyInJourney)
+    end
+
+    it "raises RouteNotAtStop when hackr is not at a stop on the route" do
+      other_room = create(:grid_room, grid_zone: zone)
+      hackr.update!(current_room: other_room)
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::LocalTransitService::RouteNotAtStop)
+    end
+
+    it "raises InsufficientFunds when hackr cannot afford fare" do
+      # Drain the cache by burning all funds
+      Grid::TransactionService.burn!(from_cache: cache, amount: 1000, memo: "drain")
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::LocalTransitService::InsufficientFunds)
+    end
+  end
+
+  describe ".wait!" do
+    before { described_class.board!(hackr: hackr, route: route) }
+
+    it "advances to next stop and moves hackr" do
+      result = described_class.wait!(hackr: hackr)
+
+      expect(result.current_stop.grid_room).to eq(room_b)
+      expect(hackr.reload.current_room).to eq(room_b)
+      expect(result.arrived).to be false
+    end
+
+    it "shows arrival at end of line" do
+      described_class.wait!(hackr: hackr) # A → B
+      result = described_class.wait!(hackr: hackr) # B → C (end)
+
+      expect(result.current_stop.grid_room).to eq(room_c)
+      expect(hackr.reload.current_room).to eq(room_c)
+    end
+
+    it "auto-disembarks at end of non-loop route" do
+      described_class.wait!(hackr: hackr) # A → B
+      described_class.wait!(hackr: hackr) # B → C
+      result = described_class.wait!(hackr: hackr) # C → end of line
+
+      expect(result.arrived).to be true
+      expect(result.journey.state).to eq("completed")
+    end
+  end
+
+  describe ".disembark!" do
+    before { described_class.board!(hackr: hackr, route: route) }
+
+    it "completes journey at current stop" do
+      described_class.wait!(hackr: hackr) # Move to B
+      result = described_class.disembark!(hackr: hackr)
+
+      expect(result.journey.state).to eq("completed")
+      expect(result.room).to eq(room_b)
+    end
+
+    it "increments transit stats" do
+      described_class.wait!(hackr: hackr)
+      described_class.disembark!(hackr: hackr)
+
+      expect(hackr.stat("local_transit_trips_count")).to eq(1)
+    end
+  end
+
+  describe ".abandon!" do
+    before { described_class.board!(hackr: hackr, route: route) }
+
+    it "returns hackr to origin room and sets state to abandoned" do
+      described_class.wait!(hackr: hackr) # Move to B
+      result = described_class.abandon!(hackr: hackr)
+
+      expect(result.journey.state).to eq("abandoned")
+      expect(hackr.reload.current_room).to eq(room_a)
+    end
+  end
+
+  describe "private transit" do
+    let(:private_type) { create(:grid_transit_type, :private_type) }
+    let(:private_route) do
+      create(:grid_transit_route, grid_transit_type: private_type, grid_region: region).tap do |r|
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0)
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_c, position: 2)
+      end
+    end
+
+    it "boards with destination and arrives in single wait" do
+      dest_stop = private_route.grid_transit_stops.find_by(position: 2)
+      result = described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
+      expect(result.journey.journey_type).to eq("local_private")
+
+      wait_result = described_class.wait!(hackr: hackr)
+      expect(wait_result.arrived).to be true
+      expect(hackr.reload.current_room).to eq(room_c)
+    end
+
+    it "raises DestinationNotOnRoute without destination" do
+      expect {
+        described_class.board!(hackr: hackr, route: private_route)
+      }.to raise_error(Grid::LocalTransitService::DestinationNotOnRoute)
+    end
+
+    it "raises AlreadyAtDestination when destination is current stop" do
+      dest_stop = private_route.grid_transit_stops.find_by(position: 0)
+      expect {
+        described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
+      }.to raise_error(Grid::LocalTransitService::AlreadyAtDestination)
+    end
+
+    it "scales fare by distance" do
+      dest_stop = private_route.grid_transit_stops.find_by(position: 2)
+      result = described_class.board!(hackr: hackr, route: private_route, destination_stop: dest_stop)
+      # Distance is 2 stops, fare = base_fare * max(distance, 1)
+      expect(result.fare_charged).to eq(private_type.base_fare * 2)
+    end
+  end
+
+  describe ".routes_at_room" do
+    it "returns routes that stop at the given room" do
+      route # ensure created
+      results = described_class.routes_at_room(room: room_a, hackr: hackr)
+      expect(results).to include(route)
+    end
+
+    it "excludes inactive routes" do
+      route.update!(active: false)
+      results = described_class.routes_at_room(room: room_a, hackr: hackr)
+      expect(results).to be_empty
+    end
+  end
+end

--- a/spec/services/grid/slipstream_service_spec.rb
+++ b/spec/services/grid/slipstream_service_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::SlipstreamService do
+  let(:origin_region) { create(:grid_region) }
+  let(:dest_region) { create(:grid_region) }
+  let(:origin_zone) { create(:grid_zone, grid_region: origin_region) }
+  let(:dest_zone) { create(:grid_zone, grid_region: dest_region) }
+  let(:origin_room) { create(:grid_room, grid_zone: origin_zone) }
+  let(:dest_room) { create(:grid_room, grid_zone: dest_zone) }
+  let(:hackr) { create(:grid_hackr, current_room: origin_room, stats: {"clearance" => 20}) }
+
+  let(:route) do
+    create(:grid_slipstream_route,
+      origin_region: origin_region,
+      destination_region: dest_region,
+      origin_room: origin_room,
+      destination_room: dest_room,
+      detection_risk_base: 0) # Disable detection for predictable tests
+  end
+
+  let!(:leg1) do
+    create(:grid_slipstream_leg, grid_slipstream_route: route, position: 1, name: "Leg 1")
+  end
+  let!(:leg2) do
+    create(:grid_slipstream_leg, grid_slipstream_route: route, position: 2, name: "Leg 2",
+      fork_options: [])
+  end
+
+  describe ".board!" do
+    it "creates an active slipstream journey" do
+      result = described_class.board!(hackr: hackr, route: route)
+
+      expect(result.journey.state).to eq("active")
+      expect(result.journey.journey_type).to eq("slipstream")
+      expect(result.journey.current_leg).to eq(leg1)
+      expect(result.journey.pending_fork).to be true
+      expect(result.display).to include("SLIPSTREAM INITIATED")
+    end
+
+    it "raises ClearanceRequired when hackr clearance is too low" do
+      hackr.set_stat!("clearance", 5)
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::SlipstreamService::ClearanceRequired)
+    end
+
+    it "raises NotAtBoardingPoint when hackr is not at origin room" do
+      hackr.update!(current_room: dest_room)
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::SlipstreamService::NotAtBoardingPoint)
+    end
+
+    it "raises AlreadyInJourney when hackr has active journey" do
+      described_class.board!(hackr: hackr, route: route)
+      expect {
+        described_class.board!(hackr: hackr, route: route)
+      }.to raise_error(Grid::SlipstreamService::AlreadyInJourney)
+    end
+  end
+
+  describe ".choose_fork!" do
+    before { described_class.board!(hackr: hackr, route: route) }
+
+    it "records fork choice and clears pending_fork" do
+      result = described_class.choose_fork!(hackr: hackr, fork_key: "A")
+
+      expect(result.journey.pending_fork).to be false
+      expect(result.journey.chosen_forks).to eq({"1" => "A"})
+      expect(result.display).to include("Maintenance Corridor")
+    end
+
+    it "raises InvalidForkKey for unknown fork" do
+      expect {
+        described_class.choose_fork!(hackr: hackr, fork_key: "Z")
+      }.to raise_error(Grid::SlipstreamService::InvalidForkKey)
+    end
+
+    it "raises NotAwaitingFork when no fork pending" do
+      described_class.choose_fork!(hackr: hackr, fork_key: "A")
+      expect {
+        described_class.choose_fork!(hackr: hackr, fork_key: "B")
+      }.to raise_error(Grid::SlipstreamService::NotAwaitingFork)
+    end
+  end
+
+  describe ".advance_leg!" do
+    before do
+      described_class.board!(hackr: hackr, route: route)
+      described_class.choose_fork!(hackr: hackr, fork_key: "A")
+    end
+
+    it "advances to next leg" do
+      result = described_class.advance_leg!(hackr: hackr)
+
+      expect(result.completed).to be false
+      expect(result.breach_triggered).to be false
+      expect(result.journey.current_leg).to eq(leg2)
+      expect(result.journey.legs_completed).to eq(1)
+    end
+
+    it "completes journey on final leg" do
+      described_class.advance_leg!(hackr: hackr) # Leg 1 → Leg 2 (no forks)
+      result = described_class.advance_leg!(hackr: hackr) # Leg 2 → arrival
+
+      expect(result.completed).to be true
+      expect(result.journey.state).to eq("completed")
+      expect(hackr.reload.current_room).to eq(dest_room)
+      expect(result.display).to include("TRANSIT COMPLETE")
+    end
+
+    it "raises AwaitingFork when fork not yet chosen" do
+      # Start fresh journey
+      hackr2 = create(:grid_hackr, current_room: origin_room, stats: {"clearance" => 20})
+      described_class.board!(hackr: hackr2, route: route)
+      expect {
+        described_class.advance_leg!(hackr: hackr2)
+      }.to raise_error(Grid::SlipstreamService::AwaitingFork)
+    end
+
+    it "accumulates heat on successful leg traversal" do
+      described_class.advance_leg!(hackr: hackr)
+      journey = hackr.active_journey
+      expect(journey.heat_accumulated).to be > 0
+    end
+  end
+
+  describe ".abandon!" do
+    before { described_class.board!(hackr: hackr, route: route) }
+
+    it "sets journey to abandoned and returns hackr to origin" do
+      result = described_class.abandon!(hackr: hackr)
+
+      expect(result.journey.state).to eq("abandoned")
+      expect(hackr.reload.current_room).to eq(origin_room)
+    end
+  end
+
+  describe "slipstream stats" do
+    before do
+      described_class.board!(hackr: hackr, route: route)
+      described_class.choose_fork!(hackr: hackr, fork_key: "A")
+      described_class.advance_leg!(hackr: hackr) # Leg 1 → Leg 2
+      described_class.advance_leg!(hackr: hackr) # Leg 2 → arrival
+    end
+
+    it "increments slipstream_trips_count" do
+      expect(hackr.stat("slipstream_trips_count")).to eq(1)
+    end
+
+    it "tracks visited region IDs" do
+      visited = hackr.stat("visited_region_ids")
+      expect(visited).to include(dest_region.id)
+    end
+
+    it "applies heat to hackr on arrival" do
+      expect(hackr.slipstream_heat).to be > 0
+    end
+  end
+
+  describe "heat decay" do
+    it "decays 1 point per minute" do
+      hackr.set_stat!("slipstream_heat", 50)
+      hackr.set_stat!("slipstream_heat_last_at", 10.minutes.ago.to_i)
+
+      expect(hackr.slipstream_heat).to eq(40)
+    end
+
+    it "floors at zero" do
+      hackr.set_stat!("slipstream_heat", 5)
+      hackr.set_stat!("slipstream_heat_last_at", 60.minutes.ago.to_i)
+
+      expect(hackr.slipstream_heat).to eq(0)
+    end
+  end
+
+  describe ".routes_from" do
+    it "returns active routes accessible by hackr" do
+      route # ensure created
+      results = described_class.routes_from(region: origin_region, hackr: hackr)
+      expect(results).to include(route)
+    end
+
+    it "excludes routes above hackr clearance" do
+      route.update!(min_clearance: 99)
+      results = described_class.routes_from(region: origin_region, hackr: hackr)
+      expect(results).not_to include(route)
+    end
+  end
+end

--- a/spec/services/grid/transit_command_parser_spec.rb
+++ b/spec/services/grid/transit_command_parser_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Grid::TransitCommandParser do
 
     it "routes 'off' alias to disembark" do
       execute("wait")
-      result = execute("off")
+      execute("off")
       expect(hackr.reload.active_journey).to be_nil
     end
 

--- a/spec/services/grid/transit_command_parser_spec.rb
+++ b/spec/services/grid/transit_command_parser_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::TransitCommandParser do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room_a) { create(:grid_room, grid_zone: zone, name: "Stop A") }
+  let(:room_b) { create(:grid_room, grid_zone: zone, name: "Stop B") }
+  let(:room_c) { create(:grid_room, grid_zone: zone, name: "Stop C") }
+  let(:hackr) { create(:grid_hackr, current_room: room_a) }
+
+  let(:transit_type) { create(:grid_transit_type, :public_type) }
+  let!(:burn_cache) { create(:grid_cache, :burn) }
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+
+  let(:route) do
+    create(:grid_transit_route, grid_transit_type: transit_type, grid_region: region).tap do |r|
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0, is_terminus: true)
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
+      create(:grid_transit_stop, grid_transit_route: r, grid_room: room_c, position: 2, is_terminus: true)
+    end
+  end
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  def execute(input)
+    Grid::CommandParser.new(hackr, input).execute
+  end
+
+  before do
+    fund_cache(cache, 1000)
+    route # ensure created
+  end
+
+  # Helper: board the hackr onto the route so TransitCommandParser takes over
+  def board_hackr!
+    Grid::LocalTransitService.board!(hackr: hackr, route: route)
+  end
+
+  describe "local transit command routing" do
+    before { board_hackr! }
+
+    it "routes 'wait' to advance one stop" do
+      result = execute("wait")
+      expect(result[:output]).to include("Stop B")
+      expect(hackr.reload.current_room).to eq(room_b)
+    end
+
+    it "routes 'w' alias to wait" do
+      result = execute("w")
+      expect(result[:output]).to include("Stop B")
+    end
+
+    it "routes 'ride' alias to wait" do
+      result = execute("ride")
+      expect(result[:output]).to include("Stop B")
+    end
+
+    it "routes 'disembark' to exit transit" do
+      execute("wait") # move to B
+      result = execute("disembark")
+      expect(result[:output]).to include("disembark")
+      expect(hackr.reload.active_journey).to be_nil
+    end
+
+    it "routes 'off' alias to disembark" do
+      execute("wait")
+      result = execute("off")
+      expect(hackr.reload.active_journey).to be_nil
+    end
+
+    it "routes 'abandon' to abort transit" do
+      execute("wait") # move to B
+      result = execute("abandon")
+      expect(result[:output]).to include("abandoned")
+      expect(hackr.reload.current_room).to eq(room_a) # returned to origin
+    end
+
+    it "routes 'status' to show journey info" do
+      result = execute("status")
+      expect(result[:output]).to include("IN TRANSIT")
+      expect(result[:output]).to include(route.name)
+    end
+
+    it "routes 'tr' alias to status" do
+      result = execute("tr")
+      expect(result[:output]).to include("IN TRANSIT")
+    end
+  end
+
+  describe "blocked commands" do
+    before { board_hackr! }
+
+    %w[go north south breach buy sell fabricate equip].each do |cmd|
+      it "blocks '#{cmd}' with informative message" do
+        result = execute(cmd)
+        expect(result[:output]).to include("In transit")
+        expect(result[:output]).to include("unavailable")
+      end
+    end
+  end
+
+  describe "passthrough commands" do
+    before { board_hackr! }
+
+    it "passes 'look' through to main parser" do
+      result = execute("look")
+      expect(result[:output]).to include(room_a.name.upcase) # look renders room name
+    end
+
+    it "passes 'stat' through to main parser" do
+      result = execute("stat")
+      expect(result[:output]).not_to include("unavailable")
+    end
+
+    it "passes 'inventory' through to main parser" do
+      result = execute("inv")
+      expect(result[:output]).not_to include("unavailable")
+    end
+  end
+
+  describe "slipstream command routing" do
+    let(:dest_region) { create(:grid_region) }
+    let(:dest_zone) { create(:grid_zone, grid_region: dest_region) }
+    let(:origin_room) { create(:grid_room, grid_zone: zone) }
+    let(:dest_room) { create(:grid_room, grid_zone: dest_zone) }
+
+    let(:slip_route) do
+      create(:grid_slipstream_route,
+        origin_region: region, destination_region: dest_region,
+        origin_room: origin_room, destination_room: dest_room,
+        detection_risk_base: 0)
+    end
+
+    let!(:leg1) do
+      create(:grid_slipstream_leg, grid_slipstream_route: slip_route, position: 1, name: "Leg 1")
+    end
+    let!(:leg2) do
+      create(:grid_slipstream_leg, grid_slipstream_route: slip_route, position: 2, name: "Leg 2",
+        fork_options: [])
+    end
+
+    let(:slip_hackr) { create(:grid_hackr, current_room: origin_room, stats: {"clearance" => 20}) }
+
+    def slip_execute(input)
+      Grid::CommandParser.new(slip_hackr, input).execute
+    end
+
+    before do
+      Grid::SlipstreamService.board!(hackr: slip_hackr, route: slip_route)
+    end
+
+    it "routes 'choose' to fork selection" do
+      result = slip_execute("choose A")
+      expect(result[:output]).to include("Maintenance Corridor")
+    end
+
+    it "routes 'ch' alias to choose" do
+      result = slip_execute("ch B")
+      expect(result[:output]).to include("Freight Car")
+    end
+
+    it "routes 'advance' to traverse leg" do
+      slip_execute("choose A")
+      result = slip_execute("advance")
+      expect(result[:output]).to include("Leg 2")
+    end
+
+    it "'wait' aliases to advance for slipstream" do
+      slip_execute("choose A")
+      result = slip_execute("wait")
+      expect(result[:output]).to include("Leg 2")
+    end
+
+    it "'advance' without fork choice shows fork prompt" do
+      result = slip_execute("advance")
+      expect(result[:output]).to include("Choose your path")
+    end
+
+    it "blocks 'disembark' on slipstream" do
+      result = slip_execute("disembark")
+      expect(result[:output]).to include("Cannot disembark from Slipstream")
+    end
+
+    it "'choose' on local transit returns error" do
+      board_hackr! # local transit journey for `hackr`
+      result = execute("choose A")
+      expect(result[:output]).to include("only available on Slipstream")
+    end
+
+    it "'advance' on local transit returns error" do
+      board_hackr!
+      result = execute("advance")
+      expect(result[:output]).to include("Slipstream transit")
+    end
+
+    it "completes full slipstream journey" do
+      slip_execute("choose A")
+      slip_execute("advance") # leg 1 → leg 2 (no forks)
+      result = slip_execute("advance") # leg 2 → arrival
+
+      expect(result[:output]).to include("TRANSIT COMPLETE")
+      expect(slip_hackr.reload.current_room).to eq(dest_room)
+      expect(slip_hackr.active_journey).to be_nil
+    end
+  end
+
+  describe "empty input" do
+    before { board_hackr! }
+
+    it "returns prompt message" do
+      result = execute("")
+      expect(result[:output]).to include("Please enter a command")
+    end
+  end
+end


### PR DESCRIPTION
  Two-scale transportation for THE PULSE GRID — inter-region Slipstream corridors and intra-region local transit (public routes + private point-to-point).

  Slipstream (inter-region): Leg-by-leg covert journey through GovCorp freight infrastructure with fork choices per leg (risk/speed tradeoffs). Per-hackr usage heat with lazy minute-by-minute decay drives detection probability. Normal BREACH encounters trigger mid-journey; BreachCommandParser takes over, transit resumes on resolution. Failure consequences scale by heat tier: light (replay leg), severe (eject + vitals + 5m corridor lockout), fatal (eject + heavy vitals + HEALTH hit + 10m lockout). All transit vitals drain floors at 1 — slipstream can't kill you. CL15 minimum. 50 rooms across 16 regions, 50 directional routes (25 bidirectional pairs), 116 legs with fork options. Nearest-neighbor connectivity only.

  Local transit (intra-region): Public routes (board → wait through stops → disembark) and private (hail → single wait → arrive). 10 vehicle types: Elevated Traincar, Underground Rail, Metro Bus, Electric Rail Bus, Trolley/Streetcar, All-Terrain Transport (public); Taxi Car, Private Car, Water Taxi, Airboat (private). 30 region-type assignments. Fare via TransactionService.burn!. Transit rooms auto-display route info on look. Zone boundary tracking on transit movement (fixes BREACH ejection targeting).

  Commands: transit/tr (show local routes), board <route> (public), hail <type> <dest> (private), slipstream/slip (list/initiate inter-region), wait/ride (advance), disembark/off, choose <key> (fork, case-insensitive), advance/adv (traverse leg), abandon. TransitCommandParser gates all input during active journey (after BREACH, after captured — captured takes priority).

  Schema: 7 tables — grid_transit_types, grid_region_transit_assignments, grid_transit_routes, grid_transit_stops, grid_slipstream_routes, grid_slipstream_legs, grid_transit_journeys. Partial unique index enforces one active journey per hackr.

  Admin: Full CRUD for transit types, transit routes (with inline stop management via combobox scoped to region), slipstream routes (with leg display), transit journeys (read-only ops log + dev-only force-abandon). Nav links in Grid dropdown.

  Achievements: 8 seeded — First Ride, Frequent Rider, Commuter, Ghost in the Machine, Corridor Runner, First Step into a Larger World, Well-Travelled,
  Continental. 5 new trigger types in AchievementChecker.

  Frontend: TransitMapPage.tsx at /transit — three tabs (Local Transit grouped by type, Slipstream with heat indicator, Region Network grid).

  BREACH UX: Added debuff hints to exec (energy depletion → "damage output disabled") and analyze (psyche depletion → "intel unreliable") output. Hints show at all degradation tiers so players understand why damage/intel is reduced.