### PR TITLE
[TPG] Partial name matching for all PULSE GRID commands

### DIFF
--- a/app/services/grid/breach_action_service.rb
+++ b/app/services/grid/breach_action_service.rb
@@ -275,9 +275,7 @@ module Grid
       raise NotInBreach, "You are not in a BREACH encounter." unless breach
       raise NoActionsRemaining, "No actions remaining this round." if breach.actions_remaining <= 0
 
-      item = @hackr.grid_items.in_inventory(@hackr)
-        .where(item_type: "consumable")
-        .find_by("LOWER(name) = ?", item_name.to_s.downcase)
+      item = Grid::NameResolver.resolve(@hackr.grid_items.in_inventory(@hackr).where(item_type: "consumable"), item_name)
       raise ItemNotFound, "No consumable named '#{item_name}' in your inventory." unless item
 
       effect_output = nil

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -43,6 +43,9 @@ module Grid
       end
 
       result.is_a?(Hash) ? result : {output: result, event: nil}
+    rescue Grid::NameResolver::AmbiguousMatch => e
+      names = e.candidates.map { |n| "'#{ERB::Util.html_escape(n)}'" }.join(", ")
+      {output: "<span style='color: #fbbf24;'>Did you mean: #{names}?</span>", event: nil}
     end
 
     private

--- a/app/services/grid/captured_command_parser.rb
+++ b/app/services/grid/captured_command_parser.rb
@@ -42,6 +42,9 @@ module Grid
       end
 
       result.is_a?(Hash) ? result : {output: result, event: nil}
+    rescue Grid::NameResolver::AmbiguousMatch => e
+      names = e.candidates.map { |n| "'#{ERB::Util.html_escape(n)}'" }.join(", ")
+      {output: "<span style='color: #fbbf24;'>Did you mean: #{names}?</span>", event: nil}
     end
 
     private
@@ -55,7 +58,7 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere.</span>" unless room
 
-      mob = room.grid_mobs.find_by("LOWER(name) = ?", mob_name.downcase)
+      mob = Grid::NameResolver.resolve(room.grid_mobs, mob_name)
       return "<span style='color: #f87171;'>You don't see '#{h(mob_name)}' here.</span>" unless mob
 
       case mob.mob_type

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -184,6 +184,8 @@ module Grid
       else
         "<span style='color: #f87171;'>Unknown command: #{h(command)}. Type 'help' for a list of commands.</span>"
       end
+    rescue Grid::NameResolver::AmbiguousMatch => e
+      ambiguous_match_error(e)
     end
 
     private
@@ -555,7 +557,7 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      item = room.grid_items.in_room(room).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(room.grid_items.in_room(room), item_name)
       return "<span style='color: #f87171;'>You don't see '#{h(item_name)}' here.</span>" unless item
 
       # Den owner-only take restriction
@@ -613,7 +615,7 @@ module Grid
       item_name = parsed.remainder
       return "<span style='color: #fbbf24;'>Drop what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       # Fixtures must be placed via the place command
@@ -674,22 +676,21 @@ module Grid
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
       # Check items in room
-      item = room.grid_items.in_room(room).find_by("LOWER(name) = ?", target.downcase)
+      item = Grid::NameResolver.resolve(room.grid_items.in_room(room), target)
       return examine_item(item) if item
 
       # Check items in inventory
-      item = hackr.grid_items.find_by("LOWER(name) = ?", target.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items, target)
       return examine_item(item) if item
 
       # Check vendor shop listings (respecting per-listing clearance gate)
       vendor = room.grid_mobs.find_by(mob_type: "vendor")
       if vendor
         clearance = hackr.stat("clearance")
-        listing = vendor.grid_shop_listings.includes(:grid_item_definition).joins(:grid_item_definition)
+        scope = vendor.grid_shop_listings.includes(:grid_item_definition).joins(:grid_item_definition)
           .where(active: true)
           .where("min_clearance <= ?", clearance)
-          .where("LOWER(grid_item_definitions.name) = ?", target.downcase)
-          .first
+        listing = Grid::NameResolver.resolve(scope, target, column: "grid_item_definitions.name")
         if listing
           price = Grid::ShopService.effective_price(listing: listing, mob: vendor, clearance: clearance)
           return examine_listing(listing, price)
@@ -697,14 +698,14 @@ module Grid
       end
 
       # Check Mobs
-      mob = room.grid_mobs.find_by("LOWER(name) = ?", target.downcase)
+      mob = Grid::NameResolver.resolve(room.grid_mobs, target)
       return "<span style='color: #d0d0d0;'>#{codex_linkify(mob.description)}</span>" if mob
 
       # Check hackrs in room (or self)
       target_hackr = if target.downcase == hackr.hackr_alias.downcase
         hackr
       else
-        room.grid_hackrs.recently_active.find_by("LOWER(hackr_alias) = ?", target.downcase)
+        Grid::NameResolver.resolve(room.grid_hackrs.recently_active, target, column: "hackr_alias")
       end
       return examine_hackr(target_hackr) if target_hackr
 
