### PR TITLE
[TPG] Playable Tutorial

### DIFF
--- a/app/controllers/admin/grid_starting_rooms_controller.rb
+++ b/app/controllers/admin/grid_starting_rooms_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Admin::GridStartingRoomsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable GridStartingRoom
+
+  before_action :set_starting_room, only: %i[edit update destroy]
+  before_action :load_rooms, only: %i[new edit create update]
+
+  def index
+    @starting_rooms = GridStartingRoom.includes(grid_room: {grid_zone: :grid_region}).order(:position, :name)
+  end
+
+  def new
+    @starting_room = GridStartingRoom.new(active: true, position: (GridStartingRoom.maximum(:position) || 0) + 1)
+  end
+
+  def create
+    @starting_room = GridStartingRoom.new(starting_room_params)
+    if @starting_room.save
+      set_flash_success("Starting room '#{@starting_room.name}' created.")
+      redirect_to admin_grid_starting_rooms_path
+    else
+      flash.now[:error] = @starting_room.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @starting_room.update(starting_room_params)
+      set_flash_success("Starting room '#{@starting_room.name}' updated.")
+      redirect_to admin_grid_starting_rooms_path
+    else
+      flash.now[:error] = @starting_room.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @starting_room.name
+    @starting_room.destroy!
+    set_flash_success("Starting room '#{name}' deleted.")
+    redirect_to admin_grid_starting_rooms_path
+  end
+
+  private
+
+  def set_starting_room
+    @starting_room = GridStartingRoom.find(params[:id])
+  end
+
+  def load_rooms
+    @rooms = GridRoom.includes(grid_zone: :grid_region)
+      .order(:name)
+  end
+
+  def starting_room_params
+    params.require(:grid_starting_room).permit(:grid_room_id, :name, :blurb, :position, :active)
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -264,6 +264,22 @@ class Api::GridController < ApplicationController
       end
 
       hackr.ensure_current_room!
+
+      # Start tutorial for hackrs who haven't seen it (e.g., seeded accounts)
+      if hackr.stat("tutorial_active").nil? && hackr.stat("tutorial_completed").nil?
+        tutorial = Grid::TutorialService.new(hackr)
+        tutorial.start!
+        # Move to Bootloader hub (start! doesn't move — only sets state)
+        hub = tutorial.tutorial_hub_room
+        hackr.update!(current_room: hub) if hub
+        # Remove den chip if provisioned before tutorial was set up.
+        # Skip if hackr already has a den (chip was already used).
+        unless hackr.den.present?
+          hackr.grid_items.joins(:grid_item_definition)
+            .where(grid_item_definitions: {slug: "den-access-chip"}).destroy_all
+        end
+      end
+
       log_in(hackr)
       hackr.touch_activity!
       Grid::AchievementSweepJob.perform_later(hackr.id)
@@ -389,6 +405,7 @@ class Api::GridController < ApplicationController
       if @hackr.save
         @hackr.ensure_current_room!
         token.mark_used!
+        Grid::TutorialService.new(@hackr).start!
         @hackr.provision_economy!
         log_in(@hackr)
         @hackr.touch_activity!
@@ -660,6 +677,21 @@ class Api::GridController < ApplicationController
   # POST /api/grid/command - Execute game command
   def command
     Rails.logger.info "=== API COMMAND RECEIVED: #{params[:input]} from #{current_hackr.hackr_alias} ==="
+
+    # Ensure hackr has a room (handles stale sessions after DB reset)
+    current_hackr.ensure_current_room!
+
+    # Start tutorial for hackrs who haven't seen it (handles stale sessions)
+    if current_hackr.stat("tutorial_active").nil? && current_hackr.stat("tutorial_completed").nil?
+      tutorial = Grid::TutorialService.new(current_hackr)
+      tutorial.start!
+      hub = tutorial.tutorial_hub_room
+      current_hackr.update!(current_room: hub) if hub
+      unless current_hackr.den.present?
+        current_hackr.grid_items.joins(:grid_item_definition)
+          .where(grid_item_definitions: {slug: "den-access-chip"}).destroy_all
+      end
+    end
 
     # Update last activity timestamp
     current_hackr.touch_activity!

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -155,7 +155,9 @@ class GridHackr < ApplicationRecord
       GridItem.create!(defn.item_attributes.merge(grid_mining_rig: rig))
     end
 
-    provision_den_chip!
+    # Den chip deferred until tutorial completion (DenService crashes in Bootloader zone).
+    # For hackrs bypassing tutorial, provision_den_chip! is called from TutorialService#complete!.
+    provision_den_chip! unless stat("tutorial_active")
   end
 
   # Grant a Den Access Chip if the hackr doesn't already have one.
@@ -211,13 +213,22 @@ class GridHackr < ApplicationRecord
     admin? || feature_grants.exists?(feature: feature_name)
   end
 
-  # Ensure hackr has a current room, spawning in the starting hub if needed.
+  # Ensure hackr has a current room, spawning in the appropriate location.
+  # Tutorial-active hackrs → Bootloader hub.
+  # Everyone else → first starting room, hackr-tv-central, or any hub.
   def ensure_current_room!
     return if current_room.present?
-    starting_room = GridRoom.joins(:grid_zone)
-      .where(grid_zones: {slug: "hackr-tv-central"})
-      .where(room_type: "hub")
-      .first
+
+    starting_room = if stat("tutorial_active")
+      GridRoom.joins(:grid_zone)
+        .where(grid_zones: {slug: Grid::TutorialService::TUTORIAL_HUB_ZONE_SLUG})
+        .where(room_type: "hub")
+        .first
+    end
+
+    starting_room ||= GridStartingRoom.ordered.first&.grid_room
+    starting_room ||= GridRoom.where(room_type: "hub").first
+
     update!(current_room: starting_room) if starting_room
   end
 

--- a/app/models/grid_shop_listing.rb
+++ b/app/models/grid_shop_listing.rb
@@ -44,7 +44,7 @@ class GridShopListing < ApplicationRecord
     :rarity_color, :rarity_label,
     to: :grid_item_definition
 
-  validates :base_price, numericality: {only_integer: true, greater_than: 0}
+  validates :base_price, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :sell_price, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :stock, numericality: {only_integer: true, greater_than_or_equal_to: 0}, allow_nil: true
   validates :max_stock, numericality: {only_integer: true, greater_than: 0}, allow_nil: true

--- a/app/models/grid_starting_room.rb
+++ b/app/models/grid_starting_room.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: grid_starting_rooms
+# Database name: primary
+#
+#  id           :integer          not null, primary key
+#  active       :boolean          default(TRUE), not null
+#  blurb        :text             not null
+#  name         :string           not null
+#  position     :integer          default(0), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  grid_room_id :integer          not null
+#
+# Indexes
+#
+#  index_grid_starting_rooms_on_grid_room_id  (grid_room_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_room_id  (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
+class GridStartingRoom < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :grid_room
+
+  validates :name, presence: true
+  validates :blurb, presence: true
+  validates :grid_room_id, uniqueness: true
+
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { active.order(:position, :name) }
+end

--- a/app/services/grid/captured_command_parser.rb
+++ b/app/services/grid/captured_command_parser.rb
@@ -9,7 +9,7 @@ module Grid
       look l go move north n south s east e west w up u down d out
       northeast ne southeast se southwest sw northwest nw
       stat stats st inventory inv i help ?
-      breach br bribe talk examine ex x who clear cls cl say
+      breach br bribe talk examine ex x who clear cls cl say code
     ].freeze
 
     attr_reader :hackr, :input, :parser

--- a/app/services/grid/code_service.rb
+++ b/app/services/grid/code_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Grid
+  class CodeService
+    CODES = {
+      "complete-tutorial" => :handle_complete_tutorial,
+      "skip-tutorial" => :handle_complete_tutorial,
+      "start-tutorial" => :handle_start_tutorial
+    }.freeze
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def execute(code_string)
+      code = code_string.to_s.strip.downcase
+      return invalid_code if code.empty?
+
+      handler = CODES[code]
+      return invalid_code unless handler
+
+      send(handler)
+    end
+
+    private
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+
+    def tutorial_service
+      @tutorial_service ||= TutorialService.new(@hackr)
+    end
+
+    def handle_complete_tutorial
+      unless tutorial_service.active?
+        return "<span style='color: #9ca3af;'>Nothing happens.</span>"
+      end
+
+      # Re-entry: return to where they came from, no starting room selection
+      if @hackr.stat("tutorial_return_room_id").present?
+        tutorial_service.return_to_world!
+        look_output = Grid::CommandParser.new(@hackr, "look").execute[:output]
+        return "<span style='color: #34d399; font-weight: bold;'>[ BOOTLOADER TERMINATED ]</span>\n" \
+          "<span style='color: #9ca3af;'>Returning to previous location...</span>\n\n" + look_output
+      end
+
+      # First-time: show starting room selection
+      starting_rooms = GridStartingRoom.ordered.includes(:grid_room)
+      if starting_rooms.empty?
+        tutorial_service.complete!(starting_room: @hackr.current_room)
+        return "<span style='color: #34d399; font-weight: bold;'>Tutorial skipped.</span>"
+      end
+
+      output = []
+      output << "<span style='color: #22d3ee; font-weight: bold;'>[ TUTORIAL COMPLETE — CHOOSE STARTING LOCATION ]</span>"
+      output << ""
+      starting_rooms.each_with_index do |sr, i|
+        output << "<span style='color: #fbbf24;'>[#{i + 1}]</span> <span style='color: #22d3ee; font-weight: bold;'>#{h(sr.name)}</span>"
+        output << "    <span style='color: #d0d0d0;'>#{h(sr.blurb)}</span>"
+        output << ""
+      end
+      output << "<span style='color: #9ca3af;'>Type</span> <span style='color: #22d3ee;'>choose &lt;number&gt;</span> <span style='color: #9ca3af;'>to select your starting location.</span>"
+
+      @hackr.set_stat!("tutorial_choosing_start", true)
+      output.join("\n")
+    end
+
+    def handle_start_tutorial
+      if tutorial_service.active?
+        return "<span style='color: #fbbf24;'>You are already in the tutorial.</span>"
+      end
+
+      tutorial_service.re_enter!
+      look_output = Grid::CommandParser.new(@hackr, "look").execute[:output]
+      "<span style='color: #34d399; font-weight: bold;'>[ BOOTLOADER REACTIVATED ]</span>\n" \
+        "<span style='color: #9ca3af;'>Returning to training simulation...</span>\n\n" + look_output
+    rescue TutorialService::CannotEnterTutorial => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def invalid_code
+      "<span style='color: #9ca3af;'>Nothing happens.</span>"
+    end
+  end
+end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -35,6 +35,11 @@ module Grid
         return Grid::TransitCommandParser.new(hackr, input, active_journey, self).execute
       end
 
+      # Tutorial mode: guided training with hint injection
+      if hackr.stat("tutorial_active") == true
+        return Grid::TutorialCommandParser.new(hackr, input, self).execute
+      end
+
       # Split input but preserve case in arguments
       parts = input.split
       command = parts.first&.downcase
@@ -174,6 +179,8 @@ module Grid
         clear_command
       when "bribe"
         "<span style='color: #9ca3af;'>Bribe is only available inside a GovCorp facility while in custody.</span>"
+      when "code"
+        code_command(args)
       else
         "<span style='color: #f87171;'>Unknown command: #{h(command)}. Type 'help' for a list of commands.</span>"
       end
@@ -1162,6 +1169,10 @@ module Grid
         output: "",
         event: {type: "clear"}
       }
+    end
+
+    def code_command(args)
+      Grid::CodeService.new(hackr).execute(args&.join(" "))
     end
 
     def stat_command

--- a/app/services/grid/fabrication_service.rb
+++ b/app/services/grid/fabrication_service.rb
@@ -18,6 +18,10 @@ module Grid
     def fabricate!
       ingredients = @schematic.ingredients.ordered.includes(:input_definition)
 
+      if ingredients.empty?
+        raise IngredientsInsufficient, "Schematic has no components defined — cannot fabricate."
+      end
+
       ActiveRecord::Base.transaction do
         # Pre-flight check inside the transaction: lock ingredient rows
         # to prevent a concurrent fabrication from passing the check and

--- a/app/services/grid/inventory.rb
+++ b/app/services/grid/inventory.rb
@@ -19,7 +19,7 @@ module Grid
     # Acquires an exclusive lock on the hackr row to serialize concurrent grants.
     def check_capacity!(hackr)
       hackr.lock!
-      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil, grid_impound_record_id: nil).count
+      used = GridItem.where(grid_hackr_id: hackr.id, grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil, grid_impound_record_id: nil, deck_id: nil).count
       if used >= hackr.inventory_capacity
         raise Grid::InventoryErrors::InventoryFull,
           "Inventory full (#{used}/#{hackr.inventory_capacity} slots). Drop, sell, or store items to make room."
@@ -31,26 +31,25 @@ module Grid
         raise "Grid::Inventory.grant_item! must be called inside a transaction"
       end
 
-      existing = hackr.grid_items
+      existing_stacks = hackr.grid_items
         .where(grid_item_definition_id: definition.id)
         .in_inventory(hackr)
-        .lock.first
+        .lock.order(:id)
 
       remaining = quantity
 
-      if existing
-        space_in_stack = stack_space(definition, existing.quantity)
+      # Fill existing stacks first
+      existing_stacks.each do |stack|
+        break if remaining <= 0
+        space = stack_space(definition, stack.quantity)
+        next if space <= 0
 
-        if space_in_stack >= remaining
-          # Entire grant fits in existing stack
-          existing.update!(quantity: existing.quantity + remaining)
-          return existing
-        elsif space_in_stack > 0
-          # Partial fit — fill existing stack, remainder overflows to new slots
-          existing.update!(quantity: definition.max_stack)
-          remaining -= space_in_stack
-        end
+        add = [space, remaining].min
+        stack.update!(quantity: stack.quantity + add)
+        remaining -= add
       end
+
+      return existing_stacks.last if remaining <= 0
 
       # Remaining needs new slot(s) — create as many as needed
       last_item = nil

--- a/app/services/grid/transit_command_parser.rb
+++ b/app/services/grid/transit_command_parser.rb
@@ -5,7 +5,7 @@ module Grid
     # Commands delegated to main parser while in transit
     PASSTHROUGH_COMMANDS = %w[
       look l stat stats st inventory inv i help ? who clear cls cl
-      say examine ex x
+      say examine ex x code
     ].freeze
 
     attr_reader :hackr, :input, :journey, :parser

