### PR TITLE
[TPG] Tactical UI Vendor Shop Panel, INV sell buttons

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,9 +2,9 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index shop_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
-  before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: [:zone_map]
+  before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: %i[zone_map shop_index]
   before_action :require_admin_api, only: [:debit]
 
   INVENTORY_TYPE_ORDER = %w[gear consumable tool software module firmware material data rig_component fixture collectible faction].freeze
@@ -191,6 +191,11 @@ class Api::GridController < ApplicationController
       .includes(:grid_item_definition).to_a
 
     grouped = items.group_by(&:item_type)
+    vendor_mob = current_hackr.current_room&.grid_mobs&.find_by(mob_type: "vendor")
+    vendor_listings_by_def = if vendor_mob
+      vendor_mob.grid_shop_listings.includes(:grid_item_definition)
+        .index_by(&:grid_item_definition_id)
+    end
 
     render json: {
       capacity: {used: items.size, max: current_hackr.inventory_capacity},
@@ -202,7 +207,40 @@ class Api::GridController < ApplicationController
           label: INVENTORY_TYPE_LABELS[type] || type.upcase,
           items: type_items
             .sort_by { |i| [-(GridItem::RARITIES.index(i.rarity) || 0), i.name.to_s] }
-            .map { |i| inventory_item_json(i) }
+            .map { |i| inventory_item_json(i, vendor_listings_by_def: vendor_listings_by_def) }
+        }
+      }
+    }
+  end
+
+  # GET /api/grid/shop - Vendor shop listings for current room
+  def shop_index
+    room = current_hackr.current_room
+    vendor = room&.grid_mobs&.find_by(mob_type: "vendor")
+    return render(json: {error: "No vendor here"}, status: :not_found) unless vendor
+
+    listings = Grid::ShopService.listing_display(mob: vendor, hackr: current_hackr)
+
+    balance = current_hackr.default_cache&.balance || 0
+
+    render json: {
+      vendor_name: vendor.name,
+      shop_type: vendor.shop_type,
+      balance: balance,
+      listings: listings.map { |entry|
+        listing = entry[:listing]
+        {
+          id: listing.id,
+          name: listing.name,
+          description: listing.description,
+          item_type: listing.item_type,
+          rarity: listing.rarity,
+          rarity_color: listing.rarity_color,
+          rarity_label: listing.rarity_label,
+          price: entry[:effective_price],
+          affordable: entry[:affordable],
+          out_of_stock: entry[:out_of_stock],
+          stock: listing.unlimited_stock? ? nil : listing.stock
         }
       }
     }
@@ -823,7 +861,8 @@ class Api::GridController < ApplicationController
       z_level: result.z_level,
       in_breach: current_hackr.in_breach?,
       breach_encounters: breach_encounters,
-      deck_status: deck_status
+      deck_status: deck_status,
+      has_vendor: room.grid_mobs.loaded? ? room.grid_mobs.any?(&:vendor?) : room.grid_mobs.exists?(mob_type: "vendor")
     }
   end
 
@@ -948,10 +987,11 @@ class Api::GridController < ApplicationController
     }
   end
 
-  def inventory_item_json(item)
+  def inventory_item_json(item, vendor_listings_by_def: nil)
     actions = (INVENTORY_ITEM_ACTIONS[item.item_type] || %w[drop]).dup
     actions.delete("salvage") if item.unicorn?