@@ -727,7 +728,7 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      mob = room.grid_mobs.find_by("LOWER(name) = ?", npc_name.downcase)
+      mob = Grid::NameResolver.resolve(room.grid_mobs, npc_name)
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
       return "<span style='color: #9ca3af;'>#{h(mob.name)} doesn't seem interested in talking.</span>" if mob.dialogue_tree.blank?
 
@@ -773,7 +774,7 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      mob = room.grid_mobs.find_by("LOWER(name) = ?", npc_name.downcase)
+      mob = Grid::NameResolver.resolve(room.grid_mobs, npc_name)
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
       return "<span style='color: #9ca3af;'>#{h(mob.name)} doesn't seem interested in talking.</span>" if mob.dialogue_tree.blank?
 
@@ -1291,9 +1292,9 @@ module Grid
     def equip_command(item_name)
       return "<span style='color: #fbbf24;'>Equip what? Usage: equip &lt;item&gt;</span>" if item_name.empty?
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       unless item
-        candidate = hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+        candidate = Grid::NameResolver.resolve(hackr.grid_items.equipped_by(hackr), item_name)
         if candidate
           return "<span style='color: #f87171;'>#{h(candidate.name)} is already equipped.</span>"
         end
@@ -1346,7 +1347,7 @@ module Grid
         return format_unequip_output(result)
       end
 
-      item = hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.equipped_by(hackr), item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}' equipped.</span>" unless item
 
       result = Grid::LoadoutService.unequip!(hackr: hackr, item: item)
@@ -1476,9 +1477,7 @@ module Grid
       deck = hackr.equipped_deck
       return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
 
-      software = hackr.grid_items.in_inventory(hackr)
-        .where(item_type: "software")
-        .find_by("LOWER(name) = ?", software_name.downcase)
+      software = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr).where(item_type: "software"), software_name)
       return "<span style='color: #f87171;'>No software named '#{h(software_name)}' in your inventory.</span>" unless software
 
       slot_cost = (software.properties&.dig("slot_cost") || 1).to_i
@@ -1507,7 +1506,7 @@ module Grid
       deck = hackr.equipped_deck
       return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
 
-      software = deck.loaded_software.find_by("LOWER(name) = ?", software_name.downcase)
+      software = Grid::NameResolver.resolve(deck.loaded_software, software_name)
       return "<span style='color: #f87171;'>No software named '#{h(software_name)}' loaded in your DECK.</span>" unless software
 
       ActiveRecord::Base.transaction do
@@ -1577,9 +1576,7 @@ module Grid
       return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
 
       # Find the module in inventory (must be unflashed OR reflash overwrites)
-      mod = hackr.grid_items.in_inventory(hackr)
-        .where(item_type: "module")
-        .find_by("LOWER(name) = ?", module_name.downcase)
+      mod = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr).where(item_type: "module"), module_name)
       return "<span style='color: #f87171;'>No module named '#{h(module_name)}' in your inventory.</span>" unless mod
 
       room = hackr.current_room
@@ -1595,13 +1592,10 @@ module Grid
       # Find firmware
       firmware = if at_vendor
         # At vendor: firmware available from vendor catalog (just need definition)
-        GridItemDefinition.where(item_type: "firmware")
-          .find_by("LOWER(name) = ?", firmware_name.downcase)
+        Grid::NameResolver.resolve(GridItemDefinition.where(item_type: "firmware"), firmware_name)
       else
         # DIY: firmware must be in inventory
-        hackr.grid_items.in_inventory(hackr)
-          .where(item_type: "firmware")
-          .find_by("LOWER(name) = ?", firmware_name.downcase)
+        Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr).where(item_type: "firmware"), firmware_name)
       end
 
       if firmware.nil?
@@ -1672,9 +1666,7 @@ module Grid
       deck = hackr.equipped_deck
       return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
 
-      mod = hackr.grid_items.in_inventory(hackr)
-        .where(item_type: "module")
-        .find_by("LOWER(name) = ?", module_name.downcase)
+      mod = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr).where(item_type: "module"), module_name)
       return "<span style='color: #f87171;'>No module named '#{h(module_name)}' in your inventory.</span>" unless mod
 
       unless mod.properties&.dig("flashed")
@@ -1712,7 +1704,7 @@ module Grid
       deck = hackr.equipped_deck
       return "<span style='color: #f87171;'>No DECK equipped.</span>" unless deck
 
-      mod = deck.installed_modules.find_by("LOWER(name) = ?", module_name.downcase)
+      mod = Grid::NameResolver.resolve(deck.installed_modules, module_name)
       return "<span style='color: #f87171;'>No module named '#{h(module_name)}' installed in your DECK.</span>" unless mod
 
       ActiveRecord::Base.transaction do
@@ -1780,9 +1772,17 @@ module Grid
       encounters.find { |enc| enc.name.downcase.include?(target.downcase) }
     end
 