--- a/app/services/grid/tutorial_command_parser.rb
+++ b/app/services/grid/tutorial_command_parser.rb
@@ -1,0 +1,1044 @@
+# frozen_string_literal: true
+
+module Grid
+  # Handles command dispatch during the Bootloader tutorial.
+  # Sits in the CommandParser#execute priority chain after breach/captured/transit.
+  # Delegates most commands to the main parser, wrapping output with tutorial chrome.
+  class TutorialCommandParser
+    BLOCKED_COMMANDS = %w[say drop].freeze
+
+    # Commands only available during their relevant tutorial chapter steps
+    GATED_COMMANDS = {
+      %w[sell] => %w[sell-item],
+      %w[fabricate fab] => %w[fabricate-item],
+      %w[schematics schem sch schematic] => %w[check-schematics fabricate-item],
+      %w[salvage sal] => %w[salvage-item],
+      %w[buy purchase] => %w[buy-item sell-item],
+      %w[shop browse] => %w[browse-shop buy-item sell-item]
+    }.freeze
+
+    # Commands that bypass tutorial hint injection (output passes through clean)
+    PASSTHROUGH_COMMANDS = %w[clear cls cl].freeze
+
+    attr_reader :hackr, :input, :parser
+
+    # ─── Step Definitions ────────────────────────────────────────────
+    # Each step: slug, chapter, narrative (shown on step activation),
+    # hint (shown if hackr hasn't completed step yet), condition type + target,
+    # and optional grants (items given when step activates).
+    #
+    # Condition types:
+    #   :command_used   — hackr ran this command (matches first word)
+    #   :in_room        — hackr is in room with this slug
+    #   :has_item       — hackr has item with this definition slug
+    #   :moved          — hackr moved to any room (event type == movement)
+    #   :deck_not_fried — equipped deck is not fried
+    #   :deck_has_software — equipped deck has loaded software
+    #   :breach_completed  — hackr completed a breach with target template slug
+    #   :rig_inactive   — mining rig is not active
+    #   :rig_not_functional — mining rig is not functional
+    #   :rig_functional — mining rig is functional
+    #   :rig_active     — mining rig is active
+    #   :choosing_start — hackr is choosing starting room (final step)
+
+    STEPS = [
+      # ═══ Chapter 1: BOOT SEQUENCE ═══
+      {slug: "look-around", chapter: "BOOT SEQUENCE",
+       narrative: "BOOTLOADER v4.7.2 // FRACTURE NETWORK TRAINING SIMULATION\n" \
+                  "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n" \
+                  "Welcome, operative. You have been selected for orientation.\n" \
+                  "This VR training environment will prepare you for THE PULSE GRID.\n" \
+                  "Start by observing your environment.",
+       hint: "Type <span style='color: #22d3ee;'>look</span> to observe your surroundings.",
+       condition: {type: :command_used, match: %w[look l]}},
+
+      {slug: "first-move", chapter: "BOOT SEQUENCE",
+       narrative: "Good. You can see the room layout, exits, NPCs, and items.\n" \
+                  "Now try moving — pick any exit direction.",
+       hint: "Move to another room. Type a direction like <span style='color: #22d3ee;'>north</span> or <span style='color: #22d3ee;'>go north</span>.",
+       condition: {type: :moved}},
+
+      {slug: "find-locker", chapter: "BOOT SEQUENCE",
+       narrative: "Navigation functional. Explore the hub area — find the Equipment Locker.\n" \
+                  "Check the exits in each room to find your way.",
+       hint: "Navigate to the Equipment Locker. It's east of the hub.",
+       condition: {type: :in_room, target: "bl-equipment-locker"}},
+
+      {slug: "take-item", chapter: "BOOT SEQUENCE",
+       narrative: "Supply cache located. You notice a <span style='color: #22d3ee;'>Training Stim Pack</span> on the floor.\n" \
+                  "Items on the floor can be picked up.",
+       hint: "Type <span style='color: #22d3ee;'>take Training Stim Pack</span> to pick up the item.",
+       condition: {type: :has_item, target: "training-stim-pack"},
+       ensure_floor_item: {slug: "training-stim-pack", room: "bl-equipment-locker"}},
+
+      {slug: "check-inventory", chapter: "BOOT SEQUENCE",
+       narrative: "Item acquired. Check your inventory to confirm what you're carrying.",
+       hint: "Type <span style='color: #22d3ee;'>inv</span> to see your inventory.",
+       condition: {type: :command_used, match: %w[inventory inv i]}},
+
+      # ═══ Chapter 2: INTERFACE TRAINING ═══
+      {slug: "use-item", chapter: "INTERFACE TRAINING",
+       narrative: "Good — you can see everything you're carrying.\n" \
+                  "Consumable items can restore vitals and provide other effects.",
+       hint: "Type <span style='color: #22d3ee;'>use Training Stim Pack</span> to consume the item.",
+       condition: {type: :not_has_item, target: "training-stim-pack"}},
+
+      {slug: "find-guide", chapter: "INTERFACE TRAINING",
+       narrative: "Effect applied. Now proceed to the Interface Chamber for NPC interaction training.\n" \
+                  "An instructor is waiting.",
+       hint: "Navigate to the Interface Chamber — south from the hub.",
+       condition: {type: :in_room, target: "bl-interface-chamber"}},
+
+      {slug: "talk-npc", chapter: "INTERFACE TRAINING",
+       narrative: "You see AXIOM, your training coordinator. Interact with them.",
+       hint: "Type <span style='color: #22d3ee;'>talk AXIOM</span> to speak with the instructor.",
+       condition: {type: :stat_positive, target: "npcs_talked"}},
+
+      {slug: "ask-npc", chapter: "INTERFACE TRAINING",
+       narrative: "NPCs have knowledge on various topics you can inquire about.",
+       hint: "Type <span style='color: #22d3ee;'>ask AXIOM about training</span> to ask about a topic.",
+       condition: {type: :dialogue_depth, target: 1}},
+
+      {slug: "check-status", chapter: "INTERFACE TRAINING",
+       narrative: "Good. You can always review your operational status — vitals, clearance, CRED, and more.",
+       hint: "Type <span style='color: #22d3ee;'>stat</span> to see your current status.",
+       condition: {type: :command_used, match: %w[stat stats st]}},
+
+      {slug: "examine", chapter: "INTERFACE TRAINING",
+       narrative: "Status confirmed. You can also examine items, NPCs, and equipment in detail.",
+       hint: "Type <span style='color: #22d3ee;'>examine AXIOM</span> or examine any item.",
+       condition: {type: :command_used, match: %w[examine ex x]}},
+
+      # ═══ Chapter 3: DECK OPERATIONS ═══
+      {slug: "find-deck-lab", chapter: "DECK OPERATIONS",
+       narrative: "Interface protocols confirmed. Proceed to the DECK Lab for equipment issue.",
+       hint: "Navigate to the DECK Lab — south from the Interface Chamber.",
+       condition: {type: :in_room, target: "bl-deck-lab"},
+       grants: [{slug: "training-deck", fried_level: 1, equip: true}],
+       grant_narrative: "<span style='color: #fbbf24;'>PATCH slides a battered DECK unit across the counter.</span>\n" \
+                        "<span style='color: #d0d0d0;'>'This one took a hit during a failed BREACH. Fried — level 1 damage.\n" \
+                        "A DECK is your primary tool for breaching network nodes.\n" \
+                        "But this one won't work until you get it repaired. Check its status first.'</span>"},
+
+      {slug: "check-deck", chapter: "DECK OPERATIONS",
+       narrative: "You've been issued a DECK — but it's damaged from a prior BREACH failure.\n" \
+                  "This is what happens when things go wrong. Check its status.",
+       hint: "Type <span style='color: #22d3ee;'>deck</span> to see your DECK status.",
+       condition: {type: :command_used, match: %w[deck dk]}},
+
+      {slug: "find-repair", chapter: "DECK OPERATIONS",
+       narrative: "DECK status: FRIED (level 1). Cannot initiate BREACH operations.\n" \
+                  "In the Grid, you can repair at designated service points or use Repair Kits.\n" \
+                  "The Repair Bay is east of here.",
+       hint: "Navigate to the Repair Bay to repair your DECK.",
+       condition: {type: :in_room, target: "bl-repair-bay"}},
+
+      {slug: "repair-deck", chapter: "DECK OPERATIONS",
+       narrative: "Repair Bay located. In the real Grid, repairs cost CRED.\n" \
+                  "Training sim covers the cost. Type repair to fix your DECK.",
+       hint: "Type <span style='color: #22d3ee;'>repair</span> to fix your DECK.",
+       condition: {type: :deck_not_fried}},
+
+      {slug: "return-deck-lab", chapter: "DECK OPERATIONS",
+       narrative: "DECK operational! Head back to the DECK Lab for your software loadout.",
+       hint: "Navigate back to the DECK Lab.",
+       condition: {type: :in_room, target: "bl-deck-lab"},
+       grants: [{slug: "training-probe"}, {slug: "training-shield"}],
+       grant_narrative: "<span style='color: #fbbf24;'>PATCH sets two data chips onto the counter.</span>\n" \
+                        "<span style='color: #d0d0d0;'>'These chips contain two different types of software.\n" \
+                        "Offensive software damages protocols. Defensive software protects you.\n" \
+                        "Load each one onto your DECK separately.'</span>"},
+
+      {slug: "load-software", chapter: "DECK OPERATIONS",
+       narrative: "Software issued. Load each piece onto your DECK individually to prepare for BREACH training.",
+       hint: "Type <span style='color: #22d3ee;'>deck load Training Probe</span> then <span style='color: #22d3ee;'>deck load Training Shield</span> to load both.",
+       condition: {type: :deck_software_count, target: 2}},
+
+      # ═══ Chapter 4: BREACH TRAINING ═══
+      {slug: "find-arena", chapter: "BREACH TRAINING",
+       narrative: "DECK loaded and operational. Time for combat simulation.\n" \
+                  "Head to the Arena Lobby — south from the DECK Lab.",
+       hint: "Navigate to the Arena Lobby.",
+       condition: {type: :in_room, target: "bl-arena-lobby"}},
+
+      {slug: "breach-protocol", chapter: "BREACH TRAINING",
+       narrative: "Three simulation chambers available.\n\n" \
+                  "Start with <span style='color: #22d3ee;'>Simulation α</span> — a protocol-only BREACH.\n" \
+                  "Protocols are hostile programs you must destroy using your software.\n" \
+                  "Commands: <span style='color: #22d3ee;'>exec &lt;software&gt;</span> to attack, <span style='color: #22d3ee;'>analyze &lt;protocol&gt;</span> to identify weaknesses.\n" \
+                  "Watch the detection meter — if it hits 100%, you fail.",
+       hint: "Go <span style='color: #22d3ee;'>northeast</span> to Simulation α, then type <span style='color: #22d3ee;'>breach</span> to begin.",
+       condition: {type: :breach_completed, target: "protocol-drill-alpha"}},
+
+      {slug: "breach-pcg", chapter: "BREACH TRAINING",
+       narrative: "Protocol BREACH cleared! Next: <span style='color: #22d3ee;'>Simulation β</span> — a puzzle circumvention gate (PCG) BREACH.\n" \
+                  "Instead of protocols, you'll solve puzzle gates to win.\n" \
+                  "Command: <span style='color: #22d3ee;'>interface &lt;answer&gt;</span> to attempt a gate solution.",
+       hint: "Go to Simulation β (east from lobby), then <span style='color: #22d3ee;'>breach</span> to begin.",
+       condition: {type: :breach_completed, target: "cipher-drill-beta"}},
+
+      {slug: "breach-mixed", chapter: "BREACH TRAINING",
+       narrative: "PCG solved! Final simulation: <span style='color: #22d3ee;'>Simulation γ</span> — a mixed BREACH.\n" \
+                  "Both protocols AND puzzle gates. Destroy all protocols OR solve all gates to win.\n" \
+                  "Two paths to victory — choose your approach.",
+       hint: "Go to Simulation γ (southeast from lobby), then <span style='color: #22d3ee;'>breach</span> to begin.",
+       condition: {type: :breach_completed, target: "combined-drill-gamma"}},
+
+      {slug: "post-breach", chapter: "BREACH TRAINING",
+       narrative: "All BREACH simulations cleared. After breaching, your DECK battery drains.\n" \
+                  "Head to the Debrief Room for a Power Bank.",
+       hint: "Go <span style='color: #22d3ee;'>south</span> from the Arena Lobby to the Debrief Room.",
+       condition: {type: :in_room, target: "bl-arena-debrief"},
+       grants: [{slug: "training-power-bank"}],
+       grant_narrative: "<span style='color: #fbbf24;'>A supply crate contains a Power Bank.</span>\n" \
+                        "<span style='color: #d0d0d0;'>'Power Banks recharge your DECK battery.\n" \
+                        "If your battery runs out during a BREACH, you can't use software.\n" \
+                        "Keep one in your inventory.'</span>"},
+
+      {slug: "check-battery", chapter: "BREACH TRAINING",
+       narrative: "Your DECK battery drains with every software execution during a BREACH.\n" \
+                  "Check your DECK status to see where your battery stands.",
+       hint: "Type <span style='color: #22d3ee;'>deck</span> to check your DECK battery level.",
+       condition: {type: :command_used, match: %w[deck dk]}},
+
+      {slug: "recharge-deck", chapter: "BREACH TRAINING",
+       narrative: "See the battery level? Power Banks restore it. Use the one you just received.",
+       hint: "Type <span style='color: #22d3ee;'>use Training Power Bank</span> to recharge your DECK.",
+       condition: {type: :not_has_item, target: "training-power-bank"}},
+
+      {slug: "verify-battery", chapter: "BREACH TRAINING",
+       narrative: "Good. Check your DECK again to confirm the recharge.",
+       hint: "Type <span style='color: #22d3ee;'>deck</span> to verify your battery was restored.",
+       condition: {type: :command_used, match: %w[deck dk]}},
+
+      # ═══ Chapter 5: SUPPLY CHAIN ═══
+      {slug: "find-supply", chapter: "SUPPLY CHAIN",
+       narrative: "Combat training complete. Time to learn the supply chain.\n" \
+                  "Head to the Supply Depot.",
+       hint: "Navigate to the Supply Depot — south from the Debrief Room.",
+       condition: {type: :in_room, target: "bl-supply-depot"}},
+
+      {slug: "browse-shop", chapter: "SUPPLY CHAIN",
+       narrative: "VECTOR runs a supply cache here. In the Grid, vendors sell items for CRED.\n" \
+                  "Training sim prices are zero — but real-world items cost CRED.\n" \
+                  "You earn CRED by mining (your rig), completing missions, and salvaging.",
+       hint: "Type <span style='color: #22d3ee;'>shop</span> to see what's for sale.",
+       condition: {type: :command_used, match: %w[shop browse]}},
+
+      {slug: "buy-item", chapter: "SUPPLY CHAIN",
+       narrative: "Good. Try buying something.",
+       hint: "Type <span style='color: #22d3ee;'>buy</span> followed by an item name to purchase it.",
+       condition: {type: :flag, target: "tutorial_buy_succeeded"}},
+
+      {slug: "sell-item", chapter: "SUPPLY CHAIN",
+       narrative: "Item purchased. You can also sell items back to vendors.",
+       hint: "Type <span style='color: #22d3ee;'>sell</span> followed by an item name to sell it.",
+       condition: {type: :flag, target: "tutorial_sell_succeeded"}},
+
+      {slug: "find-salvage", chapter: "SUPPLY CHAIN",
+       narrative: "Buy/sell confirmed. Items can also be broken down into raw materials.\n" \
+                  "Head to the Salvage Workshop.",
+       hint: "Navigate to the Salvage Workshop — east from the Supply Depot.",
+       condition: {type: :in_room, target: "bl-salvage-workshop"},
+       grants: [{slug: "training-scrap", quantity: 2}],
+       grant_narrative: "<span style='color: #fbbf24;'>Training materials issued:</span> <span style='color: #d0d0d0;'>2x Training Scrap</span>"},
+
+      {slug: "salvage-item", chapter: "SUPPLY CHAIN",
+       narrative: "Materials received. Salvaging breaks items into components.\n" \
+                  "Tip: use <span style='color: #22d3ee;'>analyze &lt;item&gt;</span> first to preview what you'll get.",
+       hint: "Type <span style='color: #22d3ee;'>salvage Training Scrap</span> to break it down.",
+       condition: {type: :has_item, target: "training-alloy"}},
+
+      {slug: "find-fabrication", chapter: "SUPPLY CHAIN",
+       narrative: "Materials acquired from salvage. Now learn fabrication — crafting new items from materials.\n" \
+                  "Head to the Fabrication Terminal.",
+       hint: "Navigate to the Fabrication Terminal — east from the Salvage Workshop.",
+       condition: {type: :in_room, target: "bl-fabrication-terminal"}},
+
+      {slug: "check-schematics", chapter: "SUPPLY CHAIN",
+       narrative: "Schematics are blueprints for crafting. Check what's available to build.",
+       hint: "Type <span style='color: #22d3ee;'>schematics</span> to see available crafting recipes.",
+       condition: {type: :command_used, match: %w[schematics schem sch]}},
+
+      {slug: "fabricate-item", chapter: "SUPPLY CHAIN",
+       narrative: "Schematics listed. You have the materials — try fabricating something.",
+       hint: "Type <span style='color: #22d3ee;'>fabricate fab-training-tool-kit</span> to craft the Training Tool Kit.",
+       condition: {type: :has_item, target: "training-tool-kit"}},
+
+      # ═══ Chapter 6: TRANSIT OPERATIONS ═══
+      {slug: "find-transit", chapter: "TRANSIT OPERATIONS",
+       narrative: "Supply chain training complete.\n" \
+                  "THE PULSE GRID spans multiple regions connected by transit networks.\n" \
+                  "Head to the Transit Hub to learn public and private transit.",
+       hint: "Navigate to the Transit Hub.",
+       condition: {type: :in_room, target: "bl-transit-hub"}},
+
+      {slug: "check-transit", chapter: "TRANSIT OPERATIONS",
+       narrative: "Transit routes are displayed when you look around a transit stop.\n" \
+                  "You can also check route info with the transit command.",
+       hint: "Type <span style='color: #22d3ee;'>transit</span> to see transit options.",
+       condition: {type: :command_used, match: %w[transit tr]}},
+
+      {slug: "ride-public", chapter: "TRANSIT OPERATIONS",
+       narrative: "Board the shuttle using its route slug. Once aboard:\n" \
+                  "  <span style='color: #22d3ee;'>wait</span> — advance to next stop\n" \
+                  "  <span style='color: #22d3ee;'>disembark</span> — exit at current stop\n" \
+                  "Ride to the last stop — Relay Point B.",
+       hint: "<span style='color: #22d3ee;'>board bootloader-shuttle</span> to board, then <span style='color: #22d3ee;'>wait</span> to ride through stops. Destination: Relay Point B.",
+       condition: {type: :in_room, target: "bl-transit-stop-b"}},
+
+      {slug: "hail-private", chapter: "TRANSIT OPERATIONS",
+       narrative: "Public transit mastered! Private transit is point-to-point — pick a destination and arrive in one stop.\n" \
+                  "Hail a Training Taxi to Relay Point C.",
+       hint: "Type <span style='color: #22d3ee;'>hail training-taxi relay point c</span> to hail a taxi, then <span style='color: #22d3ee;'>wait</span> to arrive.",
+       condition: {type: :in_room, target: "bl-transit-stop-c"}},
+
+      # ═══ Chapter 7: SYSTEM CHECK ═══
+      {slug: "find-systems", chapter: "SYSTEM CHECK",
+       narrative: "Transit mastered. Final phase — system diagnostics.\n" \
+                  "Head to the Systems Lab.",
+       hint: "Navigate to the Systems Lab.",
+       condition: {type: :in_room, target: "bl-systems-lab"}},
+
+      {slug: "rig-status", chapter: "SYSTEM CHECK",
+       narrative: "Your mining rig generates CRED passively while you're active on the Grid.\n" \
+                  "It was provisioned during registration with basic components.\n" \
+                  "Start by checking its status.",
+       hint: "Type <span style='color: #22d3ee;'>rig</span> to see your mining rig status.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "rig-inspect-detail", chapter: "SYSTEM CHECK",
+       narrative: "That shows the overview. You can see a detailed component breakdown\n" \
+                  "including slot types, multipliers, and what's installed where.",
+       hint: "Type <span style='color: #22d3ee;'>rig inspect</span> for the detailed component view.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "rig-ensure-off", chapter: "SYSTEM CHECK",
+       narrative: "To install or remove components, the rig must be offline.\n" \
+                  "In the Grid, rig modifications also require your den — here, the lab simulates that.\n" \
+                  "Your rig may already be off. If it's active, deactivate it.",
+       hint: "Type <span style='color: #22d3ee;'>rig off</span> to deactivate. If already off, type it anyway — it's safe.",
+       condition: {type: :rig_inactive}},
+
+      {slug: "rig-verify-off", chapter: "SYSTEM CHECK",
+       narrative: "Good. Confirm the rig is offline.",
+       hint: "Type <span style='color: #22d3ee;'>rig</span> to verify the rig is offline.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "rig-uninstall", chapter: "SYSTEM CHECK",
+       narrative: "Rig is offline and ready for modifications.\n" \
+                  "Let's remove a component to see what happens. The GPU handles mining calculations.",
+       hint: "Type <span style='color: #22d3ee;'>rig uninstall Basic GPU</span> to remove the GPU.",
+       condition: {type: :rig_not_functional}},
+
+      {slug: "rig-check-inv", chapter: "SYSTEM CHECK",
+       narrative: "GPU removed. The component is now in your inventory — not lost, just uninstalled.\n" \
+                  "Check your inventory to confirm.",
+       hint: "Type <span style='color: #22d3ee;'>inv</span> to see the GPU in your inventory.",
+       condition: {type: :command_used, match: %w[inventory inv i]}},
+
+      {slug: "rig-inspect-broken", chapter: "SYSTEM CHECK",
+       narrative: "There it is. Now check the rig — notice the missing component.",
+       hint: "Type <span style='color: #22d3ee;'>rig inspect</span> to see the gap in your rig.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "rig-try-start", chapter: "SYSTEM CHECK",
+       narrative: "See the empty GPU slot? A rig needs all core components to function:\n" \
+                  "motherboard, PSU, CPU, GPU, and RAM. Try starting it anyway.",
+       hint: "Type <span style='color: #22d3ee;'>rig on</span> to attempt activation.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "rig-reinstall", chapter: "SYSTEM CHECK",
+       narrative: "Won't start — missing components. Reinstall the GPU from your inventory.",
+       hint: "Type <span style='color: #22d3ee;'>rig install Basic GPU</span> to reinstall it.",
+       condition: {type: :rig_functional}},
+
+      {slug: "rig-start", chapter: "SYSTEM CHECK",
+       narrative: "Rig functional again — all slots filled. Now activate it.",
+       hint: "Type <span style='color: #22d3ee;'>rig on</span> to start mining.",
+       condition: {type: :rig_active}},
+
+      {slug: "rig-final-inspect", chapter: "SYSTEM CHECK",
+       narrative: "Rig is online and mining. Do a final inspection to confirm everything is working.",
+       hint: "Type <span style='color: #22d3ee;'>rig inspect</span> to verify all components are active.",
+       condition: {type: :command_used, match: %w[rig]}},
+
+      {slug: "check-rep", chapter: "SYSTEM CHECK",
+       narrative: "As you interact with factions, you'll build reputation.\n" \
+                  "Reputation unlocks access to restricted zones, vendors, and missions.",
+       hint: "Type <span style='color: #22d3ee;'>rep</span> to view your reputation standing.",
+       condition: {type: :command_used, match: %w[rep reputation standing]}},
+
+      {slug: "graduation", chapter: "SYSTEM CHECK",
+       narrative: "All systems green. Training complete.\n" \
+                  "Proceed to the Graduation Chamber to choose your starting location.",
+       hint: "Navigate to the Graduation Chamber — south from the Systems Lab.",
+       condition: {type: :in_room, target: "bl-graduation-chamber"}},
+
+      {slug: "choose-start", chapter: "DEPLOYMENT",
+       narrative: nil, # Rendered by render_starting_room_selection
+       hint: "Type <span style='color: #22d3ee;'>choose &lt;number&gt;</span> to select your starting location.",
+       condition: {type: :choosing_start}}
+    ].freeze
+
+    CHAPTER_COLORS = {
+      "BOOT SEQUENCE" => "#22d3ee",
+      "INTERFACE TRAINING" => "#60a5fa",
+      "DECK OPERATIONS" => "#fbbf24",
+      "BREACH TRAINING" => "#f87171",
+      "SUPPLY CHAIN" => "#34d399",
+      "TRANSIT OPERATIONS" => "#a78bfa",
+      "SYSTEM CHECK" => "#f59e0b",
+      "DEPLOYMENT" => "#34d399"
+    }.freeze
+
+    def initialize(hackr, input, parser)
+      @hackr = hackr
+      @input = input.to_s.strip
+      @parser = parser
+    end
+
+    def execute
+      return {output: "<span style='color: #fbbf24;'>Please enter a command.</span>", event: nil} if input.empty?
+
+      parts = input.split
+      command = parts.first&.downcase
+      args = parts[1..]
+
+      step_index = hackr.stat("tutorial_step").to_i
+      step = STEPS[step_index]
+
+      # First command ever — show boot narrative + look
+      if step_index == 0 && !hackr.stat("tutorial_boot_shown")
+        hackr.set_stat!("tutorial_boot_shown", true)
+        ensure_floor_items(step)
+        narrative = render_narrative(step)
+        look = parser.send(:dispatch_command, "look", [])
+        look_output = look.is_a?(Hash) ? look[:output] : look
+        return {output: narrative + "\n\n" + look_output + "\n" + render_hint(step), event: nil}
+      end
+
+      # Ensure current step's floor items exist before any command runs
+      # (so `look` shows floor items placed on a prior step transition)
+      ensure_floor_items(step) if step
+
+      # Auto-advance if step condition was met externally (transit arrival, breach end).
+      # Skip command-based conditions — they depend on the command about to run.
+      @pre_advance_text = nil
+      condition_type = step&.dig(:condition, :type)
+      if step && !%i[command_used flag choosing_start].include?(condition_type) &&
+          step_completed?(step, command, args, {})
+        grant_step_items(step)
+        step_index += 1
+        hackr.set_stat!("tutorial_step", step_index)
+        step = STEPS[step_index]
+        if step
+          ensure_floor_items(step)
+          @pre_advance_text = render_step_completion(STEPS[step_index - 1], step)
+        end
+      end
+
+      # Handle tutorial end (choose-start step or choosing flag set)
+      if hackr.stat("tutorial_choosing_start") || step&.dig(:slug) == "choose-start"
+        # Re-entry: warp back to origin, no starting room selection
+        if hackr.stat("tutorial_return_room_id").present?
+          tutorial_service.return_to_world!
+          look = Grid::CommandParser.new(hackr, "look").execute[:output]
+          return {output: render_deployment_complete(nil) + "\n\n" + look, event: nil}
+        end
+        hackr.set_stat!("tutorial_choosing_start", true)
+        return handle_choose_start(command, args)
+      end
+
+      # Handle blocked commands
+      if BLOCKED_COMMANDS.include?(command)
+        return {output: blocked_message(command), event: nil}
+      end
+
+      # Gate economy commands to their relevant tutorial steps
+      if step && command_gated?(command, step)
+        return {output: "<span style='color: #9ca3af;'>That command isn't available yet. Follow the current training objective.</span>", event: nil}
+      end
+
+      # Handle code command (no step advancement)
+      if command == "code"
+        return {output: Grid::CodeService.new(hackr).execute(args&.join(" ")), event: nil}
+      end
+
+      # Handle help — tutorial-scoped (no step advancement)
+      if command == "help" || command == "?"
+        return {output: tutorial_help_command, event: nil}
+      end
+
+      # Handle choose — for starting room selection at graduation
+      if command == "choose" && step&.dig(:slug) == "choose-start"
+        hackr.set_stat!("tutorial_choosing_start", true)
+        return handle_choose_start("choose", args)
+      end
+
+      # Tutorial-intercepted commands — set result and fall through to step completion
+      result = if %w[rep reputation standing].include?(command)
+        {output: fake_rep_command, event: nil}
+      elsif %w[buy purchase].include?(command)
+        {output: tutorial_buy_command(args&.join(" ")), event: nil}
+      elsif command == "sell"
+        {output: tutorial_sell_command(args&.join(" ")), event: nil}
+      elsif command == "repair" && step && in_repair_step?
+        {output: free_repair_command, event: nil}
+      elsif command == "rig" && args&.first&.downcase&.in?(%w[install uninstall])
+        handle_tutorial_rig(args)
+      end
+
+      # Delegate to main parser if not intercepted
+      unless result
+        result = parser.send(:dispatch_command, command, args)
+        result = result.is_a?(Hash) ? result : {output: result, event: nil}
+      end
+
+      # Skip hint injection for passthrough commands
+      return result if PASSTHROUGH_COMMANDS.include?(command)
+
+      # Check step completion
+      if step && step_completed?(step, command, args, result)
+        # Grant items for the COMPLETING step (hackr just met the condition)
+        grant_step_items(step)
+
+        step_index += 1
+        hackr.set_stat!("tutorial_step", step_index)
+
+        next_step = STEPS[step_index]
+        if next_step
+          ensure_floor_items(next_step)
+
+          if next_step[:slug] == "choose-start"
+            completion_text = "\n<span style='color: #34d399;'>✓ Step complete</span>"
+
+            if hackr.stat("tutorial_return_room_id").present?
+              # Re-entry: warp back to origin, no selection needed
+              tutorial_service.return_to_world!
+              look = Grid::CommandParser.new(hackr, "look").execute[:output]
+              completion_text += "\n" + render_deployment_complete(nil) + "\n\n" + look
+            else
+              # First-time: show starting room selection
+              starting_rooms = GridStartingRoom.ordered.includes(:grid_room)
+              if starting_rooms.any?
+                hackr.set_stat!("tutorial_choosing_start", true)
+                completion_text += "\n" + render_starting_room_selection(starting_rooms)
+              else
+                tutorial_service.complete!(starting_room: hackr.current_room)
+                completion_text += "\n" + render_deployment_complete(nil, first_time: true)
+              end
+            end
+            result[:output] = result[:output].to_s + completion_text
+          else
+            completion_text = render_step_completion(step, next_step)
+            result[:output] = result[:output].to_s + "\n" + completion_text
+          end
+        end
+      elsif step
+        # Show hint if not completed
+        result[:output] = result[:output].to_s + "\n" + render_hint(step)
+      end
+
+      # Prepend auto-advance text if step was pre-completed (transit arrival, breach end)
+      if @pre_advance_text
+        result[:output] = @pre_advance_text + "\n" + result[:output].to_s
+      end
+
+      result
+    end
+
+    private
+
+    def h(text)
+      ERB::Util.html_escape(text.to_s)
+    end
+
+    # ─── Step Completion Checks ──────────────────────────────────────
+
+    def step_completed?(step, command, _args, result)
+      cond = step[:condition]
+      case cond[:type]
+      when :command_used
+        cond[:match].include?(command)
+      when :in_room
+        hackr.current_room&.slug == cond[:target]
+      when :has_item
+        hackr.grid_items.joins(:grid_item_definition)
+          .where(grid_item_definitions: {slug: cond[:target]})
+          .where(grid_mining_rig_id: nil, container_id: nil, equipped_slot: nil)
+          .exists?
+      when :not_has_item
+        !hackr.grid_items.joins(:grid_item_definition)
+          .where(grid_item_definitions: {slug: cond[:target]})
+          .exists?
+      when :stat_positive
+        hackr.stat(cond[:target]).to_i > 0
+      when :dialogue_depth
+        ctx = hackr.stat("dialogue_context")
+        ctx.is_a?(Hash) && ctx.values.any? { |path| path.is_a?(Array) && path.length >= cond[:target].to_i }
+      when :moved
+        result.is_a?(Hash) && result.dig(:event, :type) == "movement"
+      when :deck_not_fried
+        deck = hackr.equipped_deck
+        deck && !deck.deck_fried?
+      when :deck_has_software
+        hackr.equipped_deck&.loaded_software&.any? || false
+      when :deck_software_count
+        (hackr.equipped_deck&.loaded_software&.count || 0) >= cond[:target].to_i
+      when :breach_completed
+        GridHackrBreach.where(grid_hackr: hackr, state: "success")
+          .joins(:grid_breach_template)
+          .where(grid_breach_templates: {slug: cond[:target]})
+          .exists?
+      when :rig_inactive
+        hackr.grid_mining_rig&.active? == false
+      when :rig_not_functional
+        hackr.grid_mining_rig&.functional? == false
+      when :rig_functional
+        hackr.grid_mining_rig&.functional? || false
+      when :rig_active
+        hackr.grid_mining_rig&.active? || false
+      when :flag
+        @tutorial_flags&.include?(cond[:target])
+      when :choosing_start
+        hackr.stat("tutorial_choosing_start") == true
+      else
+        false
+      end
+    end
+
+    # ─── Item Grants ─────────────────────────────────────────────────
+
+    def ensure_floor_items(step)
+      return unless (floor_item = step[:ensure_floor_item])
+      ensure_floor_item(floor_item[:slug], floor_item[:room])
+    end
+
+    def grant_step_items(step)
+      return unless step[:grants]
+
+      granted_steps = hackr.stat("tutorial_granted_steps") || []
+      return if granted_steps.include?(step[:slug])
+
+      hackr.set_stat!("tutorial_granted_steps", granted_steps + [step[:slug]])
+
+      step[:grants].each do |grant|
+        defn = GridItemDefinition.find_by(slug: grant[:slug])
+        next unless defn
+
+        qty = grant[:quantity] || 1
+
+        ActiveRecord::Base.transaction do
+          if grant[:equip]
+            # Create and auto-equip (e.g., DECK)
+            item = GridItem.create!(defn.item_attributes.merge(grid_hackr: hackr, equipped_slot: "deck"))
+            if grant[:fried_level]
+              item.update!(properties: item.properties.merge("fried_level" => grant[:fried_level]))
+            end
+          elsif grant[:deck_load]
+            # Load software onto equipped deck
+            deck = hackr.equipped_deck
+            if deck
+              GridItem.create!(defn.item_attributes.merge(grid_hackr: hackr, deck_id: deck.id))
+            end
+          else
+            Grid::Inventory.grant_item!(hackr: hackr, definition: defn, quantity: qty)
+          end
+        rescue Grid::InventoryErrors::InventoryFull, Grid::InventoryErrors::StackLimitExceeded
+          # Silently skip if inventory is full
+        end
+      end
+    end
+
+    def ensure_floor_item(slug, room_slug)
+      room = GridRoom.find_by(slug: room_slug)
+      defn = GridItemDefinition.find_by(slug: slug)
+      return unless room && defn
+
+      # Only create if none exist on the floor of this room
+      unless room.grid_items.joins(:grid_item_definition)
+          .where(grid_item_definitions: {slug: slug}).exists?
+        GridItem.create!(defn.item_attributes.merge(room: room))
+      end
+    end
+
+    # ─── Rendering ───────────────────────────────────────────────────
+
+    def render_narrative(step)
+      return "" unless step[:narrative]
+
+      chapter_color = CHAPTER_COLORS[step[:chapter]] || "#22d3ee"
+      progress = render_progress_bar
+
+      lines = []
+      lines << "<span style='color: #{chapter_color};'>━━━ #{step[:chapter]} ━━━</span> #{progress}"
+      lines << "<span style='color: #d0d0d0;'>#{step[:narrative]}</span>"
+
+      "\n<div style='border-left: 2px solid #{chapter_color}; padding: 6px 12px; margin: 4px 0; background: #0a1420;'>" \
+        "#{lines.join("\n")}</div>"
+    end
+
+    def render_hint(step)
+      return "" unless step
+      chapter_color = CHAPTER_COLORS[step[:chapter]] || "#22d3ee"
+      "\n<div style='border-left: 2px solid #{chapter_color}; padding: 4px 12px; margin: 2px 0; background: #0a1420;'>" \
+        "<span style='color: #{chapter_color};'>▸</span> <span style='color: #9ca3af;'>#{step[:hint]}</span></div>"
+    end
+
+    def render_step_completion(completed_step, next_step)
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399;'>✓ Step complete</span>"
+      # Show grant narrative from the step that just completed (hackr met the condition)
+      if completed_step[:grant_narrative]
+        lines << ""
+        lines << completed_step[:grant_narrative]
+      end
+      # Show next step's narrative and hint
+      lines << render_narrative(next_step) if next_step[:narrative]
+      lines << render_hint(next_step)
+      lines.join("\n")
+    end
+
+    def render_progress_bar
+      step_index = hackr.stat("tutorial_step").to_i
+      total = STEPS.size
+      pct = ((step_index.to_f / total) * 100).round
+      filled = (pct / 5.0).round
+      empty = 20 - filled
+      bar = "█" * filled + "░" * empty
+      "<span style='color: #6b7280;'>[#{bar}] #{pct}%</span>"
+    end
+
+    # ─── Starting Room Selection ─────────────────────────────────────
+
+    def handle_choose_start(command, args)
+      starting_rooms = GridStartingRoom.ordered.includes(:grid_room)
+      if starting_rooms.empty?
+        tutorial_service.complete!(starting_room: hackr.current_room)
+        hackr.set_stat!("tutorial_choosing_start", false)
+        return {output: render_deployment_complete, event: nil}
+      end
+
+      if command == "choose" && args&.first
+        index = args.first.to_i - 1
+        if index >= 0 && index < starting_rooms.size
+          sr = starting_rooms.to_a[index]
+          hackr.set_stat!("tutorial_choosing_start", false)
+
+          # Capture before complete! changes the state
+          was_first_time = tutorial_service.first_time?
+
+          if was_first_time
+            tutorial_service.complete!(starting_room: sr.grid_room)
+          else
+            tutorial_service.return_to_world!
+            hackr.update!(current_room: sr.grid_room)
+          end
+
+          look = Grid::CommandParser.new(hackr, "look").execute[:output]
+          return {output: render_deployment_complete(sr.name, first_time: was_first_time) + "\n\n" + look, event: nil}
+        else
+          return {output: "<span style='color: #f87171;'>Invalid selection. Choose a number between 1 and #{starting_rooms.size}.</span>", event: nil}
+        end
+      end
+
+      # Show the selection list
+      output = render_starting_room_selection(starting_rooms)
+      {output: output, event: nil}
+    end
+
+    def render_starting_room_selection(starting_rooms)
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399;'>━━━ DEPLOYMENT ━━━</span> #{render_progress_bar}"
+      lines << "<span style='color: #22d3ee; font-weight: bold;'>TRAINING COMPLETE — CHOOSE YOUR DEPLOYMENT ZONE</span>"
+      lines << ""
+      lines << "<span style='color: #d0d0d0;'>Where you start shapes your early experience on the Grid.</span>"
+      lines << "<span style='color: #d0d0d0;'>Each zone has its own factions, threats, and opportunities.</span>"
+      lines << ""
+
+      starting_rooms.each_with_index do |sr, i|
+        lines << "<span style='color: #fbbf24;'>[#{i + 1}]</span> <span style='color: #22d3ee; font-weight: bold;'>#{h(sr.name)}</span>"
+        lines << "    <span style='color: #d0d0d0;'>#{h(sr.blurb)}</span>"
+        lines << ""
+      end
+
+      lines << "<span style='color: #9ca3af;'>Type</span> <span style='color: #22d3ee;'>choose &lt;number&gt;</span> <span style='color: #9ca3af;'>to deploy.</span>"
+      lines.join("\n")
+    end
+
+    def render_deployment_complete(location_name = nil, first_time: false)
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>════════════════════════════════════════════════════════════════</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>  BOOTLOADER COMPLETE — DEPLOYING TO THE PULSE GRID</span>"
+      lines << "<span style='color: #34d399; font-weight: bold;'>════════════════════════════════════════════════════════════════</span>"
+      lines << ""
+      lines << "<span style='color: #d0d0d0;'>Welcome to THE PULSE GRID, #{h(hackr.hackr_alias)}.</span>"
+      lines << "<span style='color: #d0d0d0;'>Your journey with the Fracture Network begins now.</span>" if first_time
+      lines << "<span style='color: #9ca3af;'>Deploying to: #{h(location_name)}</span>" if location_name
+      lines << ""
+      lines << "<span style='color: #6b7280;'>Type <span style='color: #22d3ee;'>help</span> for commands. Type <span style='color: #22d3ee;'>look</span> to observe.</span>"
+      lines.join("\n")
+    end
+
+    # ─── Special Command Handlers ────────────────────────────────────
+
+    def blocked_message(command)
+      case command
+      when "say"
+        "<span style='color: #9ca3af;'>Communications restricted during training simulation.</span>"
+      else
+        "<span style='color: #9ca3af;'>That action is disabled during training.</span>"
+      end
+    end
+
+    def set_flag!(flag)
+      @tutorial_flags ||= []
+      @tutorial_flags << flag
+    end
+
+    def command_gated?(command, step)
+      GATED_COMMANDS.each do |commands, allowed_steps|
+        next unless commands.include?(command)
+        return !allowed_steps.include?(step[:slug])
+      end
+      false
+    end
+
+    # Simulated buy — grants item directly, no shop stock or CRED involved
+    TUTORIAL_SHOP_ITEMS = %w[training-data-chip training-stim-pack].freeze
+
+    def tutorial_buy_command(item_name)
+      return "<span style='color: #fbbf24;'>Buy what? Usage: buy &lt;item&gt;</span>" if item_name.to_s.strip.empty?
+
+      slug = TUTORIAL_SHOP_ITEMS.find do |s|
+        defn = GridItemDefinition.find_by(slug: s)
+        defn && defn.name.downcase == item_name.strip.downcase
+      end
+
+      unless slug
+        return "<span style='color: #f87171;'>VECTOR doesn't stock '#{h(item_name)}'.</span>"
+      end
+
+      defn = GridItemDefinition.find_by(slug: slug)
+      ActiveRecord::Base.transaction do
+        Grid::Inventory.grant_item!(hackr: hackr, definition: defn, quantity: 1)
+      end
+
+      set_flag!("tutorial_buy_succeeded")
+      "<span style='color: #34d399;'>Purchased: #{h(defn.name)}.</span>\n" \
+        "<span style='color: #9ca3af;'>In the real Grid, this would cost CRED.</span>"
+    rescue Grid::InventoryErrors::InventoryFull
+      "<span style='color: #f87171;'>Inventory full.</span>"
+    end
+
+    # Simulated sell — destroys item, no CRED granted
+    def tutorial_sell_command(item_name)
+      return "<span style='color: #fbbf24;'>Sell what? Usage: sell &lt;item&gt;</span>" if item_name.to_s.strip.empty?
+
+      item = hackr.grid_items.in_inventory(hackr)
+        .find_by("LOWER(name) = ?", item_name.strip.downcase)
+      unless item
+        return "<span style='color: #f87171;'>You don't have '#{h(item_name)}' to sell.</span>"
+      end
+
+      name = item.name
+      if item.quantity > 1
+        item.update!(quantity: item.quantity - 1)
+      else
+        item.destroy!
+      end
+
+      set_flag!("tutorial_sell_succeeded")
+      "<span style='color: #34d399;'>Sold: #{h(name)}.</span>\n" \
+        "<span style='color: #9ca3af;'>In the real Grid, you'd receive CRED for this.</span>"
+    end
+
+    def in_repair_step?
+      step_index = hackr.stat("tutorial_step").to_i
+      step = STEPS[step_index]
+      step && step[:slug] == "repair-deck"
+    end
+
+    def free_repair_command
+      deck = hackr.equipped_deck
+      unless deck
+        return "<span style='color: #f87171;'>No DECK equipped.</span>"
+      end
+      unless deck.deck_fried?
+        return "<span style='color: #9ca3af;'>Your DECK doesn't need repair.</span>"
+      end
+      room = hackr.current_room
+      unless room&.room_type == "repair_service"
+        return "<span style='color: #f87171;'>There's no repair service here.</span>"
+      end
+
+      fried_level = deck.deck_fried_level
+      deck.update!(properties: deck.properties.merge("fried_level" => 0))
+
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>[ DECK REPAIR COMPLETE ]</span>"
+      lines << "<span style='color: #d0d0d0;'>  DECK: #{h(deck.name)}</span>"
+      lines << "<span style='color: #9ca3af;'>  Damage cleared: level #{fried_level}/5</span>"
+      lines << "<span style='color: #fbbf24;'>  Cost: 0 CRED (training sim)</span>"
+      lines.join("\n")
+    end
+
+    def handle_tutorial_rig(args)
+      subcommand = args.first&.downcase
+      item_name = args[1..]&.join(" ")
+
+      rig = hackr.grid_mining_rig
+      unless rig
+        return {output: "<span style='color: #f87171;'>You don't have a mining rig.</span>", event: nil}
+      end
+
+      if subcommand == "install"
+        return {output: tutorial_rig_install(rig, item_name), event: nil}
+      elsif subcommand == "uninstall"
+        return {output: tutorial_rig_uninstall(rig, item_name), event: nil}
+      end
+
+      # Shouldn't reach here, but delegate just in case
+      result = parser.send(:dispatch_command, "rig", args)
+      result.is_a?(Hash) ? result : {output: result, event: nil}
+    end
+
+    def tutorial_rig_install(rig, item_name)
+      return "<span style='color: #fbbf24;'>Install what? Usage: rig install &lt;component&gt;</span>" if item_name.to_s.empty?
+
+      if rig.active?
+        return "<span style='color: #f87171;'>Rig must be offline to install components. Type 'rig off' first.</span>"
+      end
+
+      item = hackr.grid_items.in_inventory(hackr)
+        .where(item_type: "rig_component")
+        .find_by("LOWER(name) = ?", item_name.downcase)
+      unless item
+        return "<span style='color: #f87171;'>No rig component '#{h(item_name)}' in inventory.</span>"
+      end
+
+      slot = item.properties&.dig("slot")
+      unless slot
+        return "<span style='color: #f87171;'>#{h(item.name)} has no component slot defined.</span>"
+      end
+
+      # Check slot capacity
+      unless rig.slot_available?(slot)
+        return "<span style='color: #f87171;'>No #{slot} slot available on your rig.</span>"
+      end
+
+      item.update!(grid_mining_rig: rig, grid_hackr: nil)
+
+      output = "<span style='color: #34d399;'>Installed #{h(item.name)} into rig.</span>"
+      output += "\n<span style='color: #34d399; font-weight: bold;'>Rig is now FUNCTIONAL.</span>" if rig.reload.functional?
+      output += "\n<span style='color: #f87171;'>Rig still non-functional — missing components.</span>" unless rig.functional?
+      output
+    end
+
+    def tutorial_rig_uninstall(rig, item_name)
+      return "<span style='color: #fbbf24;'>Uninstall what? Usage: rig uninstall &lt;component&gt;</span>" if item_name.to_s.empty?
+
+      if rig.active?
+        return "<span style='color: #f87171;'>Rig must be offline to remove components. Type 'rig off' first.</span>"
+      end
+
+      item = rig.components.find_by("LOWER(name) = ?", item_name.downcase)
+      unless item
+        return "<span style='color: #f87171;'>No component '#{h(item_name)}' installed in your rig.</span>"
+      end
+
+      item.update!(grid_mining_rig: nil, grid_hackr: hackr)
+      "<span style='color: #fbbf24;'>Removed #{h(item.name)} from rig → inventory.</span>"
+    end
+
+    def fake_rep_command
+      lines = []
+      lines << "\n<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines << "<span style='color: #22d3ee; font-weight: bold;'>STANDING REPORT :: #{h(hackr.hackr_alias)}</span>"
+      lines << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines << ""
+      lines << "<span style='color: #9ca3af;'>This is a preview of what your reputation report will look like</span>"
+      lines << "<span style='color: #9ca3af;'>as you interact with factions across THE PULSE GRID:</span>"
+      lines << ""
+      lines << "<span style='color: #22d3ee;'>Fracture Network      </span> <span style='color: #34d399;'>████████████████████ Trusted    (+1250)</span>"
+      lines << "<span style='color: #fbbf24;'>  ↳ Signal Corps       </span> <span style='color: #34d399;'>██████████████████░░ Respected  (+980)</span>"
+      lines << "<span style='color: #fbbf24;'>  ↳ Deep Circuit       </span> <span style='color: #60a5fa;'>███████████████░░░░░ Friendly   (+720)</span>"
+      lines << "<span style='color: #f87171;'>GovCorp               </span> <span style='color: #f87171;'>████░░░░░░░░░░░░░░░░ Hostile    (-850)</span>"
+      lines << "<span style='color: #fbbf24;'>  ↳ RAINN Division     </span> <span style='color: #f87171;'>██░░░░░░░░░░░░░░░░░░ Despised   (-1200)</span>"
+      lines << "<span style='color: #a78bfa;'>Underbelly Collective  </span> <span style='color: #fbbf24;'>██████████░░░░░░░░░░ Neutral    (+200)</span>"
+      lines << ""
+      lines << "<span style='color: #6b7280;'>Reputation grows through missions, NPC interactions, and faction-aligned actions.</span>"
+      lines << "<span style='color: #a78bfa;'>════════════════════════════════════════</span>"
+      lines.join("\n")
+    end
+
+    def tutorial_help_command
+      step_index = hackr.stat("tutorial_step").to_i
+      step = STEPS[step_index]
+
+      lines = []
+      lines << "<span style='color: #22d3ee; font-weight: bold;'>BOOTLOADER — Training Commands</span>"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Navigation:</span>"
+      lines << "  <span style='color: #22d3ee;'>look</span> / <span style='color: #22d3ee;'>l</span>          — Observe your surroundings"
+      lines << "  <span style='color: #22d3ee;'>north</span> <span style='color: #22d3ee;'>south</span> etc.  — Move in a direction"
+      lines << "  <span style='color: #22d3ee;'>go &lt;direction&gt;</span>    — Move in a direction"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Interaction:</span>"
+      lines << "  <span style='color: #22d3ee;'>talk &lt;npc&gt;</span>        — Talk to an NPC"
+      lines << "  <span style='color: #22d3ee;'>ask &lt;npc&gt; about &lt;topic&gt;</span> — Ask about a topic"
+      lines << "  <span style='color: #22d3ee;'>examine &lt;target&gt;</span>  — Examine something in detail"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Items:</span>"
+      lines << "  <span style='color: #22d3ee;'>inventory</span> / <span style='color: #22d3ee;'>inv</span>   — Check your inventory"
+      lines << "  <span style='color: #22d3ee;'>take &lt;item&gt;</span>       — Pick up an item"
+      lines << "  <span style='color: #22d3ee;'>use &lt;item&gt;</span>        — Use a consumable item"
+      lines << "  <span style='color: #22d3ee;'>drop &lt;item&gt;</span>       — Drop an item"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>DECK:</span>"
+      lines << "  <span style='color: #22d3ee;'>deck</span>              — DECK status"
+      lines << "  <span style='color: #22d3ee;'>deck load &lt;sw&gt;</span>    — Load software"
+      lines << "  <span style='color: #22d3ee;'>deck unload &lt;sw&gt;</span>  — Unload software"
+      lines << "  <span style='color: #22d3ee;'>repair</span>            — Repair DECK at service point"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Combat:</span>"
+      lines << "  <span style='color: #22d3ee;'>breach</span>            — Initiate a BREACH encounter"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Economy:</span>"
+      lines << "  <span style='color: #22d3ee;'>shop</span>              — Browse vendor inventory"
+      lines << "  <span style='color: #22d3ee;'>buy &lt;item&gt;</span>        — Purchase an item"
+      lines << "  <span style='color: #22d3ee;'>sell &lt;item&gt;</span>       — Sell an item"
+      lines << "  <span style='color: #22d3ee;'>salvage &lt;item&gt;</span>    — Break down an item"
+      lines << "  <span style='color: #22d3ee;'>fabricate &lt;slug&gt;</span>  — Craft from schematic"
+      lines << "  <span style='color: #22d3ee;'>schematics</span>        — List crafting recipes"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Transit:</span>"
+      lines << "  <span style='color: #22d3ee;'>transit</span>           — Transit info"
+      lines << "  <span style='color: #22d3ee;'>board &lt;route&gt;</span>     — Board public transit"
+      lines << "  <span style='color: #22d3ee;'>hail &lt;type&gt; to &lt;dest&gt;</span> — Hail private transit"
+      lines << ""
+      lines << "<span style='color: #fbbf24;'>Systems:</span>"
+      lines << "  <span style='color: #22d3ee;'>stat</span>              — Your stats and vitals"
+      lines << "  <span style='color: #22d3ee;'>rep</span>               — Reputation standing"
+      lines << "  <span style='color: #22d3ee;'>rig</span>               — Mining rig status"
+      lines << "  <span style='color: #22d3ee;'>who</span>               — Who's online"
+      lines << ""
+
+      if step
+        lines << "<span style='color: #6b7280;'>Current objective:</span>"
+        lines << "  #{render_hint(step).strip}"
+      end
+
+      lines.join("\n")
+    end
+
+    def tutorial_service
+      @tutorial_service ||= TutorialService.new(hackr)
+    end
+  end
+end