-    {
+
+    result = {
       id: item.id,
       name: item.name,
       description: item.description,
@@ -965,6 +1005,22 @@ class Api::GridController < ApplicationController
       properties: item.properties || {},
       actions: actions
     }
+
+    if vendor_listings_by_def && !item.unicorn? && item.value.to_i > 0
+      result[:sell_price] = sell_price_for(item, vendor_listings_by_def)
+    end
+
+    result
+  end
+
+  def sell_price_for(item, vendor_listings_by_def)
+    listing = vendor_listings_by_def[item.grid_item_definition_id]
+    price = if listing
+      listing.sell_price
+    else
+      (item.value * Grid::EconomyConfig::SELL_PRICE_RATIO).ceil
+    end
+    [price, 1].max
   end
 
   def transit_journey_json(journey)

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -11,23 +11,37 @@ import { BreachTargetButtons } from '~/components/tactical/breach/BreachTargetBu
 import { BreachConfirmModal } from '~/components/tactical/breach/BreachConfirmModal'
 import { BreachPanel } from '~/components/tactical/breach/BreachPanel'
 import { BreachEncounter, DeckStatus } from '~/types/zoneMap'
+import { VendorHandle } from '~/components/tactical/vendor/VendorHandle'
+import { VendorPanel } from '~/components/tactical/vendor/VendorPanel'
 
 const TacticalInner: React.FC = () => {
   const { hackr } = useGridAuth()
   const {
     currentRoomId, setCurrentRoomId, setOutput,
     refreshToken, sendCommand, commandInputRef,
-    inBreach, breachMeta, breachOutput
+    inBreach, breachMeta, breachOutput,
+    hasVendor, setHasVendor
   } = useTactical()
   const initialLoadDoneRef = useRef(false)
   const [breachEncounters, setBreachEncounters] = useState<BreachEncounter[]>([])
   const [deckStatus, setDeckStatus] = useState<DeckStatus>({ equipped: false, fried: false })
   const [confirmTarget, setConfirmTarget] = useState<BreachEncounter | null>(null)
+  const [vendorOpen, setVendorOpen] = useState(false)
 
   const handleBreachEncountersChange = useCallback((encounters: BreachEncounter[], ds: DeckStatus) => {
     setBreachEncounters(encounters)
     setDeckStatus(ds)
   }, [])
+
+  const handleVendorPresenceChange = useCallback((v: boolean) => {
+    setHasVendor(v)
+    if (!v) setVendorOpen(false)
+  }, [setHasVendor])
+
+  // Close vendor panel when breach starts
+  useEffect(() => {
+    if (inBreach) setVendorOpen(false)
+  }, [inBreach])
 
   const handleBreachConfirm = useCallback(() => {
     if (confirmTarget) {
@@ -125,7 +139,7 @@ const TacticalInner: React.FC = () => {
         overflow: 'hidden'
       }}>
         <div style={{ flex: 2, minHeight: 0, overflow: 'hidden', borderBottom: '1px solid #333' }}>
-          <TacticalStatusPanel refreshToken={refreshToken} onCommand={sendCommand} />
+          <TacticalStatusPanel refreshToken={refreshToken} onCommand={sendCommand} hasVendor={hasVendor} />
         </div>
         <div style={{ flex: 3, minHeight: 0, overflow: 'hidden', padding: '6px' }}>
           <TacticalTerminal />
@@ -138,6 +152,7 @@ const TacticalInner: React.FC = () => {
           currentRoomId={currentRoomId}
           onNavigate={(dir) => sendCommand(`go ${dir}`)}
           onBreachEncountersChange={handleBreachEncountersChange}
+          onVendorPresenceChange={handleVendorPresenceChange}
         />
         {!inBreach && breachEncounters.length > 0 && (
           <BreachTargetButtons
@@ -152,6 +167,15 @@ const TacticalInner: React.FC = () => {
           breachOutput={breachOutput}
           refreshToken={refreshToken}
           onCommand={sendCommand}
+        />
+        {hasVendor && !inBreach && !vendorOpen && (
+          <VendorHandle onClick={() => setVendorOpen(true)} />
+        )}
+        <VendorPanel
+          visible={vendorOpen && !inBreach}
+          refreshToken={refreshToken}
+          onCommand={sendCommand}
+          onClose={() => setVendorOpen(false)}
         />
       </div>
 

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -38,9 +38,11 @@ interface TacticalContextValue {
   inBreach: boolean
   breachMeta: BreachMeta | null
   breachOutput: string[]
+  hasVendor: boolean
   sendCommand: (command: string) => Promise<void>
   setOutput: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentRoomId: React.Dispatch<React.SetStateAction<number | null>>
+  setHasVendor: React.Dispatch<React.SetStateAction<boolean>>
   commandInputRef: React.RefObject<CommandInputHandle | null>
 }
 
@@ -60,6 +62,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [inBreach, setInBreach] = useState(false)
   const [breachMeta, setBreachMeta] = useState<BreachMeta | null>(null)
   const [breachOutput, setBreachOutput] = useState<string[]>([])
+  const [hasVendor, setHasVendor] = useState(false)
   const commandInputRef = useRef<CommandInputHandle | null>(null)
   const inBreachRef = useRef(false)
 
@@ -131,8 +134,8 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   return (
     <TacticalContext.Provider value={{
       output, currentRoomId, executing, refreshToken,
-      inBreach, breachMeta, breachOutput,
-      sendCommand, setOutput, setCurrentRoomId, commandInputRef
+      inBreach, breachMeta, breachOutput, hasVendor,
+      sendCommand, setOutput, setCurrentRoomId, setHasVendor, commandInputRef
     }}>
       {children}
     </TacticalContext.Provider>

--- a/app/javascript/components/tactical/TacticalStatusPanel.tsx
+++ b/app/javascript/components/tactical/TacticalStatusPanel.tsx
@@ -22,9 +22,10 @@ const TABS: { key: TabKey; label: string }[] = [
 interface TacticalStatusPanelProps {
   refreshToken: number
   onCommand?: (cmd: string) => void
+  hasVendor?: boolean
 }
 
-export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refreshToken, onCommand }) => {
+export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refreshToken, onCommand, hasVendor }) => {
   const [activeTab, setActiveTab] = useState<TabKey>('deck')
   const [mountedTabs, setMountedTabs] = useState<Set<TabKey>>(new Set(['deck']))
 
@@ -45,7 +46,7 @@ export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refres
       <div key={tab.key} style={{ display: isActive ? 'block' : 'none', height: '100%' }}>
         {tab.key === 'deck' && <DeckTab refreshToken={refreshToken} />}
         {tab.key === 'loadout' && <LoadoutTab refreshToken={refreshToken} />}
-        {tab.key === 'inventory' && <InventoryTab refreshToken={refreshToken} onCommand={onCommand} />}
+        {tab.key === 'inventory' && <InventoryTab refreshToken={refreshToken} onCommand={onCommand} hasVendor={hasVendor} />}
         {tab.key === 'rep' && <RepTab refreshToken={refreshToken} />}
         {tab.key === 'cred' && <CredTab refreshToken={refreshToken} onCommand={onCommand} />}
         {tab.key === 'missions' && <MissionsTab refreshToken={refreshToken} onCommand={onCommand} />}

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -13,6 +13,7 @@ interface ZoneMapProps {
   currentRoomId: number | null
   onNavigate?: (direction: string) => void
   onBreachEncountersChange?: (encounters: BreachEncounter[], deckStatus: DeckStatus) => void
+  onVendorPresenceChange?: (hasVendor: boolean) => void
 }
 
 interface Tooltip {
@@ -23,7 +24,7 @@ interface Tooltip {
 
 const Z_DIRS = new Set(['up', 'down'])
 
-export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange }) => {
+export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange, onVendorPresenceChange }) => {
   const [mapData, setMapData] = useState<ZoneMapData | null>(null)
   const [tooltip, setTooltip] = useState<Tooltip | null>(null)
   const [zoom, setZoom] = useState(1.25)
@@ -41,6 +42,7 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
         setMapData(data)
         setPanOffset([0, 0])
         onBreachEncountersChange?.(data.breach_encounters || [], data.deck_status || { equipped: false, fried: false })
+        onVendorPresenceChange?.(data.has_vendor ?? false)
       })
       .catch(err => console.error('Zone map fetch failed:', err))
   // eslint-disable-next-line react-hooks/exhaustive-deps -- callback ref change should not re-trigger fetch; refreshToken controls cadence

--- a/app/javascript/components/tactical/tabs/InventoryTab.tsx
+++ b/app/javascript/components/tactical/tabs/InventoryTab.tsx
@@ -1,31 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
-
-interface InventoryItem {
-  id: number
-  name: string
-  description: string | null
-  item_type: string
-  rarity: string
-  rarity_color: string
-  rarity_label: string
-  quantity: number
-  max_stack: number | null
-  definition_slug: string | null
-  properties: Record<string, unknown>
-  actions: string[]
-}
-
-interface ItemGroup {
-  item_type: string
-  label: string
-  items: InventoryItem[]
-}
-
-interface InventoryResponse {
-  capacity: { used: number; max: number }
-  groups: ItemGroup[]
-}
+import { InventoryItem, InventoryResponse } from '~/types/zoneMap'
 
 const ITEM_TYPE_LABELS: Record<string, string> = {
   gear: 'Gear', software: 'Software', module: 'Module', firmware: 'Firmware',
@@ -52,7 +27,8 @@ const ACTION_CONFIG: Record<string, { label: string; color: string }> = {
   equip: { label: 'EQUIP', color: '#22d3ee' },
   drop: { label: 'DROP', color: '#fbbf24' },
   salvage: { label: 'SALVAGE', color: '#f97316' },
-  place: { label: 'PLACE', color: '#22d3ee' }
+  place: { label: 'PLACE', color: '#22d3ee' },
+  sell: { label: 'SELL', color: '#fbbf24' }
 }
 
 function actionHint (action: string, item: InventoryItem): string {
@@ -66,6 +42,7 @@ function actionHint (action: string, item: InventoryItem): string {
   case 'drop': return 'Item will be left on the ground.'
   case 'salvage': return 'Item will be destroyed for XP.'
   case 'place': return 'Fixture will be installed in your den.'
+  case 'sell': return item.sell_price ? `Sells for ${item.sell_price} CRED.` : ''
   default: return ''
   }
 }
@@ -91,7 +68,7 @@ function humanizeProperties (props: Record<string, unknown>): { label: string; v
   return result
 }
 
-export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void; hasVendor?: boolean }> = ({ refreshToken, onCommand, hasVendor }) => {
   const [data, setData] = useState<InventoryResponse | null>(null)
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null)
   const [pendingAction, setPendingAction] = useState<{ item: InventoryItem; action: string } | null>(null)
@@ -128,23 +105,36 @@ export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: st
           <div style={{ color: '#666', fontSize: '0.85em', marginBottom: '4px' }}>
             {group.label} ({group.items.length})
           </div>
-          {group.items.map(item => (
-            <div key={item.id}
-              onClick={() => setSelectedItem(item)}
-              style={{
-                display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
-                padding: '3px 0', borderBottom: '1px solid #1a1a1a', cursor: 'pointer', gap: '6px'
-              }}
-            >
-              <span style={{ color: item.rarity_color, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {item.name}
-              </span>
-              <span style={{ whiteSpace: 'nowrap', flexShrink: 0, fontSize: '0.9em' }}>
-                {item.quantity > 1 && <span style={{ color: '#6b7280' }}>x{item.quantity} </span>}
-                <span style={{ color: item.rarity_color }}>[{item.rarity_label}]</span>
-              </span>
-            </div>
-          ))}
+          {group.items.map(item => {
+            const canSell = hasVendor && item.sell_price && item.sell_price > 0
+            return (
+              <div key={item.id}
+                onClick={() => setSelectedItem(item)}
+                style={{
+                  display: 'flex', alignItems: 'baseline',
+                  padding: '3px 0', borderBottom: '1px solid #1a1a1a', cursor: 'pointer', gap: '6px'
+                }}
+              >
+                {canSell && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setPendingAction({ item, action: 'sell' }) }}
+                    style={{
+                      background: '#fbbf24', color: '#0a0a0a', border: 'none', borderRadius: '2px',
+                      padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+                      fontFamily: '\'Courier New\', monospace', lineHeight: 1, flexShrink: 0
+                    }}
+                  >SELL</button>
+                )}
+                <span style={{ color: item.rarity_color, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                  {item.name}
+                </span>
+                <span style={{ whiteSpace: 'nowrap', flexShrink: 0, fontSize: '0.9em' }}>
+                  {item.quantity > 1 && <span style={{ color: '#6b7280' }}>x{item.quantity} </span>}
+                  <span style={{ color: item.rarity_color }}>[{item.rarity_label}]</span>
+                </span>
+              </div>
+            )
+          })}
         </div>
       ))}
 
@@ -208,6 +198,13 @@ export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: st
                   }}>{config.label}</button>
                 )
               })}