+    def ambiguous_match_error(exception)
+      names = exception.candidates.map { |n| "'#{h(n)}'" }.join(", ")
+      "<span style='color: #fbbf24;'>Did you mean: #{names}?</span>"
+    end
+
     def equipped_item_hint(item_name)
-      return nil unless hackr.grid_items.equipped_by(hackr).find_by("LOWER(name) = ?", item_name.downcase)
-      "<span style='color: #f87171;'>That item is equipped. Use 'unequip #{h(item_name)}' first.</span>"
+      item = Grid::NameResolver.resolve(hackr.grid_items.equipped_by(hackr), item_name)
+      return nil unless item
+      "<span style='color: #f87171;'>That item is equipped. Use 'unequip #{h(item.name)}' first.</span>"
+    rescue Grid::NameResolver::AmbiguousMatch
+      nil
     end
 
     def format_unequip_output(result)
@@ -1809,7 +1809,7 @@ module Grid
     def use_command(item_name)
       return "<span style='color: #fbbf24;'>Use what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items, item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       saved_name = item.name
@@ -1836,7 +1836,7 @@ module Grid
       item_name = parsed.remainder
       return "<span style='color: #fbbf24;'>Salvage what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       if item.unicorn?
@@ -1891,7 +1891,7 @@ module Grid
     def analyze_command(item_name)
       return "<span style='color: #fbbf24;'>Analyze what?</span>" if item_name.empty?
 
-      item = hackr.grid_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items, item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       if item.unicorn?
@@ -1970,9 +1970,10 @@ module Grid
     def schematic_detail_command(slug)
       return "<span style='color: #fbbf24;'>Which schematic? Usage: schematic &lt;slug&gt;</span>" if slug.blank?
 
-      schematic = GridSchematic.published
-        .includes(:output_definition, ingredients: :input_definition)
-        .find_by(slug: slug.downcase)
+      schematic = Grid::NameResolver.resolve(
+        GridSchematic.published.includes(:output_definition, ingredients: :input_definition),
+        slug, column: "slug"
+      )
       return "<span style='color: #f87171;'>Unknown schematic: #{h(slug)}. Use 'schematics' to browse.</span>" unless schematic
 
       output = []
@@ -2014,9 +2015,10 @@ module Grid
     def fabricate_command(recipe_slug)
       return "<span style='color: #fbbf24;'>Fabricate what? Usage: fab &lt;schematic-slug&gt;</span>" if recipe_slug.blank?
 
-      schematic = GridSchematic.published
-        .includes(:output_definition, ingredients: :input_definition)
-        .find_by(slug: recipe_slug.downcase)
+      schematic = Grid::NameResolver.resolve(
+        GridSchematic.published.includes(:output_definition, ingredients: :input_definition),
+        recipe_slug, column: "slug"
+      )
       return "<span style='color: #f87171;'>Unknown schematic: #{h(recipe_slug)}. Use 'schematics' to browse.</span>" unless schematic
 
       unless schematic.craftable_by?(hackr, **schematic_gate_context, current_room: hackr.current_room)
@@ -2732,7 +2734,7 @@ module Grid
       return "<span style='color: #f87171;'>Your rig isn't here. It's in your Den.</span>" unless in_own_den?
       return "<span style='color: #f87171;'>Your rig must be powered down before modifying components. Use 'rig off' first.</span>" if rig.active?
 
-      item = hackr.grid_items.where(grid_mining_rig_id: nil).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.where(grid_mining_rig_id: nil), item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}' in your inventory.</span>" unless item
       return "<span style='color: #f87171;'>#{h(item.name)} is not a rig component.</span>" unless item.rig_component?
 
@@ -2766,7 +2768,7 @@ module Grid
       return "<span style='color: #f87171;'>Your rig isn't here. It's in your Den.</span>" unless in_own_den?
       return "<span style='color: #f87171;'>Your rig must be powered down before modifying components. Use 'rig off' first.</span>" if rig.active?
 
-      item = rig.components.find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(rig.components, item_name)
       return "<span style='color: #f87171;'>No component named '#{h(item_name)}' is installed in your rig.</span>" unless item
 
       # Motherboard removal: check that remaining boards have capacity for installed components
@@ -3021,16 +3023,15 @@ module Grid
     def mission_detail_command(slug)
       return "<span style='color: #fbbf24;'>Usage: mission &lt;slug&gt;</span>" if slug.blank?
 
-      # First check active instance (player's current progress view)
-      active = hackr.grid_hackr_missions.active.joins(:grid_mission)
-        .where(grid_missions: {slug: slug}).first
-      if active
-        return format_active_mission_detail(active)
-      end
-
-      # Otherwise show definition (if in giver's room, show accept hint)
-      mission = GridMission.published.find_by(slug: slug)
+      # Resolve against published missions + missions the hackr has active
+      active_ids = hackr.grid_hackr_missions.active.select(:grid_mission_id)
+      scope = GridMission.published.or(GridMission.where(id: active_ids))
+      mission = Grid::NameResolver.resolve(scope, slug, column: "slug")
       return "<span style='color: #f87171;'>No mission with slug '#{h(slug)}'.</span>" unless mission