--- a/app/services/grid/tutorial_service.rb
+++ b/app/services/grid/tutorial_service.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Grid
+  class TutorialService
+    TUTORIAL_HUB_ZONE_SLUG = "bootloader-training-core"
+    TUTORIAL_HUB_ROOM_TYPE = "hub"
+
+    class AlreadyInTutorial < StandardError; end
+    class NotInTutorial < StandardError; end
+    class CannotEnterTutorial < StandardError; end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    # Start tutorial for a brand-new hackr (called during registration).
+    def start!
+      @hackr.set_stat!("tutorial_active", true)
+      @hackr.set_stat!("tutorial_step", 0)
+      grant_grid_access!
+    end
+
+    # Re-enter tutorial from the live world.
+    # Guards: not in BREACH, not captured, not in transit, not already in tutorial.
+    def re_enter!
+      raise AlreadyInTutorial, "You are already in the tutorial." if active?
+      raise CannotEnterTutorial, "Cannot enter tutorial during a BREACH." if @hackr.in_breach?
+      raise CannotEnterTutorial, "Cannot enter tutorial while captured." if Grid::ContainmentService.captured?(@hackr)
+      raise CannotEnterTutorial, "Cannot enter tutorial while in transit." if @hackr.in_transit?
+
+      hub = tutorial_hub_room
+      raise CannotEnterTutorial, "Tutorial zone not available." unless hub
+
+      # Persist return room so we can send them back
+      @hackr.set_stat!("tutorial_return_room_id", @hackr.current_room_id)
+      @hackr.set_stat!("tutorial_active", true)
+      @hackr.set_stat!("tutorial_step", 0)
+      @hackr.set_stat!("tutorial_boot_shown", false)
+      @hackr.set_stat!("tutorial_granted_steps", [])
+      @hackr.update!(current_room: hub)
+    end
+
+    # Complete tutorial — hackr chooses a starting room.
+    def complete!(starting_room:)
+      raise NotInTutorial, "Not in tutorial." unless active?
+
+      strip_tutorial_items!
+
+      @hackr.set_stat!("tutorial_active", false)
+      @hackr.set_stat!("tutorial_completed", true)
+      @hackr.set_stat!("tutorial_step", nil)
+      @hackr.update!(current_room: starting_room)
+
+      # Grant pulse_grid feature if not already granted
+      grant_grid_access!
+
+      # Grant den chip (deferred from provision_economy! — DenService needs real zones)
+      @hackr.provision_den_chip!
+
+      # Clear return room (not needed after completion)
+      @hackr.set_stat!("tutorial_return_room_id", nil)
+    end
+
+    # Skip tutorial via code command.
+    def skip!(starting_room:)
+      complete!(starting_room: starting_room)
+    end
+
+    # Return to the room they came from (for re-entry).
+    def return_to_world!
+      raise NotInTutorial, "Not in tutorial." unless active?
+
+      strip_tutorial_items!
+
+      return_room_id = @hackr.stat("tutorial_return_room_id")
+      return_room = return_room_id ? GridRoom.find_by(id: return_room_id) : nil
+
+      # Fall back to a starting room if return room is gone
+      return_room ||= GridStartingRoom.ordered.first&.grid_room
+
+      @hackr.set_stat!("tutorial_active", false)
+      @hackr.set_stat!("tutorial_step", nil)
+      @hackr.set_stat!("tutorial_return_room_id", nil)
+      @hackr.set_stat!("tutorial_choosing_start", nil)
+      @hackr.update!(current_room: return_room) if return_room
+    end
+
+    def active?
+      @hackr.stat("tutorial_active") == true
+    end
+
+    def completed?
+      @hackr.stat("tutorial_completed") == true
+    end
+
+    def first_time?
+      !completed?
+    end
+
+    def tutorial_hub_room
+      GridRoom.joins(:grid_zone)
+        .where(grid_zones: {slug: TUTORIAL_HUB_ZONE_SLUG})
+        .where(room_type: TUTORIAL_HUB_ROOM_TYPE)
+        .first
+    end
+
+    private
+
+    # Remove all training items from hackr's inventory, equipped slots, and loaded software.
+    # Training items are identified by definition slug prefix "training-".
+    def strip_tutorial_items!
+      training_def_ids = GridItemDefinition.where("slug LIKE ?", "training-%").pluck(:id)
+      return if training_def_ids.empty?
+
+      # Find training DECKs to also remove software loaded onto them
+      training_decks = @hackr.grid_items.where(grid_item_definition_id: training_def_ids, item_type: "gear")
+      training_deck_ids = training_decks.pluck(:id)
+
+      # Destroy software loaded on training DECKs (any definition, not just training-)
+      GridItem.where(deck_id: training_deck_ids).destroy_all if training_deck_ids.any?
+
+      # Destroy all training items (inventory, equipped, loaded on deck, etc.)
+      @hackr.grid_items.where(grid_item_definition_id: training_def_ids).destroy_all
+    end
+
+    def grant_grid_access!
+      return if @hackr.admin?
+      return if @hackr.feature_grants.exists?(feature: FeatureGrant::PULSE_GRID)
+
+      @hackr.feature_grants.create!(feature: FeatureGrant::PULSE_GRID)
+    end
+  end
+end