+              {hasVendor && selectedItem.sell_price && selectedItem.sell_price > 0 && (
+                <button onClick={() => { setPendingAction({ item: selectedItem, action: 'sell' }); setSelectedItem(null) }} style={{
+                  background: '#fbbf24', color: '#0a0a0a', border: 'none',
+                  padding: '6px 16px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}>SELL</button>
+              )}
             </div>
           </div>
         </div>

--- a/app/javascript/components/tactical/vendor/VendorHandle.tsx
+++ b/app/javascript/components/tactical/vendor/VendorHandle.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+
+interface VendorHandleProps {
+  onClick: () => void
+}
+
+export const VendorHandle: React.FC<VendorHandleProps> = ({ onClick }) => {
+  const [hover, setHover] = useState(false)
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: 'absolute',
+        right: 0,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 25,
+        background: hover ? '#1a1a1a' : '#111',
+        border: '1px solid #fbbf24',
+        borderRight: 'none',
+        borderRadius: '6px 0 0 6px',
+        padding: '12px 6px',
+        cursor: 'pointer',
+        writingMode: 'vertical-rl',
+        textOrientation: 'mixed',
+        fontFamily: '\'Courier New\', monospace',
+        fontSize: '0.7em',
+        fontWeight: 'bold',
+        letterSpacing: '2px',
+        color: '#fbbf24',
+        transition: 'background 0.2s, box-shadow 0.2s',
+        boxShadow: hover ? '0 0 10px rgba(251, 191, 36, 0.3)' : 'none'
+      }}
+    >
+      VENDOR
+    </button>
+  )
+}