+
+      # Check active instance (player's current progress view)
+      active = hackr.grid_hackr_missions.active.find_by(grid_mission_id: mission.id)
+      return format_active_mission_detail(active) if active
 
       room = hackr.current_room
       mission_brief_response(mission.giver_mob, mission, room) || "<span style='color: #9ca3af;'>Nothing to show.</span>"
@@ -3070,11 +3071,14 @@ module Grid
     def accept_mission_command(slug)
       return "<span style='color: #fbbf24;'>Usage: accept &lt;slug&gt;</span>" if slug.blank?
 
+      # Resolve partial slug
+      resolved = Grid::NameResolver.resolve(GridMission.published, slug, column: "slug")
+      slug = resolved.slug if resolved
+
       # Dialogue-path gate — can't accept a mission you haven't discovered
-      mission = GridMission.published.find_by(slug: slug)
-      if mission&.giver_mob_id && mission.dialogue_path.present?
-        giver = mission.giver_mob
-        if giver && dialogue_path_blocked?(mission, giver)
+      if resolved&.giver_mob_id && resolved.dialogue_path.present?
+        giver = resolved.giver_mob
+        if giver && dialogue_path_blocked?(resolved, giver)
           return "<span style='color: #f87171;'>You haven't learned about that job yet.</span>"
         end
       end
@@ -3082,7 +3086,7 @@ module Grid
       room = hackr.current_room
       mission_service.accept!(slug, room: room)
 
-      mission = GridMission.find_by(slug: slug)
+      mission = resolved || GridMission.find_by(slug: slug)
       giver = mission&.giver_mob
       giver_line = giver ? " <span style='color: #6b7280;'>from #{h(giver.name)}</span>" : ""
 
@@ -3102,6 +3106,10 @@ module Grid
     def abandon_mission_command(slug)
       return "<span style='color: #fbbf24;'>Usage: abandon &lt;slug&gt;</span>" if slug.blank?
 
+      active_ids = hackr.grid_hackr_missions.active.select(:grid_mission_id)
+      resolved = Grid::NameResolver.resolve(GridMission.where(id: active_ids), slug, column: "slug")
+      slug = resolved.slug if resolved
+
       hackr_mission = mission_service.abandon!(slug)
       "<span style='color: #fbbf24;'>Mission abandoned:</span> " \
         "<span style='color: #d0d0d0;'>#{h(hackr_mission.grid_mission.name)}</span>\n" \
@@ -3112,6 +3120,10 @@ module Grid
 
     def turn_in_command(slug)
       return "<span style='color: #fbbf24;'>Usage: turn_in &lt;slug&gt;</span>" if slug.blank?
+
+      active_ids = hackr.grid_hackr_missions.active.select(:grid_mission_id)
+      resolved = Grid::NameResolver.resolve(GridMission.where(id: active_ids), slug, column: "slug")
+      slug = resolved.slug if resolved
 
       room = hackr.current_room
       outcome = mission_service.turn_in!(slug, room: room)
@@ -3150,13 +3162,13 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       qty = (parsed.quantity == :all) ? item.quantity : parsed.quantity
       return "<span style='color: #f87171;'>You only have #{item.quantity} #{h(item.name)} (requested #{qty}).</span>" if qty > item.quantity
 
-      mob = room.grid_mobs.find_by("LOWER(name) = ?", npc_name.downcase)
+      mob = Grid::NameResolver.resolve(room.grid_mobs, npc_name)
       return "<span style='color: #f87171;'>You don't see '#{h(npc_name)}' here.</span>" unless mob
 
       saved_name = item.name
@@ -3493,7 +3505,7 @@ module Grid
 
       room = hackr.current_room
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
       unless item.fixture?
         return "<span style='color: #f87171;'>#{h(item.name)} is not a fixture.</span>"
@@ -3520,7 +3532,7 @@ module Grid
       return "<span style='color: #f87171;'>You can only unplace fixtures from your own den.</span>" unless in_own_den?
 
       room = hackr.current_room
-      item = room.placed_fixtures.find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(room.placed_fixtures, item_name)
       return "<span style='color: #f87171;'>No placed fixture called '#{h(item_name)}' here.</span>" unless item
 
       if item.stored_items.exists?
@@ -3555,10 +3567,10 @@ module Grid
       return "<span style='color: #f87171;'>You can only store items in fixtures in your own den.</span>" unless in_own_den?
 
       room = hackr.current_room
-      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      fixture = Grid::NameResolver.resolve(room.placed_fixtures, fixture_name)
       return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       return "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
 
       if item.fixture?