--- a/app/services/grid/world_exporter.rb
+++ b/app/services/grid/world_exporter.rb
@@ -39,6 +39,7 @@ module Grid
       export_schematics
       export_breach_templates
       export_breach_encounters
+      export_starting_rooms
 
       @dir
     end
@@ -67,7 +68,24 @@ module Grid
     private
 
     def write_yaml(filename, data)
-      File.write(File.join(@dir, filename), data.to_yaml(line_width: YAML_LINE_WIDTH))
+      # Sanitize BigDecimal values to floats before YAML serialization.
+      # Ruby's YAML emitter writes BigDecimal as !ruby/object:BigDecimal which
+      # Psych.safe_load rejects on re-import.
+      sanitized = sanitize_for_yaml(data)
+      File.write(File.join(@dir, filename), sanitized.to_yaml(line_width: YAML_LINE_WIDTH))
+    end
+
+    def sanitize_for_yaml(obj)
+      case obj
+      when Hash
+        obj.transform_values { |v| sanitize_for_yaml(v) }
+      when Array
+        obj.map { |v| sanitize_for_yaml(v) }
+      when BigDecimal
+        obj.to_f
+      else
+        obj
+      end
     end
 
     # ── Factions ──────────────────────────────────────────────
@@ -345,6 +363,22 @@ module Grid
         h
       end.compact
       write_yaml("breach_encounters.yml", {"breach_encounters" => encounters})
