### PR TITLE
[TPG] Transit System Refinements

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -213,9 +213,18 @@ class Api::GridController < ApplicationController
       GridSlipstreamRoute.none
     end
 
-    region_assignments = GridRegionTransitAssignment
-      .includes(:grid_region, :grid_transit_type)
-      .order(:position)
+    # Derive region transit types from actual routes — lightweight query,
+    # only fetches distinct (region, type) pairs instead of full route objects.
+    region_type_pairs = GridTransitRoute.active
+      .joins(:grid_transit_type, :grid_region)
+      .select("grid_regions.slug AS region_slug, grid_transit_types.slug AS type_slug, grid_transit_types.name AS type_name, grid_transit_types.category AS type_category, grid_transit_types.position AS type_position")
+      .distinct
+    region_transit = region_type_pairs
+      .group_by(&:region_slug)
+      .transform_values { |rows|
+        rows.sort_by(&:type_position)
+          .map { |r| {slug: r.type_slug, name: r.type_name, category: r.type_category} }
+      }
 
     render json: {
       slipstream_heat: current_hackr.slipstream_heat,
@@ -224,10 +233,7 @@ class Api::GridController < ApplicationController
       current_journey: active_journey ? transit_journey_json(active_journey) : nil,
       local_routes: local_routes.map { |r| transit_route_json(r) },
       slipstream_routes: slip_routes.map { |r| slipstream_route_json(r) },
-      region_assignments: region_assignments.group_by { |a| a.grid_region.slug }
-        .transform_values { |assignments|
-          assignments.map { |a| {slug: a.grid_transit_type.slug, name: a.grid_transit_type.name, category: a.grid_transit_type.category} }
-        }
+      region_transit: region_transit
     }
   end
 

--- a/app/javascript/components/pages/grid/TransitPage.tsx
+++ b/app/javascript/components/pages/grid/TransitPage.tsx
@@ -57,7 +57,7 @@ interface TransitResponse {
   current_journey: object | null
   local_routes: TransitRoute[]
   slipstream_routes: SlipstreamRoute[]
-  region_assignments: Record<string, RegionAssignment[]>
+  region_transit: Record<string, RegionAssignment[]>
 }
 
 type TabKey = 'local' | 'slipstream' | 'network'
@@ -166,7 +166,7 @@ const TransitPage: React.FC = () => {
         {/* Tab Content */}
         {activeTab === 'local' && <LocalTransitTab routes={data.local_routes} expandedRoutes={expandedRoutes} toggleRoute={toggleRoute} />}
         {activeTab === 'slipstream' && <SlipstreamTab routes={data.slipstream_routes} heat={data.slipstream_heat} heatTier={data.slipstream_heat_tier} />}
-        {activeTab === 'network' && <NetworkTab assignments={data.region_assignments} />}
+        {activeTab === 'network' && <NetworkTab assignments={data.region_transit} />}
       </div>
     </DefaultLayout>
   )

--- a/app/models/grid_region_transit_assignment.rb
+++ b/app/models/grid_region_transit_assignment.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class GridRegionTransitAssignment < ApplicationRecord
-  belongs_to :grid_region
-  belongs_to :grid_transit_type
-
-  validates :grid_region_id, uniqueness: {scope: :grid_transit_type_id}
-  validates :position, numericality: {only_integer: true, greater_than_or_equal_to: 0}
-end

--- a/app/models/grid_slipstream_leg.rb
+++ b/app/models/grid_slipstream_leg.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_slipstream_legs
+# Database name: primary
+#
+#  id                       :integer          not null, primary key
+#  breach_template_slug     :string
+#  description              :text
+#  fork_options             :json             not null
+#  name                     :string           not null
+#  position                 :integer          not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  grid_slipstream_route_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_slipstream_legs_on_grid_slipstream_route_id  (grid_slipstream_route_id)
+#  index_slipstream_legs_route_position                    (grid_slipstream_route_id,position) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_slipstream_route_id  (grid_slipstream_route_id => grid_slipstream_routes.id) ON DELETE => cascade
+#
 class GridSlipstreamLeg < ApplicationRecord
   belongs_to :grid_slipstream_route
 