@@ -3609,10 +3621,10 @@ module Grid
       return "<span style='color: #f87171;'>You can only retrieve items from fixtures in your own den.</span>" unless in_own_den?
 
       room = hackr.current_room
-      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      fixture = Grid::NameResolver.resolve(room.placed_fixtures, fixture_name)
       return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
 
-      item = fixture.stored_items.find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(fixture.stored_items, item_name)
       return "<span style='color: #f87171;'>#{h(fixture.name)} doesn't contain '#{h(item_name)}'.</span>" unless item
 
       saved_name = item.name
@@ -3644,7 +3656,7 @@ module Grid
       room = hackr.current_room
       return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
 
-      fixture = room.placed_fixtures.find_by("LOWER(name) = ?", fixture_name.downcase)
+      fixture = Grid::NameResolver.resolve(room.placed_fixtures, fixture_name)
       return "<span style='color: #f87171;'>No placed fixture called '#{h(fixture_name)}' here.</span>" unless fixture
 
       cap = fixture.storage_capacity

--- a/app/services/grid/dialogue_navigator.rb
+++ b/app/services/grid/dialogue_navigator.rb
@@ -138,14 +138,13 @@ module Grid
       topics = node["topics"]
       return nil unless topics.is_a?(Hash)
 
-      key = topics.key?(topic_key) ? topic_key :
-            topics.keys.find { |k| k.downcase == topic_key.downcase }
-      return nil unless key
+      result = Grid::NameResolver.resolve_key(topics, topic_key)
+      return nil unless result
 
-      target = topics[key]
+      target = result[:value]
       return nil unless target.is_a?(Hash)
 
-      {node: target, key: key}
+      {node: target, key: result[:key]}
     end
 
     # DFS search of the entire tree for a topic key.
@@ -157,14 +156,20 @@ module Grid
         # Check this node's children
         sub = v["topics"]
         next unless sub.is_a?(Hash)
-        match = sub.key?(topic_key) ? topic_key :
-                sub.keys.find { |sk| sk.downcase == topic_key.downcase }
-        if match && sub[match].is_a?(Hash)
-          return {node: sub[match], key: match, path: path + [k, match]}
+
+        begin
+          result = Grid::NameResolver.resolve_key(sub, topic_key)
+          if result && result[:value].is_a?(Hash)
+            return {node: result[:value], key: result[:key], path: path + [k, result[:key]]}
+          end
+        rescue Grid::NameResolver::AmbiguousMatch
+          # Ambiguity in this branch — continue DFS, may find unique match deeper.
+          # If nothing else matches, the caller's rescue handles it.
+          nil
         end
         # Recurse deeper
-        result = search_tree(sub, topic_key, path + [k])
-        return result if result
+        deeper = search_tree(sub, topic_key, path + [k])
+        return deeper if deeper
       end
 
       nil

--- a/app/services/grid/dialogue_navigator.rb
+++ b/app/services/grid/dialogue_navigator.rb
@@ -151,9 +151,10 @@ module Grid
     def search_tree(topics, topic_key, path)
       return nil unless topics.is_a?(Hash)
 
+      last_ambiguous = nil
+
       topics.each do |k, v|
         next unless v.is_a?(Hash)
-        # Check this node's children
         sub = v["topics"]
         next unless sub.is_a?(Hash)
 
@@ -162,15 +163,21 @@ module Grid
           if result && result[:value].is_a?(Hash)
             return {node: result[:value], key: result[:key], path: path + [k, result[:key]]}
           end
-        rescue Grid::NameResolver::AmbiguousMatch
-          # Ambiguity in this branch — continue DFS, may find unique match deeper.
-          # If nothing else matches, the caller's rescue handles it.
-          nil
+        rescue Grid::NameResolver::AmbiguousMatch => e
+          last_ambiguous = e
         end
-        # Recurse deeper
-        deeper = search_tree(sub, topic_key, path + [k])
-        return deeper if deeper
+
+        begin
+          deeper = search_tree(sub, topic_key, path + [k])
+          return deeper if deeper
+        rescue Grid::NameResolver::AmbiguousMatch => e
+          last_ambiguous = e
+        end
       end
+
+      # No unique match in any branch. If ambiguity was encountered, propagate it
+      # so the player gets "Did you mean: ..." instead of "NPC doesn't know."
+      raise last_ambiguous if last_ambiguous
 
       nil
     end