+    end
+
+    # ── Starting Rooms ───────────────────────────────────────────
+
+    def export_starting_rooms
+      rooms = GridStartingRoom.includes(:grid_room).order(:position, :name).map do |sr|
+        next unless sr.grid_room&.slug
+        {
+          "room_slug" => sr.grid_room.slug,
+          "name" => sr.name,
+          "blurb" => sr.blurb,
+          "position" => sr.position,
+          "active" => sr.active
+        }
+      end.compact
+      write_yaml("starting_rooms.yml", {"starting_rooms" => rooms})
     end
   end
 end

--- a/app/views/admin/grid_starting_rooms/_form.html.erb
+++ b/app/views/admin/grid_starting_rooms/_form.html.erb
@@ -1,0 +1,66 @@
+<%= render "admin/shared/combobox" %>
+
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px; max-width: 700px;">
+  <div style="margin-bottom: 15px;">
+    <label for="grid_starting_room_name" class="white-text">Name</label>
+    <%= f.text_field :name, class: "tui-input white-text full-width", style: "width: 100%;" %>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">Room</label>
+    <input type="hidden" name="grid_starting_room[grid_room_id]" id="room-cb-hidden" value="<%= f.object.grid_room_id %>">
+    <div class="admin-combobox">
+      <input type="text" id="room-cb-input" class="admin-combobox-input<%= ' selected' if f.object.grid_room_id.present? %>" autocomplete="off"
+        placeholder="Type to search rooms..."
+        value="<%= "#{f.object.grid_room&.grid_zone&.grid_region&.name} / #{f.object.grid_room&.grid_zone&.name} / #{f.object.grid_room&.name}" if f.object.grid_room_id.present? %>">
+      <div id="room-cb-dropdown" class="admin-combobox-dropdown"></div>
+    </div>
+    <p style="color: #666; margin-top: 4px; font-size: 0.85em;" id="room-cb-status">
+      <%= @rooms.size %> rooms
+    </p>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <label for="grid_starting_room_blurb" class="white-text">Blurb</label>
+    <p style="color: #6b7280; font-size: 0.85em; margin: 2px 0 6px;">Shown to hackrs when choosing their starting location after tutorial.</p>
+    <%= f.text_area :blurb, class: "tui-input white-text full-width", style: "width: 100%; min-height: 100px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div>
+      <label for="grid_starting_room_position" class="white-text">Position</label>
+      <%= f.number_field :position, class: "tui-input white-text", style: "width: 80px;" %>
+    </div>
+
+    <div style="display: flex; align-items: center; gap: 8px; padding-top: 20px;">
+      <%= f.check_box :active, class: "tui-checkbox" %>
+      <label for="grid_starting_room_active" class="white-text">Active</label>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit(f.object.persisted? ? "Update" : "Create", class: "tui-button green-168") %>
+    <%= link_to "Cancel", admin_grid_starting_rooms_path, class: "tui-button", style: "margin-left: 10px;" %>
+  </div>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  AdminCombobox.init({
+    inputId: 'room-cb-input',
+    hiddenId: 'room-cb-hidden',
+    dropdownId: 'room-cb-dropdown',
+    statusId: 'room-cb-status',
+    formId: '<%= f.object.persisted? ? "edit_grid_starting_room_#{f.object.id}" : "new_grid_starting_room" %>',
+    items: <%= raw @rooms.map { |r| { id: r.id, name: r.name, zone_name: r.grid_zone&.name, region_name: r.grid_zone&.grid_region&.name || "Unknown", room_type: r.room_type } }.to_json %>,
+    getSearchText: function(r) { return (r.name + ' ' + r.zone_name + ' ' + r.region_name + ' ' + r.room_type).toLowerCase(); },
+    getGroupKey: function(r) { return r.region_name + ' / ' + r.zone_name; },
+    renderOption: function(r, e) {
+      return '<span class="cb-name">' + e(r.name) + '</span> <span class="cb-meta">' + e(r.room_type) + '</span>';
+    },
+    getId: function(r) { return String(r.id); },
+    getLabel: function(r) { return r.region_name + ' / ' + r.zone_name + ' / ' + r.name; },
+    emptyText: 'No rooms match',
+    selectedText: 'Room selected',
+    submitError: 'Select a room first'
+  });
+</script>