--- a/app/models/grid_slipstream_route.rb
+++ b/app/models/grid_slipstream_route.rb
@@ -1,5 +1,42 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_slipstream_routes
+# Database name: primary
+#
+#  id                    :integer          not null, primary key
+#  active                :boolean          default(TRUE), not null
+#  base_heat_cost        :integer          default(10), not null
+#  description           :text
+#  detection_risk_base   :integer          default(15), not null
+#  min_clearance         :integer          default(15), not null
+#  name                  :string           not null
+#  position              :integer          default(0), not null
+#  slug                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  destination_region_id :integer          not null
+#  destination_room_id   :integer          not null
+#  origin_region_id      :integer          not null
+#  origin_room_id        :integer          not null
+#
+# Indexes
+#
+#  index_grid_slipstream_routes_on_destination_region_id  (destination_region_id)
+#  index_grid_slipstream_routes_on_destination_room_id    (destination_room_id)
+#  index_grid_slipstream_routes_on_origin_region_id       (origin_region_id)
+#  index_grid_slipstream_routes_on_origin_room_id         (origin_room_id)
+#  index_grid_slipstream_routes_on_slug                   (slug) UNIQUE
+#  index_slipstream_routes_origin_dest                    (origin_region_id,destination_region_id) UNIQUE
+#
+# Foreign Keys
+#
+#  destination_region_id  (destination_region_id => grid_regions.id) ON DELETE => restrict
+#  destination_room_id    (destination_room_id => grid_rooms.id) ON DELETE => restrict
+#  origin_region_id       (origin_region_id => grid_regions.id) ON DELETE => restrict
+#  origin_room_id         (origin_room_id => grid_rooms.id) ON DELETE => restrict
+#
 class GridSlipstreamRoute < ApplicationRecord
   has_paper_trail
 

--- a/app/models/grid_transit_journey.rb
+++ b/app/models/grid_transit_journey.rb
@@ -1,5 +1,53 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_transit_journeys
+# Database name: primary
+#
+#  id                       :integer          not null, primary key
+#  breach_mid_journey       :boolean          default(FALSE), not null
+#  ended_at                 :datetime
+#  fare_paid                :integer          default(0), not null
+#  heat_accumulated         :integer          default(0), not null
+#  journey_type             :string           not null
+#  legs_completed           :integer          default(0), not null
+#  meta                     :json             not null
+#  pending_fork             :boolean          default(FALSE), not null
+#  started_at               :datetime         not null
+#  state                    :string           default("active"), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  current_leg_id           :integer
+#  current_stop_id          :integer
+#  destination_room_id      :integer
+#  grid_hackr_id            :integer          not null
+#  grid_slipstream_route_id :integer
+#  grid_transit_route_id    :integer
+#  origin_room_id           :integer
+#
+# Indexes
+#
+#  index_grid_transit_journeys_on_current_leg_id            (current_leg_id)
+#  index_grid_transit_journeys_on_current_stop_id           (current_stop_id)
+#  index_grid_transit_journeys_on_destination_room_id       (destination_room_id)
+#  index_grid_transit_journeys_on_grid_hackr_id             (grid_hackr_id)
+#  index_grid_transit_journeys_on_grid_slipstream_route_id  (grid_slipstream_route_id)
+#  index_grid_transit_journeys_on_grid_transit_route_id     (grid_transit_route_id)
+#  index_grid_transit_journeys_on_origin_room_id            (origin_room_id)
+#  index_grid_transit_journeys_on_state                     (state)
+#  index_transit_journeys_one_active_per_hackr              (grid_hackr_id) UNIQUE WHERE state = 'active'
+#
+# Foreign Keys
+#
+#  current_leg_id            (current_leg_id => grid_slipstream_legs.id) ON DELETE => nullify
+#  current_stop_id           (current_stop_id => grid_transit_stops.id) ON DELETE => nullify
+#  destination_room_id       (destination_room_id => grid_rooms.id) ON DELETE => nullify
+#  grid_hackr_id             (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_slipstream_route_id  (grid_slipstream_route_id => grid_slipstream_routes.id) ON DELETE => nullify
+#  grid_transit_route_id     (grid_transit_route_id => grid_transit_routes.id) ON DELETE => nullify
+#  origin_room_id            (origin_room_id => grid_rooms.id) ON DELETE => nullify
+#
 class GridTransitJourney < ApplicationRecord
   JOURNEY_TYPES = %w[slipstream local_public local_private].freeze
   STATES = %w[active completed abandoned ejected].freeze

