### PR TITLE
[TPG] Tactical UI: BREACH panel, CRED tab, polish

### DIFF
--- a/app/controllers/admin/grid_breach_encounters_controller.rb
+++ b/app/controllers/admin/grid_breach_encounters_controller.rb
@@ -5,7 +5,7 @@ class Admin::GridBreachEncountersController < Admin::ApplicationController
 
   versionable GridBreachEncounter
 
-  before_action :set_encounter, only: %i[edit update destroy]
+  before_action :set_encounter, only: %i[edit update destroy make_available]
 
   def index
     @encounters = GridBreachEncounter
@@ -47,6 +47,19 @@ class Admin::GridBreachEncountersController < Admin::ApplicationController
       load_selects
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def make_available
+    if @encounter.available?
+      flash[:error] = "Encounter is already available."
+    elsif @encounter.grid_hackr_breaches.where(state: "active").exists?
+      flash[:error] = "Cannot reset — active breaches reference this encounter."
+    elsif @encounter.update(state: "available", cooldown_until: nil)
+      set_flash_success("Encounter '#{@encounter.name}' set to available.")
+    else
+      flash[:error] = @encounter.errors.full_messages.join(", ")
+    end
+    redirect_to admin_grid_breach_encounters_path
   end
 
   def destroy

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,7 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: [:zone_map]
   before_action :require_admin_api, only: [:debit]
@@ -176,6 +176,7 @@ class Api::GridController < ApplicationController
       },
       inventory_gear: inventory_gear.map { |item| loadout_item_json(item) },
       active_effects: effects.reject { |_, v| v == 0 || v == false },
+      clearance: current_hackr.stat("clearance"),
       vitals: {
         health: {current: current_hackr.stat("health"), max: current_hackr.effective_max("health")},
         energy: {current: current_hackr.stat("energy"), max: current_hackr.effective_max("energy")},
@@ -244,6 +245,26 @@ class Api::GridController < ApplicationController
           depth: entry[:depth]
         }
       }
+    }
+  end
+
+  # GET /api/grid/cred - CRED/cache data for the tactical CRED tab
+  def cred_index
+    caches = current_hackr.grid_caches.player.order(:created_at)
+    debt = current_hackr.stat("govcorp_debt").to_i
+
+    render json: {
+      caches: caches.map { |c|
+        {
+          address: c.address,
+          nickname: c.nickname,
+          balance: c.balance,
+          is_default: c.is_default?,
+          abandoned: c.abandoned?
+        }
+      },
+      total_balance: caches.sum(&:balance),
+      debt: debt
     }
   end
 
@@ -779,6 +800,19 @@ class Api::GridController < ApplicationController
 
     result = Grid::ZoneMapBuilder.new(zone: room.grid_zone, hackr: current_hackr).build
 
+    # Breach encounters available in current room (clearance-filtered)
+    encounters = Grid::BreachService.available_encounters(room: room, hackr: current_hackr)
+    breach_encounters = encounters.map do |enc|
+      {id: enc.id, name: enc.name, tier_label: enc.tier_label, min_clearance: enc.min_clearance}
+    end
+
+    # DECK status for pre-checking breach eligibility
+    deck = current_hackr.equipped_deck
+    deck_status = {
+      equipped: deck.present?,
+      fried: deck.present? && deck.deck_fried?
+    }
+
     render json: {
       zone: result.zone,
       current_room_id: result.current_room_id,
@@ -786,7 +820,10 @@ class Api::GridController < ApplicationController
       exits: result.exits,
       ghost_rooms: result.ghost_rooms,
       z_levels: result.z_levels,
-      z_level: result.z_level
+      z_level: result.z_level,
+      in_breach: current_hackr.in_breach?,
+      breach_encounters: breach_encounters,
+      deck_status: deck_status
     }
   end
 
@@ -837,11 +874,15 @@ class Api::GridController < ApplicationController
     # Reload hackr to get updated current_room
     current_hackr.reload
 
+    breach_meta = breach_meta_for(current_hackr)
+
     render json: {
       success: true,
       output: output,
       room_id: current_hackr.current_room&.id,
-      current_room: current_hackr.current_room ? room_json(current_hackr.current_room) : nil
+      current_room: current_hackr.current_room ? room_json(current_hackr.current_room) : nil,
+      in_breach: breach_meta.present?,
+      breach_meta: breach_meta
     }
   end
 
@@ -978,6 +1019,31 @@ class Api::GridController < ApplicationController
     }
   end
 
+  def breach_meta_for(hackr)
+    breach = hackr.active_breach
+    return nil unless breach
+
+    protocols = breach.grid_breach_protocols.sort_by(&:position).map do |p|
+      {
+        position: p.position,
+        alive: p.alive?,
+        type_label: (p.analyze_level >= 1) ? p.type_label : "???",
+        state: p.state
+      }
+    end
+
+    {
+      template_name: breach.grid_breach_template.name,
+      tier_label: breach.grid_breach_template.tier_label,
+      protocols: protocols,
+      detection_level: breach.detection_level,
+      pnr_threshold: breach.pnr_threshold,
+      actions_remaining: breach.actions_remaining,
+      actions_this_round: breach.actions_this_round,
+      round_number: breach.round_number
+    }
+  end
+
   def playlist_json(playlist)
     {
       id: playlist.id,
@@ -1010,6 +1076,7 @@ class Api::GridController < ApplicationController
       giver: mission.giver_mob ? {
         name: mission.giver_mob.name,
         room_id: mission.giver_mob.grid_room_id,
+        room_name: mission.giver_mob.grid_room&.name,
         room_slug: mission.giver_mob.grid_room&.slug
       } : nil,
       prereq_slug: mission.prereq_mission&.slug,

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGridAuth } from '~/hooks/useGridAuth'
 import { useActionCable, GridEvent } from '~/hooks/useActionCable'
@@ -7,20 +7,34 @@ import { TacticalBar } from '~/components/tactical/TacticalBar'
 import { TacticalTerminal } from '~/components/tactical/TacticalTerminal'
 import { TacticalStatusPanel } from '~/components/tactical/TacticalStatusPanel'
 import { ZoneMap } from '~/components/tactical/map/ZoneMap'