--- a/app/views/admin/grid_starting_rooms/edit.html.erb
+++ b/app/views/admin/grid_starting_rooms/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/starting_rooms/<%= @starting_room.id %> :: EDIT STARTING ROOM</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= form_with(model: [:admin, @starting_room]) do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_starting_rooms/index.html.erb
+++ b/app/views/admin/grid_starting_rooms/index.html.erb
@@ -1,0 +1,63 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/starting_rooms :: STARTING ROOMS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin: 20px 0;">
+          <p class="green-255-text"><%= flash[:success] %></p>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+        <%= link_to "+ New Starting Room", new_admin_grid_starting_room_path, class: "tui-button green-168" %>
+      </div>
+
+      <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
+        <table class="tui-table" style="width: 100%; min-width: 800px;">
+          <thead>
+            <tr>
+              <th style="text-align: center;">Pos</th>
+              <th style="text-align: left;">Name</th>
+              <th style="text-align: left;">Room</th>
+              <th style="text-align: left;">Region</th>
+              <th style="text-align: center;">Active</th>
+              <th style="text-align: right;">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @starting_rooms.each do |sr| %>
+              <tr>
+                <td style="text-align: center; color: #6b7280;"><%= sr.position %></td>
+                <td><%= sr.name %></td>
+                <td style="color: #22d3ee;"><%= sr.grid_room.name %></td>
+                <td style="color: #a78bfa;"><%= sr.grid_room.grid_zone&.grid_region&.name %></td>
+                <td style="text-align: center;">
+                  <% if sr.active? %>
+                    <span class="green-255-text">&#10003;</span>
+                  <% else %>
+                    <span style="color: #6b7280;">&mdash;</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right; white-space: nowrap;">
+                  <%= link_to "Edit", edit_admin_grid_starting_room_path(sr), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "History", history_admin_grid_starting_room_path(sr), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                  <%= link_to "Delete", admin_grid_starting_room_path(sr), data: { turbo_method: :delete, turbo_confirm: "Delete starting room '#{sr.name}'?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <% if @starting_rooms.empty? %>
+        <p style="color: #6b7280; text-align: center; padding: 20px;">No starting rooms configured. New hackrs completing the tutorial will stay in their current room.</p>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_starting_rooms/new.html.erb
+++ b/app/views/admin/grid_starting_rooms/new.html.erb
@@ -1,0 +1,17 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/grid/starting_rooms/new :: NEW STARTING ROOM</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:error] %>
+        <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin: 20px 0;">
+          <p class="red-255-text"><%= flash[:error] %></p>
+        </div>
+      <% end %>
+
+      <%= form_with(model: [:admin, @starting_room]) do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -104,6 +104,7 @@
           <%= link_to "Mobs", admin_grid_mobs_path, class: "green-168-text" %>
           <%= link_to "Exits", admin_grid_exits_path, class: "green-168-text" %>
           <%= link_to "Map Editor", admin_grid_map_editor_region_show_path(region_id: GridRegion.first&.id || 0), class: "green-168-text" %>
+          <%= link_to "Starting Rooms", admin_grid_starting_rooms_path, class: "green-168-text" %>
           <%= link_to "Rep Log", admin_grid_reputation_events_path, class: "green-168-text" %>
           <%= link_to "Impound", admin_grid_impound_records_path, class: "green-168-text" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -523,6 +523,13 @@ Rails.application.routes.draw do
       end
     end
 
+    # Starting rooms (tutorial graduation choices)
+    resources :grid_starting_rooms, except: [:show] do
+      member do
+        get :history
+      end
+    end
+
     # Hackr Handbook (docs — full CRUD)
     resources :handbook_sections do
       member do

--- a/data/world/breach_templates.yml
+++ b/data/world/breach_templates.yml
@@ -1320,3 +1320,70 @@ breach_templates:
         health: 45
         max_health: 45
         charge_rounds: 2
+
+  # ── Tutorial (Bootloader) ──────────────────────────────────────
+
+  - slug: protocol-drill-alpha
+    name: "Protocol Drill \u03B1"
+    description: "Training simulation — protocol-only. A single TRACE protocol with low health. Destroy it to win."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 95
+    base_detection_rate: 2
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 10
+    cred_reward: 0
+    published: true
+    position: 100
+    protocol_composition:
+      - type: trace
+        count: 1
+        health: 20
+        max_health: 20
+        charge_rounds: 0
+        weakness: offensive
+
+  - slug: cipher-drill-beta
+    name: "Cipher Drill \u03B2"
+    description: "Training simulation — puzzle gate only. Solve the credential gate to win. No protocols."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 95
+    base_detection_rate: 2
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 10
+    cred_reward: 0
+    published: true
+    position: 101
+    protocol_composition: []
+    puzzle_gates:
+      - id: A
+        type: credential
+        difficulty: 1
+
+  - slug: combined-drill-gamma
+    name: "Combined Drill \u03B3"
+    description: "Training simulation — mixed. One protocol and one puzzle gate. Destroy the protocol OR solve the gate to win."
+    tier: standard
+    min_clearance: 0
+    pnr_threshold: 95
+    base_detection_rate: 3
+    cooldown_min: 0
+    cooldown_max: 0
+    xp_reward: 15
+    cred_reward: 0
+    published: true
+    position: 102
+    protocol_composition:
+      - type: feedback
+        count: 1
+        health: 25
+        max_health: 25
+        charge_rounds: 0
+        weakness: defensive
+    puzzle_gates:
+      - id: A
+        type: sequence
+        difficulty: 1

--- a/data/world/item_definitions.yml
+++ b/data/world/item_definitions.yml
@@ -830,3 +830,103 @@ item_definitions:
     rarity: ultra_rare
     value: 5000
     properties: {}
+
+  # ── Tutorial Items (Bootloader) ────────────────────────────────
+  - slug: training-stim-pack
+    name: Training Stim Pack
+    description: "A simulated health restoration pack. Demonstrates consumable item usage."
+    item_type: consumable
+    rarity: common
+    value: 0
+    max_stack: 5
+    properties:
+      effect_type: heal
+      amount: 20
+
+  - slug: training-probe
+    name: Training Probe
+    description: "Simulated offensive software. Targets hostile protocols during BREACH encounters."
+    item_type: software
+    rarity: common
+    value: 0
+    properties:
+      software_category: offensive
+      damage: 25
+      battery_cost: 5
+
+  - slug: training-shield
+    name: Training Shield
+    description: "Simulated defensive software. Provides protection during BREACH encounters."
+    item_type: software
+    rarity: common
+    value: 0
+    properties:
+      software_category: defensive
+      damage: 15
+      battery_cost: 3
+
+  - slug: training-power-bank
+    name: Training Power Bank
+    description: "A simulated DECK power cell. Restores battery charge."
+    item_type: consumable
+    rarity: common
+    value: 0
+    max_stack: 3
+    properties:
+      effect_type: deck_recharge
+      amount: 50
+
+  - slug: training-scrap
+    name: Training Scrap
+    description: "Simulated salvageable material. Break it down for components."
+    item_type: material
+    rarity: scrap
+    value: 0
+    max_stack: 10
+
+  - slug: training-alloy
+    name: Recycled Training Alloy
+    description: "Simulated refined material recovered from salvage."
+    item_type: material
+    rarity: common
+    value: 0
+    max_stack: 10
+
+  - slug: training-circuit
+    name: Training Circuit
+    description: "A simulated circuit board. Crafting ingredient."
+    item_type: material
+    rarity: common
+    value: 0
+    max_stack: 10
+
+  - slug: training-tool-kit
+    name: Training Tool Kit
+    description: "A basic simulated tool kit. Demonstrates crafting output."
+    item_type: tool
+    rarity: common
+    value: 5
+
+  - slug: training-data-chip
+    name: Training Data Chip
+    description: "A simulated data chip. Practice buying and selling."
+    item_type: data
+    rarity: common
+    value: 10
+    max_stack: 5
+
+  - slug: training-deck
+    name: Training Deck
+    description: "A simulated hacking deck for Bootloader training. Cannot be used outside the training environment."
+    item_type: gear
+    rarity: common
+    value: 0
+    max_stack: 1
+    properties:
+      slot: deck
+      required_clearance: 0
+      slot_count: 4
+      battery_max: 64
+      battery_current: 64
+      module_slot_count: 1
+      effects: {}

--- a/data/world/regions.yml
+++ b/data/world/regions.yml
@@ -63,3 +63,7 @@ regions:
   - name: The Hollows
     slug: the-hollows
     description: "Ancient mountain ridges folded tight around deep valleys where mist pools and signal dies — a region of coal seams, abandoned mines, and communities that GovCorp's RIDE infrastructure has never fully reached."
+
+  - name: Bootloader
+    slug: bootloader
+    description: "Fracture Network VR training simulation. A sandboxed environment for orienting new operatives before deployment to THE PULSE GRID."

--- a/data/world/salvage_yields.yml
+++ b/data/world/salvage_yields.yml
@@ -75,3 +75,14 @@ salvage_yields:
     output_slug: scrap-wire-bundle
     quantity: 4
     position: 0
+
+  # ── Tutorial ───────────────────────────────────────────────────
+  - source_slug: training-scrap
+    output_slug: training-alloy
+    quantity: 1
+    position: 0
+
+  - source_slug: training-scrap
+    output_slug: training-circuit
+    quantity: 1
+    position: 1

--- a/data/world/schematics.yml
+++ b/data/world/schematics.yml
@@ -531,3 +531,21 @@ schematics:
       - input_slug: alloy-plate
         quantity: 10
         position: 2
+
+  # ── Tutorial ───────────────────────────────────────────────────
+  - slug: fab-training-tool-kit
+    name: Fabricate Training Tool Kit
+    description: "Assemble a basic tool kit from training materials."
+    output_slug: training-tool-kit
+    output_quantity: 1
+    xp_reward: 5
+    required_clearance: 0
+    published: true
+    position: 500
+    ingredients:
+      - input_slug: training-alloy
+        quantity: 1
+        position: 0
+      - input_slug: training-circuit
+        quantity: 1
+        position: 1

--- a/data/world/starting_rooms.yml
+++ b/data/world/starting_rooms.yml
@@ -1,0 +1,9 @@
+---
+starting_rooms:
+- room_slug: bus-stop
+  name: The Lakeshore Bus Stop
+  blurb: >-
+    Right in the middle of The Lakeshore. Starting here allows you to navigate just about anywhere in the region...if you
+    have the CRED.
+  position: 1
+  active: true

--- a/data/world/transit_types.yml
+++ b/data/world/transit_types.yml
@@ -113,3 +113,24 @@ transit_types:
     min_clearance: 15
     published: true
     position: 11
+
+  # ── Tutorial Transit Types ─────────────────────────────────────
+  - slug: training-shuttle
+    name: "Training Shuttle"
+    category: public
+    description: "Simulated public transit for Bootloader training. No fare."
+    icon_key: TRAIN
+    base_fare: 0
+    min_clearance: 0
+    published: true
+    position: 100
+
+  - slug: training-taxi
+    name: "Training Taxi"
+    category: private
+    description: "Simulated private transit for Bootloader training. No fare."
+    icon_key: TAXI
+    base_fare: 0
+    min_clearance: 0
+    published: true
+    position: 101