--- a/app/models/grid_transit_route.rb
+++ b/app/models/grid_transit_route.rb
@@ -1,5 +1,34 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_transit_routes
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  active               :boolean          default(TRUE), not null
+#  description          :text
+#  loop_route           :boolean          default(FALSE), not null
+#  name                 :string           not null
+#  position             :integer          default(0), not null
+#  slug                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  grid_region_id       :integer          not null
+#  grid_transit_type_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_transit_routes_on_active                (active)
+#  index_grid_transit_routes_on_grid_region_id        (grid_region_id)
+#  index_grid_transit_routes_on_grid_transit_type_id  (grid_transit_type_id)
+#  index_grid_transit_routes_on_slug                  (slug) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_region_id        (grid_region_id => grid_regions.id) ON DELETE => restrict
+#  grid_transit_type_id  (grid_transit_type_id => grid_transit_types.id) ON DELETE => restrict
+#
 class GridTransitRoute < ApplicationRecord
   has_paper_trail
 

--- a/app/models/grid_transit_stop.rb
+++ b/app/models/grid_transit_stop.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_transit_stops
+# Database name: primary
+#
+#  id                    :integer          not null, primary key
+#  is_terminus           :boolean          default(FALSE), not null
+#  label                 :string
+#  position              :integer          not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  grid_room_id          :integer          not null
+#  grid_transit_route_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_transit_stops_on_grid_room_id           (grid_room_id)
+#  index_grid_transit_stops_on_grid_transit_route_id  (grid_transit_route_id)
+#  index_transit_stops_route_position                 (grid_transit_route_id,position) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_room_id           (grid_room_id => grid_rooms.id) ON DELETE => restrict
+#  grid_transit_route_id  (grid_transit_route_id => grid_transit_routes.id) ON DELETE => cascade
+#
 class GridTransitStop < ApplicationRecord
   belongs_to :grid_transit_route
   belongs_to :grid_room

--- a/app/models/grid_transit_type.rb
+++ b/app/models/grid_transit_type.rb
@@ -1,12 +1,33 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: grid_transit_types
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  base_fare     :integer          default(0), not null
+#  category      :string           not null
+#  description   :text
+#  icon_key      :string
+#  min_clearance :integer          default(0), not null
+#  name          :string           not null
+#  position      :integer          default(0), not null
+#  published     :boolean          default(FALSE), not null
+#  slug          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_grid_transit_types_on_category  (category)
+#  index_grid_transit_types_on_slug      (slug) UNIQUE
+#
 class GridTransitType < ApplicationRecord
   has_paper_trail
 
   CATEGORIES = %w[public private slipstream].freeze
 
-  has_many :grid_region_transit_assignments, dependent: :destroy
-  has_many :grid_regions, through: :grid_region_transit_assignments
   has_many :grid_transit_routes, dependent: :restrict_with_error
 
   validates :slug, presence: true, uniqueness: true

--- a/app/services/grid/local_transit_service.rb
+++ b/app/services/grid/local_transit_service.rb
@@ -36,17 +36,17 @@ module Grid
       new(hackr).status
     end
 
-    # Private transit types available at this room (route-free, region-wide)
+    # Private transit types available at this room — derived from private routes
+    # that have a stop at this room (routes define boarding points, not destinations)
     def self.private_types_at_room(room:, hackr:)
       return [] unless room.room_type == "transit"
-      region = room.grid_zone&.grid_region
-      return [] unless region
 
-      GridRegionTransitAssignment
-        .where(grid_region: region)
-        .includes(:grid_transit_type)
-        .map(&:grid_transit_type)
-        .select { |t| t.private_point? && t.published? && hackr.stat("clearance").to_i >= t.min_clearance }
+      GridTransitType.where(category: "private").published
+        .joins(grid_transit_routes: :grid_transit_stops)
+        .where(grid_transit_stops: {grid_room_id: room.id})
+        .where(grid_transit_routes: {active: true})
+        .distinct
+        .select { |t| hackr.stat("clearance").to_i >= t.min_clearance }
     end
 
     # All transit rooms in the same region as the given room (for private destinations)
