### PR TITLE
[TPG] Tactical Grid UI (/grid/1337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ hackr.tv/
 │       ├── easter_eggs.rb             # Hidden commands
 │       ├── realtime_subscriber.rb     # Action Cable pubsub for terminal
 │       └── handlers/                  # Terminal command handlers
-├── spec/                              # Test suite (2969 total)
+├── spec/                              # Test suite (2994 total)
 │   ├── models/                        # Model specs
 │   ├── controllers/                   # Controller specs
 │   ├── components/                    # ViewComponent specs
@@ -472,9 +472,9 @@ bundle exec rspec spec/components/
 ```
 
 **Test Coverage:**
-- **Backend:** 2725 examples (RSpec)
+- **Backend:** 2750 examples (RSpec)
 - **Frontend:** 244 examples (Vitest)
-- **Total:** 2969 passing tests
+- **Total:** 2994 passing tests
 
 ---
 
@@ -763,7 +763,7 @@ This project is released into the public domain, so feel free to fork, modify, a
 | `bin/rails data:catalog` | Load artists, albums, tracks only |
 | `bin/rails data:world` | Load all world data (regions, zones, rooms, mobs, items, BREACH, transit, etc.) |
 | `bin/rails data:reset` | Reset seed content (preserves user data) |
-| `bundle exec rspec` | Run backend test suite (2725 tests) |
+| `bundle exec rspec` | Run backend test suite (2750 tests) |
 | `pnpm test` | Run frontend test suite (244 tests) |
 | `bundle exec standardrb` | Lint backend code |
 | `bundle exec brakeman` | Run security scanner |

--- a/app/channels/zone_channel.rb
+++ b/app/channels/zone_channel.rb
@@ -1,0 +1,22 @@
+class ZoneChannel < ApplicationCable::Channel
+  def self.stream_name_for(zone_id)
+    "zone_channel_#{zone_id}"
+  end
+
+  def subscribed
+    unless current_hackr
+      reject
+      return
+    end
+
+    current_hackr.reload
+    zone_id = current_hackr.current_room&.grid_zone_id
+
+    unless zone_id
+      reject
+      return
+    end
+
+    stream_from self.class.stream_name_for(zone_id)
+  end
+end

--- a/app/controllers/admin/grid_hackrs_controller.rb
+++ b/app/controllers/admin/grid_hackrs_controller.rb
@@ -131,6 +131,7 @@ class Admin::GridHackrsController < Admin::ApplicationController
     end
 
     @hackr.update!(current_room_id: room.id, zone_entry_room_id: room.id)
+    Grid::RoomVisitRecorder.record!(hackr: @hackr, room: room)
 
     zone_name = room.grid_zone&.name || "unknown zone"
     set_flash_success("#{@hackr.hackr_alias} warped to #{room.name} (#{zone_name}).")

--- a/app/controllers/admin/grid_map_editor_controller.rb
+++ b/app/controllers/admin/grid_map_editor_controller.rb
@@ -646,13 +646,15 @@ class Admin::GridMapEditorController < Admin::ApplicationController
 
     while remaining.any?
       seed_id = remaining.include?(seed.id) ? seed.id : remaining.first
-      queue = [[seed_id, 0, positions.empty? ? 0 : (positions.values.map(&:last).max + 3)]]
+      # Queue items: [room_id, x, y, vertical?]
+      queue = [[seed_id, 0, positions.empty? ? 0 : (positions.values.map(&:last).max + 3), false]]
       visited = Set.new([seed_id])
 
       while (item = queue.shift)
-        rid, lx, ly = item
+        rid, lx, ly, vertical = item
 
-        if occupied[[lx, ly]] && occupied[[lx, ly]] != rid
+        # Skip collision detection for vertical exits (they share x,y by design)
+        if !vertical && occupied[[lx, ly]] && occupied[[lx, ly]] != rid
           placed = false
           (1..10).each do |radius|
             break if placed
@@ -672,17 +674,21 @@ class Admin::GridMapEditorController < Admin::ApplicationController
         end
 
         positions[rid] = [lx, ly]
-        occupied[[lx, ly]] = rid
+        occupied[[lx, ly]] = rid unless vertical
         remaining.delete(rid)
 
         (exits_by_from[rid] || []).each do |ex|
-          next if z_directions.key?(ex.direction)
           next unless room_ids.include?(ex.to_room_id)
           next if visited.include?(ex.to_room_id)
-          vec = direction_vectors[ex.direction]
-          next unless vec
-          visited.add(ex.to_room_id)
-          queue << [ex.to_room_id, lx + vec[0], ly + vec[1]]
+          if z_directions.key?(ex.direction)
+            visited.add(ex.to_room_id)
+            queue << [ex.to_room_id, lx, ly, true]
+          else
+            vec = direction_vectors[ex.direction]
+            next unless vec
+            visited.add(ex.to_room_id)
+            queue << [ex.to_room_id, lx + vec[0], ly + vec[1], false]
+          end
         end
       end
 

--- a/app/controllers/admin/grid_transit_journeys_controller.rb
+++ b/app/controllers/admin/grid_transit_journeys_controller.rb
@@ -30,6 +30,7 @@ class Admin::GridTransitJourneysController < Admin::ApplicationController
       journey.update!(state: "abandoned", ended_at: Time.current)
       hackr = journey.grid_hackr
       hackr.update!(current_room: journey.origin_room) if journey.origin_room
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: journey.origin_room) if journey.origin_room
       set_flash_success("Journey ##{journey.id} force-abandoned.")
     else
       flash[:error] = "Journey is not active (state: #{journey.state})."

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,8 +2,9 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
+  before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: [:zone_map]
   before_action :require_admin_api, only: [:debit]
 
   # GET /api/grid/achievements - All visible achievements grouped by
@@ -73,7 +74,7 @@ class Api::GridController < ApplicationController
   # GET /api/grid/schematics - Published schematics with ingredients,
   # craftable status, and per-ingredient ownership for the current hackr.
   def schematics_index
-    schematics = GridSchematic.published.ordered
+    schematics = GridSchematic.published.non_tutorial.ordered
       .includes(:output_definition, ingredients: :input_definition)
 
     # Pre-load hackr state to avoid N+1 on craftable_by? checks
@@ -105,8 +106,13 @@ class Api::GridController < ApplicationController
           output: {
             slug: s.output_definition.slug,
             name: s.output_definition.name,
+            description: s.output_definition.description,
+            item_type: s.output_definition.item_type,
             rarity: s.output_definition.rarity,
-            rarity_color: s.output_definition.rarity_color
+            rarity_color: s.output_definition.rarity_color,
+            rarity_label: s.output_definition.rarity_label,
+            max_stack: s.output_definition.max_stack,
+            properties: s.output_definition.properties
           },
           output_quantity: s.output_quantity,
           xp_reward: s.xp_reward,
@@ -175,6 +181,8 @@ class Api::GridController < ApplicationController
     inventory_sw = current_hackr.grid_items.in_inventory(current_hackr)
       .where(item_type: "software").includes(:grid_item_definition)
 
+    modules = deck.installed_modules.includes(:grid_item_definition)
+
     render json: {
       deck: {
         id: deck.id,
@@ -190,6 +198,15 @@ class Api::GridController < ApplicationController
         modules_used: deck.deck_modules_used
       },
       software: loaded.map { |s| software_item_json(s) },
+      modules: modules.map { |m|
+        {
+          id: m.id,
+          name: m.name,
+          rarity_color: m.rarity_color,
+          description: m.description,
+          firmware: m.properties&.dig("firmware_name")
+        }
+      },
       inventory_software: inventory_sw.map { |s| software_item_json(s) }
     }
   end
@@ -674,6 +691,26 @@ class Api::GridController < ApplicationController
     }, status: :unprocessable_entity
   end
 
+  # GET /api/grid/zone_map - Zone map data for the tactical UI
+  def zone_map
+    room = current_hackr.current_room
+    unless room
+      return render json: {error: "No current room."}, status: :unprocessable_entity
+    end
+
+    result = Grid::ZoneMapBuilder.new(zone: room.grid_zone, hackr: current_hackr).build
+
+    render json: {
+      zone: result.zone,
+      current_room_id: result.current_room_id,
+      rooms: result.rooms,
+      exits: result.exits,
+      ghost_rooms: result.ghost_rooms,
+      z_levels: result.z_levels,
+      z_level: result.z_level
+    }
+  end
+
   # POST /api/grid/command - Execute game command
   def command
     Rails.logger.info "=== API COMMAND RECEIVED: #{params[:input]} from #{current_hackr.hackr_alias} ==="
@@ -709,6 +746,8 @@ class Api::GridController < ApplicationController
         # Broadcast to both old and new rooms
         broadcast_event(GridRoom.find(event[:from_room_id]), event) if event[:from_room_id]
         broadcast_event(GridRoom.find(event[:to_room_id]), event) if event[:to_room_id]
+        # Zone-level presence broadcast for tactical map
+        broadcast_zone_presence(event)
       when "say", "take", "drop"
         # Broadcast to current room
         Rails.logger.info "=== Broadcasting #{event[:type]} to room #{current_hackr.current_room&.id} ==="
@@ -739,6 +778,18 @@ class Api::GridController < ApplicationController
     Rails.logger.info "=== BROADCASTING to room #{room.id} (#{room.name}): #{event.inspect} ==="
     GridChannel.broadcast_to(room, event)
     Rails.logger.info "=== BROADCAST COMPLETE ==="
+  end
+
+  def broadcast_zone_presence(event)
+    from_room = GridRoom.find_by(id: event[:from_room_id])
+    to_room = GridRoom.find_by(id: event[:to_room_id])
+
+    zone_ids = [from_room&.grid_zone_id, to_room&.grid_zone_id].compact.uniq
+    presence_event = event.merge(type: "presence_update")
+
+    zone_ids.each do |zone_id|
+      ActionCable.server.broadcast(ZoneChannel.stream_name_for(zone_id), presence_event)
+    end
   end
 
   def loadout_item_json(item)

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -25,6 +25,7 @@ const TrackDetailPage = lazy(() => import('~/components/pages/tracks/TrackDetail
 const ReleaseListPage = lazy(() => import('~/components/pages/releases/ReleaseListPage'))
 const ReleaseDetailPage = lazy(() => import('~/components/pages/releases/ReleaseDetailPage'))
 const GridGamePage = lazy(() => import('~/components/pages/grid/GridGamePage').then(m => ({ default: m.GridGamePage })))
+const GridTacticalPage = lazy(() => import('~/components/pages/grid/GridTacticalPage').then(m => ({ default: m.GridTacticalPage })))
 const AchievementsPage = lazy(() => import('~/components/pages/grid/AchievementsPage'))
 const MissionsPage = lazy(() => import('~/components/pages/grid/MissionsPage'))
 const SchematicsPage = lazy(() => import('~/components/pages/grid/SchematicsPage'))
@@ -114,6 +115,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/deck" element={<ProtectedRoute><DeckPage /></ProtectedRoute>} />
           <Route path="/transit" element={<ProtectedRoute><TransitPage /></ProtectedRoute>} />
           <Route path="/grid" element={<FeatureGate feature="pulse_grid"><GridGamePage /></FeatureGate>} />
+          <Route path="/grid/1337" element={<FeatureGate feature="tactical_grid"><GridTacticalPage /></FeatureGate>} />
           <Route path="/grid/login" element={<GridLoginPage />} />
           <Route path="/grid/register" element={<GridRegisterPage />} />
           <Route path="/grid/forgot_password" element={<ForgotPasswordPage />} />

--- a/app/javascript/components/pages/grid/DeckPage.tsx
+++ b/app/javascript/components/pages/grid/DeckPage.tsx
@@ -34,9 +34,18 @@ interface DeckInfo {
   modules_used: number
 }
 
+interface ModuleItem {
+  id: number
+  name: string
+  rarity_color: string
+  description: string | null
+  firmware: string | null
+}
+
 interface DeckResponse {
   deck: DeckInfo | null
   software: SoftwareItem[]
+  modules: ModuleItem[]
   inventory_software: SoftwareItem[]
 }
 
@@ -128,7 +137,7 @@ const DeckPage: React.FC = () => {
     )
   }
 
-  const { deck, software, inventory_software } = data
+  const { deck, software, modules, inventory_software } = data
 
   return (
     <DefaultLayout>
@@ -170,6 +179,28 @@ const DeckPage: React.FC = () => {
                     </div>
                   </div>
                 </div>
+
+                {modules.length > 0 && (
+                  <div style={{ borderTop: '1px solid #333', paddingTop: 15, marginTop: 10 }}>
+                    <h3 style={{ color: '#fbbf24', margin: '0 0 10px 0', fontSize: '1em' }}>INSTALLED MODULES</h3>
+                    {modules.map(mod => (
+                      <div key={mod.id} style={{
+                        background: '#1a1a2e', border: '1px solid #333', borderRadius: 4,
+                        padding: '8px 12px', marginBottom: 6
+                      }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <span style={{ color: mod.rarity_color, fontWeight: 'bold' }}>{mod.name}</span>
+                          {mod.firmware && (
+                            <span style={{ color: '#a78bfa', fontSize: '0.85em' }}>{mod.firmware}</span>
+                          )}
+                        </div>
+                        {mod.description && (
+                          <div style={{ color: '#6b7280', fontSize: '0.85em', marginTop: 4 }}>{mod.description}</div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
 
                 <div style={{ borderTop: '1px solid #333', paddingTop: 15, marginTop: 10 }}>
                   <h3 style={{ color: '#fbbf24', margin: '0 0 10px 0', fontSize: '1em' }}>LOADED SOFTWARE</h3>

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useActionCable, GridEvent } from '~/hooks/useActionCable'
+import { TacticalProvider, useTactical } from '~/components/tactical/TacticalContext'
+import { TacticalBar } from '~/components/tactical/TacticalBar'
+import { TacticalTerminal } from '~/components/tactical/TacticalTerminal'
+import { TacticalStatusPanel } from '~/components/tactical/TacticalStatusPanel'
+import { ZoneMap } from '~/components/tactical/map/ZoneMap'
+import { apiJson } from '~/utils/apiClient'
+
+interface GridCommandResponse {
+  output?: string
+  room_id?: number
+}
+
+const TacticalInner: React.FC = () => {
+  const { hackr } = useGridAuth()
+  const {
+    currentRoomId, setCurrentRoomId, setOutput,
+    refreshToken, sendCommand, commandInputRef
+  } = useTactical()
+  const initialLoadDoneRef = useRef(false)
+
+  // Tab anywhere → focus command input
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        commandInputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [commandInputRef])
+
+  // Set initial room and execute look
+  useEffect(() => {
+    if (hackr?.current_room && !initialLoadDoneRef.current) {
+      initialLoadDoneRef.current = true
+      setCurrentRoomId(hackr.current_room.id)
+
+      const loadInitial = async () => {
+        setOutput([`<div style="color: #a78bfa; font-size: 0.9em;">
+════════════════════════════════════════════════════
+  TACTICAL INTERFACE — THE PULSE GRID
+════════════════════════════════════════════════════
+</div>`])
+
+        try {
+          const data = await apiJson<GridCommandResponse>('/api/grid/command', {
+            method: 'POST',
+            body: JSON.stringify({ input: 'look' })
+          })
+          if (data.output?.trim()) {
+            setOutput(prev => [...prev, data.output!.trim()])
+          }
+          if (data.room_id) setCurrentRoomId(data.room_id)
+        } catch (err) {
+          console.error('Failed to load initial room:', err)
+        }
+      }
+
+      loadInitial()
+    }
+  }, [hackr, setCurrentRoomId, setOutput])
+
+  // ActionCable for room events (terminal output)
+  const handleEvent = React.useCallback((event: GridEvent) => {
+    const ts = new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' })
+    let message = ''
+
+    switch (event.type) {
+    case 'say':
+      message = `\n<span style="color: #a78bfa;">[${event.hackr_alias}]</span>: ${event.message}`
+      break
+    case 'movement':
+      if (event.to_room_id === currentRoomId) {
+        message = `\n<span style="color: #22d3ee;">[${ts}] ${event.hackr_alias} arrives.</span>`
+      } else if (event.from_room_id === currentRoomId) {
+        message = `\n<span style="color: #22d3ee;">[${ts}] ${event.hackr_alias} departs.</span>`
+      }
+      break
+    case 'take':
+      message = `\n<span style="color: #fbbf24;">[${ts}] ${event.hackr_alias} takes the ${event.item_name}.</span>`
+      break
+    case 'drop':
+      message = `\n<span style="color: #fbbf24;">[${ts}] ${event.hackr_alias} drops the ${event.item_name}.</span>`
+      break
+    case 'system_broadcast':
+      message = `\n<span style="color: #f87171; font-weight: bold;">[${ts}] ${event.message}</span>`
+      break
+    }
+
+    if (message) setOutput(prev => [...prev, message])
+  }, [currentRoomId, setOutput])
+
+  const { connectionStatus } = useActionCable({
+    roomId: currentRoomId,
+    onEvent: handleEvent,
+    enabled: !!hackr && !!currentRoomId
+  })
+
+  return (
+    <div style={{
+      position: 'fixed',
+      inset: 0,
+      overflow: 'hidden',
+      display: 'grid',
+      gridTemplateAreas: '"topbar topbar" "leftcol map" "cmdinput cmdinput"',
+      gridTemplateColumns: '55fr 45fr',
+      gridTemplateRows: '44px 1fr 58px',
+      background: '#0a0a0a',
+      fontFamily: '\'Courier New\', Courier, monospace',
+      color: '#d0d0d0'
+    }}>
+      <div style={{ gridArea: 'topbar' }}>
+        <TacticalBar connectionStatus={connectionStatus} />
+      </div>
+
+      <div style={{
+        gridArea: 'leftcol',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden'
+      }}>
+        <div style={{ flex: 2, minHeight: 0, overflow: 'hidden', borderBottom: '1px solid #333' }}>
+          <TacticalStatusPanel refreshToken={refreshToken} onCommand={sendCommand} />
+        </div>
+        <div style={{ flex: 3, minHeight: 0, overflow: 'hidden', padding: '6px' }}>
+          <TacticalTerminal />
+        </div>
+      </div>
+
+      <div style={{ gridArea: 'map', overflow: 'hidden', borderLeft: '1px solid #333' }}>
+        <ZoneMap refreshToken={refreshToken} currentRoomId={currentRoomId} onNavigate={(dir) => sendCommand(`go ${dir}`)} />
+      </div>
+
+      <div style={{
+        gridArea: 'cmdinput',
+        padding: '8px 12px',
+        borderTop: '1px solid #333',
+        background: '#111'
+      }}>
+        <div style={{ fontSize: '0.75em', color: '#555', textAlign: 'center' }}>
+          Commands: look, go [dir], take/drop [item], say [msg], talk/ask [npc], inventory, who, help, clear
+          <span style={{ marginLeft: '10px', color: '#333' }}>|</span>
+          <span style={{ marginLeft: '10px' }}>↑/↓ for history</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const GridTacticalPage: React.FC = () => {
+  const { hackr, loading: authLoading } = useGridAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!authLoading && !hackr) {
+      navigate('/grid/login')
+    }
+  }, [hackr, authLoading, navigate])
+
+  if (authLoading) {
+    return (
+      <div style={{
+        position: 'fixed', inset: 0, display: 'flex',
+        alignItems: 'center', justifyContent: 'center',
+        background: '#0a0a0a', color: '#a78bfa',
+        fontFamily: '\'Courier New\', monospace'
+      }}>
+        Loading TACTICAL INTERFACE...
+      </div>
+    )
+  }
+
+  if (!hackr) return null
+
+  return (
+    <TacticalProvider>
+      <TacticalInner />
+    </TacticalProvider>
+  )
+}

--- a/app/javascript/components/tactical/TacticalBar.tsx
+++ b/app/javascript/components/tactical/TacticalBar.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useNavigate } from 'react-router-dom'
+
+interface TacticalBarProps {
+  connectionStatus: 'connected' | 'connecting' | 'reconnecting' | 'disconnected'
+}
+
+export const TacticalBar: React.FC<TacticalBarProps> = ({ connectionStatus }) => {
+  const { hackr, disconnect } = useGridAuth()
+  const navigate = useNavigate()
+
+  const handleDisconnect = async () => {
+    if (confirm('Disconnect from THE PULSE GRID?')) {
+      await disconnect()
+      navigate('/grid/login')
+    }
+  }
+
+  return (
+    <div style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: '0 12px',
+      height: '100%',
+      borderBottom: '1px solid #333',
+      background: '#111'
+    }}>
+      <div style={{ fontSize: '0.85em', display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <span style={{ color: '#a78bfa', fontWeight: 'bold', letterSpacing: '1px' }}>TACTICAL</span>
+        <span style={{ color: '#333' }}>|</span>
+        <span style={{ color: '#e0e0e0' }}>{hackr?.hackr_alias}</span>
+        <span style={{ color: '#333' }}>|</span>
+        <span style={{
+          color: connectionStatus === 'connected' ? '#34d399'
+            : connectionStatus === 'reconnecting' ? '#fbbf24' : '#f87171',
+          fontSize: '0.8em'
+        }}>
+          {connectionStatus === 'connected' ? 'LIVE'
+            : connectionStatus === 'reconnecting' ? 'RECONNECTING'
+              : connectionStatus === 'connecting' ? 'CONNECTING' : 'OFFLINE'}
+        </span>
+        {hackr?.role === 'admin' && (
+          <a href="/root" style={{ color: '#f87171', fontSize: '0.85em', textDecoration: 'none' }}>[ADMIN]</a>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <a href="/grid" style={{
+          color: '#666',
+          fontSize: '0.8em',
+          textDecoration: 'none'
+        }}>
+          STANDARD VIEW
+        </a>
+        <button
+          onClick={handleDisconnect}
+          style={{
+            background: '#dc2626',
+            color: 'white',
+            border: 'none',
+            padding: '4px 12px',
+            fontSize: '0.8em',
+            cursor: 'pointer',
+            borderRadius: '3px'
+          }}
+        >
+          KILLSWITCH
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import { CommandInputHandle } from '~/components/grid/CommandInput'
+
+interface GridCommandResponse {
+  output?: string
+  room_id?: number
+  current_room?: {
+    ambient_playlist?: unknown
+  }
+}
+
+interface TacticalContextValue {
+  output: string[]
+  currentRoomId: number | null
+  executing: boolean
+  refreshToken: number
+  sendCommand: (command: string) => Promise<void>
+  setOutput: React.Dispatch<React.SetStateAction<string[]>>
+  setCurrentRoomId: React.Dispatch<React.SetStateAction<number | null>>
+  commandInputRef: React.RefObject<CommandInputHandle | null>
+}
+
+const TacticalContext = createContext<TacticalContextValue | null>(null)
+
+export const useTactical = () => {
+  const ctx = useContext(TacticalContext)
+  if (!ctx) throw new Error('useTactical must be used within TacticalProvider')
+  return ctx
+}
+
+export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [output, setOutput] = useState<string[]>([])
+  const [currentRoomId, setCurrentRoomId] = useState<number | null>(null)
+  const [executing, setExecuting] = useState(false)
+  const [refreshToken, setRefreshToken] = useState(0)
+  const commandInputRef = useRef<CommandInputHandle | null>(null)
+
+  const sendCommand = useCallback(async (command: string) => {
+    if (['clear', 'cls', 'cl'].includes(command.toLowerCase())) {
+      setOutput([])
+      return
+    }
+
+    setOutput(prev => [
+      ...prev,
+      '<div style="height: 1px; background: #444; margin-top: 16px; margin-bottom: 12px; overflow: hidden;"></div>',
+      `<span style="color: #22d3ee;">&gt; ${command}</span>`
+    ])
+
+    setExecuting(true)
+
+    try {
+      const data = await apiJson<GridCommandResponse>('/api/grid/command', {
+        method: 'POST',
+        body: JSON.stringify({ input: command })
+      })
+
+      const outputText = data.output?.trim()
+      if (outputText) {
+        setOutput(prev => [...prev, outputText])
+      }
+
+      if (data.room_id) {
+        setCurrentRoomId(prev => data.room_id !== prev ? data.room_id! : prev)
+      }
+
+      setRefreshToken(prev => prev + 1)
+    } catch (err) {
+      console.error('Command execution failed:', err)
+      setOutput(prev => [...prev, '<span style="color: #f87171;">Error: Network error. Please try again.</span>'])
+    } finally {
+      setExecuting(false)
+    }
+  }, [])
+
+  return (
+    <TacticalContext.Provider value={{
+      output, currentRoomId, executing, refreshToken,
+      sendCommand, setOutput, setCurrentRoomId, commandInputRef
+    }}>
+      {children}
+    </TacticalContext.Provider>
+  )
+}

--- a/app/javascript/components/tactical/TacticalStatusPanel.tsx
+++ b/app/javascript/components/tactical/TacticalStatusPanel.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { StatsTab } from './tabs/StatsTab'
+import { DeckTab } from './tabs/DeckTab'
+import { LoadoutTab } from './tabs/LoadoutTab'
+import { InventoryTab } from './tabs/InventoryTab'
+import { RepTab } from './tabs/RepTab'
+import { MissionsTab } from './tabs/MissionsTab'
+import { SchematicsTab } from './tabs/SchematicsTab'
+
+type TabKey = 'stats' | 'deck' | 'loadout' | 'inventory' | 'rep' | 'missions' | 'schematics'
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'stats', label: 'STATS' },
+  { key: 'deck', label: 'DECK' },
+  { key: 'loadout', label: 'GEAR' },
+  { key: 'inventory', label: 'INV' },
+  { key: 'rep', label: 'REP' },
+  { key: 'missions', label: 'MISSIONS' },
+  { key: 'schematics', label: 'SCHEM' }
+]
+
+interface TacticalStatusPanelProps {
+  refreshToken: number
+  onCommand?: (cmd: string) => void
+}
+
+export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refreshToken, onCommand }) => {
+  const [activeTab, setActiveTab] = useState<TabKey>('stats')
+  const [mountedTabs, setMountedTabs] = useState<Set<TabKey>>(new Set(['stats']))
+
+  const handleTabClick = (key: TabKey) => {
+    setActiveTab(key)
+    setMountedTabs(prev => {
+      if (prev.has(key)) return prev
+      const next = new Set(prev)
+      next.add(key)
+      return next
+    })
+  }
+
+  const renderTab = (key: TabKey) => {
+    if (!mountedTabs.has(key)) return null
+    const isActive = key === activeTab
+
+    return (
+      <div key={key} style={{ display: isActive ? 'block' : 'none', height: '100%', overflow: 'auto' }}>
+        {key === 'stats' && <StatsTab refreshToken={refreshToken} />}
+        {key === 'deck' && <DeckTab refreshToken={refreshToken} />}
+        {key === 'loadout' && <LoadoutTab refreshToken={refreshToken} />}
+        {key === 'inventory' && <InventoryTab refreshToken={refreshToken} />}
+        {key === 'rep' && <RepTab refreshToken={refreshToken} />}
+        {key === 'missions' && <MissionsTab refreshToken={refreshToken} />}
+        {key === 'schematics' && <SchematicsTab refreshToken={refreshToken} onCommand={onCommand} />}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <div style={{
+        display: 'flex', gap: 0, flexShrink: 0,
+        borderBottom: '1px solid #333', background: '#111'
+      }}>
+        {TABS.map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => handleTabClick(tab.key)}
+            style={{
+              background: tab.key === activeTab ? '#1a1a1a' : 'transparent',
+              color: tab.key === activeTab ? '#22d3ee' : '#666',
+              border: 'none',
+              borderBottom: tab.key === activeTab ? '2px solid #22d3ee' : '2px solid transparent',
+              padding: '6px 10px',
+              fontSize: '0.7em',
+              fontFamily: '\'Courier New\', monospace',
+              cursor: 'pointer',
+              fontWeight: tab.key === activeTab ? 'bold' : 'normal',
+              letterSpacing: '0.5px'
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: '8px' }}>
+        {TABS.map(tab => renderTab(tab.key))}
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/TacticalTerminal.tsx
+++ b/app/javascript/components/tactical/TacticalTerminal.tsx
@@ -1,0 +1,67 @@
+import React, { useRef, useEffect, useCallback } from 'react'
+import { CommandInput } from '~/components/grid/CommandInput'
+import { useTactical } from './TacticalContext'
+
+export const TacticalTerminal: React.FC = () => {
+  const { output, executing, sendCommand, commandInputRef } = useTactical()
+  const outputRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [output])
+
+  const handleOutputClick = useCallback(() => {
+    commandInputRef.current?.focus()
+  }, [commandInputRef])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      <style>{`
+        @keyframes rainbow-cycle {
+          0%   { color: #ff6b6b; }
+          17%  { color: #fbbf24; }
+          33%  { color: #34d399; }
+          50%  { color: #22d3ee; }
+          67%  { color: #60a5fa; }
+          83%  { color: #a78bfa; }
+          100% { color: #ff6b6b; }
+        }
+        .rarity-unicorn {
+          animation: rainbow-cycle 3s linear infinite;
+          font-weight: bold;
+        }
+      `}</style>
+      <div
+        ref={outputRef}
+        onClick={handleOutputClick}
+        style={{
+          cursor: 'text',
+          fontFamily: 'monospace',
+          fontSize: '0.75em',
+          lineHeight: '1.2',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          overflowWrap: 'break-word',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          padding: '8px',
+          background: '#0d0d0d',
+          color: '#d0d0d0',
+          border: '1px solid #333',
+          borderRadius: '3px'
+        }}
+      >
+        {output.map((line, index) => (
+          <div key={index} dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }} />
+        ))}
+      </div>
+      <div style={{ padding: '6px 0 0 0', flexShrink: 0 }}>
+        <CommandInput ref={commandInputRef} onSubmit={sendCommand} disabled={executing} />
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -1,0 +1,525 @@
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import { ZoneMapData, ZoneMapRoom, ZoneMapGhostRoom } from '~/types/zoneMap'
+import { iso, isoPts, ISO_WALL_H, ISO_TILE_W, ISO_TILE_H, DIRECTION_VECTORS } from './isoGeometry'
+import {
+  buildRenderList, tileStyles, tileColor, connectorEndpoints,
+  computeViewBox, RenderRoom
+} from './isoRenderer'
+
+interface ZoneMapProps {
+  refreshToken: number
+  currentRoomId: number | null
+  onNavigate?: (direction: string) => void
+}
+
+interface Tooltip {
+  room: ZoneMapRoom
+  x: number
+  y: number
+}
+
+const Z_DIRS = new Set(['up', 'down'])
+
+export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate }) => {
+  const [mapData, setMapData] = useState<ZoneMapData | null>(null)
+  const [tooltip, setTooltip] = useState<Tooltip | null>(null)
+  const [zoom, setZoom] = useState(1.25)
+  const [panOffset, setPanOffset] = useState<[number, number]>([0, 0])
+  const svgRef = useRef<SVGSVGElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isPanningState, setIsPanningState] = useState(false)
+  const isPanning = useRef(false)
+  const panStart = useRef<{ clientX: number; clientY: number; panX: number; panY: number } | null>(null)
+
+  // Fetch zone map data
+  useEffect(() => {
+    apiJson<ZoneMapData>('/api/grid/zone_map')
+      .then(data => {
+        setMapData(data)
+        setPanOffset([0, 0])
+      })
+      .catch(err => console.error('Zone map fetch failed:', err))
+  }, [refreshToken])
+
+  // Build render list: visited rooms + unvisited rooms adjacent to current room
+  const renderList = useMemo(() => {
+    if (!mapData || !currentRoomId) return []
+    // Find IDs of rooms reachable from current room (one hop)
+    const adjacentIds = new Set<number>()
+    for (const exit of mapData.exits) {
+      if (exit.from_room_id === currentRoomId) adjacentIds.add(exit.to_room_id)
+    }
+    const visible = mapData.rooms.filter(r => r.visited || adjacentIds.has(r.id))
+    return buildRenderList(visible)
+  }, [mapData, currentRoomId])
+
+  // Room index for connector lookups
+  const roomById = useMemo(() => {
+    if (!mapData) return new Map<number, ZoneMapRoom>()
+    return new Map(mapData.rooms.map(r => [r.id, r]))
+  }, [mapData])
+
+  // Exits from current room: roomId → direction (for click-to-move)
+  // Includes both intra-zone exits and cross-zone ghost room exits
+  const navigableExits = useMemo(() => {
+    if (!mapData || !currentRoomId) return new Map<number, string>()
+    const map = new Map<number, string>()
+    for (const exit of mapData.exits) {
+      if (exit.from_room_id === currentRoomId) {
+        map.set(exit.to_room_id, exit.direction)
+      }
+    }
+    for (const ghost of mapData.ghost_rooms) {
+      if (ghost.local_room_id === currentRoomId) {
+        map.set(ghost.id, ghost.direction)
+      }
+    }
+    return map
+  }, [mapData, currentRoomId])
+
+  // Ghost room positions: compute from local room position + direction vector
+  const ghostRenderList = useMemo(() => {
+    if (!mapData) return []
+    const result: { ghost: ZoneMapGhostRoom; cx: number; cy: number; hw: number; hh: number; navigable: boolean }[] = []
+    for (const ghost of mapData.ghost_rooms) {
+      const localRoom = roomById.get(ghost.local_room_id)
+      if (!localRoom || !localRoom.visited) continue
+      if (Z_DIRS.has(ghost.direction)) continue // vertical ghosts handled separately
+      const vec = DIRECTION_VECTORS[ghost.direction]
+      if (!vec) continue
+      const gx = localRoom.map_x + vec[0]
+      const gy = localRoom.map_y + vec[1]
+      const center = iso(gx, gy, localRoom.map_z)
+      result.push({
+        ghost,
+        cx: center[0],
+        cy: center[1],
+        hw: ISO_TILE_W / 2,
+        hh: ISO_TILE_H / 2,
+        navigable: navigableExits.has(ghost.id)
+      })
+    }
+    return result
+  }, [mapData, roomById, navigableExits])
+
+  // Horizontal connectors between rendered rooms (visited + adjacent-to-current)
+  const connectors = useMemo(() => {
+    if (!mapData || !currentRoomId) return []
+    const visitedIds = new Set(mapData.rooms.filter(r => r.visited).map(r => r.id))
+    const adjacentIds = new Set<number>()
+    for (const exit of mapData.exits) {
+      if (exit.from_room_id === currentRoomId) adjacentIds.add(exit.to_room_id)
+    }
+    const renderedIds = new Set([...visitedIds, ...adjacentIds])
+    const seen = new Set<string>()
+    const result: { key: string; x1: number; y1: number; x2: number; y2: number }[] = []
+
+    for (const exit of mapData.exits) {
+      if (Z_DIRS.has(exit.direction)) continue
+      if (!renderedIds.has(exit.from_room_id) || !renderedIds.has(exit.to_room_id)) continue
+      const pairKey = [Math.min(exit.from_room_id, exit.to_room_id), Math.max(exit.from_room_id, exit.to_room_id)].join('-')
+      if (seen.has(pairKey)) continue
+      seen.add(pairKey)
+
+      const from = roomById.get(exit.from_room_id)
+      const to = roomById.get(exit.to_room_id)
+      if (!from || !to) continue
+
+      const pts = connectorEndpoints(from, to)
+      if (pts) result.push({ key: pairKey, ...pts })
+    }
+    return result
+  }, [mapData, roomById, currentRoomId])
+
+  // Vertical connectors (up/down between z-levels)
+  const verticalConnectors = useMemo(() => {
+    if (!mapData) return []
+    const visitedIds = new Set(mapData.rooms.filter(r => r.visited).map(r => r.id))
+    const seen = new Set<string>()
+    const result: { key: string; x1: number; y1: number; x2: number; y2: number; mx: number; my: number; isUp: boolean }[] = []
+
+    for (const exit of mapData.exits) {
+      if (!Z_DIRS.has(exit.direction)) continue
+      if (!visitedIds.has(exit.from_room_id) || !visitedIds.has(exit.to_room_id)) continue
+      const pairKey = [Math.min(exit.from_room_id, exit.to_room_id), Math.max(exit.from_room_id, exit.to_room_id)].join('-')
+      if (seen.has(pairKey)) continue
+      seen.add(pairKey)
+
+      const from = roomById.get(exit.from_room_id)
+      const to = roomById.get(exit.to_room_id)
+      if (!from || !to) continue
+
+      const p1 = iso(from.map_x, from.map_y, from.map_z)
+      const p2 = iso(to.map_x, to.map_y, to.map_z)
+      // Direction relative to hackr's current z-level
+      const otherZ = from.is_current ? to.map_z : to.is_current ? from.map_z : Math.max(from.map_z, to.map_z)
+      const currentZ = mapData!.z_level
+      const isUp = otherZ > currentZ
+
+      result.push({
+        key: pairKey,
+        x1: p1[0], y1: p1[1],
+        x2: p2[0], y2: p2[1],
+        mx: (p1[0] + p2[0]) / 2,
+        my: (p1[1] + p2[1]) / 2,
+        isUp
+      })
+    }
+    return result
+  }, [mapData, roomById])
+
+  // Compute viewBox
+  const baseViewBox = useMemo(() => {
+    // Include ghost rooms in viewBox calculation
+    const allPoints = [...renderList]
+    for (const g of ghostRenderList) {
+      allPoints.push({
+        room: {} as ZoneMapRoom,
+        depth: 0,
+        points: {
+          top: [g.cx, g.cy - g.hh],
+          right: [g.cx + g.hw, g.cy],
+          bottom: [g.cx, g.cy + g.hh],
+          left: [g.cx - g.hw, g.cy],
+          center: [g.cx, g.cy]
+        }
+      })
+    }
+    return computeViewBox(allPoints)
+  }, [renderList, ghostRenderList])
+
+  const viewBox = useMemo(() => {
+    const w = baseViewBox.w / zoom
+    const h = baseViewBox.h / zoom
+    const cx = baseViewBox.x + baseViewBox.w / 2
+    const cy = baseViewBox.y + baseViewBox.h / 2
+    return {
+      x: cx - w / 2 + panOffset[0],
+      y: cy - h / 2 + panOffset[1],
+      w, h
+    }
+  }, [baseViewBox, zoom, panOffset])
+
+  // Pan handlers
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return
+    if ((e.target as Element).closest('[data-room-id]')) return
+    isPanning.current = true
+    setIsPanningState(true)
+    panStart.current = { clientX: e.clientX, clientY: e.clientY, panX: panOffset[0], panY: panOffset[1] }
+  }, [panOffset])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isPanning.current || !panStart.current || !svgRef.current || !containerRef.current) return
+    const rect = containerRef.current.getBoundingClientRect()
+    const scaleX = viewBox.w / rect.width
+    const scaleY = viewBox.h / rect.height
+    const dx = (e.clientX - panStart.current.clientX) * scaleX
+    const dy = (e.clientY - panStart.current.clientY) * scaleY
+    // Direct viewBox mutation during drag for performance
+    const vb = `${panStart.current.panX - dx + viewBox.x - panOffset[0]} ${panStart.current.panY - dy + viewBox.y - panOffset[1]} ${viewBox.w} ${viewBox.h}`
+    svgRef.current.setAttribute('viewBox', vb)
+  }, [viewBox, panOffset])
+
+  const handleMouseUp = useCallback((e: React.MouseEvent) => {
+    if (!isPanning.current || !panStart.current || !containerRef.current) return
+    isPanning.current = false
+    setIsPanningState(false)
+    const rect = containerRef.current.getBoundingClientRect()
+    const scaleX = viewBox.w / rect.width
+    const scaleY = viewBox.h / rect.height
+    const dx = (e.clientX - panStart.current.clientX) * scaleX
+    const dy = (e.clientY - panStart.current.clientY) * scaleY
+    setPanOffset([panStart.current.panX - dx, panStart.current.panY - dy])
+    panStart.current = null
+  }, [viewBox])
+
+  // Zoom handler
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault()
+    const delta = e.deltaY > 0 ? 0.9 : 1.1
+    setZoom(prev => Math.max(0.5, Math.min(4.0, prev * delta)))
+  }, [])
+
+  // Room click
+  const handleRoomClick = useCallback((room: ZoneMapRoom, e: React.MouseEvent) => {
+    e.stopPropagation()
+    const direction = navigableExits.get(room.id)
+    if (direction && onNavigate) {
+      setTooltip(null)
+      onNavigate(direction)
+    } else {
+      setTooltip(prev =>
+        prev?.room.id === room.id ? null : { room, x: e.clientX, y: e.clientY }
+      )
+    }
+  }, [navigableExits, onNavigate])
+
+  const dismissTooltip = useCallback(() => setTooltip(null), [])
+
+  if (!mapData) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        height: '100%', color: '#555', fontSize: '0.85em'
+      }}>
+        Loading zone map...
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden', background: '#080808' }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={() => { isPanning.current = false; setIsPanningState(false); panStart.current = null }}
+      onWheel={handleWheel}
+      onClick={dismissTooltip}
+    >
+      <style>{`
+        @keyframes pulse-marker {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+
+      {/* Zone label */}
+      <div style={{
+        position: 'absolute', top: 8, left: 12, zIndex: 10,
+        fontSize: '0.8em', pointerEvents: 'none'
+      }}>
+        <span style={{ color: '#888' }}>{mapData.zone.region_name}</span>
+        <span style={{ color: '#444', margin: '0 6px' }}>&gt;</span>
+        <span style={{ color: '#f0abfc', fontWeight: 'bold' }}>{mapData.zone.name}</span>
+        {mapData.z_levels.length > 1 && (
+          <span style={{ marginLeft: 8, color: '#a78bfa' }}>Z:{mapData.z_level}</span>
+        )}
+      </div>
+
+      <svg
+        ref={svgRef}
+        viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`}
+        style={{ width: '100%', height: '100%', cursor: isPanningState ? 'grabbing' : 'grab' }}
+      >
+        {/* Connectors (render before tiles for correct depth) */}
+        {connectors.map(c => (
+          <line
+            key={c.key}
+            x1={c.x1} y1={c.y1} x2={c.x2} y2={c.y2}
+            stroke="#444" strokeWidth={2}
+          />
+        ))}
+
+        {/* Tiles — depth-sorted back-to-front */}
+        {renderList.map(({ room, points }: RenderRoom) => {
+          const isCurrent = room.id === currentRoomId
+          const isNavigable = navigableExits.has(room.id)
+          const isUnexplored = !room.visited && isNavigable
+          const reach = isCurrent ? 'current' as const
+            : isUnexplored ? 'unexplored' as const
+              : isNavigable ? 'adjacent' as const
+                : 'distant' as const
+          const styles = tileStyles(room, reach)
+          const name = isUnexplored ? '?' : (room.name.length > 14 ? room.name.substring(0, 13) + '\u2026' : room.name)
+
+          return (
+            <g key={room.id} data-room-id={room.id}
+              onClick={(e) => handleRoomClick(room, e)}
+              style={{ cursor: isNavigable ? 'pointer' : 'default', opacity: styles.opacity }}>
+              {/* Left wall */}
+              <polygon
+                points={isoPts([points.left, points.bottom,
+                  [points.bottom[0], points.bottom[1] + ISO_WALL_H],
+                  [points.left[0], points.left[1] + ISO_WALL_H]])}
+                fill={styles.leftFill} stroke={styles.sideStroke} strokeWidth={0.5}
+              />
+              {/* Right wall */}
+              <polygon
+                points={isoPts([points.bottom, points.right,
+                  [points.right[0], points.right[1] + ISO_WALL_H],
+                  [points.bottom[0], points.bottom[1] + ISO_WALL_H]])}
+                fill={styles.rightFill} stroke={styles.sideStroke} strokeWidth={0.5}
+              />
+              {/* Top face (diamond) */}
+              <polygon
+                points={isoPts([points.top, points.right, points.bottom, points.left])}
+                fill={styles.topFill} stroke={styles.topStroke} strokeWidth={styles.topStrokeW}
+              />
+              {/* Room name */}
+              <text
+                x={points.center[0]} y={points.center[1] - 4}
+                textAnchor="middle" fill={styles.nameColor}
+                fontFamily="'Courier New', monospace" fontSize="11px"
+                pointerEvents="none"
+              >
+                {name}
+              </text>
+              {/* Room type */}
+              {room.room_type && room.room_type !== 'standard' && (
+                <text
+                  x={points.center[0]} y={points.center[1] + 12}
+                  textAnchor="middle" fill="#555"
+                  fontFamily="'Courier New', monospace" fontSize="8px"
+                  pointerEvents="none"
+                >
+                  {room.room_type}
+                </text>
+              )}
+
+              {/* "You are here" pulsing marker */}
+              {isCurrent && (
+                <polygon
+                  points={isoPts([points.top, points.right, points.bottom, points.left])}
+                  fill="none" stroke="#22d3ee" strokeWidth={3}
+                  style={{
+                    animation: 'pulse-marker 2s ease-in-out infinite',
+                    filter: 'drop-shadow(0 0 6px #22d3ee)'
+                  }}
+                />
+              )}
+
+              {/* Hackr presence dots */}
+              {room.hackr_count > 0 && !isCurrent && (
+                <circle
+                  cx={points.center[0]}
+                  cy={points.top[1] - 8}
+                  r={4}
+                  fill="#fbbf24"
+                  stroke="#0a0a0a" strokeWidth={1}
+                />
+              )}
+              {room.hackr_count > 1 && !isCurrent && (
+                <text
+                  x={points.center[0]} y={points.top[1] - 16}
+                  textAnchor="middle" fill="#fbbf24"
+                  fontFamily="'Courier New', monospace" fontSize="8px"
+                  pointerEvents="none"
+                >
+                  {room.hackr_count}
+                </text>
+              )}
+            </g>
+          )
+        })}
+
+        {/* Ghost rooms (cross-zone boundary) */}
+        {ghostRenderList.map(({ ghost, cx, cy, hw, hh, navigable }) => {
+          const top: [number, number] = [cx, cy - hh]
+          const right: [number, number] = [cx + hw, cy]
+          const bottom: [number, number] = [cx, cy + hh]
+          const left: [number, number] = [cx - hw, cy]
+          const ghostName = ghost.name.length > 12 ? ghost.name.substring(0, 11) + '\u2026' : ghost.name
+
+          // Connector from local room to ghost
+          const localRoom = roomById.get(ghost.local_room_id)
+          const conn = localRoom ? connectorEndpoints(localRoom, {
+            map_x: localRoom.map_x + (DIRECTION_VECTORS[ghost.direction]?.[0] || 0),
+            map_y: localRoom.map_y + (DIRECTION_VECTORS[ghost.direction]?.[1] || 0),
+            map_z: localRoom.map_z
+          } as ZoneMapRoom) : null
+
+          return (
+            <g key={`ghost-${ghost.id}`}
+              opacity={navigable ? 0.5 : 0.25}
+              style={{ cursor: navigable ? 'pointer' : 'default' }}
+              onClick={(e) => {
+                if (navigable && onNavigate) {
+                  e.stopPropagation()
+                  setTooltip(null)
+                  onNavigate(ghost.direction)
+                }
+              }}
+            >
+              {/* Connector line */}
+              {conn && (
+                <line x1={conn.x1} y1={conn.y1} x2={conn.x2} y2={conn.y2}
+                  stroke="#555" strokeWidth={1.5} strokeDasharray="6,4" />
+              )}
+              {/* Top face (dashed diamond) */}
+              <polygon
+                points={isoPts([top, right, bottom, left])}
+                fill="#0e0e0e" stroke="#555" strokeWidth={1} strokeDasharray="4,3"
+              />
+              {/* Name */}
+              <text x={cx} y={cy - 2} textAnchor="middle" fill="#666"
+                fontFamily="'Courier New', monospace" fontSize="9px" pointerEvents="none">
+                {ghostName}
+              </text>
+              {/* Zone name */}
+              <text x={cx} y={cy + 12} textAnchor="middle" fill="#444"
+                fontFamily="'Courier New', monospace" fontSize="7px" pointerEvents="none">
+                {ghost.zone_name}
+              </text>
+            </g>
+          )
+        })}
+
+        {/* Vertical connectors (between z-levels, rendered on top) */}
+        {verticalConnectors.map(vc => {
+          const color = vc.isUp ? '#a78bfa' : '#fb923c'
+          return (
+            <g key={`vert-${vc.key}`}>
+              {/* Glow line */}
+              <line
+                x1={vc.x1} y1={vc.y1} x2={vc.x2} y2={vc.y2}
+                stroke={color} strokeWidth={4} opacity={0.08}
+              />
+              {/* Dashed line */}
+              <line
+                x1={vc.x1} y1={vc.y1} x2={vc.x2} y2={vc.y2}
+                stroke={color} strokeWidth={2} strokeDasharray="8,5" opacity={0.35}
+              />
+              {/* Midpoint badge */}
+              <circle
+                cx={vc.mx} cy={vc.my} r={10}
+                fill="#0a0a0a" stroke={color} strokeWidth={1.5} opacity={0.5}
+              />
+              <text
+                x={vc.mx} y={vc.my + 4}
+                textAnchor="middle" fill={color}
+                fontFamily="'Courier New', monospace" fontSize="12px" fontWeight="bold"
+                opacity={0.5} pointerEvents="none"
+              >
+                {vc.isUp ? '\u2191' : '\u2193'}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div style={{
+          position: 'fixed',
+          left: tooltip.x + 12,
+          top: tooltip.y - 10,
+          background: '#1a1a1a',
+          border: '1px solid #444',
+          borderRadius: '4px',
+          padding: '8px 12px',
+          fontSize: '0.8em',
+          color: '#d0d0d0',
+          pointerEvents: 'none',
+          zIndex: 100,
+          maxWidth: '250px'
+        }}>
+          <div style={{ color: tileColor(tooltip.room), fontWeight: 'bold' }}>
+            {tooltip.room.name}
+          </div>
+          {tooltip.room.room_type && tooltip.room.room_type !== 'standard' && (
+            <div style={{ color: '#888', fontSize: '0.9em' }}>{tooltip.room.room_type}</div>
+          )}
+          {tooltip.room.hackr_count > 0 && (
+            <div style={{ color: '#fbbf24', fontSize: '0.9em', marginTop: '4px' }}>
+              {tooltip.room.hackr_aliases.join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { apiJson } from '~/utils/apiClient'
 import { ZoneMapData, ZoneMapRoom, ZoneMapGhostRoom } from '~/types/zoneMap'
 import { iso, isoPts, ISO_WALL_H, ISO_TILE_W, ISO_TILE_H, DIRECTION_VECTORS } from './isoGeometry'
+import { useZonePresence } from './useZonePresence'
 import {
   buildRenderList, tileStyles, tileColor, connectorEndpoints,
   computeViewBox, RenderRoom
@@ -41,6 +42,37 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
       })
       .catch(err => console.error('Zone map fetch failed:', err))
   }, [refreshToken])
+
+  // Zone-level presence updates via ZoneChannel
+  const handlePresenceUpdate = useCallback((event: { hackr_alias: string; from_room_id: number; to_room_id: number }) => {
+    setMapData(prev => {
+      if (!prev) return prev
+      const roomIds = new Set(prev.rooms.map(r => r.id))
+      // Only update if the event involves rooms in this zone
+      if (!roomIds.has(event.from_room_id) && !roomIds.has(event.to_room_id)) return prev
+
+      return {
+        ...prev,
+        rooms: prev.rooms.map(r => {
+          if (r.id === event.from_room_id && r.hackr_aliases.includes(event.hackr_alias)) {
+            const aliases = r.hackr_aliases.filter(a => a !== event.hackr_alias)
+            return { ...r, hackr_aliases: aliases, hackr_count: aliases.length }
+          }
+          if (r.id === event.to_room_id && r.visited && !r.hackr_aliases.includes(event.hackr_alias)) {
+            const aliases = [...r.hackr_aliases, event.hackr_alias]
+            return { ...r, hackr_aliases: aliases, hackr_count: aliases.length }
+          }
+          return r
+        })
+      }
+    })
+  }, [])
+
+  useZonePresence({
+    enabled: !!currentRoomId,
+    refreshToken,
+    onPresenceUpdate: handlePresenceUpdate
+  })
 
   // Build render list: visited rooms + unvisited rooms adjacent to current room
   const renderList = useMemo(() => {

--- a/app/javascript/components/tactical/map/isoGeometry.ts
+++ b/app/javascript/components/tactical/map/isoGeometry.ts
@@ -1,0 +1,67 @@
+// Isometric geometry constants and transforms
+// Ported from admin map editor (show.html.erb)
+
+export const ISO_TILE_W = 160
+export const ISO_TILE_H = 80
+export const ISO_WALL_H = 32
+export const ISO_Z_SPACING = 120
+
+export function iso (gx: number, gy: number, gz: number): [number, number] {
+  return [
+    (gx - gy) * (ISO_TILE_W / 2),
+    (gx + gy) * (ISO_TILE_H / 2) - gz * ISO_Z_SPACING
+  ]
+}
+
+export function isoInverse (sx: number, sy: number, gz: number): [number, number] {
+  const hw = ISO_TILE_W / 2
+  const hh = ISO_TILE_H / 2
+  const syAdj = sy + gz * ISO_Z_SPACING
+  return [
+    Math.round((sx / hw + syAdj / hh) / 2),
+    Math.round((syAdj / hh - sx / hw) / 2)
+  ]
+}
+
+export function isoPts (arr: [number, number][]): string {
+  return arr.map(p => `${p[0]},${p[1]}`).join(' ')
+}
+
+export function isoDarken (hex: string, factor: number): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return '#' + [r, g, b].map(c =>
+    ('0' + Math.round(c * factor).toString(16)).slice(-2)
+  ).join('')
+}
+
+export const DIRECTION_VECTORS: Record<string, [number, number]> = {
+  north: [0, -1],
+  south: [0, 1],
+  east: [1, 0],
+  west: [-1, 0],
+  northeast: [1, -1],
+  northwest: [-1, -1],
+  southeast: [1, 1],
+  southwest: [-1, 1]
+}
+
+export const ROOM_TYPE_COLORS: Record<string, string> = {
+  hub: '#fbbf24',
+  faction_base: '#a78bfa',
+  govcorp: '#f87171',
+  special: '#34d399',
+  safe_zone: '#86efac',
+  transit: '#38bdf8',
+  shop: '#fb923c',
+  danger_zone: '#ef4444',
+  hospital: '#f472b6',
+  containment: '#dc2626',
+  impound: '#b91c1c',
+  den: '#818cf8',
+  sally_port: '#991b1b',
+  sally_port_anteroom: '#7f1d1d',
+  repair_service: '#f472b6',
+  standard: '#00ffff'
+}

--- a/app/javascript/components/tactical/map/isoRenderer.ts
+++ b/app/javascript/components/tactical/map/isoRenderer.ts
@@ -1,0 +1,147 @@
+// Pure rendering functions for isometric SVG tiles
+// Ported from admin map editor — read-only player version
+
+import { iso, ISO_TILE_W, ISO_TILE_H, ISO_WALL_H, isoDarken, ROOM_TYPE_COLORS } from './isoGeometry'
+import { ZoneMapRoom } from '~/types/zoneMap'
+
+export interface TilePoints {
+  top: [number, number]
+  right: [number, number]
+  bottom: [number, number]
+  left: [number, number]
+  center: [number, number]
+}
+
+export interface RenderRoom {
+  room: ZoneMapRoom
+  depth: number
+  points: TilePoints
+}
+
+export function tilePoints (gx: number, gy: number, gz: number): TilePoints {
+  const center = iso(gx, gy, gz)
+  const cx = center[0], cy = center[1]
+  const hw = ISO_TILE_W / 2, hh = ISO_TILE_H / 2
+  return {
+    top: [cx, cy - hh],
+    right: [cx + hw, cy],
+    bottom: [cx, cy + hh],
+    left: [cx - hw, cy],
+    center: [cx, cy]
+  }
+}
+
+export function buildRenderList (rooms: ZoneMapRoom[]): RenderRoom[] {
+  return rooms
+    .map(room => ({
+      room,
+      depth: room.map_x + room.map_y,
+      points: tilePoints(room.map_x, room.map_y, room.map_z)
+    }))
+    .sort((a, b) => a.depth - b.depth)
+}
+
+export function tileColor (room: ZoneMapRoom): string {
+  return ROOM_TYPE_COLORS[room.room_type || 'standard'] || room.zone_color || '#00ffff'
+}
+
+export type TileReach = 'current' | 'adjacent' | 'distant' | 'unexplored'
+
+export function tileStyles (room: ZoneMapRoom, reach: TileReach) {
+  const color = tileColor(room)
+  if (reach === 'current') {
+    return {
+      topFill: '#1a2a2a',
+      topStroke: '#fff',
+      topStrokeW: 2.5,
+      leftFill: isoDarken(color, 0.25),
+      rightFill: isoDarken(color, 0.18),
+      sideStroke: isoDarken(color, 0.45),
+      nameColor: color,
+      opacity: 1.0
+    }
+  }
+  if (reach === 'adjacent') {
+    return {
+      topFill: '#111',
+      topStroke: color,
+      topStrokeW: 1.5,
+      leftFill: isoDarken(color, 0.20),
+      rightFill: isoDarken(color, 0.14),
+      sideStroke: isoDarken(color, 0.35),
+      nameColor: color,
+      opacity: 0.7
+    }
+  }
+  if (reach === 'unexplored') {
+    return {
+      topFill: '#0c0c0c',
+      topStroke: '#444',
+      topStrokeW: 1,
+      leftFill: '#0a0a0a',
+      rightFill: '#080808',
+      sideStroke: '#1a1a1a',
+      nameColor: '#555',
+      opacity: 0.55
+    }
+  }
+  // distant
+  return {
+    topFill: '#0e0e0e',
+    topStroke: isoDarken(color, 0.4),
+    topStrokeW: 1,
+    leftFill: isoDarken(color, 0.10),
+    rightFill: isoDarken(color, 0.07),
+    sideStroke: isoDarken(color, 0.15),
+    nameColor: isoDarken(color, 0.45),
+    opacity: 0.35
+  }
+}
+
+export function connectorEndpoints (
+  from: ZoneMapRoom,
+  to: ZoneMapRoom
+): { x1: number; y1: number; x2: number; y2: number } | null {
+  const p1 = iso(from.map_x, from.map_y, from.map_z)
+  const p2 = iso(to.map_x, to.map_y, to.map_z)
+  const dx = p2[0] - p1[0], dy = p2[1] - p1[1]
+  const dist = Math.sqrt(dx * dx + dy * dy)
+  if (dist === 0) return null
+
+  const ux = dx / dist, uy = dy / dist
+  const shorten = Math.min(ISO_TILE_W, ISO_TILE_H) * 0.45
+
+  return {
+    x1: Math.round(p1[0] + ux * shorten),
+    y1: Math.round(p1[1] + uy * shorten),
+    x2: Math.round(p2[0] - ux * shorten),
+    y2: Math.round(p2[1] - uy * shorten)
+  }
+}
+
+export function computeViewBox (
+  renderList: RenderRoom[],
+  padding: number = 120
+): { x: number; y: number; w: number; h: number } {
+  if (renderList.length === 0) {
+    return { x: -400, y: -300, w: 800, h: 600 }
+  }
+
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const { points } of renderList) {
+    const pts = [points.top, points.right, points.bottom, points.left]
+    for (const [px, py] of pts) {
+      if (px < minX) minX = px
+      if (py < minY) minY = py
+      if (px > maxX) maxX = px
+      if (py + ISO_WALL_H > maxY) maxY = py + ISO_WALL_H
+    }
+  }
+
+  return {
+    x: minX - padding,
+    y: minY - padding,
+    w: maxX - minX + padding * 2,
+    h: maxY - minY + padding * 2
+  }
+}

--- a/app/javascript/components/tactical/map/useZonePresence.ts
+++ b/app/javascript/components/tactical/map/useZonePresence.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { createConsumer, Cable, Channel } from '@rails/actioncable'
+
+interface PresenceEvent {
+  type: 'presence_update'
+  hackr_alias: string
+  from_room_id: number
+  to_room_id: number
+}
+
+interface UseZonePresenceOptions {
+  enabled: boolean
+  refreshToken: number
+  onPresenceUpdate: (event: PresenceEvent) => void
+}
+
+export function useZonePresence ({ enabled, refreshToken, onPresenceUpdate }: UseZonePresenceOptions) {
+  const cableRef = useRef<Cable | null>(null)
+  const channelRef = useRef<Channel | null>(null)
+  const [connected, setConnected] = useState(false)
+
+  const connect = useCallback(() => {
+    if (!enabled) return
+
+    if (channelRef.current) {
+      channelRef.current.unsubscribe()
+      channelRef.current = null
+    }
+
+    if (!cableRef.current) {
+      const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const wsUrl = `${wsProtocol}//${window.location.host}/cable`
+      cableRef.current = createConsumer(wsUrl)
+    }
+
+    channelRef.current = cableRef.current.subscriptions.create(
+      { channel: 'ZoneChannel' },
+      {
+        connected () {
+          setConnected(true)
+        },
+        disconnected () {
+          setConnected(false)
+        },
+        received (data: PresenceEvent) {
+          if (data.type === 'presence_update') {
+            onPresenceUpdate(data)
+          }
+        }
+      }
+    )
+  }, [enabled, onPresenceUpdate])
+
+  const disconnect = useCallback(() => {
+    if (channelRef.current) {
+      channelRef.current.unsubscribe()
+      channelRef.current = null
+    }
+    if (cableRef.current) {
+      cableRef.current.disconnect()
+      cableRef.current = null
+    }
+    setConnected(false)
+  }, [])
+
+  useEffect(() => {
+    if (enabled) {
+      connect()
+    } else {
+      disconnect()
+    }
+    return () => disconnect()
+  }, [enabled, refreshToken, connect, disconnect])
+
+  return { connected }
+}

--- a/app/javascript/components/tactical/tabs/DeckTab.tsx
+++ b/app/javascript/components/tactical/tabs/DeckTab.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface DeckResponse {
+  deck: {
+    name: string
+    rarity: string
+    rarity_color: string
+    battery_current: number
+    battery_max: number
+    slot_count: number
+    slots_used: number
+    module_slot_count: number
+    modules_used: number
+  } | null
+  software: {
+    id: number
+    name: string
+    rarity_color: string
+    software_category: string
+    slot_cost: number
+    battery_cost: number
+    effect_type: string | null
+    effect_magnitude: number
+    target_types: string[] | null
+    level: number
+  }[]
+  modules: {
+    id: number
+    name: string
+    rarity_color: string
+    description: string | null
+    firmware: string | null
+  }[]
+}
+
+export const DeckTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+  const [data, setData] = useState<DeckResponse | null>(null)
+
+  useEffect(() => {
+    apiJson<DeckResponse>('/api/grid/deck').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+  if (!data.deck) return <div style={{ color: '#666', fontSize: '0.8em' }}>No DECK equipped</div>
+
+  const { deck, software } = data
+  const batteryPct = deck.battery_max > 0 ? Math.round((deck.battery_current / deck.battery_max) * 100) : 0
+
+  return (
+    <div style={{ fontSize: '0.8em' }}>
+      <div style={{ color: deck.rarity_color, fontWeight: 'bold', marginBottom: '8px' }}>
+        {deck.name}
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', color: '#888', marginBottom: '4px' }}>
+        <span>Battery</span>
+        <span>{deck.battery_current}/{deck.battery_max}</span>
+      </div>
+      <div style={{ background: '#1a1a1a', borderRadius: '2px', height: '6px', border: '1px solid #333', marginBottom: '8px' }}>
+        <div style={{
+          width: `${batteryPct}%`, height: '100%', borderRadius: '2px',
+          background: batteryPct > 25 ? '#34d399' : '#f87171'
+        }} />
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', color: '#888', marginBottom: '8px', fontSize: '0.9em' }}>
+        <span>Slots: {deck.slots_used}/{deck.slot_count}</span>
+        <span>Modules: {deck.modules_used}/{deck.module_slot_count}</span>
+      </div>
+
+      {data.modules.length > 0 && (
+        <>
+          <div style={{ color: '#666', fontSize: '0.85em', marginBottom: '4px' }}>INSTALLED MODULES</div>
+          {data.modules.map(mod => (
+            <div key={mod.id} style={{ padding: '2px 0', borderBottom: '1px solid #1a1a1a' }}>
+              <span style={{ color: mod.rarity_color }}>{mod.name}</span>
+              {mod.firmware && (
+                <span style={{ color: '#888', fontSize: '0.85em' }}> &larr; {mod.firmware}</span>
+              )}
+            </div>
+          ))}
+          <div style={{ height: '8px' }} />
+        </>
+      )}
+
+      {software.length > 0 && (
+        <>
+          <div style={{ color: '#666', fontSize: '0.85em', marginBottom: '4px' }}>LOADED SOFTWARE</div>
+          {software.map(sw => {
+            const specs: string[] = []
+            if (sw.battery_cost > 0) specs.push(`${sw.battery_cost} bat`)
+            if (sw.effect_magnitude > 0) specs.push(`${sw.effect_magnitude} ${sw.effect_type || 'dmg'}`)
+            if (sw.target_types?.length) specs.push(sw.target_types.join('/'))
+
+            return (
+              <div key={sw.id} style={{ padding: '3px 0', borderBottom: '1px solid #1a1a1a' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span style={{ color: sw.rarity_color }}>
+                    {sw.name}
+                    {sw.slot_cost > 1 && <span style={{ color: '#888', fontSize: '0.85em' }}> [{sw.slot_cost} slots]</span>}
+                  </span>
+                  <span style={{ color: '#555' }}>{sw.software_category}</span>
+                </div>
+                {specs.length > 0 && (
+                  <div style={{ fontSize: '0.85em', color: '#666', marginTop: '1px' }}>
+                    {specs.join(' · ')}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/InventoryTab.tsx
+++ b/app/javascript/components/tactical/tabs/InventoryTab.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const InventoryTab: React.FC<{ refreshToken: number }> = ({ refreshToken: _refreshToken }) => {
+  return (
+    <div style={{ color: '#555', fontSize: '0.8em', padding: '8px 0' }}>
+      <div style={{ color: '#666', marginBottom: '4px' }}>INVENTORY</div>
+      <div>Use &apos;inventory&apos; command in terminal for now.</div>
+      <div style={{ color: '#444', marginTop: '8px', fontSize: '0.9em' }}>API endpoint pending.</div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/LoadoutTab.tsx
+++ b/app/javascript/components/tactical/tabs/LoadoutTab.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface SlotData {
+  slot: string
+  label: string
+  item: {
+    name: string
+    rarity: string
+    rarity_color: string
+  } | null
+}
+
+interface LoadoutResponse {
+  slots: SlotData[]
+}
+
+export const LoadoutTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+  const [data, setData] = useState<LoadoutResponse | null>(null)
+
+  useEffect(() => {
+    apiJson<LoadoutResponse>('/api/grid/loadout').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+
+  const mid = Math.ceil(data.slots.length / 2)
+  const left = data.slots.slice(0, mid)
+  const right = data.slots.slice(mid)
+
+  const renderSlot = (slot: SlotData) => (
+    <div key={slot.slot} style={{
+      display: 'flex', justifyContent: 'space-between',
+      padding: '3px 0', borderBottom: '1px solid #1a1a1a'
+    }}>
+      <span style={{ color: '#888', minWidth: '55px', fontSize: '0.9em' }}>{slot.label}</span>
+      {slot.item ? (
+        <span style={{ color: slot.item.rarity_color }}>{slot.item.name}</span>
+      ) : (
+        <span style={{ color: '#333' }}>—</span>
+      )}
+    </div>
+  )
+
+  return (
+    <div style={{ fontSize: '0.8em' }}>
+      <div style={{ color: '#666', fontSize: '0.85em', marginBottom: '6px' }}>LOADOUT</div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 16px' }}>
+        <div>{left.map(renderSlot)}</div>
+        <div>{right.map(renderSlot)}</div>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/MissionsTab.tsx
+++ b/app/javascript/components/tactical/tabs/MissionsTab.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface MissionObjective {
+  description: string
+  current: number
+  target: number
+  completed: boolean
+}
+
+interface HackrMission {
+  mission: {
+    name: string
+    slug: string
+  }
+  status: string
+  objectives: MissionObjective[]
+}
+
+interface MissionsResponse {
+  active: HackrMission[]
+  completed: HackrMission[]
+}
+
+export const MissionsTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+  const [data, setData] = useState<MissionsResponse | null>(null)
+
+  useEffect(() => {
+    apiJson<MissionsResponse>('/api/grid/missions').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+
+  return (
+    <div style={{ fontSize: '0.8em' }}>
+      {data.active.length > 0 && (
+        <>
+          <div style={{ color: '#22d3ee', fontSize: '0.85em', marginBottom: '4px' }}>ACTIVE</div>
+          {data.active.map(hm => (
+            <div key={hm.mission.slug} style={{ marginBottom: '8px', paddingBottom: '6px', borderBottom: '1px solid #1a1a1a' }}>
+              <div style={{ color: '#e0e0e0', fontWeight: 'bold' }}>{hm.mission.name}</div>
+              {hm.objectives.map((obj, i) => (
+                <div key={i} style={{
+                  display: 'flex', justifyContent: 'space-between',
+                  fontSize: '0.9em', color: obj.completed ? '#34d399' : '#888'
+                }}>
+                  <span>{obj.completed ? '✓' : '○'} {obj.description}</span>
+                  <span>{obj.current}/{obj.target}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </>
+      )}
+
+      {data.active.length === 0 && (
+        <div style={{ color: '#555' }}>No active missions</div>
+      )}
+
+      {data.completed.length > 0 && (
+        <>
+          <div style={{ color: '#666', fontSize: '0.85em', marginTop: '8px', marginBottom: '4px' }}>
+            COMPLETED ({data.completed.length})
+          </div>
+          {data.completed.slice(0, 5).map(hm => (
+            <div key={hm.mission.slug} style={{ color: '#444', fontSize: '0.9em' }}>
+              ✓ {hm.mission.name}
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/RepTab.tsx
+++ b/app/javascript/components/tactical/tabs/RepTab.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const RepTab: React.FC<{ refreshToken: number }> = ({ refreshToken: _refreshToken }) => {
+  return (
+    <div style={{ color: '#555', fontSize: '0.8em', padding: '8px 0' }}>
+      <div style={{ color: '#666', marginBottom: '4px' }}>REPUTATION</div>
+      <div>Use &apos;rep&apos; command in terminal for now.</div>
+      <div style={{ color: '#444', marginTop: '8px', fontSize: '0.9em' }}>API endpoint pending.</div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/SchematicsTab.tsx
+++ b/app/javascript/components/tactical/tabs/SchematicsTab.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface Ingredient {
+  item_name: string
+  rarity_color: string
+  required: number
+  owned: number
+}
+
+interface OutputDef {
+  name: string
+  description: string | null
+  item_type: string
+  rarity: string
+  rarity_color: string
+  rarity_label: string
+  max_stack: number | null
+  properties: Record<string, unknown>
+}
+
+interface Schematic {
+  slug: string
+  name: string
+  output: OutputDef
+  ingredients: Ingredient[]
+  craftable: boolean
+  has_ingredients: boolean
+}
+
+interface SchematicsResponse {
+  schematics: Schematic[]
+}
+
+const ITEM_TYPE_LABELS: Record<string, string> = {
+  gear: 'Gear', software: 'Software', module: 'Module', firmware: 'Firmware',
+  consumable: 'Consumable', material: 'Material', data: 'Data', tool: 'Tool',
+  rig_component: 'Rig Component', collectible: 'Collectible', faction: 'Faction', fixture: 'Fixture'
+}
+
+const EFFECT_LABELS: Record<string, string> = {
+  heal: 'Restores Health', energy_restore: 'Restores Energy', psyche_restore: 'Restores Psyche',
+  energize: 'Restores Energy', psyche_boost: 'Restores Psyche',
+  inspire: 'Grants Inspiration', deck_recharge: 'Recharges DECK Battery', repair_deck: 'Repairs Fried DECK',
+  signal_flare: 'Reduces Detection', emergency_jackout: 'Emergency BREACH Exit',
+  dmg: 'Damage', detection_reduction: 'Detection Reduction'
+}
+
+function humanizeProperties (props: Record<string, unknown>): { label: string; value: string }[] {
+  const result: { label: string; value: string }[] = []
+  if (props.software_category) result.push({ label: 'Category', value: String(props.software_category) })
+  if (props.effect_type) {
+    const effectLabel = EFFECT_LABELS[String(props.effect_type)] || String(props.effect_type)
+    const mag = Number(props.effect_magnitude) || Number(props.amount) || 0
+    result.push({ label: 'Effect', value: mag > 0 ? `${effectLabel} (${mag})` : effectLabel })
+  }
+  if (props.target_types && Array.isArray(props.target_types) && props.target_types.length > 0) result.push({ label: 'Targets', value: props.target_types.join(', ') })
+  if (props.slot_cost && Number(props.slot_cost) > 1) result.push({ label: 'Slot Cost', value: `${props.slot_cost} slots` })
+  if (props.battery_cost && Number(props.battery_cost) > 0) result.push({ label: 'Battery Cost', value: String(props.battery_cost) })
+  if (props.effects && typeof props.effects === 'object') {
+    for (const [k, v] of Object.entries(props.effects as Record<string, unknown>)) {
+      if (v && v !== 0 && v !== false) result.push({ label: k.replace(/_/g, ' '), value: `+${v}` })
+    }
+  }
+  return result
+}
+
+export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+  const [data, setData] = useState<SchematicsResponse | null>(null)
+  const [confirm, setConfirm] = useState<Schematic | null>(null)
+  const [detail, setDetail] = useState<OutputDef | null>(null)
+
+  useEffect(() => {
+    apiJson<SchematicsResponse>('/api/grid/schematics').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+
+  const ready = data.schematics.filter(s => s.craftable && s.has_ingredients)
+  const available = data.schematics.filter(s => s.craftable && !s.has_ingredients)
+  const locked = data.schematics.filter(s => !s.craftable)
+
+  return (
+    <div style={{ fontSize: '0.8em' }}>
+      {ready.length > 0 && (
+        <>
+          <div style={{ color: '#34d399', fontSize: '0.85em', marginBottom: '4px' }}>READY ({ready.length})</div>
+          {ready.map(s => (
+            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0' }}>
+              <button onClick={() => setConfirm(s)} style={{
+                background: '#34d399', color: '#0a0a0a', border: 'none', borderRadius: '2px',
+                padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+                fontFamily: '\'Courier New\', monospace', lineHeight: 1
+              }}>FAB</button>
+              <span onClick={() => setDetail(s.output)}
+                style={{ color: s.output.rarity_color, cursor: 'pointer' }}>{s.output.name}</span>
+            </div>
+          ))}
+        </>
+      )}
+
+      {available.length > 0 && (
+        <>
+          <div style={{ color: '#fbbf24', fontSize: '0.85em', marginTop: '8px', marginBottom: '4px' }}>
+            AVAILABLE ({available.length})
+          </div>
+          {available.map(s => (
+            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0' }}>
+              <button onClick={() => setConfirm(s)} style={{
+                background: 'transparent', color: '#fbbf24', border: '1px solid #fbbf24', borderRadius: '2px',
+                padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+                fontFamily: '\'Courier New\', monospace', lineHeight: 1
+              }}>FAB</button>
+              <span onClick={() => setDetail(s.output)}
+                style={{ color: '#888', cursor: 'pointer' }}>{s.output.name}</span>
+            </div>
+          ))}
+        </>
+      )}
+
+      {locked.length > 0 && (
+        <div style={{ color: '#444', fontSize: '0.85em', marginTop: '8px' }}>
+          {locked.length} locked schematic{locked.length !== 1 ? 's' : ''}
+        </div>
+      )}
+
+      {detail && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 200,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(0,0,0,0.7)'
+        }} onClick={() => setDetail(null)}>
+          <div style={{
+            background: '#1a1a1a', border: '1px solid #444', borderRadius: '6px',
+            padding: '24px 28px', maxWidth: '460px', fontSize: '1.05em',
+            fontFamily: '\'Courier New\', monospace'
+          }} onClick={e => e.stopPropagation()}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+              <span style={{ color: detail.rarity_color, fontWeight: 'bold', fontSize: '1.15em' }}>{detail.name}</span>
+              <span style={{ color: detail.rarity_color, fontSize: '0.8em' }}>{detail.rarity_label}</span>
+            </div>
+
+            <div style={{ display: 'flex', gap: '12px', fontSize: '0.85em', color: '#888', marginBottom: '12px' }}>
+              <span>{ITEM_TYPE_LABELS[detail.item_type] || detail.item_type}</span>
+              {detail.max_stack && detail.max_stack > 1 && <span>Stack: {detail.max_stack}</span>}
+            </div>
+
+            {detail.description && (
+              <div style={{ color: '#aaa', fontSize: '0.9em', marginBottom: '14px', lineHeight: '1.4' }}>
+                {detail.description}
+              </div>
+            )}
+
+            {(() => {
+              const props = humanizeProperties(detail.properties)
+              if (props.length === 0) return null
+              return (
+                <div style={{ borderTop: '1px solid #333', paddingTop: '10px' }}>
+                  {props.map((p, i) => (
+                    <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '2px 0', fontSize: '0.9em' }}>
+                      <span style={{ color: '#888', textTransform: 'capitalize' }}>{p.label}</span>
+                      <span style={{ color: '#34d399' }}>{p.value}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            })()}
+
+            <div style={{ marginTop: '16px', textAlign: 'right' }}>
+              <button onClick={() => setDetail(null)} style={{
+                background: 'transparent', color: '#888', border: '1px solid #444',
+                padding: '6px 16px', fontSize: '0.9em', cursor: 'pointer',
+                borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+              }}>CLOSE</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirm && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 200,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(0,0,0,0.7)'
+        }} onClick={() => setConfirm(null)}>
+          <div style={{
+            background: '#1a1a1a', border: '1px solid #444', borderRadius: '6px',
+            padding: '24px 28px', maxWidth: '460px', fontSize: '1.15em',
+            fontFamily: '\'Courier New\', monospace'
+          }} onClick={e => e.stopPropagation()}>
+            <div style={{ color: '#e0e0e0', marginBottom: '16px', fontSize: '1.2em' }}>
+              Fabricate <span style={{ color: confirm.output.rarity_color, fontWeight: 'bold' }}>{confirm.output.name}</span>?
+            </div>
+            {confirm.ingredients.length > 0 && (
+              <div style={{ marginBottom: '18px', fontSize: '0.95em' }}>
+                <div style={{ color: '#888', marginBottom: '6px' }}>This will consume:</div>
+                {confirm.ingredients.map((ing, i) => (
+                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '3px 0', gap: '20px' }}>
+                    <span style={{ color: ing.rarity_color }}>{ing.item_name}</span>
+                    <span style={{ color: ing.owned >= ing.required ? '#34d399' : '#f87171', whiteSpace: 'nowrap' }}>
+                      {ing.required}x <span style={{ color: '#555' }}>({ing.owned} owned)</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setConfirm(null)}
+                style={{
+                  background: 'transparent', color: '#888', border: '1px solid #444',
+                  padding: '8px 20px', fontSize: '0.95em', cursor: 'pointer',
+                  borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                CANCEL
+              </button>
+              <button
+                onClick={() => { onCommand?.(`fab ${confirm.slug}`); setConfirm(null) }}
+                style={{
+                  background: '#34d399', color: '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.95em', cursor: 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                FABRICATE
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/StatsTab.tsx
+++ b/app/javascript/components/tactical/tabs/StatsTab.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface LoadoutResponse {
+  vitals: {
+    health: { current: number; max: number }
+    energy: { current: number; max: number }
+    psyche: { current: number; max: number }
+  }
+  active_effects: Record<string, number | boolean>
+}
+
+const VitalBar: React.FC<{ label: string; current: number; max: number; color: string }> = ({
+  label, current, max, color
+}) => {
+  const pct = max > 0 ? Math.round((current / max) * 100) : 0
+  return (
+    <div style={{ marginBottom: '8px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.8em', marginBottom: '2px' }}>
+        <span style={{ color }}>{label}</span>
+        <span style={{ color: '#888' }}>{current}/{max}</span>
+      </div>
+      <div style={{ background: '#1a1a1a', borderRadius: '2px', height: '8px', border: '1px solid #333' }}>
+        <div style={{
+          width: `${pct}%`, height: '100%', borderRadius: '2px',
+          background: color, transition: 'width 0.3s'
+        }} />
+      </div>
+    </div>
+  )
+}
+
+export const StatsTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+  const [data, setData] = useState<LoadoutResponse | null>(null)
+
+  useEffect(() => {
+    apiJson<LoadoutResponse>('/api/grid/loadout').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+
+  const { vitals, active_effects } = data
+  const effectEntries = Object.entries(active_effects).filter(([, v]) => v !== 0 && v !== false)
+
+  return (
+    <div style={{ fontSize: '0.85em' }}>
+      <VitalBar label="HEALTH" current={vitals.health.current} max={vitals.health.max} color="#f87171" />
+      <VitalBar label="ENERGY" current={vitals.energy.current} max={vitals.energy.max} color="#fbbf24" />
+      <VitalBar label="PSYCHE" current={vitals.psyche.current} max={vitals.psyche.max} color="#a78bfa" />
+
+      {effectEntries.length > 0 && (
+        <div style={{ marginTop: '12px' }}>
+          <div style={{ color: '#666', fontSize: '0.8em', marginBottom: '4px' }}>ACTIVE EFFECTS</div>
+          {effectEntries.map(([key, val]) => (
+            <div key={key} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.8em', color: '#888' }}>
+              <span>{key.replace(/_/g, ' ')}</span>
+              <span style={{ color: '#34d399' }}>+{String(val)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -1,0 +1,49 @@
+export interface ZoneMapRoom {
+  id: number
+  name: string
+  slug: string
+  room_type: string | null
+  map_x: number
+  map_y: number
+  map_z: number
+  zone_id: number
+  zone_color: string
+  visited: boolean
+  is_current: boolean
+  hackr_count: number
+  hackr_aliases: string[]
+}
+
+export interface ZoneMapExit {
+  from_room_id: number
+  to_room_id: number
+  direction: string
+  locked: boolean
+}
+
+export interface ZoneMapGhostRoom {
+  id: number
+  name: string
+  zone_id: number
+  zone_name: string
+  region_name: string
+  local_room_id: number
+  direction: string
+}
+
+export interface ZoneMapData {
+  zone: {
+    id: number
+    name: string
+    slug: string
+    danger_level: number
+    region_id: number
+    region_name: string
+  }
+  rooms: ZoneMapRoom[]
+  exits: ZoneMapExit[]
+  ghost_rooms: ZoneMapGhostRoom[]
+  current_room_id: number
+  z_levels: number[]
+  z_level: number
+}

--- a/app/models/feature_grant.rb
+++ b/app/models/feature_grant.rb
@@ -23,6 +23,7 @@ class FeatureGrant < ApplicationRecord
   has_paper_trail
 
   PULSE_GRID = "pulse_grid"
+  TACTICAL_GRID = "tactical_grid"
 
   belongs_to :grid_hackr
 

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -103,6 +103,7 @@ class GridHackr < ApplicationRecord
   has_many :moderation_logs_as_target, class_name: "ModerationLog", foreign_key: :target_id, dependent: :nullify
   has_many :feature_grants, dependent: :destroy
   has_many :grid_hackr_achievements, dependent: :destroy
+  has_many :grid_room_visits, dependent: :destroy
   has_many :grid_achievements, through: :grid_hackr_achievements
   has_many :grid_shop_transactions, dependent: :nullify
   has_many :grid_hackr_reputations, dependent: :destroy
@@ -230,6 +231,7 @@ class GridHackr < ApplicationRecord
     starting_room ||= GridRoom.where(room_type: "hub").first
 
     update!(current_room: starting_room) if starting_room
+    Grid::RoomVisitRecorder.record!(hackr: self, room: starting_room) if starting_room
   end
 
   # Update last activity timestamp without triggering callbacks

--- a/app/models/grid_item_definition.rb
+++ b/app/models/grid_item_definition.rb
@@ -13,6 +13,7 @@
 #  properties  :json             not null
 #  rarity      :string           not null
 #  slug        :string           not null
+#  tutorial    :boolean          default(FALSE), not null
 #  value       :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -49,6 +50,7 @@ class GridItemDefinition < ApplicationRecord
 
   scope :ordered, -> { order(:item_type, :name) }
   scope :by_item_type, ->(t) { where(item_type: t) }
+  scope :non_tutorial, -> { where(tutorial: false) }
 
   def to_param
     slug

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -42,6 +42,7 @@ class GridRoom < ApplicationRecord
   has_many :grid_items, foreign_key: :room_id
   has_many :grid_mobs
   has_many :grid_hackrs, foreign_key: :current_room_id
+  has_many :grid_room_visits, dependent: :destroy
   has_many :grid_breach_encounters, dependent: :destroy
   has_many :den_invites, class_name: "GridDenInvite", foreign_key: :den_id, dependent: :destroy
 

--- a/app/models/grid_room_visit.rb
+++ b/app/models/grid_room_visit.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: grid_room_visits
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  first_visited_at :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  grid_hackr_id    :integer          not null
+#  grid_room_id     :integer          not null
+#
+# Indexes
+#
+#  index_grid_room_visits_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_room_visits_on_grid_room_id   (grid_room_id)
+#  index_grid_room_visits_unique            (grid_hackr_id,grid_room_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_room_id   (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
+class GridRoomVisit < ApplicationRecord
+  belongs_to :grid_hackr
+  belongs_to :grid_room
+
+  validates :grid_hackr_id, uniqueness: {scope: :grid_room_id}
+end

--- a/app/models/grid_schematic.rb
+++ b/app/models/grid_schematic.rb
@@ -54,6 +54,7 @@ class GridSchematic < ApplicationRecord
   validates :required_room_type, inclusion: {in: ROOM_TYPE_LABELS.keys, allow_nil: true}
 
   scope :published, -> { where(published: true) }
+  scope :non_tutorial, -> { where(output_definition_id: GridItemDefinition.where(tutorial: false).select(:id)) }
   scope :ordered, -> { order(:position, :name) }
 
   def to_param

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -398,6 +398,7 @@ module Grid
         destination = region&.cell_block_room
         if destination
           hackr.update!(current_room_id: destination.id)
+          Grid::RoomVisitRecorder.record!(hackr: hackr, room: destination)
           "<span style='color: #34d399; font-weight: bold;'>Cell seal breached. You slip into the corridor.</span>"
         end
       when "sally_port"
@@ -409,6 +410,7 @@ module Grid
         destination = region&.sally_port_room
         if destination
           hackr.update!(current_room_id: destination.id)
+          Grid::RoomVisitRecorder.record!(hackr: hackr, room: destination)
           "<span style='color: #34d399; font-weight: bold;'>Outer door seal breached. You enter the sally port.</span>"
         end
       else

--- a/app/services/grid/breach_generator_service.rb
+++ b/app/services/grid/breach_generator_service.rb
@@ -104,6 +104,7 @@ module Grid
         eject_room_id = @hackr.zone_entry_room_id
         if eject_room_id && eject_room_id != @hackr.current_room_id
           @hackr.update!(current_room_id: eject_room_id)
+          Grid::RoomVisitRecorder.record_by_id!(hackr: @hackr, room_id: eject_room_id)
           ejected = true
         end
       end

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -539,6 +539,7 @@ module Grid
           eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
           if eject_room_id && eject_room_id != @hackr.current_room_id
             @hackr.update!(current_room_id: eject_room_id)
+            Grid::RoomVisitRecorder.record_by_id!(hackr: @hackr, room_id: eject_room_id)
           end
         end
         # Capture path is handled outside the transaction (ContainmentService has its own)
@@ -925,6 +926,7 @@ module Grid
         eject_room_id = @hackr.zone_entry_room_id || hackr_breach.origin_room_id
         if eject_room_id && eject_room_id != @hackr.current_room_id
           @hackr.update!(current_room_id: eject_room_id)
+          Grid::RoomVisitRecorder.record_by_id!(hackr: @hackr, room_id: eject_room_id)
         end
       end
 

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -432,6 +432,7 @@ module Grid
       else
         hackr.update!(current_room: new_room)
       end
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: new_room)
 
       # Track exploration (unique rooms via visited_rooms array in stats)
       visited = hackr.stat("visited_rooms") || []
@@ -1921,7 +1922,7 @@ module Grid
     # --- Fabrication commands ---
 
     def schematics_command
-      all_schematics = GridSchematic.published.ordered
+      all_schematics = GridSchematic.published.non_tutorial.ordered
         .includes(:output_definition, ingredients: :input_definition).to_a
 
       inventory_qtys = hackr.grid_items.group(:grid_item_definition_id).sum(:quantity)
@@ -1971,7 +1972,7 @@ module Grid
       return "<span style='color: #fbbf24;'>Which schematic? Usage: schematic &lt;slug&gt;</span>" if slug.blank?
 
       schematic = Grid::NameResolver.resolve(
-        GridSchematic.published.includes(:output_definition, ingredients: :input_definition),
+        GridSchematic.published.non_tutorial.includes(:output_definition, ingredients: :input_definition),
         slug, column: "slug"
       )
       return "<span style='color: #f87171;'>Unknown schematic: #{h(slug)}. Use 'schematics' to browse.</span>" unless schematic
@@ -2016,7 +2017,7 @@ module Grid
       return "<span style='color: #fbbf24;'>Fabricate what? Usage: fab &lt;schematic-slug&gt;</span>" if recipe_slug.blank?
 
       schematic = Grid::NameResolver.resolve(
-        GridSchematic.published.includes(:output_definition, ingredients: :input_definition),
+        GridSchematic.published.non_tutorial.includes(:output_definition, ingredients: :input_definition),
         recipe_slug, column: "slug"
       )
       return "<span style='color: #f87171;'>Unknown schematic: #{h(recipe_slug)}. Use 'schematics' to browse.</span>" unless schematic

--- a/app/services/grid/containment_service.rb
+++ b/app/services/grid/containment_service.rb
@@ -98,6 +98,7 @@ module Grid
         @hackr.set_stat!("captured_origin_room_id", @hackr.current_room_id)
         @hackr.set_stat!("facility_alert_level", 0)
         @hackr.update!(current_room_id: containment_room.id)
+        Grid::RoomVisitRecorder.record!(hackr: @hackr, room: containment_room)
       end
 
       # Impound gear outside main transaction (ImpoundService has its own)
@@ -187,6 +188,7 @@ module Grid
         @hackr.set_stat!("captured_origin_room_id", nil)
         @hackr.set_stat!("facility_alert_level", nil)
         @hackr.update!(current_room_id: destination.id)
+        Grid::RoomVisitRecorder.record!(hackr: @hackr, room: destination)
       end
 
       display = render_escape(destination)
@@ -236,6 +238,7 @@ module Grid
 
       @hackr.set_stat!("facility_alert_level", 0)
       @hackr.update!(current_room_id: containment_room.id)
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: containment_room)
     end
 
     def find_containment_room

--- a/app/services/grid/local_transit_service.rb
+++ b/app/services/grid/local_transit_service.rb
@@ -245,6 +245,7 @@ module Grid
         journey.lock!
         # Return to origin room
         @hackr.update!(current_room: journey.origin_room) if journey.origin_room
+        Grid::RoomVisitRecorder.record!(hackr: @hackr, room: journey.origin_room) if journey.origin_room
         journey.update!(state: "abandoned", ended_at: Time.current)
         display = Grid::TransitRenderer.render_abandon(journey)
         AbandonResult.new(journey: journey.reload, display: display)
@@ -281,6 +282,7 @@ module Grid
       else
         @hackr.update!(current_room: room)
       end
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: room)
     end
 
     def complete_journey!(journey)

--- a/app/services/grid/restore_point_service.rb
+++ b/app/services/grid/restore_point_service.rb
@@ -48,6 +48,7 @@ module Grid
 
         if destination && destination.id != @hackr.current_room_id
           @hackr.update!(current_room_id: destination.id)
+          Grid::RoomVisitRecorder.record!(hackr: @hackr, room: destination)
         end
       end
 

--- a/app/services/grid/room_visit_recorder.rb
+++ b/app/services/grid/room_visit_recorder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Grid
+  module RoomVisitRecorder
+    def self.record!(hackr:, room:)
+      return unless hackr && room
+
+      GridRoomVisit.find_or_create_by!(
+        grid_hackr: hackr,
+        grid_room: room
+      ) do |v|
+        v.first_visited_at = Time.current
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Race condition: another request inserted first. Idempotent — ignore.
+    end
+
+    def self.record_by_id!(hackr:, room_id:)
+      return unless hackr && room_id
+
+      GridRoomVisit.find_or_create_by!(
+        grid_hackr_id: hackr.id,
+        grid_room_id: room_id
+      ) do |v|
+        v.first_visited_at = Time.current
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # Race condition: another request inserted first. Idempotent — ignore.
+    end
+  end
+end

--- a/app/services/grid/slipstream_service.rb
+++ b/app/services/grid/slipstream_service.rb
@@ -181,6 +181,7 @@ module Grid
       ActiveRecord::Base.transaction do
         journey.lock!
         @hackr.update!(current_room: journey.origin_room) if journey.origin_room
+        Grid::RoomVisitRecorder.record!(hackr: @hackr, room: journey.origin_room) if journey.origin_room
         journey.update!(state: "abandoned", ended_at: Time.current)
         display = Grid::TransitRenderer.render_slipstream_abandon(journey)
         AbandonResult.new(journey: journey.reload, display: display)
@@ -343,6 +344,7 @@ module Grid
       else
         @hackr.update!(current_room: dest)
       end
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: dest)
       @hackr.add_slipstream_heat!(journey.heat_accumulated)
       journey.update!(
         state: "completed",
@@ -359,6 +361,7 @@ module Grid
     def eject!(journey, severity)
       origin = journey.origin_room
       @hackr.update!(current_room: origin) if origin
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: origin) if origin
 
       case severity
       when :severe

--- a/app/services/grid/tutorial_command_parser.rb
+++ b/app/services/grid/tutorial_command_parser.rb
@@ -735,6 +735,7 @@ module Grid
           else
             tutorial_service.return_to_world!
             hackr.update!(current_room: sr.grid_room)
+            Grid::RoomVisitRecorder.record!(hackr: hackr, room: sr.grid_room)
           end
 
           look = Grid::CommandParser.new(hackr, "look").execute[:output]

--- a/app/services/grid/tutorial_service.rb
+++ b/app/services/grid/tutorial_service.rb
@@ -38,6 +38,7 @@ module Grid
       @hackr.set_stat!("tutorial_boot_shown", false)
       @hackr.set_stat!("tutorial_granted_steps", [])
       @hackr.update!(current_room: hub)
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: hub)
     end
 
     # Complete tutorial — hackr chooses a starting room.
@@ -50,6 +51,7 @@ module Grid
       @hackr.set_stat!("tutorial_completed", true)
       @hackr.set_stat!("tutorial_step", nil)
       @hackr.update!(current_room: starting_room)
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: starting_room)
 
       # Grant pulse_grid feature if not already granted
       grant_grid_access!
@@ -83,6 +85,7 @@ module Grid
       @hackr.set_stat!("tutorial_return_room_id", nil)
       @hackr.set_stat!("tutorial_choosing_start", nil)
       @hackr.update!(current_room: return_room) if return_room
+      Grid::RoomVisitRecorder.record!(hackr: @hackr, room: return_room) if return_room
     end
 
     def active?

--- a/app/services/grid/zone_map_builder.rb
+++ b/app/services/grid/zone_map_builder.rb
@@ -22,53 +22,41 @@ module Grid
       positions = bfs_positions(rooms, all_exits)
       z_levels_map = compute_z_levels(rooms, all_exits)
 
-      # Visit status (fog of war)
+      # Fog of war: compute visible set (visited + adjacent to current room)
       visited_ids = GridRoomVisit.where(grid_hackr: @hackr, grid_room_id: room_ids)
         .pluck(:grid_room_id).to_set
-      # Current room always visible
       visited_ids.add(@hackr.current_room_id) if room_ids.include?(@hackr.current_room_id)
 
-      # Hackr presence
+      # Adjacent = rooms reachable in one step from current room
+      exits_by_from = all_exits.group_by(&:from_room_id)
+      adjacent_ids = Set.new
+      (exits_by_from[@hackr.current_room_id] || []).each do |ex|
+        adjacent_ids.add(ex.to_room_id)
+      end
+
+      # Visible = visited + adjacent (server only sends these)
+      visible_ids = visited_ids | adjacent_ids
+
+      # Hackr presence (only for visited rooms — no info leak through fog)
       presence_data = GridHackr.where(current_room_id: room_ids)
         .pluck(:current_room_id, :hackr_alias)
       presence_by_room = presence_data.group_by(&:first)
         .transform_values { |pairs| pairs.map(&:last) }
 
-      # Zone color
       zone_color = build_zone_color(@zone)
-
-      # Ghost rooms (cross-zone exit targets)
       room_id_set = Set.new(room_ids)
-      cross_exit_room_ids = all_exits
-        .reject { |e| room_id_set.include?(e.to_room_id) }
-        .map(&:to_room_id).uniq
-      ghost_rooms_raw = GridRoom.where(id: cross_exit_room_ids)
-        .includes(grid_zone: :grid_region).to_a
 
-      ghost_rooms = ghost_rooms_raw.map do |gr|
-        connecting_exits = all_exits.select { |e| e.to_room_id == gr.id }
-        {
-          id: gr.id,
-          name: gr.name,
-          zone_id: gr.grid_zone_id,
-          zone_name: gr.grid_zone.name,
-          region_name: gr.grid_zone.grid_region.name,
-          local_room_id: connecting_exits.first&.from_room_id,
-          direction: connecting_exits.first&.direction
-        }
-      end
-
-      # Build room data
-      room_data = rooms.map do |r|
+      # Build room data — only visible rooms get full details
+      room_data = rooms.select { |r| visible_ids.include?(r.id) }.map do |r|
         pos = positions[r.id] || [0, 0]
         z = z_levels_map[r.id] || 0
         visited = visited_ids.include?(r.id)
 
         {
           id: r.id,
-          name: r.name,
-          slug: r.slug,
-          room_type: r.room_type,
+          name: visited ? r.name : "???",
+          slug: visited ? r.slug : nil,
+          room_type: visited ? r.room_type : nil,
           map_x: pos[0],
           map_y: pos[1],
           map_z: z,
@@ -81,8 +69,9 @@ module Grid
         }
       end
 
-      # Build exit data (only intra-zone exits for rendering)
+      # Build exit data — only exits between visible rooms
       exit_data = all_exits
+        .select { |e| visible_ids.include?(e.from_room_id) && visible_ids.include?(e.to_room_id) }
         .select { |e| room_id_set.include?(e.to_room_id) }
         .map do |e|
           {
@@ -92,6 +81,27 @@ module Grid
             locked: e.locked?
           }
         end
+
+      # Ghost rooms — only those connected to visible rooms
+      cross_exit_room_ids = all_exits
+        .select { |e| visible_ids.include?(e.from_room_id) }
+        .reject { |e| room_id_set.include?(e.to_room_id) }
+        .map(&:to_room_id).uniq
+      ghost_rooms_raw = GridRoom.where(id: cross_exit_room_ids)
+        .includes(grid_zone: :grid_region).to_a
+
+      ghost_rooms = ghost_rooms_raw.map do |gr|
+        connecting_exits = all_exits.select { |e| e.to_room_id == gr.id && visible_ids.include?(e.from_room_id) }
+        {
+          id: gr.id,
+          name: gr.name,
+          zone_id: gr.grid_zone_id,
+          zone_name: gr.grid_zone.name,
+          region_name: gr.grid_zone.grid_region.name,
+          local_room_id: connecting_exits.first&.from_room_id,
+          direction: connecting_exits.first&.direction
+        }
+      end
 
       current_z = z_levels_map[@hackr.current_room_id] || 0
       z_level_list = z_levels_map.values.uniq.sort

--- a/app/services/grid/zone_map_builder.rb
+++ b/app/services/grid/zone_map_builder.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+module Grid
+  class ZoneMapBuilder
+    ZoneMapResult = Struct.new(
+      :zone, :rooms, :exits, :ghost_rooms,
+      :current_room_id, :z_levels, :z_level,
+      keyword_init: true
+    )
+
+    def initialize(zone:, hackr:)
+      @zone = zone
+      @hackr = hackr
+    end
+
+    def build
+      rooms = @zone.grid_rooms.to_a
+      room_ids = rooms.map(&:id)
+      all_exits = GridExit.where(from_room_id: room_ids).to_a
+
+      # BFS positioning
+      positions = bfs_positions(rooms, all_exits)
+      z_levels_map = compute_z_levels(rooms, all_exits)
+
+      # Visit status (fog of war)
+      visited_ids = GridRoomVisit.where(grid_hackr: @hackr, grid_room_id: room_ids)
+        .pluck(:grid_room_id).to_set
+      # Current room always visible
+      visited_ids.add(@hackr.current_room_id) if room_ids.include?(@hackr.current_room_id)
+
+      # Hackr presence
+      presence_data = GridHackr.where(current_room_id: room_ids)
+        .pluck(:current_room_id, :hackr_alias)
+      presence_by_room = presence_data.group_by(&:first)
+        .transform_values { |pairs| pairs.map(&:last) }
+
+      # Zone color
+      zone_color = build_zone_color(@zone)
+
+      # Ghost rooms (cross-zone exit targets)
+      room_id_set = Set.new(room_ids)
+      cross_exit_room_ids = all_exits
+        .reject { |e| room_id_set.include?(e.to_room_id) }
+        .map(&:to_room_id).uniq
+      ghost_rooms_raw = GridRoom.where(id: cross_exit_room_ids)
+        .includes(grid_zone: :grid_region).to_a
+
+      ghost_rooms = ghost_rooms_raw.map do |gr|
+        connecting_exits = all_exits.select { |e| e.to_room_id == gr.id }
+        {
+          id: gr.id,
+          name: gr.name,
+          zone_id: gr.grid_zone_id,
+          zone_name: gr.grid_zone.name,
+          region_name: gr.grid_zone.grid_region.name,
+          local_room_id: connecting_exits.first&.from_room_id,
+          direction: connecting_exits.first&.direction
+        }
+      end
+
+      # Build room data
+      room_data = rooms.map do |r|
+        pos = positions[r.id] || [0, 0]
+        z = z_levels_map[r.id] || 0
+        visited = visited_ids.include?(r.id)
+
+        {
+          id: r.id,
+          name: r.name,
+          slug: r.slug,
+          room_type: r.room_type,
+          map_x: pos[0],
+          map_y: pos[1],
+          map_z: z,
+          zone_id: r.grid_zone_id,
+          zone_color: zone_color,
+          visited: visited,
+          is_current: r.id == @hackr.current_room_id,
+          hackr_count: visited ? (presence_by_room[r.id]&.size || 0) : 0,
+          hackr_aliases: visited ? (presence_by_room[r.id] || []) : []
+        }
+      end
+
+      # Build exit data (only intra-zone exits for rendering)
+      exit_data = all_exits
+        .select { |e| room_id_set.include?(e.to_room_id) }
+        .map do |e|
+          {
+            from_room_id: e.from_room_id,
+            to_room_id: e.to_room_id,
+            direction: e.direction,
+            locked: e.locked?
+          }
+        end
+
+      current_z = z_levels_map[@hackr.current_room_id] || 0
+      z_level_list = z_levels_map.values.uniq.sort
+
+      region = @zone.grid_region
+
+      ZoneMapResult.new(
+        zone: {
+          id: @zone.id,
+          name: @zone.name,
+          slug: @zone.slug,
+          danger_level: @zone.danger_level,
+          region_id: region&.id,
+          region_name: region&.name
+        },
+        rooms: room_data,
+        exits: exit_data,
+        ghost_rooms: ghost_rooms,
+        current_room_id: @hackr.current_room_id,
+        z_levels: z_level_list,
+        z_level: current_z
+      )
+    end
+
+    private
+
+    def build_zone_color(zone)
+      Grid::WorldMapBuilder::ZONE_COLORS[zone.id % Grid::WorldMapBuilder::ZONE_COLORS.length]
+    end
+
+    def compute_z_levels(rooms, exits)
+      z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
+      room_ids = Set.new(rooms.map(&:id))
+      exits_by_from = exits.group_by(&:from_room_id)
+
+      seed = rooms.find { |r| r.room_type == "hub" } ||
+        rooms.find { |r| r.room_type == "special" } ||
+        rooms.find { |r| r.room_type == "transit" } ||
+        rooms.min_by(&:id)
+      return {} unless seed
+
+      levels = {seed.id => 0}
+      queue = [seed.id]
+      visited = Set.new([seed.id])
+
+      while (rid = queue.shift)
+        current_z = levels[rid]
+        (exits_by_from[rid] || []).each do |ex|
+          next unless room_ids.include?(ex.to_room_id)
+          next if visited.include?(ex.to_room_id)
+
+          z_delta = z_directions[ex.direction]
+          visited.add(ex.to_room_id)
+          levels[ex.to_room_id] = current_z + (z_delta || 0)
+          queue << ex.to_room_id
+        end
+      end
+
+      rooms.each { |r| levels[r.id] ||= 0 }
+      levels
+    end
+
+    def bfs_positions(rooms, exits)
+      return {} if rooms.empty?
+
+      room_index = rooms.index_by(&:id)
+      room_ids = Set.new(rooms.map(&:id))
+      exits_by_from = exits.group_by(&:from_room_id)
+
+      direction_vectors = Grid::WorldMapBuilder::DIRECTION_VECTORS
+      z_directions = Grid::WorldMapBuilder::Z_DIRECTIONS
+
+      positions = {}
+      occupied = {}
+      remaining = Set.new(room_ids)
+
+      seed = rooms.find { |r| r.room_type == "hub" } ||
+        rooms.find { |r| r.room_type == "special" } ||
+        rooms.find { |r| r.room_type == "transit" } ||
+        rooms.min_by(&:id)
+      return {} unless seed
+
+      while remaining.any?
+        seed_id = remaining.include?(seed.id) ? seed.id : remaining.first
+        # Queue items: [room_id, x, y, vertical?]
+        queue = [[seed_id, 0, positions.empty? ? 0 : (positions.values.map(&:last).max + 3), false]]
+        visited = Set.new([seed_id])
+
+        while (item = queue.shift)
+          rid, lx, ly, vertical = item
+
+          # Skip collision detection for vertical exits (they share x,y by design)
+          if !vertical && occupied[[lx, ly]] && occupied[[lx, ly]] != rid
+            placed = false
+            (1..10).each do |radius|
+              break if placed
+              (-radius..radius).each do |dx|
+                break if placed
+                (-radius..radius).each do |dy|
+                  next if dx == 0 && dy == 0
+                  nx, ny = lx + dx, ly + dy
+                  unless occupied.key?([nx, ny])
+                    lx, ly = nx, ny
+                    placed = true
+                  end
+                end
+              end
+            end
+            lx, ly = lx + 11, ly unless placed
+          end
+
+          positions[rid] = [lx, ly]
+          occupied[[lx, ly]] = rid unless vertical
+          remaining.delete(rid)
+
+          (exits_by_from[rid] || []).each do |ex|
+            next unless room_ids.include?(ex.to_room_id)
+            next if visited.include?(ex.to_room_id)
+            if z_directions.key?(ex.direction)
+              visited.add(ex.to_room_id)
+              queue << [ex.to_room_id, lx, ly, true]
+            else
+              vec = direction_vectors[ex.direction]
+              next unless vec
+              visited.add(ex.to_room_id)
+              queue << [ex.to_room_id, lx + vec[0], ly + vec[1], false]
+            end
+          end
+        end
+
+        seed = room_index[remaining.first] if remaining.any?
+      end
+
+      # Normalize to start at (0, 0)
+      if positions.any?
+        min_x = positions.values.map(&:first).min
+        min_y = positions.values.map(&:last).min
+        positions.transform_values! { |pos| [pos[0] - min_x, pos[1] - min_y] }
+      end
+
+      positions
+    end
+  end
+end

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -1255,7 +1255,8 @@
 
       var p1 = iso(from.map_x, from.map_y, from.map_z || 0);
       var p2 = iso(to.map_x, to.map_y, to.map_z || 0);
-      var isUp = (to.map_z || 0) > (from.map_z || 0);
+      var otherZ = (from.map_z || 0) === currentZ ? (to.map_z || 0) : (to.map_z || 0) === currentZ ? (from.map_z || 0) : Math.max(from.map_z || 0, to.map_z || 0);
+      var isUp = otherZ > currentZ;
       var color = isUp ? '#a78bfa' : '#fb923c';
 
       svg.appendChild(el('line', {x1: p1[0], y1: p1[1], x2: p2[0], y2: p2[1], stroke: color, 'stroke-width': 4, opacity: 0.06}));

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     get "identity/two-factor", to: "pages#spa_root", as: :grid_two_factor
     get "reset_password/:token", to: "pages#spa_root", as: :grid_password_reset
     get "confirm_email_change/:token", to: "pages#spa_root", as: :grid_confirm_email_change
+    get "1337", to: "pages#spa_root", as: :grid_tactical
   end
 
   # Vault (promoted from /fm/pulse-vault)
@@ -184,6 +185,7 @@ Rails.application.routes.draw do
     post "grid/reset_password", to: "grid#reset_password"
     post "grid/request_email_change", to: "grid#request_email_change"
     post "grid/confirm_email_change", to: "grid#confirm_email_change"
+    get "grid/zone_map", to: "grid#zone_map"
 
     # TOTP two-factor authentication
     get "totp/status", to: "totp#status"

--- a/db/migrate/20260512151936_create_grid_room_visits.rb
+++ b/db/migrate/20260512151936_create_grid_room_visits.rb
@@ -1,0 +1,19 @@
+class CreateGridRoomVisits < ActiveRecord::Migration[8.1]
+  def change
+    create_table :grid_room_visits do |t|
+      t.integer :grid_hackr_id, null: false
+      t.integer :grid_room_id, null: false
+      t.datetime :first_visited_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :grid_room_visits, :grid_hackr_id
+    add_index :grid_room_visits, :grid_room_id
+    add_index :grid_room_visits, [:grid_hackr_id, :grid_room_id],
+      unique: true, name: "index_grid_room_visits_unique"
+
+    add_foreign_key :grid_room_visits, :grid_hackrs, on_delete: :cascade
+    add_foreign_key :grid_room_visits, :grid_rooms, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260512204418_add_tutorial_to_grid_item_definitions.rb
+++ b/db/migrate/20260512204418_add_tutorial_to_grid_item_definitions.rb
@@ -1,0 +1,12 @@
+class AddTutorialToGridItemDefinitions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_item_definitions, :tutorial, :boolean, default: false, null: false
+
+    # Backfill: all training-* items are tutorial items
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE grid_item_definitions SET tutorial = TRUE WHERE slug LIKE 'training-%'"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_12_204418) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -447,6 +447,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_210000) do
     t.json "properties", default: {}, null: false
     t.string "rarity", null: false
     t.string "slug", null: false
+    t.boolean "tutorial", default: false, null: false
     t.datetime "updated_at", null: false
     t.integer "value", default: 0, null: false
     t.index ["item_type"], name: "index_grid_item_definitions_on_item_type"
@@ -618,6 +619,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_210000) do
     t.index ["grid_hackr_id"], name: "index_grid_reputation_events_on_grid_hackr_id"
     t.index ["source_type", "source_id"], name: "index_rep_events_on_source"
     t.index ["subject_type", "subject_id", "created_at"], name: "index_rep_events_on_subject_and_time", order: { created_at: :desc }
+  end
+
+  create_table "grid_room_visits", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "first_visited_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "grid_room_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "grid_room_id"], name: "index_grid_room_visits_unique", unique: true
+    t.index ["grid_hackr_id"], name: "index_grid_room_visits_on_grid_hackr_id"
+    t.index ["grid_room_id"], name: "index_grid_room_visits_on_grid_room_id"
   end
 
   create_table "grid_rooms", force: :cascade do |t|
@@ -1403,6 +1415,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_210000) do
   add_foreign_key "grid_regions", "grid_rooms", column: "hospital_room_id", on_delete: :nullify
   add_foreign_key "grid_regions", "grid_rooms", column: "sally_port_room_id", on_delete: :nullify
   add_foreign_key "grid_reputation_events", "grid_hackrs"
+  add_foreign_key "grid_room_visits", "grid_hackrs", on_delete: :cascade
+  add_foreign_key "grid_room_visits", "grid_rooms", on_delete: :cascade
   add_foreign_key "grid_rooms", "grid_hackrs", column: "owner_id"
   add_foreign_key "grid_rooms", "zone_playlists", column: "ambient_playlist_id"
   add_foreign_key "grid_salvage_yields", "grid_item_definitions", column: "output_definition_id"

--- a/spec/factories/grid_item_definitions.rb
+++ b/spec/factories/grid_item_definitions.rb
@@ -11,6 +11,7 @@
 #  properties  :json             not null
 #  rarity      :string           not null
 #  slug        :string           not null
+#  tutorial    :boolean          default(FALSE), not null
 #  value       :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/spec/factories/grid_room_visits.rb
+++ b/spec/factories/grid_room_visits.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :grid_room_visit do
+    association :grid_hackr
+    association :grid_room
+    first_visited_at { Time.current }
+  end
+end

--- a/spec/models/grid_room_visit_spec.rb
+++ b/spec/models/grid_room_visit_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe GridRoomVisit, type: :model do
+  let(:hackr) { create(:grid_hackr, :online) }
+  let(:room) { hackr.current_room }
+
+  it "creates a valid visit" do
+    visit = described_class.create!(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    expect(visit).to be_persisted
+  end
+
+  it "enforces uniqueness on hackr + room" do
+    described_class.create!(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    duplicate = described_class.new(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    expect(duplicate).not_to be_valid
+  end
+
+  it "allows same room for different hackrs" do
+    hackr2 = create(:grid_hackr, current_room: room)
+    described_class.create!(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    visit2 = described_class.create!(grid_hackr: hackr2, grid_room: room, first_visited_at: Time.current)
+    expect(visit2).to be_persisted
+  end
+
+  it "cascades on hackr deletion" do
+    described_class.create!(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    expect { hackr.destroy }.to change(described_class, :count).by(-1)
+  end
+
+  it "cascades on room deletion" do
+    room2 = create(:grid_room, grid_zone: room.grid_zone)
+    hackr.update!(current_room: room2)
+    described_class.create!(grid_hackr: hackr, grid_room: room, first_visited_at: Time.current)
+    expect { room.destroy }.to change(described_class, :count).by(-1)
+  end
+end

--- a/spec/services/grid/room_visit_recorder_spec.rb
+++ b/spec/services/grid/room_visit_recorder_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Grid::RoomVisitRecorder do
+  let(:hackr) { create(:grid_hackr, :online) }
+  let(:room) { hackr.current_room }
+
+  describe ".record!" do
+    it "creates a visit record" do
+      expect { described_class.record!(hackr: hackr, room: room) }
+        .to change(GridRoomVisit, :count).by(1)
+    end
+
+    it "is idempotent — second call does not create duplicate" do
+      described_class.record!(hackr: hackr, room: room)
+      expect { described_class.record!(hackr: hackr, room: room) }
+        .not_to change(GridRoomVisit, :count)
+    end
+
+    it "sets first_visited_at" do
+      described_class.record!(hackr: hackr, room: room)
+      visit = GridRoomVisit.last
+      expect(visit.first_visited_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it "does nothing with nil hackr" do
+      expect { described_class.record!(hackr: nil, room: room) }
+        .not_to change(GridRoomVisit, :count)
+    end
+
+    it "does nothing with nil room" do
+      expect { described_class.record!(hackr: hackr, room: nil) }
+        .not_to change(GridRoomVisit, :count)
+    end
+  end
+
+  describe ".record_by_id!" do
+    it "creates a visit record by room ID" do
+      expect { described_class.record_by_id!(hackr: hackr, room_id: room.id) }
+        .to change(GridRoomVisit, :count).by(1)
+    end
+
+    it "is idempotent" do
+      described_class.record_by_id!(hackr: hackr, room_id: room.id)
+      expect { described_class.record_by_id!(hackr: hackr, room_id: room.id) }
+        .not_to change(GridRoomVisit, :count)
+    end
+
+    it "does nothing with nil room_id" do
+      expect { described_class.record_by_id!(hackr: hackr, room_id: nil) }
+        .not_to change(GridRoomVisit, :count)
+    end
+  end
+end

--- a/spec/services/grid/zone_map_builder_spec.rb
+++ b/spec/services/grid/zone_map_builder_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+RSpec.describe Grid::ZoneMapBuilder do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+  let(:room_a) { create(:grid_room, :hub, grid_zone: zone) }
+  let(:room_b) { create(:grid_room, grid_zone: zone) }
+  let(:room_c) { create(:grid_room, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: room_a) }
+
+  before do
+    GridExit.create!(from_room: room_a, to_room: room_b, direction: "north")
+    GridExit.create!(from_room: room_b, to_room: room_a, direction: "south")
+    GridExit.create!(from_room: room_b, to_room: room_c, direction: "east")
+    GridExit.create!(from_room: room_c, to_room: room_b, direction: "west")
+  end
+
+  def build
+    described_class.new(zone: zone, hackr: hackr).build
+  end
+
+  it "returns a ZoneMapResult" do
+    result = build
+    expect(result).to be_a(described_class::ZoneMapResult)
+  end
+
+  it "includes all rooms in zone with BFS positions" do
+    result = build
+    expect(result.rooms.size).to eq(3)
+    result.rooms.each do |r|
+      expect(r[:map_x]).to be_a(Integer)
+      expect(r[:map_y]).to be_a(Integer)
+    end
+  end
+
+  it "marks current room" do
+    result = build
+    current = result.rooms.find { |r| r[:id] == room_a.id }
+    expect(current[:is_current]).to be true
+    other = result.rooms.find { |r| r[:id] == room_b.id }
+    expect(other[:is_current]).to be false
+  end
+
+  describe "fog of war" do
+    it "marks visited rooms" do
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_a)
+      result = build
+      visited = result.rooms.find { |r| r[:id] == room_a.id }
+      unvisited = result.rooms.find { |r| r[:id] == room_b.id }
+      expect(visited[:visited]).to be true
+      expect(unvisited[:visited]).to be false
+    end
+
+    it "always marks current room as visited" do
+      # No visit record, but hackr is in room_a
+      result = build
+      current = result.rooms.find { |r| r[:id] == room_a.id }
+      expect(current[:visited]).to be true
+    end
+
+    it "hides hackr presence on unvisited rooms" do
+      other_hackr = create(:grid_hackr, current_room: room_b)
+      result = build
+      room_b_data = result.rooms.find { |r| r[:id] == room_b.id }
+      expect(room_b_data[:hackr_aliases]).to be_empty
+      expect(room_b_data[:hackr_count]).to eq(0)
+
+      # Now visit it
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_b)
+      result2 = build
+      room_b_data2 = result2.rooms.find { |r| r[:id] == room_b.id }
+      expect(room_b_data2[:hackr_aliases]).to include(other_hackr.hackr_alias)
+      expect(room_b_data2[:hackr_count]).to eq(1)
+    end
+  end
+
+  describe "hackr presence" do
+    it "includes hackr aliases for visited rooms" do
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_a)
+      result = build
+      current = result.rooms.find { |r| r[:id] == room_a.id }
+      expect(current[:hackr_aliases]).to include(hackr.hackr_alias)
+    end
+  end
+
+  describe "exits" do
+    it "returns intra-zone exits" do
+      result = build
+      expect(result.exits.size).to eq(4)
+      directions = result.exits.map { |e| e[:direction] }
+      expect(directions).to include("north", "south", "east", "west")
+    end
+  end
+
+  describe "ghost rooms" do
+    it "returns cross-zone exit targets as ghosts" do
+      zone2 = create(:grid_zone, grid_region: region)
+      room_d = create(:grid_room, grid_zone: zone2)
+      GridExit.create!(from_room: room_c, to_room: room_d, direction: "east")
+
+      result = build
+      expect(result.ghost_rooms.size).to eq(1)
+      ghost = result.ghost_rooms.first
+      expect(ghost[:id]).to eq(room_d.id)
+      expect(ghost[:zone_name]).to eq(zone2.name)
+      expect(ghost[:local_room_id]).to eq(room_c.id)
+      expect(ghost[:direction]).to eq("east")
+    end
+  end
+
+  describe "z-levels" do
+    it "computes z-levels from up/down exits" do
+      room_up = create(:grid_room, grid_zone: zone)
+      GridExit.create!(from_room: room_a, to_room: room_up, direction: "up")
+      GridExit.create!(from_room: room_up, to_room: room_a, direction: "down")
+
+      result = build
+      up_data = result.rooms.find { |r| r[:id] == room_up.id }
+      base_data = result.rooms.find { |r| r[:id] == room_a.id }
+      expect(up_data[:map_z]).to eq(1)
+      expect(base_data[:map_z]).to eq(0)
+    end
+
+    it "places up/down rooms at same x,y as parent" do
+      room_up = create(:grid_room, grid_zone: zone)
+      GridExit.create!(from_room: room_a, to_room: room_up, direction: "up")
+
+      result = build
+      up_data = result.rooms.find { |r| r[:id] == room_up.id }
+      base_data = result.rooms.find { |r| r[:id] == room_a.id }
+      expect(up_data[:map_x]).to eq(base_data[:map_x])
+      expect(up_data[:map_y]).to eq(base_data[:map_y])
+    end
+  end
+
+  describe "zone metadata" do
+    it "includes zone and region info" do
+      result = build
+      expect(result.zone[:name]).to eq(zone.name)
+      expect(result.zone[:region_name]).to eq(region.name)
+    end
+  end
+end

--- a/spec/services/grid/zone_map_builder_spec.rb
+++ b/spec/services/grid/zone_map_builder_spec.rb
@@ -24,13 +24,22 @@ RSpec.describe Grid::ZoneMapBuilder do
     expect(result).to be_a(described_class::ZoneMapResult)
   end
 
-  it "includes all rooms in zone with BFS positions" do
+  it "returns only visible rooms (visited + adjacent) with BFS positions" do
+    # hackr is in room_a (visited), room_b is adjacent, room_c is 2 hops away
     result = build
-    expect(result.rooms.size).to eq(3)
+    expect(result.rooms.size).to eq(2) # room_a (current) + room_b (adjacent)
     result.rooms.each do |r|
       expect(r[:map_x]).to be_a(Integer)
       expect(r[:map_y]).to be_a(Integer)
     end
+  end
+
+  it "returns all rooms when all are visited" do
+    Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_a)
+    Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_b)
+    Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_c)
+    result = build
+    expect(result.rooms.size).to eq(3)
   end
 
   it "marks current room" do
@@ -56,6 +65,22 @@ RSpec.describe Grid::ZoneMapBuilder do
       result = build
       current = result.rooms.find { |r| r[:id] == room_a.id }
       expect(current[:visited]).to be true
+    end
+
+    it "redacts name and room_type for unvisited adjacent rooms" do
+      result = build
+      adjacent = result.rooms.find { |r| r[:id] == room_b.id }
+      expect(adjacent[:visited]).to be false
+      expect(adjacent[:name]).to eq("???")
+      expect(adjacent[:slug]).to be_nil
+      expect(adjacent[:room_type]).to be_nil
+    end
+
+    it "omits rooms beyond one hop from current" do
+      result = build
+      ids = result.rooms.map { |r| r[:id] }
+      expect(ids).to include(room_a.id, room_b.id)
+      expect(ids).not_to include(room_c.id)
     end
 
     it "hides hackr presence on unvisited rooms" do
@@ -84,27 +109,47 @@ RSpec.describe Grid::ZoneMapBuilder do
   end
 
   describe "exits" do
-    it "returns intra-zone exits" do
+    it "returns only exits between visible rooms" do
+      # Only room_a and room_b are visible (current + adjacent)
+      result = build
+      expect(result.exits.size).to eq(2) # north + south between room_a ↔ room_b
+      directions = result.exits.map { |e| e[:direction] }
+      expect(directions).to include("north", "south")
+    end
+
+    it "returns all exits when all rooms visited" do
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_a)
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_b)
+      Grid::RoomVisitRecorder.record!(hackr: hackr, room: room_c)
       result = build
       expect(result.exits.size).to eq(4)
-      directions = result.exits.map { |e| e[:direction] }
-      expect(directions).to include("north", "south", "east", "west")
     end
   end
 
   describe "ghost rooms" do
-    it "returns cross-zone exit targets as ghosts" do
+    it "returns cross-zone exit targets as ghosts when connected to visible room" do
       zone2 = create(:grid_zone, grid_region: region)
       room_d = create(:grid_room, grid_zone: zone2)
-      GridExit.create!(from_room: room_c, to_room: room_d, direction: "east")
+      # Connect ghost to room_a (current room, visible)
+      GridExit.create!(from_room: room_a, to_room: room_d, direction: "west")
 
       result = build
       expect(result.ghost_rooms.size).to eq(1)
       ghost = result.ghost_rooms.first
       expect(ghost[:id]).to eq(room_d.id)
       expect(ghost[:zone_name]).to eq(zone2.name)
-      expect(ghost[:local_room_id]).to eq(room_c.id)
-      expect(ghost[:direction]).to eq("east")
+      expect(ghost[:local_room_id]).to eq(room_a.id)
+      expect(ghost[:direction]).to eq("west")
+    end
+
+    it "omits ghost rooms connected only to non-visible rooms" do
+      zone2 = create(:grid_zone, grid_region: region)
+      room_d = create(:grid_room, grid_zone: zone2)
+      # Connect ghost to room_c (2 hops away, not visible)
+      GridExit.create!(from_room: room_c, to_room: room_d, direction: "east")
+
+      result = build
+      expect(result.ghost_rooms).to be_empty
     end
   end
 


### PR DESCRIPTION
Multi-pane tactical interface for THE PULSE GRID at /grid/1337 — desktop-only alternative to the standard terminal. Fixed CSS Grid layout: tabbed status panel (top-right, 55%), terminal I/O (bottom-right), 2.5D isometric zone map (left, 45%).

Tactical UI — Backend:
- grid_room_visits table for fog-of-war tracking (hackr_id, room_id, unique index, FK cascades)
- Grid::RoomVisitRecorder with record! and record_by_id! — idempotent, race-safe
- Wired into 22 movement code paths across 12 files
- Grid::ZoneMapBuilder — BFS positioning extracted from admin controller, ~4 queries
- GET /api/grid/zone_map gated on FeatureGrant::TACTICAL_GRID
- ZoneChannel for zone-level presence broadcasts on movement
- Installed modules added to GET /api/grid/deck response

Tactical UI — Frontend:
- GridTacticalPage — 100vh layout, TacticalContext command bus with refreshToken pattern
- ZoneMap — SVG isometric renderer: depth-sorted tiles, pan/zoom, pulsing "you are here" marker, hackr presence dots, fog of war (visited rooms only), adjacent unvisited rooms as "?" tiles, ghost rooms at zone boundaries, vertical z-level connectors (purple ↑ / orange ↓ relative to hackr's z-level), click-to-navigate adjacent rooms + cross-zone ghosts, three-tier tile fading (current/adjacent/distant)
- TacticalStatusPanel — 7 lazy tabs: Stats (vitals bars), Deck (battery + slots + installed modules + software specs), Loadout (two-column), Inventory (placeholder), Rep (placeholder), Missions (active/completed), Schematics (FAB button + confirmation modal with ingredient list + item detail modal)
- Tab key focuses command input from anywhere

Tutorial item filtering:
- tutorial boolean on grid_item_definitions (backfilled for training-* slugs)
- GridItemDefinition.non_tutorial and GridSchematic.non_tutorial scopes
- Filtered from schematics API, terminal schematics/schematic/fab commands