--- a/data/world/tutorial.yml
+++ b/data/world/tutorial.yml
@@ -1,0 +1,454 @@
+# Tutorial (Bootloader) World Data
+# Loaded by: rails data:tutorial (after regions, zones, item_definitions, breach_templates, transit_types)
+# Creates rooms, exits, mobs, breach encounters, transit routes, and shop listings
+# for the Bootloader tutorial region.
+
+rooms:
+  # ── Training Core ──────────────────────────────────────────────
+  - slug: bl-hub
+    name: "Bootloader Hub"
+    description: "A clean, minimalist VR space. Grid lines pulse faintly along the walls. Status readouts scroll across floating panels. This is the Fracture Network's training simulation — everything here is controlled, sandboxed, safe. Four corridors branch outward."
+    room_type: hub
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-corridor-north
+    name: "North Corridor"
+    description: "A featureless corridor stretching north. The grid lines here are dimmer — this section of the sim hasn't been fully rendered. Practice navigation space."
+    room_type: standard
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-observation-deck
+    name: "Observation Deck"
+    description: "A panoramic viewport showing a wireframe representation of THE PULSE GRID — cities rendered as glowing node clusters connected by transit lines. Regions pulse with data traffic. The real thing is bigger, messier, and far more dangerous than this clean visualization suggests."
+    room_type: standard
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-equipment-locker
+    name: "Equipment Locker"
+    description: "A supply alcove with reinforced shelving. Training consumables are stocked here for new operatives. Take what you need."
+    room_type: standard
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-interface-chamber
+    name: "Interface Chamber"
+    description: "A circular room with embedded data terminals. AXIOM, the training coordinator, stands at the center console. This is where you learn to interact with the Grid's inhabitants."
+    room_type: standard
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-deck-lab
+    name: "DECK Lab"
+    description: "Workbenches lined with disassembled DECK units and diagnostic equipment. Software cartridges are racked along the far wall. PATCH manages equipment issue from here."
+    room_type: standard
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  - slug: bl-repair-bay
+    name: "Repair Bay"
+    description: "An automated repair station. Diagnostic arms hang from the ceiling, ready to service damaged DECKs. In the real Grid, this costs CRED. Here, training covers the bill."
+    room_type: repair_service
+    zone_slug: bootloader-training-core
+    min_clearance: 0
+
+  # ── Combat Arena ───────────────────────────────────────────────
+  - slug: bl-arena-lobby
+    name: "Arena Lobby"
+    description: "A staging area with three sealed simulation chambers visible through reinforced glass. Status boards show BREACH difficulty ratings. Each chamber tests a different combat discipline."
+    room_type: standard
+    zone_slug: bootloader-combat-arena
+    min_clearance: 0
+
+  - slug: bl-arena-alpha
+    name: "Simulation Chamber \u03B1"
+    description: "PROTOCOL DRILL. A bare combat space with a single protocol target. Destroy the hostile protocol using your loaded software. Use 'exec' to attack and 'analyze' to identify weaknesses."
+    room_type: standard
+    zone_slug: bootloader-combat-arena
+    min_clearance: 0
+
+  - slug: bl-arena-beta
+    name: "Simulation Chamber \u03B2"
+    description: "CIPHER DRILL. A puzzle chamber with a single circumvention gate. Solve the puzzle to bypass the system. Use 'interface' to attempt solutions."
+    room_type: standard
+    zone_slug: bootloader-combat-arena
+    min_clearance: 0
+
+  - slug: bl-arena-gamma
+    name: "Simulation Chamber \u03B3"
+    description: "COMBINED DRILL. Mixed encounter — both protocols and puzzle gates. Either destroy all protocols OR solve all gates to win. Two paths to victory."
+    room_type: standard
+    zone_slug: bootloader-combat-arena
+    min_clearance: 0
+
+  - slug: bl-arena-debrief
+    name: "Debrief Room"
+    description: "A post-combat assessment area. Supply crates along the wall contain DECK maintenance equipment. A readout displays your BREACH performance metrics."
+    room_type: standard
+    zone_slug: bootloader-combat-arena
+    min_clearance: 0
+
+  # ── Supply Wing ────────────────────────────────────────────────
+  - slug: bl-supply-depot
+    name: "Supply Depot"
+    description: "A simulated vendor stall. VECTOR manages the supply cache. All prices are zeroed for training — in the real Grid, everything costs CRED."
+    room_type: shop
+    zone_slug: bootloader-supply-wing
+    min_clearance: 0
+
+  - slug: bl-salvage-workshop
+    name: "Salvage Workshop"
+    description: "A workbench with cutting tools and sorting bins. Salvaging breaks items into raw materials that can be used for fabrication. Analyze items first to preview yields."
+    room_type: standard
+    zone_slug: bootloader-supply-wing
+    min_clearance: 0
+
+  - slug: bl-fabrication-terminal
+    name: "Fabrication Terminal"
+    description: "An automated assembly station. Feed it materials and a schematic, and it produces finished items. Check available schematics to see what you can build."
+    room_type: standard
+    zone_slug: bootloader-supply-wing
+    min_clearance: 0
+
+  # ── Transit Ring ───────────────────────────────────────────────
+  - slug: bl-transit-hub
+    name: "Transit Hub"
+    description: "A transit platform with route displays and boarding gates. The Training Shuttle runs a loop through the ring. Private transit is also available from any transit point."
+    room_type: transit
+    zone_slug: bootloader-transit-ring
+    min_clearance: 0
+
+  - slug: bl-transit-stop-a
+    name: "Relay Point A"
+    description: "A transit stop along the training ring. Route displays show the current shuttle position."
+    room_type: transit
+    zone_slug: bootloader-transit-ring
+    min_clearance: 0
+
+  - slug: bl-transit-stop-b
+    name: "Relay Point B"
+    description: "End of the public shuttle line. Private transit options are available from here to reach other transit points."
+    room_type: transit
+    zone_slug: bootloader-transit-ring
+    min_clearance: 0
+
+  - slug: bl-transit-stop-c
+    name: "Relay Point C"
+    description: "A private transit destination. Reachable via private vehicle from other transit stops."
+    room_type: transit
+    zone_slug: bootloader-transit-ring
+    min_clearance: 0
+
+  # ── Systems Wing ───────────────────────────────────────────────
+  - slug: bl-systems-lab
+    name: "Systems Lab"
+    description: "A diagnostics bay with rig testing equipment. Your mining rig was provisioned during registration — this is where you learn to manage it. Component slots, power, and activation."
+    room_type: standard
+    zone_slug: bootloader-systems-wing
+    min_clearance: 0
+
+  - slug: bl-graduation-chamber
+    name: "Graduation Chamber"
+    description: "The exit point. A deployment terminal dominates the room — choose your starting zone and step into THE PULSE GRID for real."
+    room_type: standard
+    zone_slug: bootloader-systems-wing
+    min_clearance: 0
+
+exits:
+  # ── Hub connections ────────────────────────────────────────────
+  - from: bl-hub
+    direction: north
+    to: bl-corridor-north
+  - from: bl-corridor-north
+    direction: south
+    to: bl-hub
+
+  - from: bl-hub
+    direction: west
+    to: bl-observation-deck
+  - from: bl-observation-deck
+    direction: east
+    to: bl-hub
+
+  - from: bl-hub
+    direction: east
+    to: bl-equipment-locker
+  - from: bl-equipment-locker
+    direction: west
+    to: bl-hub
+
+  - from: bl-hub
+    direction: south
+    to: bl-interface-chamber
+  - from: bl-interface-chamber
+    direction: north
+    to: bl-hub
+
+  # ── Training Core flow ────────────────────────────────────────
+  - from: bl-interface-chamber
+    direction: south
+    to: bl-deck-lab
+  - from: bl-deck-lab
+    direction: north
+    to: bl-interface-chamber
+
+  - from: bl-deck-lab
+    direction: east
+    to: bl-repair-bay
+  - from: bl-repair-bay
+    direction: west
+    to: bl-deck-lab
+
+  # ── Arena connections ──────────────────────────────────────────
+  - from: bl-deck-lab
+    direction: south
+    to: bl-arena-lobby
+  - from: bl-arena-lobby
+    direction: north
+    to: bl-deck-lab
+
+  - from: bl-arena-lobby
+    direction: northeast
+    to: bl-arena-alpha
+  - from: bl-arena-alpha
+    direction: southwest
+    to: bl-arena-lobby
+
+  - from: bl-arena-lobby
+    direction: east
+    to: bl-arena-beta
+  - from: bl-arena-beta
+    direction: west
+    to: bl-arena-lobby
+
+  - from: bl-arena-lobby
+    direction: southeast
+    to: bl-arena-gamma
+  - from: bl-arena-gamma
+    direction: northwest
+    to: bl-arena-lobby
+
+  - from: bl-arena-lobby
+    direction: south
+    to: bl-arena-debrief
+  - from: bl-arena-debrief
+    direction: north
+    to: bl-arena-lobby
+
+  # ── Supply Wing connections ────────────────────────────────────
+  - from: bl-arena-debrief
+    direction: south
+    to: bl-supply-depot
+  - from: bl-supply-depot
+    direction: north
+    to: bl-arena-debrief
+
+  - from: bl-supply-depot
+    direction: east
+    to: bl-salvage-workshop
+  - from: bl-salvage-workshop
+    direction: west
+    to: bl-supply-depot
+
+  - from: bl-salvage-workshop
+    direction: east
+    to: bl-fabrication-terminal
+  - from: bl-fabrication-terminal
+    direction: west
+    to: bl-salvage-workshop
+
+  # ── Transit Ring connections ───────────────────────────────────
+  - from: bl-supply-depot
+    direction: south
+    to: bl-transit-hub
+  - from: bl-transit-hub
+    direction: north
+    to: bl-supply-depot
+
+  # Transit stops have walking fallback back to hub
+  - from: bl-transit-stop-a
+    direction: south
+    to: bl-transit-hub
+  - from: bl-transit-hub
+    direction: east
+    to: bl-transit-stop-a
+
+  # Stop B connects to Systems Wing
+  - from: bl-transit-stop-b
+    direction: south
+    to: bl-systems-lab
+
+  # Stop C connects to Systems Wing
+  - from: bl-transit-stop-c
+    direction: south
+    to: bl-systems-lab
+  - from: bl-transit-stop-c
+    direction: west
+    to: bl-transit-stop-b
+  - from: bl-transit-stop-b
+    direction: east
+    to: bl-transit-stop-c
+
+  - from: bl-systems-lab
+    direction: north
+    to: bl-transit-stop-b
+
+  # ── Systems Wing connections ───────────────────────────────────
+  - from: bl-systems-lab
+    direction: south
+    to: bl-graduation-chamber
+  - from: bl-graduation-chamber
+    direction: north
+    to: bl-systems-lab
+
+mobs:
+  - name: AXIOM
+    slug: bl-axiom
+    mob_type: quest_giver
+    description: "A holographic instructor with sharp geometric features. Its voice is calm, precise, and slightly condescending in the way all training AIs are."
+    room_slug: bl-interface-chamber
+    dialogue_tree:
+      greeting: "Welcome, operative. I am AXIOM — your training coordinator. Ask me about any topic."
+      topics:
+        training:
+          response: "This simulation covers all core systems: navigation, DECK operations, BREACH combat, economy, transit, and rig management. Complete each module to deploy to the live Grid."
+          topics:
+            breaching:
+              response: "BREACHing is how you penetrate network nodes. Load software onto your DECK, find a target, and initiate. Destroy protocols or solve puzzle gates to win. Watch the detection meter."
+            economy:
+              response: "The Grid runs on CRED — a fixed-supply cryptocurrency. You earn it through mining (your rig), completing missions, and salvaging. You spend it at vendors and repair services."
+            factions:
+              response: "THE PULSE GRID is contested between the Fracture Network and GovCorp. Your actions build reputation with different factions, unlocking access and opportunities."
+        the-grid:
+          response: "THE PULSE GRID is a decentralized network spanning multiple geographic regions. Each region has zones with different danger levels, factions, and resources. The Grid is always watching."
+        fracture:
+          response: "The Fracture Network is a decentralized resistance movement operating within THE PULSE GRID. You're one of us now. We believe information should be free — GovCorp disagrees."
+        govcorp:
+          response: "GovCorp controls the RIDE infrastructure — the augmented reality layer that defines modern life. They see everything. Their RAINN division runs automated network defense. Get caught breaching and you'll see their Perception Alignment Centers firsthand."
+
+  - name: PATCH
+    slug: bl-patch
+    mob_type: quest_giver
+    description: "A technician in a worn utility vest, surrounded by DECK components and diagnostic readouts. Grease-stained hands, sharp eyes."
+    room_slug: bl-deck-lab
+    dialogue_tree:
+      greeting: "PATCH here. DECK specialist. Your equipment's ready — let's get you wired up."
+      topics:
+        decks:
+          response: "A DECK is your primary tool. It loads software, stores battery power, and connects you to the network for BREACH operations. Keep it charged and don't let it get fried."
+        software:
+          response: "Software comes in categories — offensive damages protocols, defensive protects you, utility does everything else. Load what you need before a BREACH."
+        fried:
+          response: "When a BREACH goes bad — detection overflow on an advanced+ target — your DECK can get fried. Damaged DECKs can't initiate BREACHes. Fix them at repair services or with Repair Kits."
+
+  - name: VECTOR
+    slug: bl-vector
+    mob_type: vendor
+    description: "An efficient supply clerk behind a clean counter. Everything is catalogued, labeled, and free — for training purposes only."
+    room_slug: bl-supply-depot
+    vendor_config:
+      shop_type: standard
+    dialogue_tree:
+      greeting: "VECTOR, supply logistics. Everything here is complimentary — training budget. Out in the Grid, you'll need CRED."
+      topics:
+        cred:
+          response: "CRED is mined, earned, or salvaged. Your mining rig generates it passively while you're active. Missions pay out. Salvaging junk produces materials you can sell or craft with."
+        prices:
+          response: "Real-world prices vary. Basic items are cheap. Rare gear can cost thousands. Black market vendors have the best stuff but charge premium prices."
+
+  - name: FORGE
+    slug: bl-forge
+    mob_type: quest_giver
+    description: "A burly mechanic with circuit-tattoo sleeves. Rig components are spread across the workbench in front of them."
+    room_slug: bl-systems-lab
+    dialogue_tree:
+      greeting: "FORGE. Rig specialist. Let's talk hardware."
+      topics:
+        rigs:
+          response: "Your mining rig generates CRED while you're active on the Grid. It needs a motherboard, PSU, CPU, GPU, and RAM to function. Better components = better mining rate."
+        components:
+          response: "Components go in slots. The motherboard defines slot capacity. You can upgrade by swapping in better components — but the rig must be offline first, and you must be in your den."
+        mining:
+          response: "Mining rate depends on your total component multipliers. The network halves the base rate periodically — better gear keeps you competitive. Watch hackr.tv streams for a mining bonus."
+
+breach_encounters:
+  - template_slug: protocol-drill-alpha
+    room_slug: bl-arena-alpha
+    state: available
+
+  - template_slug: cipher-drill-beta
+    room_slug: bl-arena-beta
+    state: available
+
+  - template_slug: combined-drill-gamma
+    room_slug: bl-arena-gamma
+    state: available
+
+transit:
+  # Training shuttle — public route with 3 stops
+  route:
+    slug: bootloader-shuttle
+    name: "Training Shuttle"
+    transit_type_slug: training-shuttle
+    region_slug: bootloader
+    active: true
+    loop_route: false
+    position: 100
+    stops:
+      - room_slug: bl-transit-hub
+        label: "Transit Hub"
+        position: 0
+      - room_slug: bl-transit-stop-a
+        label: "Relay Point A"
+        position: 1
+      - room_slug: bl-transit-stop-b
+        label: "Relay Point B"
+        position: 2
+        is_terminus: true
+
+  # Private transit — taxi available from all transit rooms
+  private_route:
+    slug: bootloader-taxi
+    name: "Training Taxi"
+    transit_type_slug: training-taxi
+    region_slug: bootloader
+    active: true
+    loop_route: false
+    position: 101
+    stops:
+      - room_slug: bl-transit-hub
+        label: "Transit Hub"
+        position: 0
+      - room_slug: bl-transit-stop-a
+        label: "Relay Point A"
+        position: 1
+      - room_slug: bl-transit-stop-b
+        label: "Relay Point B"
+        position: 2
+      - room_slug: bl-transit-stop-c
+        label: "Relay Point C"
+        position: 3
+
+shop_listings:
+  vendor_name: VECTOR
+  room_slug: bl-supply-depot
+  listings:
+    - definition_slug: training-data-chip
+      base_price: 0
+      sell_price: 0
+      stock: 3
+      max_stock: 3
+      min_clearance: 0
+      active: true
+      position: 0
+
+    - definition_slug: training-stim-pack
+      base_price: 0
+      sell_price: 0
+      stock: 3
+      max_stock: 3
+      min_clearance: 0
+      active: true
+      position: 1