@@ -54,9 +54,12 @@ module Grid
       region = room.grid_zone&.grid_region
       return [] unless region
 
+      # Exclude slipstream origin rooms — those are hidden access points, not taxi destinations
+      slip_room_ids = GridSlipstreamRoute.active.where(origin_region: region).pluck(:origin_room_id)
+
       GridRoom.where(room_type: "transit")
         .joins(:grid_zone).where(grid_zones: {grid_region_id: region.id})
-        .where.not(id: room.id)
+        .where.not(id: [room.id] + slip_room_ids)
         .includes(:grid_zone)
         .order(:name)
     end
@@ -65,16 +68,23 @@ module Grid
       new(hackr).board_private!(transit_type, destination_room)
     end
 
+    # Public routes only — private transit is shown separately via private_types_at_room.
+    # Uses subquery to avoid joins/includes on the same association (which would
+    # filter preloaded stops to only the current room's stop, breaking stop_count).
     def self.routes_at_room(room:, hackr:)
       region = room.grid_zone&.grid_region
       return [] unless region
 
-      GridTransitRoute.active
-        .joins(:grid_transit_stops)
-        .where(grid_transit_stops: {grid_room_id: room.id})
-        .where(grid_region: region)
+      route_ids = GridTransitStop.where(grid_room_id: room.id)
+        .joins(grid_transit_route: :grid_transit_type)
+        .where(grid_transit_routes: {active: true, grid_region_id: region.id})
+        .where(grid_transit_types: {category: "public"})
+        .pluck(:grid_transit_route_id)
+
+      return [] if route_ids.empty?
+
+      GridTransitRoute.where(id: route_ids)
         .includes(:grid_transit_type, :grid_region, grid_transit_stops: :grid_room)
-        .distinct
         .select { |r| r.grid_transit_type.published? && hackr.stat("clearance").to_i >= r.grid_transit_type.min_clearance }
     end
 
@@ -130,10 +140,19 @@ module Grid
       end
     end
 
-    # Route-free private transit — hackr picks any transit room in the region
+    # Private transit — routes define boarding points, destinations are any transit room in region
     def board_private!(transit_type, destination_room)
       room = @hackr.current_room
       raise NotAtTransitStop unless room.room_type == "transit"
+
+      # Validate a private route for this type has a stop at the current room
+      has_route = GridTransitRoute.active
+        .where(grid_transit_type: transit_type)
+        .joins(:grid_transit_stops)
+        .where(grid_transit_stops: {grid_room_id: room.id})
+        .exists?
+      raise NotAtTransitStop unless has_route
+
       raise AlreadyAtDestination if destination_room.id == room.id
 
       fare = transit_type.base_fare

--- a/db/migrate/20260507200000_drop_grid_region_transit_assignments.rb
+++ b/db/migrate/20260507200000_drop_grid_region_transit_assignments.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DropGridRegionTransitAssignments < ActiveRecord::Migration[8.0]
+  def up
+    drop_table :grid_region_transit_assignments
+  end
+
+  def down
+    create_table :grid_region_transit_assignments do |t|
+      t.references :grid_region, null: false, foreign_key: {on_delete: :cascade}
+      t.references :grid_transit_type, null: false, foreign_key: {on_delete: :cascade}
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+    add_index :grid_region_transit_assignments, [:grid_region_id, :grid_transit_type_id],
+      unique: true, name: "index_region_transit_assignments_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -568,17 +568,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_200000) do
     t.string "name"
     t.datetime "updated_at", null: false
     t.json "vendor_config"
-  end
-
-  create_table "grid_region_transit_assignments", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.integer "grid_region_id", null: false
-    t.integer "grid_transit_type_id", null: false
-    t.integer "position", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.index ["grid_region_id", "grid_transit_type_id"], name: "index_region_transit_assignments_unique", unique: true
-    t.index ["grid_region_id"], name: "index_grid_region_transit_assignments_on_grid_region_id"
-    t.index ["grid_transit_type_id"], name: "index_grid_region_transit_assignments_on_grid_transit_type_id"
   end
 
   create_table "grid_regions", force: :cascade do |t|