--- a/app/services/grid/name_resolver.rb
+++ b/app/services/grid/name_resolver.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Grid
+  # Resolves object names from user input with exact-match-first,
+  # substring-fallback semantics.
+  #
+  # Examples:
+  #   Grid::NameResolver.resolve(room.grid_mobs, "coord")
+  #     → <GridMob name="Fracture Network Coordinator">
+  #
+  #   Grid::NameResolver.resolve(room.grid_mobs, "net")
+  #     → raises AmbiguousMatch(["Network Node", "Net Crawler"])
+  #
+  #   Grid::NameResolver.resolve_key({"network" => {…}, "news" => {…}}, "ne")
+  #     → raises AmbiguousMatch(["network", "news"])
+  module NameResolver
+    class AmbiguousMatch < StandardError
+      attr_reader :candidates
+
+      def initialize(candidates)
+        @candidates = candidates
+        super("Ambiguous match: #{candidates.join(", ")}")
+      end
+    end
+
+    ALLOWED_COLUMNS = %w[name slug hackr_alias grid_item_definitions.name].freeze
+
+    module_function
+
+    # Resolve a name against an ActiveRecord scope.
+    #
+    # scope   — any AR relation (room.grid_mobs, hackr.grid_items, etc.)
+    # input   — raw user-typed string
+    # column: — SQL column expression (default "name"; pass "hackr_alias",
+    #           "slug", or "grid_item_definitions.name" as needed)
+    #
+    # Returns the matching record or nil.
+    # Raises AmbiguousMatch when multiple partial matches exist.
+    def resolve(scope, input, column: "name")
+      raise ArgumentError, "Column #{column.inspect} not in allowlist" unless ALLOWED_COLUMNS.include?(column)
+
+      normalized = input.to_s.strip.downcase
+      return nil if normalized.empty?
+
+      # 1. Exact match — no ambiguity possible
+      exact = scope.find_by("LOWER(#{column}) = ?", normalized)
+      return exact if exact
+
+      # 2. Substring fallback
+      pattern = "%#{sanitize_like(normalized)}%"
+      partials = scope.where("LOWER(#{column}) LIKE ? ESCAPE '\\'", pattern).to_a
+
+      case partials.size
+      when 0 then nil
+      when 1 then partials.first
+      else
+        names = partials.map { |r| r.public_send(column_reader(column)) }
+        raise AmbiguousMatch.new(names)
+      end
+    end
+
+    # Resolve a Hash key by substring.
+    #
+    # hash  — Hash whose keys are topic/dialogue strings
+    # input — raw user-typed string
+    #
+    # Returns { key:, value: } or nil.
+    # Raises AmbiguousMatch when multiple partial matches exist.
+    def resolve_key(hash, input)
+      return nil unless hash.is_a?(Hash)
+
+      normalized = input.to_s.strip.downcase
+      return nil if normalized.empty?
+
+      # 1. Exact match (case-insensitive)
+      exact_key = hash.keys.find { |k| k.downcase == normalized }
+      return {key: exact_key, value: hash[exact_key]} if exact_key
+
+      # 2. Substring fallback
+      matching = hash.keys.select { |k| k.downcase.include?(normalized) }
+
+      case matching.size
+      when 0 then nil
+      when 1 then {key: matching.first, value: hash[matching.first]}
+      else
+        raise AmbiguousMatch.new(matching)
+      end
+    end
+
+    # Escapes SQL LIKE metacharacters in user input.
+    def sanitize_like(str)
+      str.gsub(/[%_\\]/) { |c| "\\#{c}" }
+    end
+    private_class_method :sanitize_like
+
+    # Derives the Ruby method name from a SQL column expression.
+    # "name" → "name", "hackr_alias" → "hackr_alias",
+    # "grid_item_definitions.name" → "name"
+    def column_reader(column)
+      column.to_s.split(".").last
+    end
+    private_class_method :column_reader
+  end
+end

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -36,10 +36,8 @@ module Grid
       raise AccessDenied, "This vendor doesn't sell anything" unless mob.vendor?
 
       clearance = hackr.stat("clearance")
-      listing = mob.grid_shop_listings.joins(:grid_item_definition)
-        .where(active: true)
-        .where("LOWER(grid_item_definitions.name) = ?", item_name.downcase)
-        .first
+      scope = mob.grid_shop_listings.joins(:grid_item_definition).where(active: true)
+      listing = Grid::NameResolver.resolve(scope, item_name, column: "grid_item_definitions.name")
 
       raise ItemNotFound, "This vendor doesn't sell '#{item_name}'" unless listing
       raise AccessDenied, "CLEARANCE #{listing.min_clearance}+ required" if clearance < listing.min_clearance
@@ -96,12 +94,12 @@ module Grid
     def self.sell!(hackr:, mob:, item_name:, quantity: 1)
       raise AccessDenied, "This vendor doesn't buy anything" unless mob.vendor?
 
-      item = hackr.grid_items.in_inventory(hackr).find_by("LOWER(name) = ?", item_name.downcase)
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       raise ItemNotFound, "You don't have '#{item_name}'" unless item
 
       # Find matching listing for sell price, or use item.value * SELL_PRICE_RATIO
       listing = mob.grid_shop_listings.joins(:grid_item_definition)
-        .where("LOWER(grid_item_definitions.name) = ?", item_name.downcase)
+        .where("LOWER(grid_item_definitions.name) = ?", item.name.downcase)
         .first
       unit_sell_price = if listing
         listing.sell_price