--- a/data/world/zones.yml
+++ b/data/world/zones.yml
@@ -1092,3 +1092,39 @@ zones:
     faction_slug: null
     danger_level: 0
 
+  # ── Bootloader (Tutorial) ─────────────────────────────────────────
+  - name: "Training Core"
+    slug: bootloader-training-core
+    description: "Primary VR training module. Navigation, interface, DECK, and combat systems."
+    region_slug: bootloader
+    faction_slug: null
+    danger_level: 0
+
+  - name: "Combat Arena"
+    slug: bootloader-combat-arena
+    description: "BREACH simulation chambers for combat training."
+    region_slug: bootloader
+    faction_slug: null
+    danger_level: 0
+
+  - name: "Supply Wing"
+    slug: bootloader-supply-wing
+    description: "Economy and supply chain training. Shops, salvage, fabrication."
+    region_slug: bootloader
+    faction_slug: null
+    danger_level: 0
+
+  - name: "Transit Ring"
+    slug: bootloader-transit-ring
+    description: "Public and private transit training network."
+    region_slug: bootloader
+    faction_slug: null
+    danger_level: 0
+
+  - name: "Systems Wing"
+    slug: bootloader-systems-wing
+    description: "System diagnostics and rig management training."
+    region_slug: bootloader
+    faction_slug: null
+    danger_level: 0
+

--- a/db/migrate/20260507210000_create_grid_starting_rooms.rb
+++ b/db/migrate/20260507210000_create_grid_starting_rooms.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGridStartingRooms < ActiveRecord::Migration[8.0]
+  def change
+    create_table :grid_starting_rooms do |t|
+      t.references :grid_room, null: false, foreign_key: {on_delete: :cascade}, index: {unique: true}
+      t.string :name, null: false
+      t.text :blurb, null: false
+      t.integer :position, null: false, default: 0
+      t.boolean :active, null: false, default: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_210000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -754,6 +754,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_200000) do
     t.index ["slug"], name: "index_grid_slipstream_routes_on_slug", unique: true
   end
 
+  create_table "grid_starting_rooms", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.text "blurb", null: false
+    t.datetime "created_at", null: false
+    t.integer "grid_room_id", null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_room_id"], name: "index_grid_starting_rooms_on_grid_room_id", unique: true
+  end
+
   create_table "grid_transactions", force: :cascade do |t|
     t.integer "amount", null: false
     t.datetime "created_at", null: false
@@ -1406,6 +1417,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_200000) do
   add_foreign_key "grid_slipstream_routes", "grid_regions", column: "origin_region_id", on_delete: :restrict
   add_foreign_key "grid_slipstream_routes", "grid_rooms", column: "destination_room_id", on_delete: :restrict
   add_foreign_key "grid_slipstream_routes", "grid_rooms", column: "origin_room_id", on_delete: :restrict
+  add_foreign_key "grid_starting_rooms", "grid_rooms", on_delete: :cascade
   add_foreign_key "grid_transit_journeys", "grid_hackrs", on_delete: :cascade
   add_foreign_key "grid_transit_journeys", "grid_rooms", column: "destination_room_id", on_delete: :nullify
   add_foreign_key "grid_transit_journeys", "grid_rooms", column: "origin_room_id", on_delete: :nullify

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -206,7 +206,7 @@ namespace :data do
   desc "Load world data (factions, regions, zones, rooms, etc.)"
   task world: :environment do
     guard_world_seed!
-    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities transit_types slipstream_routes].each do |t|
+    %i[factions regions zones rooms exits mobs item_definitions salvage_yields items achievements shop_listings missions schematics breach_templates breach_encounters pac_facilities transit_types slipstream_routes tutorial starting_rooms].each do |t|
       Rake::Task["data:#{t}"].invoke
     end
   end
@@ -2603,6 +2603,226 @@ namespace :data do
     end
 
     puts "Schematics: #{created} created, #{GridSchematic.count} total"
+  end
+
+  desc "Load tutorial (Bootloader) world data"
+  task tutorial: :environment do
+    guard_world_seed!
+    puts "\n--- Loading Tutorial (Bootloader) ---"
+    yaml_file = Rails.root.join("data", "world", "tutorial.yml")
+    next unless File.exist?(yaml_file)
+
+    data = YAML.load_file(yaml_file)
+    zone_map = GridZone.all.index_by(&:slug)
+    room_map = GridRoom.all.index_by(&:slug)
+
+    # --- Rooms ---
+    rooms_created = 0
+    (data["rooms"] || []).each do |attrs|
+      zone = zone_map[attrs["zone_slug"]]
+      next unless zone
+
+      room = GridRoom.find_or_initialize_by(slug: attrs["slug"])
+      next unless room.new_record?
+
+      room.assign_attributes(
+        name: attrs["name"],
+        description: attrs["description"],
+        room_type: attrs["room_type"] || "standard",
+        min_clearance: attrs["min_clearance"] || 0,
+        grid_zone: zone
+      )
+      room.save!
+      room_map[room.slug] = room
+      rooms_created += 1
+      puts "  ✓ Room: #{room.name}"
+    end
+
+    # --- Exits ---
+    exits_created = 0
+    (data["exits"] || []).each do |attrs|
+      from_room = room_map[attrs["from"]]
+      to_room = room_map[attrs["to"]]
+      next unless from_room && to_room
+
+      ex = GridExit.find_or_initialize_by(from_room: from_room, direction: attrs["direction"])
+      next unless ex.new_record?
+
+      ex.to_room = to_room
+      ex.save!
+      exits_created += 1
+    end
+
+    # --- Mobs ---
+    mobs_created = 0
+    (data["mobs"] || []).each do |attrs|
+      room = room_map[attrs["room_slug"]]
+      next unless room
+
+      mob = GridMob.find_or_initialize_by(name: attrs["name"], grid_room: room)
+      next unless mob.new_record?
+
+      mob.assign_attributes(
+        mob_type: attrs["mob_type"],
+        description: attrs["description"],
+        dialogue_tree: attrs["dialogue_tree"],
+        vendor_config: attrs["vendor_config"]
+      )
+      mob.save!
+      mobs_created += 1
+      puts "  ✓ Mob: #{mob.name}"
+    end
+
+    # --- Breach Encounters ---
+    encounters_created = 0
+    (data["breach_encounters"] || []).each do |attrs|
+      template = GridBreachTemplate.find_by(slug: attrs["template_slug"])
+      room = room_map[attrs["room_slug"]]
+      next unless template && room
+
+      enc = GridBreachEncounter.find_or_initialize_by(
+        grid_breach_template: template, grid_room: room
+      )
+      next unless enc.new_record?
+
+      enc.state = attrs["state"] || "available"
+      enc.save!
+      encounters_created += 1
+      puts "  ✓ Encounter: #{template.name} @ #{room.name}"
+    end
+
+    # --- Transit Route ---
+    routes_created = 0
+    if (route_data = data.dig("transit", "route"))
+      type = GridTransitType.find_by(slug: route_data["transit_type_slug"])
+      region = GridRegion.find_by(slug: route_data["region_slug"])
+      if type && region
+        route = GridTransitRoute.find_or_initialize_by(slug: route_data["slug"])
+        if route.new_record?
+          route.assign_attributes(
+            name: route_data["name"],
+            grid_transit_type: type,
+            grid_region: region,
+            active: route_data["active"],
+            loop_route: route_data["loop_route"] || false,
+            position: route_data["position"] || 0
+          )
+          route.save!
+          routes_created += 1
+
+          (route_data["stops"] || []).each do |stop_attrs|
+            stop_room = room_map[stop_attrs["room_slug"]]
+            next unless stop_room
+
+            route.grid_transit_stops.create!(
+              grid_room: stop_room,
+              label: stop_attrs["label"],
+              position: stop_attrs["position"],
+              is_terminus: stop_attrs["is_terminus"] || false
+            )
+          end
+          puts "  ✓ Route: #{route.name} (#{route.grid_transit_stops.count} stops)"
+        end
+      end
+    end
+
+    # --- Private Transit Route ---
+    if (private_data = data.dig("transit", "private_route"))
+      type = GridTransitType.find_by(slug: private_data["transit_type_slug"])
+      region = GridRegion.find_by(slug: private_data["region_slug"])
+      if type && region
+        route = GridTransitRoute.find_or_initialize_by(slug: private_data["slug"])
+        if route.new_record?
+          route.assign_attributes(
+            name: private_data["name"],
+            grid_transit_type: type,
+            grid_region: region,
+            active: private_data["active"],
+            loop_route: private_data["loop_route"] || false,
+            position: private_data["position"] || 0
+          )
+          route.save!
+          routes_created += 1
+
+          (private_data["stops"] || []).each do |stop_attrs|
+            stop_room = room_map[stop_attrs["room_slug"]]
+            next unless stop_room
+
+            route.grid_transit_stops.create!(
+              grid_room: stop_room,
+              label: stop_attrs["label"],
+              position: stop_attrs["position"],
+              is_terminus: stop_attrs["is_terminus"] || false
+            )
+          end
+          puts "  ✓ Route: #{route.name} (#{route.grid_transit_stops.count} stops)"
+        end
+      end
+    end
+
+    # --- Shop Listings ---
+    listings_created = 0
+    if (shop_data = data["shop_listings"])
+      shop_room = room_map[shop_data["room_slug"]]
+      vendor = shop_room && GridMob.find_by(name: shop_data["vendor_name"], grid_room: shop_room)
+      if vendor
+        (shop_data["listings"] || []).each do |listing_attrs|
+          defn = GridItemDefinition.find_by(slug: listing_attrs["definition_slug"])
+          next unless defn
+
+          listing = GridShopListing.find_or_initialize_by(
+            grid_mob: vendor, grid_item_definition: defn
+          )
+          next unless listing.new_record?
+
+          listing.assign_attributes(
+            base_price: listing_attrs["base_price"] || 0,
+            sell_price: listing_attrs["sell_price"] || 0,
+            stock: listing_attrs["stock"] || 99,
+            max_stock: listing_attrs["max_stock"] || 99,
+            min_clearance: listing_attrs["min_clearance"] || 0,
+            active: listing_attrs.fetch("active", true)
+          )
+          listing.save!
+          listings_created += 1
+        end
+        puts "  ✓ Shop listings: #{listings_created} for #{vendor.name}"
+      end
+    end
+
+    puts "Tutorial: #{rooms_created} rooms, #{exits_created} exits, #{mobs_created} mobs, " \
+         "#{encounters_created} encounters, #{routes_created} routes, #{listings_created} listings"
+  end
+
+  desc "Load starting rooms from YAML"
+  task starting_rooms: :environment do
+    guard_world_seed!
+    puts "\n--- Loading Starting Rooms ---"
+    yaml_file = Rails.root.join("data", "world", "starting_rooms.yml")
+    next unless File.exist?(yaml_file)
+
+    data = YAML.load_file(yaml_file)
+    created = 0
+
+    (data["starting_rooms"] || []).each do |attrs|
+      room = GridRoom.find_by(slug: attrs["room_slug"])
+      next unless room
+
+      sr = GridStartingRoom.find_or_initialize_by(grid_room: room)
+      next unless sr.new_record?
+
+      sr.assign_attributes(
+        name: attrs["name"],
+        blurb: attrs["blurb"],
+        position: attrs["position"] || 0,
+        active: attrs.fetch("active", true)
+      )
+      sr.save!
+      created += 1
+      puts "  ✓ #{sr.name} → #{room.name}"
+    end
+
+    puts "Starting Rooms: #{created} created, #{GridStartingRoom.count} total"
   end
 
   # === World Export ===

--- a/lib/terminal/handlers/register_handler.rb
+++ b/lib/terminal/handlers/register_handler.rb
@@ -104,13 +104,15 @@ module Terminal
       end
 
       def create_hackr(alias_input, password)
-        # Find starting room
+        # Find starting room — Bootloader tutorial hub, fallback to hackr-tv-central
         starting_room = GridRoom.joins(:grid_zone)
+          .where(grid_zones: {slug: Grid::TutorialService::TUTORIAL_HUB_ZONE_SLUG})
+          .where(room_type: "hub")
+          .first
+        starting_room ||= GridRoom.joins(:grid_zone)
           .where(grid_zones: {slug: "hackr-tv-central"})
           .where(room_type: "hub")
           .first
-
-        # Fallback to any hub room
         starting_room ||= GridRoom.where(room_type: "hub").first
 
         hackr = GridHackr.new(
@@ -122,6 +124,8 @@ module Terminal
         )
 
         if hackr.save
+          Grid::TutorialService.new(hackr).start!
+          hackr.provision_economy!
           registration_success(hackr)
         else
           registration_failure(hackr)


### PR DESCRIPTION
* New hackrs spawn into a scripted VR training simulation ("Bootloader") that teaches every core system before deploying to THE PULSE GRID.
* 53 steps across 7 chapters:
  * Navigation
  * NPC interaction
  * DECK operations (fried DECK → repair → software loading)
  * BREACH combat (protocol-only, PCG-only, mixed)
  * Supply chain (shop/salvage/fabrication)
  * Transit (public + private)
  * Rig management.
* Skippable via hidden `code skip-tutorial` / `code complete-tutorial` commands.
* Repeatable via `code start-tutorial` (persists return room, strips training items on exit, no starting room selection on re-entry).

* TutorialCommandParser - new context parser in the execute chain (after breach/captured/transit). Delegates most commands to main parser, wraps output with chapter-tagged tutorial chrome (narrative, hints, progress bar). Intercepts: say (blocked), drop (blocked), rep (fake rich output), repair (free), buy/sell (simulated — no shared stock or CRED), rig install/uninstall (bypasses den check). Economy commands gated to their relevant tutorial steps. Step conditions use state-based checks (room reached, item obtained, stat changed, breach completed, rig state) for actions that can fail; command_used only for observational commands that can't fail. Pre-advance system detects externally-met conditions (transit arrival, breach completion) and auto-advances on next command.

* TutorialService - lifecycle management (start, complete, skip, re-enter, return-to-world). Strips all `training-*` items on exit. Grants pulse_grid feature on start, den chip on completion. Guards re-entry against BREACH/captured/transit states.

* CodeService - hidden code command (undocumented in help). Extensible registry. Added to CapturedCommandParser allowlist and TransitCommandParser passthrough.

* GridStartingRoom - admin-managed starting location choices shown at tutorial graduation. Model + migration + admin CRUD with combobox room picker + Versionable. Included in world export/import cycle.

* Bootloader world data - 1 region, 5 zones, 21 rooms, 39 exits, 4 NPCs (AXIOM/PATCH/VECTOR/FORGE with dialogue trees), 3 BREACH encounters (zero cooldown training drills), 2 transit routes (free training shuttle + taxi types), 2 shop listings, tutorial-specific item definitions (10 items including Training Deck), salvage yields, and 1 schematic.