@@ -1396,8 +1385,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_200000) do
   add_foreign_key "grid_missions", "grid_mission_arcs", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_missions", column: "prereq_mission_id", on_delete: :nullify
   add_foreign_key "grid_missions", "grid_mobs", column: "giver_mob_id", on_delete: :nullify
-  add_foreign_key "grid_region_transit_assignments", "grid_regions", on_delete: :cascade
-  add_foreign_key "grid_region_transit_assignments", "grid_transit_types", on_delete: :cascade
   add_foreign_key "grid_regions", "grid_rooms", column: "cell_block_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "containment_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "facility_bribe_exit_room_id", on_delete: :nullify

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -206,7 +206,7 @@ namespace :data do
   desc "Load world data (factions, regions, zones, rooms, etc.)"
   task world: :environment do
     guard_world_seed!
-    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities transit_types region_transit_assignments slipstream_routes].each do |t|
+    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities transit_types slipstream_routes].each do |t|
       Rake::Task["data:#{t}"].invoke
     end
   end
@@ -1302,44 +1302,9 @@ namespace :data do
     puts "Transit Types: #{created} created, #{GridTransitType.count} total"
   end
 
-  desc "Load region transit assignments from YAML"
-  task region_transit_assignments: :environment do
-    guard_world_seed!
-    puts "\n--- Loading Region Transit Assignments ---"
-    yaml_file = Rails.root.join("data", "world", "region_transit_assignments.yml")
-    next unless File.exist?(yaml_file)
-
-    data = YAML.load_file(yaml_file)
-    type_map = GridTransitType.all.index_by(&:slug)
-    region_map = GridRegion.all.index_by(&:slug)
-    created = 0
-
-    data["region_transit_assignments"].each do |entry|
-      region = region_map[entry["region_slug"]]
-      unless region
-        puts "  ✗ Region not found: #{entry["region_slug"]}"
-        next
-      end
-
-      (entry["transit_type_slugs"] || []).each_with_index do |type_slug, idx|
-        type = type_map[type_slug]
-        unless type
-          puts "  ✗ Transit type not found: #{type_slug}"
-          next
-        end
-
-        assignment = GridRegionTransitAssignment.find_or_initialize_by(
-          grid_region: region, grid_transit_type: type
-        )
-        next unless assignment.new_record?
-        assignment.position = idx
-        assignment.save!
-        created += 1
-      end
-    end
-
-    puts "Region Transit Assignments: #{created} created, #{GridRegionTransitAssignment.count} total"
-  end
+  # NOTE: grid_region_transit_assignments table dropped — transit types per region
+  # are now derived from actual routes. See region_transit_assignments.yml for
+  # the original mapping (retained as reference for route seeding).
 
   desc "Load slipstream routes and legs from YAML"
   task slipstream_routes: :environment do

--- a/spec/factories/grid_transit.rb
+++ b/spec/factories/grid_transit.rb
@@ -45,12 +45,6 @@ FactoryBot.define do
     is_terminus { false }
   end
 
-  factory :grid_region_transit_assignment do
-    association :grid_region
-    association :grid_transit_type
-    position { 0 }
-  end
-
   factory :grid_slipstream_route do
     sequence(:slug) { |n| "slip-route-#{n}" }
     sequence(:name) { |n| "Slipstream Route #{n}" }

--- a/spec/services/grid/local_transit_service_spec.rb
+++ b/spec/services/grid/local_transit_service_spec.rb
@@ -136,9 +136,15 @@ RSpec.describe Grid::LocalTransitService do
     end
   end
 
-  describe "private transit (route-free)" do
+  describe "private transit" do
     let(:private_type) { create(:grid_transit_type, :private_type) }
-    let!(:assignment) { create(:grid_region_transit_assignment, grid_region: region, grid_transit_type: private_type) }
+    # Private route with stops defines boarding points (not destinations)
+    let!(:private_route) do
+      create(:grid_transit_route, grid_transit_type: private_type, grid_region: region).tap do |r|
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0)
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
+      end
+    end
 
     it "boards with destination room and arrives in single wait" do
       result = described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_c)
@@ -170,6 +176,14 @@ RSpec.describe Grid::LocalTransitService do
       }.to raise_error(Grid::LocalTransitService::NotAtTransitStop)
     end
 