--- a/spec/services/grid/name_resolver_spec.rb
+++ b/spec/services/grid/name_resolver_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Grid::NameResolver do
+  describe ".resolve" do
+    let!(:room) { create(:grid_room) }
+    let!(:mob_coordinator) { create(:grid_mob, name: "Fracture Network Coordinator", grid_room: room) }
+    let!(:mob_merchant) { create(:grid_mob, name: "Salvage Merchant", grid_room: room) }
+
+    it "returns exact case-insensitive match" do
+      result = described_class.resolve(room.grid_mobs, "fracture network coordinator")
+      expect(result).to eq(mob_coordinator)
+    end
+
+    it "returns single partial match" do
+      result = described_class.resolve(room.grid_mobs, "coord")
+      expect(result).to eq(mob_coordinator)
+    end
+
+    it "returns nil when no match" do
+      result = described_class.resolve(room.grid_mobs, "zzz")
+      expect(result).to be_nil
+    end
+
+    it "raises AmbiguousMatch when multiple partial matches" do
+      create(:grid_mob, name: "Network Node", grid_room: room)
+      expect {
+        described_class.resolve(room.grid_mobs, "network")
+      }.to raise_error(Grid::NameResolver::AmbiguousMatch) { |e|
+        expect(e.candidates).to contain_exactly("Fracture Network Coordinator", "Network Node")
+      }
+    end
+
+    it "prefers exact match over partial matches" do
+      create(:grid_mob, name: "Net", grid_room: room)
+      create(:grid_mob, name: "Network Node", grid_room: room)
+      result = described_class.resolve(room.grid_mobs, "net")
+      expect(result.name).to eq("Net")
+    end
+
+    it "returns nil for empty input" do
+      result = described_class.resolve(room.grid_mobs, "")
+      expect(result).to be_nil
+    end
+
+    it "returns nil for nil input" do
+      result = described_class.resolve(room.grid_mobs, nil)
+      expect(result).to be_nil
+    end
+
+    it "sanitizes LIKE wildcards in input" do
+      create(:grid_mob, name: "50% Off Vendor", grid_room: room)
+      result = described_class.resolve(room.grid_mobs, "50%")
+      expect(result.name).to eq("50% Off Vendor")
+    end
+
+    it "sanitizes underscore in input" do
+      # _ is a LIKE wildcard matching any single character
+      result = described_class.resolve(room.grid_mobs, "f_acture")
+      expect(result).to be_nil
+    end
+
+    context "with custom column" do
+      let!(:hackr) { create(:grid_hackr) }
+      let!(:other_hackr) { create(:grid_hackr, hackr_alias: "XERAEN") }
+
+      before do
+        hackr.update!(current_room: room)
+        other_hackr.update!(current_room: room)
+      end
+
+      it "resolves by hackr_alias" do
+        result = described_class.resolve(room.grid_hackrs, "xer", column: "hackr_alias")
+        expect(result).to eq(other_hackr)
+      end
+    end
+
+    context "with slug column" do
+      let!(:schematic1) { create(:grid_schematic, slug: "neural-patch-mk-iv", published: true) }
+      let!(:schematic2) { create(:grid_schematic, slug: "neural-spike", published: true) }
+
+      it "resolves partial slug uniquely" do
+        result = described_class.resolve(GridSchematic.published, "neural-patch", column: "slug")
+        expect(result).to eq(schematic1)
+      end
+
+      it "raises AmbiguousMatch for ambiguous slug" do
+        expect {
+          described_class.resolve(GridSchematic.published, "neural", column: "slug")
+        }.to raise_error(Grid::NameResolver::AmbiguousMatch)
+      end
+    end
+
+    it "sanitizes backslash in input" do
+      create(:grid_mob, name: "Back\\slash Mob", grid_room: room)
+      result = described_class.resolve(room.grid_mobs, "back\\slash")
+      expect(result.name).to eq("Back\\slash Mob")
+    end
+
+    it "resolves against an unscoped model class" do
+      schematic = create(:grid_schematic, slug: "test-resolver", published: true)
+      result = described_class.resolve(GridSchematic, "test-resolver", column: "slug")
+      expect(result).to eq(schematic)
+    end
+
+    it "raises ArgumentError for disallowed column" do
+      expect {
+        described_class.resolve(room.grid_mobs, "test", column: "'; DROP TABLE--")
+      }.to raise_error(ArgumentError, /not in allowlist/)
+    end
+  end
+
+  describe ".resolve_key" do
+    let(:topics) do
+      {
+        "missions" => {"response" => "Here are missions"},
+        "mining" => {"response" => "About mining"},
+        "network" => {"response" => "Network info"},
+        "news" => {"response" => "Latest news"}
+      }
+    end
+
+    it "returns exact match" do
+      result = described_class.resolve_key(topics, "missions")
+      expect(result[:key]).to eq("missions")
+      expect(result[:value]).to eq({"response" => "Here are missions"})
+    end
+
+    it "returns exact match case-insensitively" do
+      result = described_class.resolve_key(topics, "MISSIONS")
+      expect(result[:key]).to eq("missions")
+    end
+
+    it "returns single partial match" do
+      result = described_class.resolve_key(topics, "miss")
+      expect(result[:key]).to eq("missions")
+    end
+
+    it "returns nil when no match" do
+      result = described_class.resolve_key(topics, "zzz")
+      expect(result).to be_nil
+    end
+
+    it "raises AmbiguousMatch when multiple partial matches" do
+      expect {
+        described_class.resolve_key(topics, "ne")
+      }.to raise_error(Grid::NameResolver::AmbiguousMatch) { |e|
+        expect(e.candidates).to contain_exactly("network", "news")
+      }
+    end
+
+    it "prefers exact match over partials" do
+      hash = {"net" => {"response" => "exact"}, "network" => {"response" => "partial"}}
+      result = described_class.resolve_key(hash, "net")
+      expect(result[:key]).to eq("net")
+      expect(result[:value]["response"]).to eq("exact")
+    end
+
+    it "returns nil for empty input" do
+      result = described_class.resolve_key(topics, "")
+      expect(result).to be_nil
+    end
+
+    it "returns nil for nil hash" do
+      result = described_class.resolve_key(nil, "test")
+      expect(result).to be_nil
+    end
+
+    it "returns nil for non-hash input" do
+      result = described_class.resolve_key("not a hash", "test")
+      expect(result).to be_nil
+    end
+  end
+
+  describe "integration with CommandParser" do
+    let!(:hackr) { create(:grid_hackr) }
+    let!(:room) { create(:grid_room) }
+    let!(:item) { create(:grid_item, name: "Laser Rifle", grid_hackr: hackr, room: nil) }
+
+    before { hackr.update!(current_room: room) }
+
+    it "resolves partial item name in take command" do
+      item.update!(room: room, grid_hackr: nil)
+      result = Grid::CommandParser.new(hackr, "take laser").execute
+      expect(result[:output]).to include("Laser Rifle")
+      expect(result[:output]).to include("You take")
+    end
+
+    it "shows disambiguation for ambiguous input" do
+      create(:grid_item, name: "Laser Pistol", room: room, grid_hackr: nil)
+      item.update!(room: room, grid_hackr: nil)
+      result = Grid::CommandParser.new(hackr, "take laser").execute
+      expect(result[:output]).to include("Did you mean")
+      expect(result[:output]).to include("Laser Rifle")
+      expect(result[:output]).to include("Laser Pistol")
+    end
+
+    it "resolves partial mob name in talk command" do
+      create(:grid_mob, name: "Fracture Network Coordinator", grid_room: room,
+        dialogue_tree: {"greeting" => "Hello", "topics" => {}})
+      result = Grid::CommandParser.new(hackr, "talk coord").execute
+      output = result.is_a?(Hash) ? result[:output] : result
+      expect(output).to include("Fracture Network Coordinator")
+    end
+  end
+end