-import { apiJson } from '~/utils/apiClient'
-
-interface GridCommandResponse {
-  output?: string
-  room_id?: number
-}
+import { BreachTargetButtons } from '~/components/tactical/breach/BreachTargetButtons'
+import { BreachConfirmModal } from '~/components/tactical/breach/BreachConfirmModal'
+import { BreachPanel } from '~/components/tactical/breach/BreachPanel'
+import { BreachEncounter, DeckStatus } from '~/types/zoneMap'
 
 const TacticalInner: React.FC = () => {
   const { hackr } = useGridAuth()
   const {
     currentRoomId, setCurrentRoomId, setOutput,
-    refreshToken, sendCommand, commandInputRef
+    refreshToken, sendCommand, commandInputRef,
+    inBreach, breachMeta, breachOutput
   } = useTactical()
   const initialLoadDoneRef = useRef(false)
+  const [breachEncounters, setBreachEncounters] = useState<BreachEncounter[]>([])
+  const [deckStatus, setDeckStatus] = useState<DeckStatus>({ equipped: false, fried: false })
+  const [confirmTarget, setConfirmTarget] = useState<BreachEncounter | null>(null)
+
+  const handleBreachEncountersChange = useCallback((encounters: BreachEncounter[], ds: DeckStatus) => {
+    setBreachEncounters(encounters)
+    setDeckStatus(ds)
+  }, [])
+
+  const handleBreachConfirm = useCallback(() => {
+    if (confirmTarget) {
+      sendCommand(`breach ${confirmTarget.name}`)
+      setConfirmTarget(null)
+    }
+  }, [confirmTarget, sendCommand])
 
   // Tab anywhere → focus command input
   useEffect(() => {
@@ -34,35 +48,21 @@ const TacticalInner: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [commandInputRef])
 
-  // Set initial room and execute look
+  // Set initial room and execute look (routes through sendCommand for breach state detection)
   useEffect(() => {
     if (hackr?.current_room && !initialLoadDoneRef.current) {
       initialLoadDoneRef.current = true
       setCurrentRoomId(hackr.current_room.id)
 
-      const loadInitial = async () => {
-        setOutput([`<div style="color: #a78bfa; font-size: 0.9em;">
+      setOutput([`<div style="color: #a78bfa; font-size: 0.9em;">
 ════════════════════════════════════════════════════
   TACTICAL INTERFACE — THE PULSE GRID
 ════════════════════════════════════════════════════
 </div>`])
 
-        try {
-          const data = await apiJson<GridCommandResponse>('/api/grid/command', {
-            method: 'POST',
-            body: JSON.stringify({ input: 'look' })
-          })
-          if (data.output?.trim()) {
-            setOutput(prev => [...prev, data.output!.trim()])
-          }
-          if (data.room_id) setCurrentRoomId(data.room_id)
-        } catch (err) {
-          console.error('Failed to load initial room:', err)
-        }
-      }
-
-      loadInitial()
+      sendCommand('look')
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- sendCommand is stable (useCallback with []), initialLoadDoneRef guards against re-fire
   }, [hackr, setCurrentRoomId, setOutput])
 
   // ActionCable for room events (terminal output)
@@ -108,7 +108,7 @@ const TacticalInner: React.FC = () => {
       overflow: 'hidden',
       display: 'grid',
       gridTemplateAreas: '"topbar topbar" "leftcol map" "cmdinput cmdinput"',
-      gridTemplateColumns: '55fr 45fr',
+      gridTemplateColumns: '50fr 50fr',
       gridTemplateRows: '44px 1fr 58px',
       background: '#0a0a0a',
       fontFamily: '\'Courier New\', Courier, monospace',
@@ -132,8 +132,27 @@ const TacticalInner: React.FC = () => {
         </div>
       </div>
 
-      <div style={{ gridArea: 'map', overflow: 'hidden', borderLeft: '1px solid #333' }}>
-        <ZoneMap refreshToken={refreshToken} currentRoomId={currentRoomId} onNavigate={(dir) => sendCommand(`go ${dir}`)} />
+      <div style={{ gridArea: 'map', overflow: 'hidden', borderLeft: '1px solid #333', position: 'relative' }}>
+        <ZoneMap
+          refreshToken={refreshToken}
+          currentRoomId={currentRoomId}
+          onNavigate={(dir) => sendCommand(`go ${dir}`)}
+          onBreachEncountersChange={handleBreachEncountersChange}
+        />
+        {!inBreach && breachEncounters.length > 0 && (
+          <BreachTargetButtons
+            encounters={breachEncounters}
+            deckStatus={deckStatus}
+            onSelect={setConfirmTarget}
+          />
+        )}
+        <BreachPanel
+          visible={inBreach}
+          breachMeta={breachMeta}
+          breachOutput={breachOutput}
+          refreshToken={refreshToken}
+          onCommand={sendCommand}
+        />
       </div>
 
       <div style={{
@@ -143,11 +162,23 @@ const TacticalInner: React.FC = () => {
         background: '#111'
       }}>
         <div style={{ fontSize: '0.75em', color: '#555', textAlign: 'center' }}>
-          Commands: look, go [dir], take/drop [item], say [msg], talk/ask [npc], inventory, who, help, clear
-          <span style={{ marginLeft: '10px', color: '#333' }}>|</span>
-          <span style={{ marginLeft: '10px' }}>↑/↓ for history</span>
+          {inBreach
+            ? <>BREACH: exec [prog] [#], analyze [#], reroute [#], use [item], interface [gate] [ans], jackout, status, help</>
+            : <>Commands: look, go [dir], take/drop [item], say [msg], talk/ask [npc], inventory, who, help, clear
+              <span style={{ marginLeft: '10px', color: '#333' }}>|</span>
+              <span style={{ marginLeft: '10px' }}>↑/↓ for history</span>
+            </>
+          }
         </div>
       </div>
+
+      {confirmTarget && (
+        <BreachConfirmModal
+          encounter={confirmTarget}
+          onConfirm={handleBreachConfirm}
+          onCancel={() => setConfirmTarget(null)}
+        />
+      )}
     </div>
   )
 }

--- a/app/javascript/components/tactical/TacticalBar.tsx
+++ b/app/javascript/components/tactical/TacticalBar.tsx
@@ -8,7 +8,8 @@ interface TacticalBarProps {
   refreshToken: number
 }
 
-interface VitalsData {
+interface LoadoutData {
+  clearance: number
   vitals: {
     health: { current: number; max: number }
     energy: { current: number; max: number }
@@ -40,10 +41,12 @@ const CompactVital: React.FC<{ label: string; current: number; max: number; colo
 export const TacticalBar: React.FC<TacticalBarProps> = ({ connectionStatus, refreshToken }) => {
   const { hackr, disconnect } = useGridAuth()
   const navigate = useNavigate()
-  const [vitals, setVitals] = useState<VitalsData['vitals'] | null>(null)
+  const [vitals, setVitals] = useState<LoadoutData['vitals'] | null>(null)
+  const [clearance, setClearance] = useState<number | null>(null)
+  const [clHover, setClHover] = useState(false)
 
   useEffect(() => {
-    apiJson<VitalsData>('/api/grid/loadout').then(d => setVitals(d.vitals)).catch(console.error)
+    apiJson<LoadoutData>('/api/grid/loadout').then(d => { setVitals(d.vitals); setClearance(d.clearance) }).catch(console.error)
   }, [refreshToken])
 
   const handleDisconnect = async () => {
@@ -67,6 +70,26 @@ export const TacticalBar: React.FC<TacticalBarProps> = ({ connectionStatus, refr
         <span style={{ color: '#a78bfa', fontWeight: 'bold', letterSpacing: '1px' }}>TACTICAL</span>
         <span style={{ color: '#333' }}>|</span>
         <span style={{ color: '#e0e0e0' }}>{hackr?.hackr_alias}</span>
+        {clearance != null && (
+          <span
+            style={{ color: '#fbbf24', fontSize: '0.8em', position: 'relative', cursor: 'default' }}
+            onMouseEnter={() => setClHover(true)}
+            onMouseLeave={() => setClHover(false)}
+          >
+            CL{clearance}
+            {clHover && (
+              <div style={{
+                position: 'absolute', top: '100%', left: 0, marginTop: '6px',
+                background: '#1a1a1a', border: '1px solid #444', borderRadius: '4px',
+                padding: '6px 10px', whiteSpace: 'nowrap', zIndex: 50,
+                fontSize: '1em', color: '#d0d0d0',
+                fontFamily: '\'Courier New\', monospace'
+              }}>
+                <span style={{ color: '#fbbf24' }}>CLEARANCE:</span> {clearance}
+              </div>
+            )}
+          </span>
+        )}
         <span style={{ color: '#333' }}>|</span>
         <span style={{
           color: connectionStatus === 'connected' ? '#34d399'

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -8,6 +8,26 @@ interface GridCommandResponse {
   current_room?: {
     ambient_playlist?: unknown
   }
+  in_breach?: boolean
+  breach_meta?: BreachMeta | null
+}
+
+export interface BreachProtocolMeta {
+  position: number
+  alive: boolean
+  type_label: string
+  state: string
+}
+
+export interface BreachMeta {
+  template_name: string
+  tier_label: string
+  protocols: BreachProtocolMeta[]
+  detection_level: number
+  pnr_threshold: number
+  actions_remaining: number
+  actions_this_round: number
+  round_number: number
 }
 
 interface TacticalContextValue {
@@ -15,6 +35,9 @@ interface TacticalContextValue {
   currentRoomId: number | null
   executing: boolean
   refreshToken: number
+  inBreach: boolean
+  breachMeta: BreachMeta | null
+  breachOutput: string[]
   sendCommand: (command: string) => Promise<void>
   setOutput: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentRoomId: React.Dispatch<React.SetStateAction<number | null>>
@@ -34,7 +57,11 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [currentRoomId, setCurrentRoomId] = useState<number | null>(null)
   const [executing, setExecuting] = useState(false)
   const [refreshToken, setRefreshToken] = useState(0)
+  const [inBreach, setInBreach] = useState(false)
+  const [breachMeta, setBreachMeta] = useState<BreachMeta | null>(null)
+  const [breachOutput, setBreachOutput] = useState<string[]>([])
   const commandInputRef = useRef<CommandInputHandle | null>(null)
+  const inBreachRef = useRef(false)
 
   const sendCommand = useCallback(async (command: string) => {
     if (['clear', 'cls', 'cl'].includes(command.toLowerCase())) {
@@ -42,11 +69,12 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
       return
     }
 
-    setOutput(prev => [
-      ...prev,
+    const echoLines = [
       '<div style="height: 1px; background: #444; margin-top: 16px; margin-bottom: 12px; overflow: hidden;"></div>',
       `<span style="color: #22d3ee;">&gt; ${command}</span>`
-    ])
+    ]
+
+    setOutput(prev => [...prev, ...echoLines])
 
     setExecuting(true)
 
@@ -65,6 +93,32 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
         setCurrentRoomId(prev => data.room_id !== prev ? data.room_id! : prev)
       }
 
+      // Breach state tracking (uses ref to avoid stale closure)
+      const wasInBreach = inBreachRef.current
+      const nowInBreach = data.in_breach === true
+
+      if (nowInBreach) {
+        inBreachRef.current = true
+        setInBreach(true)
+        setBreachMeta(data.breach_meta ?? null)
+        // Replace breach output with latest command result (no scrolling)
+        const newLines = [...echoLines]
+        if (outputText) newLines.push(outputText)
+        setBreachOutput(newLines)
+      } else if (wasInBreach && !nowInBreach) {
+        // Breach just ended — show final output, then clear all breach state together
+        inBreachRef.current = false
+        const finalLines = [...echoLines]
+        if (outputText) finalLines.push(outputText)
+        setBreachOutput(finalLines)
+        // Delay clearing so panel can show final output during slide-down
+        setTimeout(() => {
+          setInBreach(false)
+          setBreachMeta(null)
+          setBreachOutput([])
+        }, 400)
+      }
+
       setRefreshToken(prev => prev + 1)
     } catch (err) {
       console.error('Command execution failed:', err)
@@ -77,6 +131,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   return (
     <TacticalContext.Provider value={{
       output, currentRoomId, executing, refreshToken,
+      inBreach, breachMeta, breachOutput,
       sendCommand, setOutput, setCurrentRoomId, commandInputRef
     }}>
       {children}

--- a/app/javascript/components/tactical/TacticalStatusPanel.tsx
+++ b/app/javascript/components/tactical/TacticalStatusPanel.tsx
@@ -5,14 +5,16 @@ import { InventoryTab } from './tabs/InventoryTab'
 import { RepTab } from './tabs/RepTab'
 import { MissionsTab } from './tabs/MissionsTab'
 import { SchematicsTab } from './tabs/SchematicsTab'
+import { CredTab } from './tabs/CredTab'
 
-type TabKey = 'deck' | 'loadout' | 'inventory' | 'rep' | 'missions' | 'schematics'
+type TabKey = 'deck' | 'loadout' | 'inventory' | 'rep' | 'cred' | 'missions' | 'schematics'
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'deck', label: 'DECK' },
   { key: 'loadout', label: 'GEAR' },
   { key: 'inventory', label: 'INV' },
   { key: 'rep', label: 'REP' },
+  { key: 'cred', label: 'CRED' },
   { key: 'missions', label: 'MISSIONS' },
   { key: 'schematics', label: 'SCHEM' }
 ]
@@ -36,18 +38,18 @@ export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refres
     })
   }
 
-  const renderTab = (key: TabKey) => {
-    if (!mountedTabs.has(key)) return null
-    const isActive = key === activeTab
-
+  const renderTab = (tab: typeof TABS[number]) => {
+    if (!mountedTabs.has(tab.key)) return null
+    const isActive = tab.key === activeTab
     return (
-      <div key={key} style={{ display: isActive ? 'block' : 'none', height: '100%', overflow: 'auto' }}>
-        {key === 'deck' && <DeckTab refreshToken={refreshToken} />}
-        {key === 'loadout' && <LoadoutTab refreshToken={refreshToken} />}
-        {key === 'inventory' && <InventoryTab refreshToken={refreshToken} onCommand={onCommand} />}
-        {key === 'rep' && <RepTab refreshToken={refreshToken} />}
-        {key === 'missions' && <MissionsTab refreshToken={refreshToken} />}
-        {key === 'schematics' && <SchematicsTab refreshToken={refreshToken} onCommand={onCommand} />}
+      <div key={tab.key} style={{ display: isActive ? 'block' : 'none', height: '100%' }}>
+        {tab.key === 'deck' && <DeckTab refreshToken={refreshToken} />}
+        {tab.key === 'loadout' && <LoadoutTab refreshToken={refreshToken} />}
+        {tab.key === 'inventory' && <InventoryTab refreshToken={refreshToken} onCommand={onCommand} />}
+        {tab.key === 'rep' && <RepTab refreshToken={refreshToken} />}
+        {tab.key === 'cred' && <CredTab refreshToken={refreshToken} onCommand={onCommand} />}
+        {tab.key === 'missions' && <MissionsTab refreshToken={refreshToken} onCommand={onCommand} />}
+        {tab.key === 'schematics' && <SchematicsTab refreshToken={refreshToken} onCommand={onCommand} />}
       </div>
     )
   }
@@ -79,8 +81,8 @@ export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refres
           </button>
         ))}
       </div>
-      <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: '8px' }}>
-        {TABS.map(tab => renderTab(tab.key))}
+      <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', padding: '8px' }}>
+        {TABS.map(tab => renderTab(tab))}
       </div>
     </div>
   )

--- a/app/javascript/components/tactical/breach/BreachConfirmModal.tsx
+++ b/app/javascript/components/tactical/breach/BreachConfirmModal.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { BreachEncounter } from '~/types/zoneMap'
+import { TIER_COLORS } from './breachConstants'
+
+interface BreachConfirmModalProps {
+  encounter: BreachEncounter
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export const BreachConfirmModal: React.FC<BreachConfirmModalProps> = ({
+  encounter, onConfirm, onCancel
+}) => {
+  const tierColor = TIER_COLORS[encounter.tier_label.toLowerCase()] || '#9ca3af'
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 200,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: 'rgba(0,0,0,0.7)'
+      }}
+      onClick={onCancel}
+    >
+      <div
+        style={{
+          background: '#1a1a1a',
+          border: '1px solid #22d3ee',
+          borderRadius: '6px',
+          padding: '24px 28px',
+          maxWidth: '420px',
+          fontFamily: '\'Courier New\', monospace'
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <div style={{
+          color: '#22d3ee',
+          fontWeight: 'bold',
+          fontSize: '1.1em',
+          letterSpacing: '1px',
+          marginBottom: '16px'
+        }}>
+          INITIATE BREACH
+        </div>
+
+        <div style={{ marginBottom: '8px' }}>
+          <span style={{ color: '#d0d0d0', fontSize: '1.05em' }}>{encounter.name}</span>
+          <span style={{ color: tierColor, marginLeft: '10px', fontSize: '0.9em' }}>
+            {encounter.tier_label}
+          </span>
+        </div>
+
+        {encounter.min_clearance > 0 && (
+          <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '12px' }}>
+            Clearance: {encounter.min_clearance}
+          </div>
+        )}
+
+        <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '20px' }}>
+          This will engage your DECK. Are you ready?
+        </div>
+
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onCancel}
+            style={{
+              background: 'transparent',
+              color: '#888',
+              border: '1px solid #444',
+              padding: '8px 20px',
+              fontSize: '0.9em',
+              cursor: 'pointer',
+              borderRadius: '3px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+          >
+            CANCEL
+          </button>
+          <button
+            onClick={onConfirm}
+            style={{
+              background: '#22d3ee',
+              color: '#0a0a0a',
+              border: 'none',
+              padding: '8px 20px',
+              fontSize: '0.9em',
+              cursor: 'pointer',
+              borderRadius: '3px',
+              fontWeight: 'bold',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+          >
+            BREACH
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/breach/BreachPanel.tsx
+++ b/app/javascript/components/tactical/breach/BreachPanel.tsx
@@ -1,0 +1,408 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import { BreachMeta, BreachProtocolMeta } from '../TacticalContext'
+
+interface DeckData {
+  deck: {
+    name: string
+    rarity_color: string
+    battery_current: number
+    battery_max: number
+  } | null
+  software: {
+    id: number
+    name: string
+    rarity_color: string
+    software_category: string
+    battery_cost: number
+    effect_magnitude: number
+    target_types: string[] | null
+  }[]
+}
+
+interface BreachPanelProps {
+  visible: boolean
+  breachMeta: BreachMeta | null
+  breachOutput: string[]
+  refreshToken: number
+  onCommand: (cmd: string) => void
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  offensive: '#f87171',
+  defensive: '#60a5fa',
+  utility: '#fbbf24',
+  exploit: '#a78bfa'
+}
+
+const TargetSelector: React.FC<{
+  protocols: BreachProtocolMeta[]
+  label: string
+  onSelect: (position: number) => void
+  onCancel: () => void
+}> = ({ protocols, label, onSelect, onCancel }) => {
+  const aliveProtocols = protocols.filter(p => p.alive)
+
+  return (
+    <div style={{
+      position: 'absolute', top: '100%', left: 0, marginTop: '4px',
+      background: '#1a1a1a', border: '1px solid #444', borderRadius: '4px',
+      padding: '8px', zIndex: 50, minWidth: '160px'
+    }}>
+      <div style={{ color: '#888', fontSize: '0.75em', marginBottom: '6px' }}>{label}</div>
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+        {aliveProtocols.map(p => (
+          <button
+            key={p.position}
+            onClick={() => onSelect(p.position + 1)}
+            style={{
+              background: '#222',
+              border: '1px solid #555',
+              borderRadius: '3px',
+              padding: '4px 10px',
+              color: '#d0d0d0',
+              fontSize: '0.8em',
+              cursor: 'pointer',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+          >
+            [{p.position + 1}] {p.type_label}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={onCancel}
+        style={{
+          background: 'none', border: 'none', color: '#666',
+          fontSize: '0.7em', cursor: 'pointer', marginTop: '4px',
+          fontFamily: '\'Courier New\', monospace'
+        }}
+      >
+        cancel
+      </button>
+    </div>
+  )
+}
+
+export const BreachPanel: React.FC<BreachPanelProps> = ({
+  visible, breachMeta, breachOutput, refreshToken, onCommand
+}) => {
+  const [deckData, setDeckData] = useState<DeckData | null>(null)
+  const [isRendered, setIsRendered] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeSelector, setActiveSelector] = useState<{ type: 'exec'; softwareName: string } | { type: 'analyze' } | { type: 'reroute' } | null>(null)
+  const [jackoutConfirm, setJackoutConfirm] = useState(false)
+  const outputRef = useRef<HTMLDivElement>(null)
+
+  // Slide animation: mount first, then open; close first, then unmount
+  // Double-rAF ensures browser paints the closed state before transitioning to open
+  useEffect(() => {
+    if (visible) {
+      setIsRendered(true) // eslint-disable-line react-hooks/set-state-in-effect -- must mount before animating
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setIsOpen(true))
+      })
+      return () => cancelAnimationFrame(raf)
+    } else {
+      setIsOpen(false)
+      const timer = setTimeout(() => setIsRendered(false), 300)
+      return () => clearTimeout(timer)
+    }
+  }, [visible])
+
+  // Fetch deck data when panel is rendered
+  useEffect(() => {
+    if (isRendered) {
+      apiJson<DeckData>('/api/grid/deck').then(setDeckData).catch(console.error)
+    }
+  }, [refreshToken, isRendered])
+
+  // Auto-scroll breach output
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [breachOutput])
+
+  // Dismiss target selector on outside click
+  const dismissSelector = useCallback(() => setActiveSelector(null), [])
+
+  if (!isRendered) return null
+
+  const protocols = breachMeta?.protocols || []
+  const deck = deckData?.deck
+  const software = deckData?.software || []
+
+  const batteryPct = deck && deck.battery_max > 0
+    ? Math.round((deck.battery_current / deck.battery_max) * 100) : 0
+
+  return (
+    <div
+      onClick={dismissSelector}
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        top: '15%',
+        zIndex: 30,
+        transform: isOpen ? 'translateY(0%)' : 'translateY(100%)',
+        transition: 'transform 300ms ease-out',
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#0d0d0d',
+        borderTop: '2px solid #22d3ee',
+        borderRadius: '8px 8px 0 0',
+        fontFamily: '\'Courier New\', monospace'
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '8px 12px',
+        background: '#111',
+        borderBottom: '1px solid #333',
+        flexShrink: 0
+      }}>
+        <div>
+          <span style={{ color: '#22d3ee', fontWeight: 'bold', fontSize: '0.8em', letterSpacing: '1px' }}>
+            BREACH
+          </span>
+          {breachMeta && (
+            <>
+              <span style={{ color: '#444', margin: '0 8px' }}>::</span>
+              <span style={{ color: '#d0d0d0', fontSize: '0.8em' }}>{breachMeta.template_name}</span>
+              <span style={{ color: '#666', fontSize: '0.7em', marginLeft: '8px' }}>{breachMeta.tier_label}</span>
+            </>
+          )}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          {breachMeta && (
+            <span style={{ color: '#9ca3af', fontSize: '0.7em' }}>
+              R{breachMeta.round_number} &middot; {breachMeta.actions_remaining}/{breachMeta.actions_this_round} actions
+            </span>
+          )}
+          <button
+            onClick={() => setJackoutConfirm(true)}
+            style={{
+              background: '#dc2626',
+              color: 'white',
+              border: 'none',
+              padding: '3px 10px',
+              fontSize: '0.7em',
+              cursor: 'pointer',
+              borderRadius: '3px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+          >
+            JACKOUT
+          </button>
+        </div>
+      </div>
+
+      {/* DECK snapshot + Action bar */}
+      <div style={{
+        display: 'flex',
+        gap: '0',
+        borderBottom: '1px solid #333',
+        flexShrink: 0,
+        background: '#0f0f0f',
+        position: 'relative',
+        zIndex: 10
+      }}>
+        {/* DECK snapshot */}
+        <div style={{ padding: '8px 12px', borderRight: '1px solid #333', minWidth: '180px', maxWidth: '200px' }}>
+          {deck ? (
+            <>
+              <div style={{ color: deck.rarity_color, fontSize: '0.7em', fontWeight: 'bold', marginBottom: '4px' }}>
+                {deck.name}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '4px' }}>
+                <span style={{ color: '#fbbf24', fontSize: '0.65em' }}>BAT</span>
+                <div style={{
+                  background: '#1a1a1a', borderRadius: '2px', height: '5px',
+                  flex: 1, border: '1px solid #333', overflow: 'hidden'
+                }}>
+                  <div style={{
+                    width: `${batteryPct}%`, height: '100%', borderRadius: '2px',
+                    background: batteryPct > 25 ? '#34d399' : '#f87171'
+                  }} />
+                </div>
+                <span style={{ color: '#888', fontSize: '0.6em' }}>{deck.battery_current}/{deck.battery_max}</span>
+              </div>
+            </>
+          ) : (
+            <div style={{ color: '#555', fontSize: '0.7em' }}>No DECK</div>
+          )}
+        </div>
+
+        {/* Software action bar */}
+        <div style={{
+          flex: 1, padding: '6px 12px',
+          display: 'flex', flexWrap: 'wrap', gap: '4px', alignItems: 'center', alignContent: 'flex-start'
+        }}>
+          {software.map(sw => {
+            const catColor = CATEGORY_COLORS[sw.software_category] || '#9ca3af'
+            return (
+              <div key={sw.id} style={{ position: 'relative' }}>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setActiveSelector(
+                      activeSelector?.type === 'exec' && activeSelector.softwareName === sw.name
+                        ? null
+                        : { type: 'exec', softwareName: sw.name }
+                    )
+                  }}
+                  style={{
+                    background: '#1a1a1a',
+                    border: `1px solid ${catColor}44`,
+                    borderRadius: '3px',
+                    padding: '3px 8px',
+                    color: sw.rarity_color,
+                    fontSize: '0.65em',
+                    cursor: 'pointer',
+                    fontFamily: '\'Courier New\', monospace',
+                    whiteSpace: 'nowrap'
+                  }}
+                  title={`${sw.software_category} · PWR:${sw.battery_cost} DMG:${sw.effect_magnitude}`}
+                >
+                  {sw.name}
+                  <span style={{ color: '#666', marginLeft: '4px' }}>
+                    {sw.battery_cost > 0 ? `⚡${sw.battery_cost}` : ''}
+                  </span>
+                </button>
+                {activeSelector?.type === 'exec' && activeSelector.softwareName === sw.name && (
+                  <TargetSelector
+                    protocols={protocols}
+                    label={`EXEC ${sw.name} →`}
+                    onSelect={(pos) => { onCommand(`exec ${sw.name} ${pos}`); setActiveSelector(null) }}
+                    onCancel={() => setActiveSelector(null)}
+                  />
+                )}
+              </div>
+            )
+          })}
+
+          {/* Quick action buttons */}
+          <span style={{ color: '#333', margin: '0 2px' }}>|</span>
+          {(['analyze', 'reroute'] as const).map(cmd => (
+            <div key={cmd} style={{ position: 'relative' }}>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setActiveSelector(activeSelector?.type === cmd ? null : { type: cmd })
+                }}
+                style={{
+                  background: '#1a1a1a', border: '1px solid #333', borderRadius: '3px',
+                  padding: '3px 8px', color: '#22d3ee', fontSize: '0.65em', cursor: 'pointer',
+                  fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                {cmd.toUpperCase()}
+              </button>
+              {activeSelector?.type === cmd && (
+                <TargetSelector
+                  protocols={protocols}
+                  label={`${cmd.toUpperCase()} \u2192`}
+                  onSelect={(pos) => { onCommand(`${cmd} ${pos}`); setActiveSelector(null) }}
+                  onCancel={() => setActiveSelector(null)}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Breach output */}
+      <div
+        ref={outputRef}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          padding: '8px 12px',
+          fontSize: '0.75em',
+          lineHeight: '1.2',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          color: '#d0d0d0'
+        }}
+      >
+        <style>{`
+          @keyframes rainbow-cycle {
+            0%   { color: #ff6b6b; }
+            17%  { color: #fbbf24; }
+            33%  { color: #34d399; }
+            50%  { color: #22d3ee; }
+            67%  { color: #60a5fa; }
+            83%  { color: #a78bfa; }
+            100% { color: #ff6b6b; }
+          }
+          .rarity-unicorn {
+            animation: rainbow-cycle 3s linear infinite;
+            font-weight: bold;
+          }
+        `}</style>
+        {breachOutput.map((line, i) => (
+          <div key={i} dangerouslySetInnerHTML={{ __html: line || '&nbsp;' }} />
+        ))}
+      </div>
+
+      {jackoutConfirm && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 200,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.7)'
+          }}
+          onClick={() => setJackoutConfirm(false)}
+        >
+          <div
+            style={{
+              background: '#1a1a1a',
+              border: '1px solid #444',
+              borderRadius: '6px',
+              padding: '24px 28px',
+              maxWidth: '420px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{ color: '#f87171', fontWeight: 'bold', fontSize: '1.1em', marginBottom: '16px' }}>
+              JACK OUT
+            </div>
+            <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '20px' }}>
+              Abort the current BREACH? Clean exit costs 5 EN. Past PNR costs 10 HP, 15 EN, 15 PS.
+            </div>
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setJackoutConfirm(false)}
+                style={{
+                  background: 'transparent', color: '#888', border: '1px solid #444',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                CANCEL
+              </button>
+              <button
+                onClick={() => { onCommand('jackout'); setJackoutConfirm(false) }}
+                style={{
+                  background: '#dc2626', color: 'white', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                JACKOUT
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/breach/BreachTargetButtons.tsx
+++ b/app/javascript/components/tactical/breach/BreachTargetButtons.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+import { BreachEncounter, DeckStatus } from '~/types/zoneMap'
+import { TIER_COLORS } from './breachConstants'
+
+interface BreachTargetButtonsProps {
+  encounters: BreachEncounter[]
+  deckStatus: DeckStatus
+  onSelect: (encounter: BreachEncounter) => void
+}
+
+const BreachTargetButton: React.FC<{
+  encounter: BreachEncounter
+  disabled: boolean
+  onSelect: (enc: BreachEncounter) => void
+}> = ({ encounter: enc, disabled, onSelect }) => {
+  const [hover, setHover] = useState(false)
+  const tierColor = TIER_COLORS[enc.tier_label.toLowerCase()] || '#9ca3af'
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        disabled={disabled}
+        onClick={(e) => { e.stopPropagation(); onSelect(enc) }}
+        onMouseEnter={(e) => {
+          setHover(true)
+          if (!disabled) {
+            e.currentTarget.style.borderColor = '#22d3ee'
+            e.currentTarget.style.boxShadow = '0 0 8px rgba(34, 211, 238, 0.3)'
+          }
+        }}
+        onMouseLeave={(e) => {
+          setHover(false)
+          e.currentTarget.style.borderColor = disabled ? '#333' : '#22d3ee'
+          e.currentTarget.style.boxShadow = 'none'
+        }}
+        style={{
+          background: disabled ? '#1a1a1a' : '#111',
+          border: `1px solid ${disabled ? '#333' : '#22d3ee'}`,
+          borderRadius: '4px',
+          padding: '6px 12px',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? 0.5 : 1,
+          textAlign: 'left',
+          fontFamily: '\'Courier New\', monospace',
+          transition: 'border-color 0.2s, box-shadow 0.2s',
+          width: '100%'
+        }}
+      >
+        <div style={{ fontSize: '0.7em', color: '#22d3ee', fontWeight: 'bold', letterSpacing: '1px', marginBottom: '2px' }}>
+          BREACH TARGET
+        </div>
+        <div style={{ fontSize: '0.75em', color: '#d0d0d0' }}>{enc.name}</div>
+        <div style={{ fontSize: '0.65em', color: tierColor }}>{enc.tier_label}</div>
+      </button>
+      {hover && !disabled && (
+        <div style={{
+          position: 'absolute', top: '50%', right: '100%', transform: 'translateY(-50%)',
+          marginRight: '8px', background: '#1a1a1a', border: '1px solid #444',
+          borderRadius: '4px', padding: '6px 10px', whiteSpace: 'nowrap', zIndex: 50,
+          fontSize: '0.8em', color: '#22d3ee', fontWeight: 'bold',
+          fontFamily: '\'Courier New\', monospace'
+        }}>
+          Initiate BREACH
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const BreachTargetButtons: React.FC<BreachTargetButtonsProps> = ({
+  encounters, deckStatus, onSelect
+}) => {
+  if (encounters.length === 0) return null
+
+  const disabled = !deckStatus.equipped || deckStatus.fried
+  const disabledReason = !deckStatus.equipped
+    ? 'NO DECK EQUIPPED'
+    : deckStatus.fried ? 'DECK FRIED' : null
+
+  return (
+    <div style={{
+      position: 'absolute',
+      top: 40,
+      right: 12,
+      zIndex: 20,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '6px',
+      maxWidth: '220px'
+    }}>
+      {disabledReason && (
+        <div style={{
+          fontSize: '0.65em',
+          color: '#f87171',
+          textAlign: 'right',
+          padding: '0 4px'
+        }}>
+          {disabledReason}
+        </div>
+      )}
+      {encounters.map(enc => (
+        <BreachTargetButton key={enc.id} encounter={enc} disabled={disabled} onSelect={onSelect} />
+      ))}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/breach/breachConstants.ts
+++ b/app/javascript/components/tactical/breach/breachConstants.ts
@@ -1,0 +1,6 @@
+export const TIER_COLORS: Record<string, string> = {
+  standard: '#34d399',
+  advanced: '#fbbf24',
+  elite: '#f87171',
+  ambient: '#a78bfa'
+}

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { apiJson } from '~/utils/apiClient'
-import { ZoneMapData, ZoneMapRoom, ZoneMapGhostRoom } from '~/types/zoneMap'
+import { ZoneMapData, ZoneMapRoom, ZoneMapGhostRoom, BreachEncounter, DeckStatus } from '~/types/zoneMap'
 import { iso, isoPts, ISO_WALL_H, ISO_TILE_W, ISO_TILE_H, DIRECTION_VECTORS } from './isoGeometry'
 import { useZonePresence } from './useZonePresence'
 import {
@@ -12,6 +12,7 @@ interface ZoneMapProps {
   refreshToken: number
   currentRoomId: number | null
   onNavigate?: (direction: string) => void
+  onBreachEncountersChange?: (encounters: BreachEncounter[], deckStatus: DeckStatus) => void
 }
 
 interface Tooltip {
@@ -22,7 +23,7 @@ interface Tooltip {
 
 const Z_DIRS = new Set(['up', 'down'])
 
-export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate }) => {
+export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange }) => {
   const [mapData, setMapData] = useState<ZoneMapData | null>(null)
   const [tooltip, setTooltip] = useState<Tooltip | null>(null)
   const [zoom, setZoom] = useState(1.25)
@@ -39,8 +40,10 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
       .then(data => {
         setMapData(data)
         setPanOffset([0, 0])
+        onBreachEncountersChange?.(data.breach_encounters || [], data.deck_status || { equipped: false, fried: false })
       })
       .catch(err => console.error('Zone map fetch failed:', err))
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- callback ref change should not re-trigger fetch; refreshToken controls cadence
   }, [refreshToken])
 
   // Zone-level presence updates via ZoneChannel

--- a/app/javascript/components/tactical/tabs/CredTab.tsx
+++ b/app/javascript/components/tactical/tabs/CredTab.tsx
@@ -1,0 +1,352 @@
+import React, { useEffect, useState } from 'react'
+import { apiJson } from '~/utils/apiClient'
+
+interface CacheData {
+  address: string
+  nickname: string | null
+  balance: number
+  is_default: boolean
+  abandoned: boolean
+}
+
+interface CredResponse {
+  caches: CacheData[]
+  total_balance: number
+  debt: number
+}
+
+function formatCred (amount: number): string {
+  return amount.toLocaleString('en-US')
+}
+
+export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+  const [data, setData] = useState<CredResponse | null>(null)
+  const [nicknameTarget, setNicknameTarget] = useState<string | null>(null)
+  const [nicknameInput, setNicknameInput] = useState('')
+  const [transferFrom, setTransferFrom] = useState<CacheData | null>(null)
+  const [transferTo, setTransferTo] = useState('')
+  const [transferCustom, setTransferCustom] = useState(false)
+  const [transferAmount, setTransferAmount] = useState('')
+
+  useEffect(() => {
+    apiJson<CredResponse>('/api/grid/cred').then(setData).catch(console.error)
+  }, [refreshToken])
+
+  if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+
+  return (
+    <div style={{ fontSize: '0.8em', maxWidth: '50%' }}>
+      {/* Summary */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+        <span style={{ color: '#fbbf24' }}>Total CRED</span>
+        <span style={{ color: '#34d399' }}>{formatCred(data.total_balance)}</span>
+      </div>
+      {data.debt > 0 && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+          <span style={{ color: '#f87171' }}>GovCorp Debt</span>
+          <span style={{ color: '#f87171' }}>-{formatCred(data.debt)}</span>
+        </div>
+      )}
+      <div style={{ height: '1px', background: '#333', margin: '8px 0' }} />
+
+      {/* Create cache button */}
+      <button
+        onClick={() => onCommand?.('cache create')}
+        style={{
+          background: '#1a1a1a',
+          border: '1px solid #34d399',
+          borderRadius: '3px',
+          padding: '3px 10px',
+          color: '#34d399',
+          fontSize: '0.85em',
+          cursor: 'pointer',
+          fontFamily: '\'Courier New\', monospace',
+          marginBottom: '8px'
+        }}
+      >
+        + NEW CACHE
+      </button>
+
+      {/* Caches */}
+      {data.caches.length === 0 ? (
+        <div style={{ color: '#555' }}>No caches.</div>
+      ) : (
+        data.caches.map(cache => (
+          <div
+            key={cache.address}
+            style={{
+              padding: '6px 0',
+              borderBottom: '1px solid #1a1a1a',
+              opacity: cache.abandoned ? 0.5 : 1,
+              breakInside: 'avoid'
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+              <div>
+                <span style={{ color: '#34d399' }}>{cache.address}</span>
+                {cache.nickname && (
+                  <span style={{ color: '#a78bfa', marginLeft: '8px' }}>{cache.nickname}</span>
+                )}
+              </div>
+              <span style={{ color: '#34d399', whiteSpace: 'nowrap' }}>{formatCred(cache.balance)} CRED</span>
+            </div>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '2px' }}>
+              {cache.is_default && (
+                <span style={{ color: '#22d3ee', fontSize: '0.85em' }}>DEFAULT</span>
+              )}
+              {cache.abandoned && (
+                <span style={{ color: '#f87171', fontSize: '0.85em' }}>ABANDONED</span>
+              )}
+              {!cache.abandoned && (
+                <>
+                  <button
+                    onClick={() => { setNicknameTarget(cache.address); setNicknameInput(cache.nickname || '') }}
+                    style={{
+                      background: 'none', border: 'none', color: '#666', fontSize: '0.85em',
+                      cursor: 'pointer', padding: 0, fontFamily: '\'Courier New\', monospace',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    rename
+                  </button>
+                  {cache.balance > 0 && (
+                    <button
+                      onClick={() => { setTransferFrom(cache); setTransferTo(''); setTransferCustom(false); setTransferAmount('') }}
+                      style={{
+                        background: 'none', border: 'none', color: '#666', fontSize: '0.85em',
+                        cursor: 'pointer', padding: 0, fontFamily: '\'Courier New\', monospace',
+                        textDecoration: 'underline'
+                      }}
+                    >
+                      send
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        ))
+      )}
+
+      {data.debt > 0 && (
+        <>
+          <div style={{ height: '1px', background: '#333', margin: '8px 0' }} />
+          <div style={{ color: '#f87171', fontSize: '0.85em' }}>
+            50% CRED income garnished until debt cleared.
+          </div>
+        </>
+      )}
+
+      {/* Nickname modal */}
+      {nicknameTarget && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 200,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.7)'
+          }}
+          onClick={() => setNicknameTarget(null)}
+        >
+          <div
+            style={{
+              background: '#1a1a1a',
+              border: '1px solid #444',
+              borderRadius: '6px',
+              padding: '24px 28px',
+              maxWidth: '420px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{ color: '#a78bfa', fontWeight: 'bold', fontSize: '1.1em', marginBottom: '12px' }}>
+              SET NICKNAME
+            </div>
+            <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '16px' }}>
+              <span style={{ color: '#34d399' }}>{nicknameTarget}</span>
+            </div>
+            <input
+              type="text"
+              value={nicknameInput}
+              onChange={e => {
+                const val = e.target.value.replace(/[^a-zA-Z0-9_-]/g, '')
+                setNicknameInput(val)
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && nicknameInput.trim()) {
+                  onCommand?.(`cache name ${nicknameTarget} ${nicknameInput.trim()}`)
+                  setNicknameTarget(null)
+                }
+              }}
+              maxLength={20}
+              placeholder="letters, numbers, hyphens, underscores"
+              autoFocus
+              style={{
+                width: '100%',
+                background: '#111',
+                border: '1px solid #444',
+                borderRadius: '3px',
+                padding: '8px 10px',
+                color: '#d0d0d0',
+                fontSize: '0.95em',
+                fontFamily: '\'Courier New\', monospace',
+                marginBottom: '16px',
+                boxSizing: 'border-box'
+              }}
+            />
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setNicknameTarget(null)}
+                style={{
+                  background: 'transparent', color: '#888', border: '1px solid #444',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                CANCEL
+              </button>
+              <button
+                onClick={() => {
+                  if (nicknameInput.trim()) {
+                    onCommand?.(`cache name ${nicknameTarget} ${nicknameInput.trim()}`)
+                    setNicknameTarget(null)
+                  }
+                }}
+                style={{
+                  background: '#a78bfa', color: '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                SET
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Transfer modal */}
+      {transferFrom && data && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 200,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.7)'
+          }}
+          onClick={() => setTransferFrom(null)}
+        >
+          <div
+            style={{
+              background: '#1a1a1a',
+              border: '1px solid #444',
+              borderRadius: '6px',
+              padding: '24px 28px',
+              maxWidth: '420px', minWidth: '320px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{ color: '#fbbf24', fontWeight: 'bold', fontSize: '1.1em', marginBottom: '12px' }}>
+              SEND CRED
+            </div>
+            <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '16px' }}>
+              From: <span style={{ color: '#34d399' }}>{transferFrom.nickname || transferFrom.address}</span>
+              <span style={{ color: '#666', marginLeft: '8px' }}>({formatCred(transferFrom.balance)} available)</span>
+            </div>
+
+            <div style={{ marginBottom: '10px' }}>
+              <label style={{ color: '#888', fontSize: '0.85em', display: 'block', marginBottom: '4px' }}>Amount</label>
+              <input
+                type="text"
+                value={transferAmount}
+                onChange={e => setTransferAmount(e.target.value.replace(/[^0-9]/g, ''))}
+                placeholder="0"
+                autoFocus
+                style={{
+                  width: '100%', background: '#111', border: '1px solid #444', borderRadius: '3px',
+                  padding: '8px 10px', color: '#d0d0d0', fontSize: '0.95em',
+                  fontFamily: '\'Courier New\', monospace', boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            <div style={{ marginBottom: '16px' }}>
+              <label style={{ color: '#888', fontSize: '0.85em', display: 'block', marginBottom: '4px' }}>To (address or nickname)</label>
+              <select
+                value={transferCustom ? '__custom__' : transferTo}
+                onChange={e => {
+                  if (e.target.value === '__custom__') {
+                    setTransferCustom(true)
+                    setTransferTo('')
+                  } else {
+                    setTransferCustom(false)
+                    setTransferTo(e.target.value)
+                  }
+                }}
+                style={{
+                  width: '100%', background: '#111', border: '1px solid #444', borderRadius: '3px',
+                  padding: '8px 10px', color: '#d0d0d0', fontSize: '0.95em',
+                  fontFamily: '\'Courier New\', monospace', boxSizing: 'border-box'
+                }}
+              >
+                <option value="">Select destination...</option>
+                {data.caches
+                  .filter(c => c.address !== transferFrom.address && !c.abandoned)
+                  .map(c => (
+                    <option key={c.address} value={c.nickname || c.address}>
+                      {c.nickname ? `${c.nickname} (${c.address})` : c.address}
+                    </option>
+                  ))
+                }
+                <option value="__custom__">Other address...</option>
+              </select>
+              {transferCustom && (
+                <input
+                  type="text"
+                  value={transferTo}
+                  onChange={e => setTransferTo(e.target.value)}
+                  placeholder="CACHE-XXXX-XXXX or nickname"
+                  autoFocus
+                  style={{
+                    width: '100%', background: '#111', border: '1px solid #444', borderRadius: '3px',
+                    padding: '8px 10px', color: '#d0d0d0', fontSize: '0.95em', marginTop: '6px',
+                    fontFamily: '\'Courier New\', monospace', boxSizing: 'border-box'
+                  }}
+                />
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setTransferFrom(null)}
+                style={{
+                  background: 'transparent', color: '#888', border: '1px solid #444',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                CANCEL
+              </button>
+              <button
+                disabled={!transferAmount || !transferTo}
+                onClick={() => {
+                  const fromArg = transferFrom.is_default ? '' : ` from ${transferFrom.nickname || transferFrom.address}`
+                  onCommand?.(`cache send ${transferAmount} ${transferTo}${fromArg}`)
+                  setTransferFrom(null)
+                }}
+                style={{
+                  background: (!transferAmount || !transferTo) ? '#333' : '#fbbf24',
+                  color: '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em',
+                  cursor: (!transferAmount || !transferTo) ? 'not-allowed' : 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                SEND
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/javascript/components/tactical/tabs/DeckTab.tsx
+++ b/app/javascript/components/tactical/tabs/DeckTab.tsx
@@ -48,7 +48,7 @@ export const DeckTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) =>
   const batteryPct = deck.battery_max > 0 ? Math.round((deck.battery_current / deck.battery_max) * 100) : 0
 
   return (
-    <div style={{ fontSize: '0.8em' }}>
+    <div style={{ fontSize: '0.8em', maxWidth: '50%' }}>
       <div style={{ color: deck.rarity_color, fontWeight: 'bold', marginBottom: '8px' }}>
         {deck.name}
       </div>

--- a/app/javascript/components/tactical/tabs/InventoryTab.tsx
+++ b/app/javascript/components/tactical/tabs/InventoryTab.tsx
@@ -107,7 +107,7 @@ export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: st
   const isFull = capacity.used >= capacity.max
 
   return (
-    <div style={{ fontSize: '0.8em' }}>
+    <div style={{ fontSize: '0.8em', maxWidth: '50%' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', color: isFull ? '#f87171' : '#888', marginBottom: '4px' }}>
         <span>Inventory</span>
         <span>{capacity.used}/{capacity.max} slots</span>

--- a/app/javascript/components/tactical/tabs/LoadoutTab.tsx
+++ b/app/javascript/components/tactical/tabs/LoadoutTab.tsx
@@ -16,6 +16,8 @@ interface LoadoutResponse {
   active_effects: Record<string, number | boolean>
 }
 
+const SLOT_ORDER = ['back', 'head', 'ears', 'eyes', 'neck', 'chest', 'left_wrist', 'right_wrist', 'hands', 'waist', 'legs', 'feet']
+
 export const LoadoutTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
   const [data, setData] = useState<LoadoutResponse | null>(null)
 
@@ -25,9 +27,12 @@ export const LoadoutTab: React.FC<{ refreshToken: number }> = ({ refreshToken })
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 
-  const mid = Math.ceil(data.slots.length / 2)
-  const left = data.slots.slice(0, mid)
-  const right = data.slots.slice(mid)
+  const deckSlot = data.slots.find(s => s.slot === 'deck')
+  const gearSlots = data.slots.filter(s => s.slot !== 'deck')
+    .sort((a, b) => SLOT_ORDER.indexOf(a.slot) - SLOT_ORDER.indexOf(b.slot))
+  const mid = Math.ceil(gearSlots.length / 2)
+  const left = gearSlots.slice(0, mid)
+  const right = gearSlots.slice(mid)
   const effectEntries = Object.entries(data.active_effects).filter(([, v]) => v !== 0 && v !== false)
 
   const renderSlot = (slot: SlotData) => (
@@ -47,6 +52,19 @@ export const LoadoutTab: React.FC<{ refreshToken: number }> = ({ refreshToken })
   return (
     <div style={{ fontSize: '0.8em' }}>
       <div style={{ color: '#666', fontSize: '0.85em', marginBottom: '6px' }}>LOADOUT</div>
+      {deckSlot && (
+        <div style={{
+          display: 'flex', justifyContent: 'space-between',
+          padding: '3px 0', marginBottom: '4px', borderBottom: '1px solid #333'
+        }}>
+          <span style={{ color: '#22d3ee', minWidth: '55px', fontSize: '0.9em' }}>{deckSlot.label}</span>
+          {deckSlot.item ? (
+            <span style={{ color: deckSlot.item.rarity_color }}>{deckSlot.item.name}</span>
+          ) : (
+            <span style={{ color: '#333' }}>—</span>
+          )}
+        </div>
+      )}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 16px' }}>
         <div>{left.map(renderSlot)}</div>
         <div>{right.map(renderSlot)}</div>

--- a/app/javascript/components/tactical/tabs/MissionsTab.tsx
+++ b/app/javascript/components/tactical/tabs/MissionsTab.tsx
@@ -1,10 +1,16 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
 
-interface MissionObjective {
-  description: string
-  current: number
-  target: number
+interface ObjectiveDefinition {
+  id: number
+  label: string
+  target_count: number
+}
+
+interface ObjectiveProgress {
+  objective_id: number
+  progress: number
+  target_count: number
   completed: boolean
 }
 
@@ -12,9 +18,12 @@ interface HackrMission {
   mission: {
     name: string
     slug: string
+    giver: { name: string; room_name: string | null } | null
+    objectives: ObjectiveDefinition[]
   }
   status: string
-  objectives: MissionObjective[]
+  objective_progress?: ObjectiveProgress[]
+  ready_to_turn_in?: boolean
 }
 
 interface MissionsResponse {
@@ -22,7 +31,7 @@ interface MissionsResponse {
   completed: HackrMission[]
 }
 
-export const MissionsTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+export const MissionsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
   const [data, setData] = useState<MissionsResponse | null>(null)
 
   useEffect(() => {
@@ -32,24 +41,60 @@ export const MissionsTab: React.FC<{ refreshToken: number }> = ({ refreshToken }
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 
   return (
-    <div style={{ fontSize: '0.8em' }}>
+    <div style={{ fontSize: '0.8em', maxWidth: '50%' }}>
       {data.active.length > 0 && (
         <>
           <div style={{ color: '#22d3ee', fontSize: '0.85em', marginBottom: '4px' }}>ACTIVE</div>
-          {data.active.map(hm => (
-            <div key={hm.mission.slug} style={{ marginBottom: '8px', paddingBottom: '6px', borderBottom: '1px solid #1a1a1a' }}>
-              <div style={{ color: '#e0e0e0', fontWeight: 'bold' }}>{hm.mission.name}</div>
-              {hm.objectives.map((obj, i) => (
-                <div key={i} style={{
-                  display: 'flex', justifyContent: 'space-between',
-                  fontSize: '0.9em', color: obj.completed ? '#34d399' : '#888'
-                }}>
-                  <span>{obj.completed ? '✓' : '○'} {obj.description}</span>
-                  <span>{obj.current}/{obj.target}</span>
+          {data.active.map(hm => {
+            const progressById = new Map(
+              (hm.objective_progress || []).map(op => [op.objective_id, op])
+            )
+            return (
+              <div key={hm.mission.slug} style={{ marginBottom: '8px', paddingBottom: '6px', borderBottom: '1px solid #1a1a1a', breakInside: 'avoid' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                  <span style={{ color: '#e0e0e0', fontWeight: 'bold' }}>{hm.mission.name}</span>
+                  {hm.mission.giver && (
+                    <span style={{ color: '#666', fontSize: '0.85em' }}>
+                      {hm.mission.giver.name}{hm.mission.giver.room_name && ` @ ${hm.mission.giver.room_name}`}
+                    </span>
+                  )}
                 </div>
-              ))}
-            </div>
-          ))}
+                {hm.mission.objectives.map(obj => {
+                  const prog = progressById.get(obj.id)
+                  const completed = prog?.completed ?? false
+                  const current = prog?.progress ?? 0
+                  return (
+                    <div key={obj.id} style={{
+                      display: 'flex', justifyContent: 'space-between',
+                      fontSize: '0.9em', color: completed ? '#34d399' : '#888'
+                    }}>
+                      <span>{completed ? '✓' : '○'} {obj.label}</span>
+                      <span>{current}/{obj.target_count}</span>
+                    </div>
+                  )
+                })}
+                {hm.ready_to_turn_in && (
+                  <button
+                    onClick={() => onCommand?.(`turn_in ${hm.mission.slug}`)}
+                    style={{
+                      marginTop: '4px',
+                      background: '#34d399',
+                      color: '#0a0a0a',
+                      border: 'none',
+                      padding: '3px 10px',
+                      fontSize: '0.85em',
+                      fontWeight: 'bold',
+                      cursor: 'pointer',
+                      borderRadius: '3px',
+                      fontFamily: '\'Courier New\', monospace'
+                    }}
+                  >
+                    TURN IN
+                  </button>
+                )}
+              </div>
+            )
+          })}
         </>
       )}
 

--- a/app/javascript/components/tactical/tabs/SchematicsTab.tsx
+++ b/app/javascript/components/tactical/tabs/SchematicsTab.tsx
@@ -81,12 +81,12 @@ export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: s
   const locked = data.schematics.filter(s => !s.craftable)
 
   return (
-    <div style={{ fontSize: '0.8em' }}>
+    <div style={{ fontSize: '0.8em', maxWidth: '50%' }}>
       {ready.length > 0 && (
         <>
           <div style={{ color: '#34d399', fontSize: '0.85em', marginBottom: '4px' }}>READY ({ready.length})</div>
           {ready.map(s => (
-            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0' }}>
+            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0', breakInside: 'avoid' }}>
               <button onClick={() => setConfirm(s)} style={{
                 background: '#34d399', color: '#0a0a0a', border: 'none', borderRadius: '2px',
                 padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
@@ -105,7 +105,7 @@ export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: s
             AVAILABLE ({available.length})
           </div>
           {available.map(s => (
-            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0' }}>
+            <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0', breakInside: 'avoid' }}>
               <button onClick={() => setConfirm(s)} style={{
                 background: 'transparent', color: '#fbbf24', border: '1px solid #fbbf24', borderRadius: '2px',
                 padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -31,6 +31,18 @@ export interface ZoneMapGhostRoom {
   direction: string
 }
 
+export interface BreachEncounter {
+  id: number
+  name: string
+  tier_label: string
+  min_clearance: number
+}
+
+export interface DeckStatus {
+  equipped: boolean
+  fried: boolean
+}
+
 export interface ZoneMapData {
   zone: {
     id: number
@@ -46,4 +58,7 @@ export interface ZoneMapData {
   current_room_id: number
   z_levels: number[]
   z_level: number
+  in_breach: boolean
+  breach_encounters: BreachEncounter[]
+  deck_status: DeckStatus
 }

--- a/app/services/grid/breach_command_parser.rb
+++ b/app/services/grid/breach_command_parser.rb
@@ -32,7 +32,7 @@ module Grid
         interface_command(args)
       when "jackout", "jo"
         jackout_command
-      when "status", "st"
+      when "status", "st", "look", "l"
         status_command
       when "deck", "dk"
         deck_command
@@ -120,10 +120,7 @@ module Grid
           output << facility_breach_success_hook if Grid::ContainmentService.captured?(hackr)
         end
       else
-        # Check if round should end
-        breach.reload
-        round_output = maybe_end_round
-        output << round_output if round_output
+        append_round_or_status(output)
       end
 
       append_notifications(output, notifications)
@@ -154,10 +151,7 @@ module Grid
       output << "<span style='color: #fbbf24;'>  ▸ #{h(result.debuff_hint)}</span>" if result.debuff_hint
       output << "<span style='color: #34d399;'>  ▸ Bonus action!</span>" if result.bonus_action
 
-      # Check if round should end
-      breach.reload
-      round_output = maybe_end_round
-      output << round_output if round_output
+      append_round_or_status(output)
 
       output.join("\n")
     rescue Grid::BreachActionService::NoActionsRemaining,
@@ -182,10 +176,7 @@ module Grid
       output = []
       output << "<span style='color: #22d3ee;'>REROUTE → Protocol [#{result.target_position + 1}] (#{result.protocol_type_label}) delayed.</span>"
 
-      # Check if round should end
-      breach.reload
-      round_output = maybe_end_round
-      output << round_output if round_output
+      append_round_or_status(output)
 
       output.join("\n")
     rescue Grid::BreachActionService::NoActionsRemaining,
@@ -221,10 +212,7 @@ module Grid
         output << jackout_result.display
         output << "<span style='color: #34d399;'>You disconnect cleanly.</span>"
       else
-        # Check if round should end
-        breach.reload
-        round_output = maybe_end_round
-        output << round_output if round_output
+        append_round_or_status(output)
       end
 
       append_notifications(output, notifications)
@@ -291,10 +279,7 @@ module Grid
         failure_result = Grid::BreachService.resolve_failure!(hackr_breach: breach, failure_mode: :gate_exhaustion)
         output << failure_result.display
       else
-        # Check if round should end
-        breach.reload
-        round_output = maybe_end_round
-        output << round_output if round_output
+        append_round_or_status(output)
       end
 
       append_notifications(output, notifications)
@@ -493,6 +478,19 @@ module Grid
 
     def mission_progressor
       @mission_progressor ||= Grid::MissionProgressor.new(hackr)
+    end
+
+    # Append round-end display if round ended, otherwise compact status so
+    # the breach panel always shows current state after each action.
+    def append_round_or_status(output)
+      breach.reload
+      round_output = maybe_end_round
+      if round_output
+        output << round_output
+      elsif breach.active?
+        output << ""
+        output << Grid::BreachRenderer.new(breach).render_full
+      end
     end
 
     def append_notifications(output, notifications)

--- a/app/views/admin/grid_breach_encounters/index.html.erb
+++ b/app/views/admin/grid_breach_encounters/index.html.erb
@@ -17,6 +17,8 @@
 
       <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
         <%= link_to "+ New Encounter", new_admin_grid_breach_encounter_path, class: "tui-button green-168" %>
+        <button id="cooldown-filter" type="button" class="tui-button" style="padding: 4px 12px; font-size: 0.85em;">Show Cooldown Only</button>
+        <span id="encounter-filter-status" style="color: #666; font-size: 0.85em;"><%= @encounters.size %> encounters</span>
       </div>
 
       <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
@@ -35,7 +37,7 @@
           </thead>
           <tbody>
             <% @encounters.each do |enc| %>
-              <tr>
+              <tr data-state="<%= enc.state %>">
                 <td><%= enc.grid_room.name %></td>
                 <td style="color: #6b7280;"><%= enc.grid_room.grid_zone.name %></td>
                 <td><%= enc.grid_breach_template.name %></td>
@@ -61,6 +63,9 @@
                   <% end %>
                 </td>
                 <td style="text-align: right; white-space: nowrap;">
+                  <% unless enc.available? %>
+                    <%= button_to "Make Available", make_available_admin_grid_breach_encounter_path(enc), method: :post, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em;", form: { style: "display: inline;", data: { turbo_confirm: "Reset this encounter to available?" } } %>
+                  <% end %>
                   <%= link_to "Edit", edit_admin_grid_breach_encounter_path(enc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
                   <%= link_to "History", history_admin_grid_breach_encounter_path(enc), class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;" %>
                   <%= link_to "Delete", admin_grid_breach_encounter_path(enc), data: { turbo_method: :delete, turbo_confirm: "Delete this encounter?" }, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;" %>
@@ -73,3 +78,26 @@
     </div>
   </fieldset>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var btn = document.getElementById('cooldown-filter');
+    var status = document.getElementById('encounter-filter-status');
+    var rows = document.querySelectorAll('.tui-table tbody tr');
+    var total = rows.length;
+    var active = false;
+
+    btn.addEventListener('click', function() {
+      active = !active;
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var show = !active || rows[i].getAttribute('data-state') === 'cooldown';
+        rows[i].style.display = show ? '' : 'none';
+        if (show) visible++;
+      }
+      btn.textContent = active ? 'Show All' : 'Show Cooldown Only';
+      btn.style.borderColor = active ? '#fbbf24' : '';
+      status.textContent = active ? visible + ' of ' + total + ' in cooldown' : total + ' encounters';
+    });
+  })();
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
     get "grid/deck", to: "grid#deck_index"
     get "grid/inventory", to: "grid#inventory_index"
     get "grid/reputation", to: "grid#reputation_index"
+    get "grid/cred", to: "grid#cred_index"
     get "grid/transit", to: "grid#transit_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"
@@ -493,6 +494,7 @@ Rails.application.routes.draw do
     resources :grid_breach_encounters, except: [:show] do
       member do
         get :history
+        post :make_available
       end
     end
 


### PR DESCRIPTION
Dedicated BREACH UI for the Tactical interface with slide-up panel, clickable actions, and encounter target buttons on the map. New CRED tab with cache management. Multiple tactical panel polish items.

  Backend:
    * in_breach + breach_meta (template, protocols, detection, PNR, actions, round) in command response
    * breach_encounters + deck_status in zone_map response. Frontend:
    * BreachTargetButtons (top-right on map, disabled when no DECK/fried, hover tooltip)
    * BreachConfirmModal
    * BreachPanel (slide-up 85% of map, 300ms CSS transition, DECK snapshot + clickable software with target selector popovers, ANALYZE/REROUTE quick actions, JACKOUT with modal confirm, scrollable breach output)
    * Breach output replaced per command (not accumulated)
    * `look`/`l` aliased to status during breach
    * Full breach status rendered after every action via append_round_or_status helper
    * Command hint bar switches to breach commands during breach
    * Page reload mid-breach correctly opens panel

  * New GET /api/grid/cred endpoint (player-scoped caches, balances, debt) CredTab:
    * total CRED
    * GovCorp debt with garnishment warning
    * per-cache display (address, nickname, balance, DEFAULT/ABANDONED flags)
    * "+ NEW CACHE" button
    * "rename" with modal input (character-filtered)
    * "send" with transfer modal (amount, destination picker with own-cache dropdown + custom address input)

  * Clearance in TacticalBar with styled hover tooltip
  * 50/50 grid split
  * Half-width constraint on DECK/INV/CRED/MISSIONS/SCHEM tabs

  * DECK slot spans full width
  * gear slots reordered (NECK after EYES)

  * fixed API shape mapping (objective_progress + mission.objectives)
  * quest giver + room shown per mission
  * TURN IN button when ready.

  Breach encounters index:
    * cooldown filter toggle
    * "Make Available" button (safe update, no bang).