+    it "raises NotAtTransitStop when no private route has a stop here" do
+      # room_c has no stop on the private route
+      hackr.update!(current_room: room_c)
+      expect {
+        described_class.board_private!(hackr: hackr, transit_type: private_type, destination_room: room_a)
+      }.to raise_error(Grid::LocalTransitService::NotAtTransitStop)
+    end
+
     it "raises InsufficientFunds when hackr cannot afford fare" do
       Grid::TransactionService.burn!(from_cache: cache, amount: 1000, memo: "drain")
       expect {
@@ -180,9 +194,13 @@ RSpec.describe Grid::LocalTransitService do
 
   describe ".private_types_at_room" do
     let(:private_type) { create(:grid_transit_type, :private_type) }
-    let!(:assignment) { create(:grid_region_transit_assignment, grid_region: region, grid_transit_type: private_type) }
+    let!(:private_route) do
+      create(:grid_transit_route, grid_transit_type: private_type, grid_region: region).tap do |r|
+        create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0)
+      end
+    end
 
-    it "returns private types for transit rooms in the region" do
+    it "returns private types when a route has a stop at the room" do
       results = described_class.private_types_at_room(room: room_a, hackr: hackr)
       expect(results).to include(private_type)
     end
@@ -190,6 +208,11 @@ RSpec.describe Grid::LocalTransitService do
     it "returns empty for non-transit rooms" do
       standard_room = create(:grid_room, :standard, grid_zone: zone)
       results = described_class.private_types_at_room(room: standard_room, hackr: hackr)
+      expect(results).to be_empty
+    end
+
+    it "returns empty when no private route has a stop here" do
+      results = described_class.private_types_at_room(room: room_c, hackr: hackr)
       expect(results).to be_empty
     end
   end


### PR DESCRIPTION
  * Dropped grid_region_transit_assignments table — transit types per region are now derived from actual routes.
    * Public transit types derive from routes with stops at the room.\
    * Private transit types derive from routes too (stops define boarding points), but destinations are any transit room in the region.
    * Slipstream origin rooms excluded from private destinations.
  * Private transit refactor:
    * board_private! validates hackr is at a stop on a private route for the given type (routes define where you can hail from).
    * Destinations are region-wide transit rooms, not route stops. hail command updated to match — type slug + destination room name, no route slug needed. look output shows [ PRIVATE TRANSIT ] banner with available types, fares, and destinations when in a transit room with private route coverage.
  * Public transit fix: routes_at_room now filters to category: "public" (no double-rendering with private section).
  * Fixed N+1/preload bug where joins + includes on grid_transit_stops caused preloaded collection to contain only the current room's stop — stop counts showed 1 for every route. Replaced with subquery approach.
  * Code review fixes:
    * N+1 in render_slipstream_routes (added :grid_region to includes).
    * Private send(:render_leg_prompt) on private method (moved to public).
    * Dead EjectResult struct (removed).
    * Unused accessible_by scope (now used in routes_from). leg_count .count → .size.
  * Off-route private destination validation.
  * Region Network API endpoint - replaced full route object load with SELECT DISTINCT join query.
  * ESLint trailing comma fixes.
  * Unused spec variable.
  * Heat read side-effect comment.
  * TransitCommandParser specs: 29 new specs covering command routing (wait/disembark/abandon/status + aliases), blocked commands, passthrough commands, slipstream fork/advance flow, cross-mode errors, full journey completion.
  * Slipstream ejection tiers differentiated:
    * Severe = ENERGY -30, PSYCHE -30, HEALTH -15, 5m corridor lockout.
    * Fatal = ENERGY -40, PSYCHE -40, HEALTH -30, 10m lockout.
  * All transit vitals floor at 1. Lockout shown in slipstream route listing.
  * Case-insensitive fork choices.
  * No-deck/fried-deck detection now returns :penalty (not :breach) — fixes ghost BREACH bug where detection set breach_mid_journey without starting an actual BREACH.
  * BREACH UX: Debuff hints on exec (energy depletion reduces/disables damage) and analyze (psyche depletion causes false intel) at all degradation tiers.
  * Look command enhancements: Transit rooms auto-display public routes + private transit options. Slipstream access rooms show destination, leg count, and slug. Stop name in "Now at:" output bolded cyan for visibility.