### PR DESCRIPTION
  Grid::NameResolver module with exact-match-first, substring-fallback resolution.
  Players can type talk coord instead of talk Fracture Network Coordinator.
  Single unique substring match resolves automatically; multiple matches show "Did you mean: X, Y?" disambiguation.

  Core module (app/services/grid/name_resolver.rb):
  - resolve(scope, input, column:) — AR scope resolution with LIKE substring fallback
  - resolve_key(hash, input) — Hash key resolution for dialogue topics
  - AmbiguousMatch exception carrying candidate names
  - ALLOWED_COLUMNS allowlist prevents SQL injection via column parameter
  - LIKE wildcards sanitized with explicit ESCAPE '\\'

  Migrated ~37 call sites across 7 files:
  - command_parser.rb — all mob, item, fixture, hackr, shop listing, DECK software/module, schematic (slug), and mission (slug) lookups
  - shop_service.rb — buy! and sell!
  - dialogue_navigator.rb — find_topic_in and search_tree (topic partial matching)
  - breach_action_service.rb — use_item! in BREACH encounters
  - breach_command_parser.rb — centralized rescue at execute level
  - captured_command_parser.rb — bribe_command + centralized rescue at execute level

  Centralized AmbiguousMatch handling: Single rescue at dispatch_command/execute level in each parser instead of per-method rescue blocks.

  Slug-based commands support partial matching: fab neur resolves neural-patch-mk-iv. Mission commands scoped to prevent leaking unpublished slugs
  (mission_detail: published + hackr's active; abandon/turn_in: hackr's active only).

  equipped_item_hint converted to partial matching so drop lase correctly suggests "That item is equipped" when "Laser Rifle" is equipped.

  DialogueNavigator search_tree: AmbiguousMatch in one branch rescued and continues DFS — won't abort when a unique match exists deeper in the tree.

  Intentionally unchanged: equipped_item_hint (returns nil on ambiguity), cache/address lookups (hex hashes), resolve_breach_target/hail_command (already have their own partial matching), tutorial parser (sandboxed simulation).