--- a/app/javascript/components/tactical/vendor/VendorPanel.tsx
+++ b/app/javascript/components/tactical/vendor/VendorPanel.tsx
@@ -1,0 +1,500 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import { ShopData, ShopListing, InventoryItem, InventoryResponse } from '~/types/zoneMap'
+
+interface VendorPanelProps {
+  visible: boolean
+  refreshToken: number
+  onCommand: (cmd: string) => void
+  onClose: () => void
+}
+
+type PanelSection = 'buy' | 'sell'
+
+interface PendingTx {
+  type: 'buy' | 'sell'
+  name: string
+  rarity_color: string
+  unitPrice: number
+  qty: number
+  maxQty: number
+}
+
+export const VendorPanel: React.FC<VendorPanelProps> = ({
+  visible, refreshToken, onCommand, onClose
+}) => {
+  const [isRendered, setIsRendered] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const [shopData, setShopData] = useState<ShopData | null>(null)
+  const [inventoryData, setInventoryData] = useState<InventoryItem[]>([])
+  const [section, setSection] = useState<PanelSection>('buy')
+  const [pendingTx, setPendingTx] = useState<PendingTx | null>(null)
+  const [buyQty, setBuyQty] = useState<Record<number, number>>({})
+
+  // Slide animation: mount first, then open; close first, then unmount
+  // Double-rAF ensures browser paints the closed state before transitioning to open
+  useEffect(() => {
+    if (visible) {
+      setIsRendered(true) // eslint-disable-line react-hooks/set-state-in-effect -- must mount before animating
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setIsOpen(true))
+      })
+      return () => cancelAnimationFrame(raf)
+    } else {
+      setIsOpen(false)
+      const timer = setTimeout(() => setIsRendered(false), 300)
+      return () => clearTimeout(timer)
+    }
+  }, [visible])
+
+  // Fetch shop data when panel is rendered
+  useEffect(() => {
+    if (isRendered) {
+      apiJson<ShopData>('/api/grid/shop').then(setShopData).catch(console.error)
+    }
+  }, [refreshToken, isRendered])
+
+  // Fetch inventory for sell section when panel is rendered
+  useEffect(() => {
+    if (isRendered) {
+      apiJson<InventoryResponse>('/api/grid/inventory').then(data => {
+        const sellable = data.groups
+          .flatMap(g => g.items)
+          .filter(i => i.sell_price && i.sell_price > 0)
+        setInventoryData(sellable)
+      }).catch(console.error)
+    }
+  }, [refreshToken, isRendered])
+
+  // Reset buy quantities when panel closes or shop data refreshes
+  useEffect(() => {
+    if (!visible) setBuyQty({})
+  }, [visible])
+
+  useEffect(() => {
+    setBuyQty({})
+  }, [shopData])
+
+  const handleBuyClick = useCallback((listing: ShopListing) => {
+    const qty = buyQty[listing.id] || 1
+    const stockMax = listing.stock ?? 99
+    const affordMax = listing.price > 0 ? Math.floor((shopData?.balance ?? 0) / listing.price) : stockMax
+    setPendingTx({
+      type: 'buy',
+      name: listing.name,
+      rarity_color: listing.rarity_color,
+      unitPrice: listing.price,
+      qty: Math.min(qty, stockMax, affordMax),
+      maxQty: Math.min(stockMax, affordMax)
+    })
+  }, [buyQty, shopData])
+
+  const handleSellClick = useCallback((item: InventoryItem) => {
+    setPendingTx({
+      type: 'sell',
+      name: item.name,
+      rarity_color: item.rarity_color,
+      unitPrice: item.sell_price || 0,
+      qty: 1,
+      maxQty: item.quantity
+    })
+  }, [])
+
+  const handleConfirm = useCallback(() => {
+    if (!pendingTx) return
+    const qtyPart = pendingTx.qty > 1 ? `${pendingTx.qty} ` : ''
+    onCommand(`${pendingTx.type} ${qtyPart}${pendingTx.name}`)
+    setPendingTx(null)
+  }, [pendingTx, onCommand])
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    onClose()
+  }, [onClose])
+
+  if (!isRendered) return null
+
+  return (
+    <>
+      {/* Backdrop — click-outside to close */}
+      <div
+        onClick={handleBackdropClick}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 29,
+          background: isOpen ? 'rgba(0,0,0,0.2)' : 'transparent',
+          transition: 'background 300ms ease-out'
+        }}
+      />
+
+      {/* Panel */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: '50%',
+          zIndex: 30,
+          transform: isOpen ? 'translateX(0%)' : 'translateX(100%)',
+          transition: 'transform 300ms ease-out',
+          display: 'flex',
+          flexDirection: 'column',
+          background: '#0d0d0d',
+          borderLeft: '2px solid #fbbf24',
+          fontFamily: '\'Courier New\', monospace'
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '8px 12px',
+          background: '#111',
+          borderBottom: '1px solid #333',
+          flexShrink: 0
+        }}>
+          <div>
+            <span style={{ color: '#fbbf24', fontWeight: 'bold', fontSize: '0.8em', letterSpacing: '1px' }}>
+              VENDOR
+            </span>
+            {shopData && (
+              <>
+                <span style={{ color: '#444', margin: '0 8px' }}>::</span>
+                <span style={{ color: '#d0d0d0', fontSize: '0.8em' }}>{shopData.vendor_name}</span>
+                {shopData.shop_type === 'black_market' && (
+                  <span style={{ color: '#f87171', fontSize: '0.65em', marginLeft: '8px' }}>BLACK MARKET</span>
+                )}
+              </>
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            {shopData && (
+              <span style={{ color: '#fbbf24', fontSize: '0.7em' }}>
+                {shopData.balance} CRED
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              style={{
+                background: 'transparent',
+                color: '#888',
+                border: '1px solid #444',
+                padding: '3px 10px',
+                fontSize: '0.7em',
+                cursor: 'pointer',
+                borderRadius: '3px',
+                fontFamily: '\'Courier New\', monospace'
+              }}
+            >
+              CLOSE
+            </button>
+          </div>
+        </div>
+
+        {/* Section tabs */}
+        <div style={{
+          display: 'flex',
+          borderBottom: '1px solid #333',
+          background: '#0f0f0f',
+          flexShrink: 0
+        }}>
+          {(['buy', 'sell'] as const).map(s => (
+            <button
+              key={s}
+              onClick={() => setSection(s)}
+              style={{
+                flex: 1,
+                background: section === s ? '#1a1a1a' : 'transparent',
+                color: section === s ? (s === 'buy' ? '#34d399' : '#fbbf24') : '#666',
+                border: 'none',
+                borderBottom: section === s ? `2px solid ${s === 'buy' ? '#34d399' : '#fbbf24'}` : '2px solid transparent',
+                padding: '6px 10px',
+                fontSize: '0.7em',
+                fontFamily: '\'Courier New\', monospace',
+                cursor: 'pointer',
+                fontWeight: section === s ? 'bold' : 'normal',
+                letterSpacing: '0.5px'
+              }}
+            >
+              {s.toUpperCase()}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', padding: '8px 10px' }}>
+          {section === 'buy' ? (
+            <BuySection
+              shopData={shopData}
+              buyQty={buyQty}
+              setBuyQty={setBuyQty}
+              onBuy={handleBuyClick}
+            />
+          ) : (
+            <SellSection
+              items={inventoryData}
+              onSell={handleSellClick}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Confirm modal */}
+      {pendingTx && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 200,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.7)'
+          }}
+          onClick={() => setPendingTx(null)}
+        >
+          <div
+            style={{
+              background: '#1a1a1a',
+              border: `1px solid ${pendingTx.type === 'buy' ? '#34d399' : '#fbbf24'}`,
+              borderRadius: '6px',
+              padding: '24px 28px',
+              maxWidth: '420px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <div style={{
+              color: pendingTx.type === 'buy' ? '#34d399' : '#fbbf24',
+              fontWeight: 'bold',
+              fontSize: '1.1em',
+              letterSpacing: '1px',
+              marginBottom: '16px'
+            }}>
+              {pendingTx.type === 'buy' ? 'CONFIRM PURCHASE' : 'CONFIRM SALE'}
+            </div>
+
+            <div style={{ marginBottom: '8px' }}>
+              <span style={{ color: pendingTx.rarity_color, fontSize: '1.05em' }}>{pendingTx.name}</span>
+              {pendingTx.qty > 1 && (
+                <span style={{ color: '#6b7280', marginLeft: '8px', fontSize: '0.9em' }}>x{pendingTx.qty}</span>
+              )}
+            </div>
+
+            {/* Quantity adjuster in modal */}
+            {pendingTx.maxQty > 1 && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
+                <span style={{ color: '#888', fontSize: '0.85em' }}>Qty:</span>
+                <button
+                  onClick={() => setPendingTx(p => p && p.qty > 1 ? { ...p, qty: p.qty - 1 } : p)}
+                  disabled={pendingTx.qty <= 1}
+                  style={{
+                    background: '#222', border: '1px solid #444', borderRadius: '3px',
+                    color: pendingTx.qty <= 1 ? '#444' : '#d0d0d0', padding: '2px 8px',
+                    cursor: pendingTx.qty <= 1 ? 'not-allowed' : 'pointer',
+                    fontFamily: '\'Courier New\', monospace', fontSize: '0.9em'
+                  }}
+                >-</button>
+                <span style={{ color: '#d0d0d0', fontSize: '0.95em', minWidth: '24px', textAlign: 'center' }}>
+                  {pendingTx.qty}
+                </span>
+                <button
+                  onClick={() => setPendingTx(p => p && p.qty < p.maxQty ? { ...p, qty: p.qty + 1 } : p)}
+                  disabled={pendingTx.qty >= pendingTx.maxQty}
+                  style={{
+                    background: '#222', border: '1px solid #444', borderRadius: '3px',
+                    color: pendingTx.qty >= pendingTx.maxQty ? '#444' : '#d0d0d0', padding: '2px 8px',
+                    cursor: pendingTx.qty >= pendingTx.maxQty ? 'not-allowed' : 'pointer',
+                    fontFamily: '\'Courier New\', monospace', fontSize: '0.9em'
+                  }}
+                >+</button>
+              </div>
+            )}
+
+            <div style={{ color: '#888', fontSize: '0.85em', marginBottom: '20px' }}>
+              {pendingTx.type === 'buy'
+                ? <>Cost: <span style={{ color: '#f87171' }}>{pendingTx.unitPrice * pendingTx.qty} CRED</span></>
+                : <>You receive: <span style={{ color: '#34d399' }}>{pendingTx.unitPrice * pendingTx.qty} CRED</span></>
+              }
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setPendingTx(null)}
+                style={{
+                  background: 'transparent', color: '#888', border: '1px solid #444',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                }}
+              >CANCEL</button>
+              <button
+                onClick={handleConfirm}
+                style={{
+                  background: pendingTx.type === 'buy' ? '#34d399' : '#fbbf24',
+                  color: '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+                }}
+              >{pendingTx.type === 'buy' ? 'BUY' : 'SELL'}</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+// --- BUY section ---
+
+const BuySection: React.FC<{
+  shopData: ShopData | null
+  buyQty: Record<number, number>
+  setBuyQty: React.Dispatch<React.SetStateAction<Record<number, number>>>
+  onBuy: (listing: ShopListing) => void
+}> = ({ shopData, buyQty, setBuyQty, onBuy }) => {
+  if (!shopData) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+  if (shopData.listings.length === 0) return <div style={{ color: '#555', fontSize: '0.8em' }}>Nothing for sale.</div>
+
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {shopData.listings.map(listing => {
+        const qty = buyQty[listing.id] || 1
+        const maxQty = listing.stock ?? 99
+        const totalPrice = listing.price * qty
+        const canAfford = totalPrice <= shopData.balance
+
+        return (
+          <div key={listing.id} style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            padding: '5px 0',
+            borderBottom: '1px solid #1a1a1a'
+          }}>
+            <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+              <div style={{
+                color: listing.rarity_color,
+                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+              }}>
+                {listing.name}
+              </div>
+              <div style={{ display: 'flex', gap: '8px', fontSize: '0.9em', color: '#888' }}>
+                <span style={{ color: listing.rarity_color }}>[{listing.rarity_label}]</span>
+                <span style={{ color: canAfford ? '#34d399' : '#f87171' }}>{listing.price} CRED</span>
+                <span>{listing.stock === null ? '∞' : listing.out_of_stock ? 'OUT' : listing.stock}</span>
+              </div>
+            </div>
+
+            {!listing.out_of_stock && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+                {maxQty > 1 && (
+                  <>
+                    <button
+                      onClick={() => setBuyQty(prev => ({ ...prev, [listing.id]: Math.max(1, qty - 1) }))}
+                      disabled={qty <= 1}
+                      style={qtyBtnStyle(qty <= 1)}
+                    >-</button>
+                    <span style={{ color: '#d0d0d0', fontSize: '0.9em', minWidth: '18px', textAlign: 'center' }}>
+                      {qty}
+                    </span>
+                    <button
+                      onClick={() => setBuyQty(prev => ({ ...prev, [listing.id]: Math.min(maxQty, qty + 1) }))}
+                      disabled={qty >= maxQty}
+                      style={qtyBtnStyle(qty >= maxQty)}
+                    >+</button>
+                  </>
+                )}
+                <button
+                  onClick={() => onBuy(listing)}
+                  disabled={!canAfford}
+                  style={{
+                    background: canAfford ? '#34d399' : '#333',
+                    color: canAfford ? '#0a0a0a' : '#666',
+                    border: 'none',
+                    borderRadius: '3px',
+                    padding: '3px 8px',
+                    fontSize: '0.9em',
+                    cursor: canAfford ? 'pointer' : 'not-allowed',
+                    fontWeight: 'bold',
+                    fontFamily: '\'Courier New\', monospace',
+                    marginLeft: '4px'
+                  }}
+                >BUY</button>
+              </div>
+            )}
+
+            {listing.out_of_stock && (
+              <span style={{ color: '#f87171', fontSize: '0.85em', flexShrink: 0 }}>OUT</span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// --- SELL section ---
+
+const SellSection: React.FC<{
+  items: InventoryItem[]
+  onSell: (item: InventoryItem) => void
+}> = ({ items, onSell }) => {
+  if (items.length === 0) return <div style={{ color: '#555', fontSize: '0.8em' }}>Nothing to sell.</div>
+
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {items.map(item => (
+        <div key={item.id} style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          padding: '5px 0',
+          borderBottom: '1px solid #1a1a1a'
+        }}>
+          <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+            <div style={{
+              color: item.rarity_color,
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+            }}>
+              {item.name}
+            </div>
+            <div style={{ display: 'flex', gap: '8px', fontSize: '0.9em' }}>
+              <span style={{ color: item.rarity_color }}>[{item.rarity_label}]</span>
+              {item.quantity > 1 && <span style={{ color: '#6b7280' }}>x{item.quantity}</span>}
+              <span style={{ color: '#34d399' }}>{item.sell_price ?? 0} CRED</span>
+            </div>
+          </div>
+
+          <button
+            onClick={() => onSell(item)}
+            style={{
+              background: '#fbbf24',
+              color: '#0a0a0a',
+              border: 'none',
+              borderRadius: '3px',
+              padding: '3px 8px',
+              fontSize: '0.9em',
+              cursor: 'pointer',
+              fontWeight: 'bold',
+              fontFamily: '\'Courier New\', monospace',
+              flexShrink: 0
+            }}
+          >SELL</button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function qtyBtnStyle (disabled: boolean): React.CSSProperties {
+  return {
+    background: '#222',
+    border: '1px solid #444',
+    borderRadius: '3px',
+    color: disabled ? '#444' : '#d0d0d0',
+    padding: '1px 6px',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontFamily: '\'Courier New\', monospace',
+    fontSize: '0.85em'
+  }
+}

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -61,4 +61,53 @@ export interface ZoneMapData {
   in_breach: boolean
   breach_encounters: BreachEncounter[]
   deck_status: DeckStatus
+  has_vendor: boolean
+}
+
+export interface InventoryItem {
+  id: number
+  name: string
+  description: string | null
+  item_type: string
+  rarity: string
+  rarity_color: string
+  rarity_label: string
+  quantity: number
+  max_stack: number | null
+  definition_slug: string | null
+  properties: Record<string, unknown>
+  actions: string[]
+  sell_price?: number | null
+}
+
+export interface InventoryGroup {
+  item_type: string
+  label: string
+  items: InventoryItem[]
+}
+
+export interface InventoryResponse {
+  capacity: { used: number; max: number }
+  groups: InventoryGroup[]
+}
+
+export interface ShopListing {
+  id: number
+  name: string
+  description: string | null
+  item_type: string
+  rarity: string
+  rarity_color: string
+  rarity_label: string
+  price: number
+  affordable: boolean
+  out_of_stock: boolean
+  stock: number | null
+}
+
+export interface ShopData {
+  vendor_name: string
+  shop_type: string
+  balance: number
+  listings: ShopListing[]
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
     get "grid/inventory", to: "grid#inventory_index"
     get "grid/reputation", to: "grid#reputation_index"
     get "grid/cred", to: "grid#cred_index"
+    get "grid/shop", to: "grid#shop_index"
     get "grid/transit", to: "grid#transit_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"


### PR DESCRIPTION
  Slide-in vendor shop panel on the tactical map with buy/sell UI, plus
  inline SELL buttons on the inventory tab when in a vendor room.

  Backend: New GET /api/grid/shop endpoint (TACTICAL_GRID gated)
  returning clearance-filtered vendor listings with effective prices and
  stock. zone_map response gains has_vendor boolean. inventory_index
  annotates items with sell_price when a vendor is present — batch-loaded
  vendor listings indexed by definition ID (no N+1). sell_price_for
  matches on grid_item_definition_id for correctness.

  Frontend: VendorHandle — amber vertical tab on map right edge,
  visible when room has vendor (hidden during BREACH). VendorPanel —
  right-side slide-in covering 50% of map, same two-boolean mount/animate
  state machine as BreachPanel (translateX). BUY section with listing
  table, inline quantity selectors, affordability-capped confirm modal.
  SELL section with sellable inventory items. InventoryTab gains inline
  SELL buttons before item names (matching SCHEM FAB pattern) and SELL
  in the item detail modal. hasVendor state in TacticalContext for
  cross-component access. Shared InventoryItem/InventoryResponse types
  extracted to zoneMap.ts.