### PR TITLE
[TPG] Tactical Transit Panel, Bidirectional Transit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Ruby](https://img.shields.io/badge/Ruby-3.4.7-red.svg)](https://www.ruby-lang.org/)
 [![Rails](https://img.shields.io/badge/Rails-8.1.3-red.svg)](https://rubyonrails.org/)
 [![React](https://img.shields.io/badge/React-19.2-61dafb.svg)](https://react.dev/)
-[![Tests](https://img.shields.io/badge/Tests-2969%20passing-brightgreen.svg)](#testing)
+[![Tests](https://img.shields.io/badge/Tests-3014%20passing-brightgreen.svg)](#testing)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 
 ---
@@ -472,9 +472,9 @@ bundle exec rspec spec/components/
 ```
 
 **Test Coverage:**
-- **Backend:** 2750 examples (RSpec)
+- **Backend:** 2770 examples (RSpec)
 - **Frontend:** 244 examples (Vitest)
-- **Total:** 2994 passing tests
+- **Total:** 3014 passing tests
 
 ---
 
@@ -725,7 +725,7 @@ bin/rails data:overlays             # Overlay scenes, elements, tickers
 - Multi-Type Transit System - Slipstream (inter-region covert travel with heat/detection) + local transit (public routes with stops, private transit), 13 vehicle types, `/transit` SPA page
 - Bootloader Tutorial - 53-step VR training simulation across 7 chapters, starting room selection, hidden `code` command
 - Partial Name Matching - Substring-fallback name resolution with "Did you mean?" disambiguation across all commands
-- Comprehensive test suite - 2725 backend + 244 frontend tests (2969 total)
+- Comprehensive test suite - 2770 backend + 244 frontend tests (3014 total)
 
 ### Future Enhancements
 - Transit System: Local transit route seeding - Seed local routes per region using admin CRUD
@@ -763,7 +763,7 @@ This project is released into the public domain, so feel free to fork, modify, a
 | `bin/rails data:catalog` | Load artists, albums, tracks only |
 | `bin/rails data:world` | Load all world data (regions, zones, rooms, mobs, items, BREACH, transit, etc.) |
 | `bin/rails data:reset` | Reset seed content (preserves user data) |
-| `bundle exec rspec` | Run backend test suite (2750 tests) |
+| `bundle exec rspec` | Run backend test suite (2770 tests) |
 | `pnpm test` | Run frontend test suite (244 tests) |
 | `bundle exec standardrb` | Lint backend code |
 | `bundle exec brakeman` | Run security scanner |

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -381,13 +381,18 @@ class Api::GridController < ApplicationController
           .map { |r| {slug: r.type_slug, name: r.type_name, category: r.type_category} }
       }
 
+    private_types = Grid::LocalTransitService.private_types_at_room(room: room, hackr: current_hackr)
+    private_destinations = private_types.any? ? Grid::LocalTransitService.private_destinations(room: room) : []
+
     render json: {
       slipstream_heat: current_hackr.slipstream_heat,
       slipstream_heat_tier: current_hackr.slipstream_heat_tier,
       current_region: region ? {slug: region.slug, name: region.name} : nil,
       current_journey: active_journey ? transit_journey_json(active_journey) : nil,
-      local_routes: local_routes.map { |r| transit_route_json(r) },
-      slipstream_routes: slip_routes.map { |r| slipstream_route_json(r) },
+      local_routes: local_routes.map { |r| transit_route_json(r, room: room) },
+      slipstream_routes: slip_routes.map { |r| slipstream_route_json(r, room: room) },
+      private_types: private_types.map { |t| {slug: t.slug, name: t.name, base_fare: t.base_fare, icon_key: t.icon_key} },
+      private_destinations: private_destinations.map { |r| {name: r.name, slug: r.slug, zone_name: r.grid_zone.name} },
       region_transit: region_transit
     }
   end
@@ -862,7 +867,10 @@ class Api::GridController < ApplicationController
       in_breach: current_hackr.in_breach?,
       breach_encounters: breach_encounters,
       deck_status: deck_status,
-      has_vendor: room.grid_mobs.loaded? ? room.grid_mobs.any?(&:vendor?) : room.grid_mobs.exists?(mob_type: "vendor")
+      has_vendor: room.grid_mobs.loaded? ? room.grid_mobs.any?(&:vendor?) : room.grid_mobs.exists?(mob_type: "vendor"),
+      has_transit: room.room_type == "transit" ||
+        GridSlipstreamRoute.active.where(origin_room_id: room.id).exists? ||
+        current_hackr.in_transit?
     }
   end
 
@@ -1024,7 +1032,7 @@ class Api::GridController < ApplicationController
   end
 
   def transit_journey_json(journey)
-    {
+    json = {
       id: journey.id,
       journey_type: journey.journey_type,
       state: journey.state,
@@ -1034,24 +1042,47 @@ class Api::GridController < ApplicationController
       breach_mid_journey: journey.breach_mid_journey,
       started_at: journey.started_at&.iso8601,
       route_name: journey.slipstream? ? journey.grid_slipstream_route&.name : journey.grid_transit_route&.name,
+      direction: journey.meta&.dig("direction") || "forward",
       current_stop: journey.current_stop ? {position: journey.current_stop.position, name: journey.current_stop.display_name} : nil,
       current_leg: journey.current_leg ? {position: journey.current_leg.position, name: journey.current_leg.name} : nil
     }
+
+    # Compute next stop name for local journeys (direction-aware)
+    if journey.local? && journey.current_stop && journey.grid_transit_route
+      dir = (journey.meta&.dig("direction") || "forward").to_sym
+      nxt = journey.grid_transit_route.next_stop_after(journey.current_stop, direction: dir)
+      json[:next_stop] = nxt&.display_name
+    end
+
+    # Include fork options when a slipstream journey is awaiting a fork choice
+    if journey.slipstream? && journey.pending_fork? && journey.current_leg&.has_forks?
+      json[:current_leg_forks] = journey.current_leg.fork_options.map do |opt|
+        {key: opt["key"], label: opt["label"], description: opt["description"]}
+      end
+    end
+
+    json
   end
 
-  def transit_route_json(route)
+  def transit_route_json(route, room: nil)
+    stops = route.grid_transit_stops.to_a
+    boarding_stop = room && stops.find { |s| s.grid_room_id == room.id }
+    at_first = boarding_stop && stops.first&.id == boarding_stop.id
+    at_last = boarding_stop && stops.last&.id == boarding_stop.id
     {
       slug: route.slug,
       name: route.name,
       transit_type: {slug: route.grid_transit_type.slug, name: route.grid_transit_type.name, category: route.grid_transit_type.category, base_fare: route.grid_transit_type.base_fare, icon_key: route.grid_transit_type.icon_key},
       region: {slug: route.grid_region.slug, name: route.grid_region.name},
       loop_route: route.loop_route,
-      stop_count: route.grid_transit_stops.size,
-      stops: route.grid_transit_stops.map { |s| {position: s.position, name: s.display_name, room_slug: s.grid_room.slug, is_terminus: s.is_terminus} }
+      stop_count: stops.size,
+      stops: stops.map { |s| {position: s.position, name: s.display_name, room_slug: s.grid_room.slug, is_terminus: s.is_terminus} },
+      at_first_stop: !!at_first,
+      at_last_stop: !!at_last
     }
   end
 
-  def slipstream_route_json(route)
+  def slipstream_route_json(route, room: nil)
     {
       slug: route.slug,
       name: route.name,
@@ -1059,7 +1090,8 @@ class Api::GridController < ApplicationController
       destination_region: {slug: route.destination_region.slug, name: route.destination_region.name},
       min_clearance: route.min_clearance,
       leg_count: route.grid_slipstream_legs.size,
-      legs: route.grid_slipstream_legs.map { |l| {position: l.position, name: l.name, has_forks: l.has_forks?} }
+      legs: route.grid_slipstream_legs.map { |l| {position: l.position, name: l.name, has_forks: l.has_forks?} },
+      boardable: room.present? && route.origin_room_id == room.id
     }
   end
 

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -13,6 +13,8 @@ import { BreachPanel } from '~/components/tactical/breach/BreachPanel'
 import { BreachEncounter, DeckStatus } from '~/types/zoneMap'
 import { VendorHandle } from '~/components/tactical/vendor/VendorHandle'
 import { VendorPanel } from '~/components/tactical/vendor/VendorPanel'
+import { TransitHandle } from '~/components/tactical/transit/TransitHandle'
+import { TransitPanel } from '~/components/tactical/transit/TransitPanel'
 
 const TacticalInner: React.FC = () => {
   const { hackr } = useGridAuth()
@@ -20,13 +22,15 @@ const TacticalInner: React.FC = () => {
     currentRoomId, setCurrentRoomId, setOutput,
     refreshToken, sendCommand, commandInputRef,
     inBreach, breachMeta, breachOutput,
-    hasVendor, setHasVendor
+    hasVendor, setHasVendor,
+    hasTransit, setHasTransit
   } = useTactical()
   const initialLoadDoneRef = useRef(false)
   const [breachEncounters, setBreachEncounters] = useState<BreachEncounter[]>([])
   const [deckStatus, setDeckStatus] = useState<DeckStatus>({ equipped: false, fried: false })
   const [confirmTarget, setConfirmTarget] = useState<BreachEncounter | null>(null)
   const [vendorOpen, setVendorOpen] = useState(false)
+  const [transitOpen, setTransitOpen] = useState(false)
 
   const handleBreachEncountersChange = useCallback((encounters: BreachEncounter[], ds: DeckStatus) => {
     setBreachEncounters(encounters)
@@ -38,9 +42,17 @@ const TacticalInner: React.FC = () => {
     if (!v) setVendorOpen(false)
   }, [setHasVendor])
 
-  // Close vendor panel when breach starts
+  const handleTransitPresenceChange = useCallback((v: boolean) => {
+    setHasTransit(v)
+    if (!v) setTransitOpen(false)
+  }, [setHasTransit])
+
+  // Close panels when breach starts
   useEffect(() => {
-    if (inBreach) setVendorOpen(false)
+    if (inBreach) {
+      setVendorOpen(false)
+      setTransitOpen(false)
+    }
   }, [inBreach])
 
   const handleBreachConfirm = useCallback(() => {
@@ -153,6 +165,7 @@ const TacticalInner: React.FC = () => {
           onNavigate={(dir) => sendCommand(`go ${dir}`)}
           onBreachEncountersChange={handleBreachEncountersChange}
           onVendorPresenceChange={handleVendorPresenceChange}
+          onTransitPresenceChange={handleTransitPresenceChange}
         />
         {!inBreach && breachEncounters.length > 0 && (
           <BreachTargetButtons
@@ -168,7 +181,16 @@ const TacticalInner: React.FC = () => {
           refreshToken={refreshToken}
           onCommand={sendCommand}
         />
-        {hasVendor && !inBreach && !vendorOpen && (
+        {hasTransit && !inBreach && !vendorOpen && !transitOpen && (
+          <TransitHandle onClick={() => setTransitOpen(true)} />
+        )}
+        <TransitPanel
+          visible={transitOpen && !inBreach}
+          refreshToken={refreshToken}
+          onCommand={sendCommand}
+          onClose={() => setTransitOpen(false)}
+        />
+        {hasVendor && !inBreach && !vendorOpen && !transitOpen && (
           <VendorHandle onClick={() => setVendorOpen(true)} />
         )}
         <VendorPanel

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -39,10 +39,12 @@ interface TacticalContextValue {
   breachMeta: BreachMeta | null
   breachOutput: string[]
   hasVendor: boolean
+  hasTransit: boolean
   sendCommand: (command: string) => Promise<void>
   setOutput: React.Dispatch<React.SetStateAction<string[]>>
   setCurrentRoomId: React.Dispatch<React.SetStateAction<number | null>>
   setHasVendor: React.Dispatch<React.SetStateAction<boolean>>
+  setHasTransit: React.Dispatch<React.SetStateAction<boolean>>
   commandInputRef: React.RefObject<CommandInputHandle | null>
 }
 
@@ -63,6 +65,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [breachMeta, setBreachMeta] = useState<BreachMeta | null>(null)
   const [breachOutput, setBreachOutput] = useState<string[]>([])
   const [hasVendor, setHasVendor] = useState(false)
+  const [hasTransit, setHasTransit] = useState(false)
   const commandInputRef = useRef<CommandInputHandle | null>(null)
   const inBreachRef = useRef(false)
 
@@ -123,9 +126,11 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
       }
 
       setRefreshToken(prev => prev + 1)
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Command execution failed:', err)
-      setOutput(prev => [...prev, '<span style="color: #f87171;">Error: Network error. Please try again.</span>'])
+      const raw = err instanceof Error ? err.message : 'Network error. Please try again.'
+      const safe = raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      setOutput(prev => [...prev, `<span style="color: #f87171;">Error: ${safe}</span>`])
     } finally {
       setExecuting(false)
     }
@@ -134,8 +139,8 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   return (
     <TacticalContext.Provider value={{
       output, currentRoomId, executing, refreshToken,
-      inBreach, breachMeta, breachOutput, hasVendor,
-      sendCommand, setOutput, setCurrentRoomId, setHasVendor, commandInputRef
+      inBreach, breachMeta, breachOutput, hasVendor, hasTransit,
+      sendCommand, setOutput, setCurrentRoomId, setHasVendor, setHasTransit, commandInputRef
     }}>
       {children}
     </TacticalContext.Provider>

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -577,14 +577,14 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
 // --- Compact compass rose + vertical nav ---
 
 const NAV_GRID: { dir: string; label: string; row: number; col: number }[] = [
-  { dir: 'nw', label: 'NW', row: 0, col: 0 },
+  { dir: 'northwest', label: 'NW', row: 0, col: 0 },
   { dir: 'north', label: 'N', row: 0, col: 1 },
-  { dir: 'ne', label: 'NE', row: 0, col: 2 },
+  { dir: 'northeast', label: 'NE', row: 0, col: 2 },
   { dir: 'west', label: 'W', row: 1, col: 0 },
   { dir: 'east', label: 'E', row: 1, col: 2 },
-  { dir: 'sw', label: 'SW', row: 2, col: 0 },
+  { dir: 'southwest', label: 'SW', row: 2, col: 0 },
   { dir: 'south', label: 'S', row: 2, col: 1 },
-  { dir: 'se', label: 'SE', row: 2, col: 2 }
+  { dir: 'southeast', label: 'SE', row: 2, col: 2 }
 ]
 
 const NAV_VERTICAL: { dir: string; label: string }[] = [

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -14,6 +14,7 @@ interface ZoneMapProps {
   onNavigate?: (direction: string) => void
   onBreachEncountersChange?: (encounters: BreachEncounter[], deckStatus: DeckStatus) => void
   onVendorPresenceChange?: (hasVendor: boolean) => void
+  onTransitPresenceChange?: (hasTransit: boolean) => void
 }
 
 interface Tooltip {
@@ -24,7 +25,7 @@ interface Tooltip {
 
 const Z_DIRS = new Set(['up', 'down'])
 
-export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange, onVendorPresenceChange }) => {
+export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange, onVendorPresenceChange, onTransitPresenceChange }) => {
   const [mapData, setMapData] = useState<ZoneMapData | null>(null)
   const [tooltip, setTooltip] = useState<Tooltip | null>(null)
   const [zoom, setZoom] = useState(1.25)
@@ -43,6 +44,7 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
         setPanOffset([0, 0])
         onBreachEncountersChange?.(data.breach_encounters || [], data.deck_status || { equipped: false, fried: false })
         onVendorPresenceChange?.(data.has_vendor ?? false)
+        onTransitPresenceChange?.(data.has_transit ?? false)
       })
       .catch(err => console.error('Zone map fetch failed:', err))
   // eslint-disable-next-line react-hooks/exhaustive-deps -- callback ref change should not re-trigger fetch; refreshToken controls cadence
@@ -114,6 +116,9 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
     }
     return map
   }, [mapData, currentRoomId])
+
+  // Available directions from current room (for nav buttons)
+  const availableDirections = useMemo(() => new Set(navigableExits.values()), [navigableExits])
 
   // Ghost room positions: compute from local room position + direction vector
   const ghostRenderList = useMemo(() => {
@@ -528,6 +533,14 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
         })}
       </svg>
 
+      {/* Navigation buttons */}
+      {onNavigate && (
+        <NavButtons
+          availableDirections={availableDirections}
+          onNavigate={(dir) => { setTooltip(null); onNavigate(dir) }}
+        />
+      )}
+
       {/* Tooltip */}
       {tooltip && (
         <div style={{
@@ -557,6 +570,113 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+// --- Compact compass rose + vertical nav ---
+
+const NAV_GRID: { dir: string; label: string; row: number; col: number }[] = [
+  { dir: 'nw', label: 'NW', row: 0, col: 0 },
+  { dir: 'north', label: 'N', row: 0, col: 1 },
+  { dir: 'ne', label: 'NE', row: 0, col: 2 },
+  { dir: 'west', label: 'W', row: 1, col: 0 },
+  { dir: 'east', label: 'E', row: 1, col: 2 },
+  { dir: 'sw', label: 'SW', row: 2, col: 0 },
+  { dir: 'south', label: 'S', row: 2, col: 1 },
+  { dir: 'se', label: 'SE', row: 2, col: 2 }
+]
+
+const NAV_VERTICAL: { dir: string; label: string }[] = [
+  { dir: 'up', label: '\u2191' },
+  { dir: 'down', label: '\u2193' }
+]
+
+const NavButtons: React.FC<{
+  availableDirections: Set<string>
+  onNavigate: (dir: string) => void
+}> = ({ availableDirections, onNavigate }) => {
+  return (
+    <div style={{
+      position: 'absolute',
+      bottom: 10,
+      left: 10,
+      zIndex: 15,
+      display: 'flex',
+      gap: '4px',
+      alignItems: 'flex-end'
+    }}>
+      {/* Compass rose */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 28px)',
+        gridTemplateRows: 'repeat(3, 28px)',
+        gap: '2px'
+      }}>
+        {NAV_GRID.map(({ dir, label, row, col }) => {
+          const available = availableDirections.has(dir)
+          return (
+            <button
+              key={dir}
+              onClick={(e) => { e.stopPropagation(); if (available) onNavigate(dir) }}
+              disabled={!available}
+              style={{
+                gridRow: row + 1,
+                gridColumn: col + 1,
+                width: 28,
+                height: 28,
+                background: available ? '#1a1a1a' : '#0e0e0e',
+                color: available ? '#22d3ee' : '#333',
+                border: `1px solid ${available ? '#333' : '#1a1a1a'}`,
+                borderRadius: '3px',
+                fontSize: '0.6em',
+                fontFamily: '\'Courier New\', monospace',
+                fontWeight: 'bold',
+                cursor: available ? 'pointer' : 'default',
+                padding: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Up / Down */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+        {NAV_VERTICAL.map(({ dir, label }) => {
+          const available = availableDirections.has(dir)
+          const color = dir === 'up' ? '#a78bfa' : '#fb923c'
+          return (
+            <button
+              key={dir}
+              onClick={(e) => { e.stopPropagation(); if (available) onNavigate(dir) }}
+              disabled={!available}
+              style={{
+                width: 28,
+                height: 28,
+                background: available ? '#1a1a1a' : '#0e0e0e',
+                color: available ? color : '#333',
+                border: `1px solid ${available ? '#333' : '#1a1a1a'}`,
+                borderRadius: '3px',
+                fontSize: '0.85em',
+                fontFamily: '\'Courier New\', monospace',
+                fontWeight: 'bold',
+                cursor: available ? 'pointer' : 'default',
+                padding: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/app/javascript/components/tactical/transit/TransitHandle.tsx
+++ b/app/javascript/components/tactical/transit/TransitHandle.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+
+interface TransitHandleProps {
+  onClick: () => void
+}
+
+export const TransitHandle: React.FC<TransitHandleProps> = ({ onClick }) => {
+  const [hover, setHover] = useState(false)
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 25,
+        background: hover ? '#1a1a1a' : '#111',
+        border: '1px solid #22d3ee',
+        borderTop: 'none',
+        borderRadius: '0 0 6px 6px',
+        padding: '4px 16px',
+        cursor: 'pointer',
+        fontFamily: '\'Courier New\', monospace',
+        fontSize: '0.7em',
+        fontWeight: 'bold',
+        letterSpacing: '2px',
+        color: '#22d3ee',
+        transition: 'background 0.2s, box-shadow 0.2s',
+        boxShadow: hover ? '0 0 10px rgba(34, 211, 238, 0.3)' : 'none'
+      }}
+    >
+      TRANSIT
+    </button>
+  )
+}

--- a/app/javascript/components/tactical/transit/TransitPanel.tsx
+++ b/app/javascript/components/tactical/transit/TransitPanel.tsx
@@ -1,0 +1,663 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import {
+  TransitData, TransitRoute, SlipstreamRoute,
+  PrivateTransitType, PrivateDestination, TransitJourney
+} from '~/types/zoneMap'
+
+interface TransitPanelProps {
+  visible: boolean
+  refreshToken: number
+  onCommand: (cmd: string) => void
+  onClose: () => void
+}
+
+type TabKey = 'local' | 'private' | 'slipstream'
+
+const HEAT_COLORS: Record<string, string> = {
+  cold: '#34d399',
+  warm: '#fbbf24',
+  hot: '#f97316',
+  burning: '#ef4444'
+}
+
+export const TransitPanel: React.FC<TransitPanelProps> = ({
+  visible, refreshToken, onCommand, onClose
+}) => {
+  const [isRendered, setIsRendered] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const [data, setData] = useState<TransitData | null>(null)
+  const [activeTab, setActiveTab] = useState<TabKey>('local')
+  const hadJourneyRef = useRef(false)
+
+  // Slide animation: mount first, then open; close first, then unmount
+  // Double-rAF ensures browser paints the closed state before transitioning to open
+  useEffect(() => {
+    if (visible) {
+      setIsRendered(true) // eslint-disable-line react-hooks/set-state-in-effect -- must mount before animating
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setIsOpen(true))
+      })
+      return () => cancelAnimationFrame(raf)
+    } else {
+      setIsOpen(false)
+      hadJourneyRef.current = false
+      const timer = setTimeout(() => setIsRendered(false), 300)
+      return () => clearTimeout(timer)
+    }
+  }, [visible])
+
+  // Fetch transit data when panel is rendered
+  useEffect(() => {
+    if (isRendered) {
+      apiJson<TransitData>('/api/grid/transit').then(fresh => {
+        // Auto-close panel when journey ends (disembark, arrival, abandon)
+        if (hadJourneyRef.current && !fresh.current_journey) {
+          onClose()
+        }
+        hadJourneyRef.current = fresh.current_journey != null
+        setData(fresh)
+      }).catch(console.error)
+    }
+  }, [refreshToken, isRendered, onClose])
+
+  // Derive available tabs from data
+  const availableTabs = useMemo(() => {
+    if (!data) return []
+    const tabs: { key: TabKey; label: string }[] = []
+    if (data.local_routes.length > 0) tabs.push({ key: 'local', label: 'LOCAL' })
+    if (data.private_types.length > 0) tabs.push({ key: 'private', label: 'PRIVATE' })
+    if (data.slipstream_routes.some(r => r.boardable)) tabs.push({ key: 'slipstream', label: 'SLIPSTREAM' })
+    return tabs
+  }, [data])
+
+  // Reset active tab to first available when tabs change
+  useEffect(() => {
+    if (availableTabs.length > 0 && !availableTabs.find(t => t.key === activeTab)) {
+      setActiveTab(availableTabs[0].key) // eslint-disable-line react-hooks/set-state-in-effect -- tab must sync with available data
+    }
+  }, [availableTabs, activeTab])
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    onClose()
+  }, [onClose])
+
+  if (!isRendered) return null
+
+  const hasJourney = data?.current_journey != null
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={handleBackdropClick}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 29,
+          background: isOpen ? 'rgba(0,0,0,0.2)' : 'transparent',
+          transition: 'background 300ms ease-out'
+        }}
+      />
+
+      {/* Panel */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '50%',
+          zIndex: 30,
+          transform: isOpen ? 'translateY(0%)' : 'translateY(-100%)',
+          transition: 'transform 300ms ease-out',
+          display: 'flex',
+          flexDirection: 'column',
+          background: '#0d0d0d',
+          borderBottom: '2px solid #22d3ee',
+          borderRadius: '0 0 8px 8px',
+          fontFamily: '\'Courier New\', monospace'
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '8px 12px',
+          background: '#111',
+          borderBottom: '1px solid #333',
+          flexShrink: 0
+        }}>
+          <div>
+            <span style={{ color: '#22d3ee', fontWeight: 'bold', fontSize: '0.8em', letterSpacing: '1px' }}>
+              TRANSIT
+            </span>
+            {data?.current_region && (
+              <>
+                <span style={{ color: '#444', margin: '0 8px' }}>::</span>
+                <span style={{ color: '#d0d0d0', fontSize: '0.8em' }}>{data.current_region.name}</span>
+              </>
+            )}
+            {hasJourney && (
+              <span style={{ color: '#f97316', fontSize: '0.65em', marginLeft: '8px' }}>IN TRANSIT</span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'transparent',
+              color: '#888',
+              border: '1px solid #444',
+              padding: '3px 10px',
+              fontSize: '0.7em',
+              cursor: 'pointer',
+              borderRadius: '3px',
+              fontFamily: '\'Courier New\', monospace'
+            }}
+          >
+            CLOSE
+          </button>
+        </div>
+
+        {/* Tab bar (hidden during active journey) */}
+        {!hasJourney && availableTabs.length > 0 && (
+          <div style={{
+            display: 'flex',
+            borderBottom: '1px solid #333',
+            background: '#0f0f0f',
+            flexShrink: 0
+          }}>
+            {availableTabs.map(tab => {
+              const tabColor = tab.key === 'local' ? '#34d399'
+                : tab.key === 'private' ? '#fbbf24'
+                  : '#a78bfa'
+              return (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  style={{
+                    flex: 1,
+                    background: activeTab === tab.key ? '#1a1a1a' : 'transparent',
+                    color: activeTab === tab.key ? tabColor : '#666',
+                    border: 'none',
+                    borderBottom: activeTab === tab.key ? `2px solid ${tabColor}` : '2px solid transparent',
+                    padding: '6px 10px',
+                    fontSize: '0.7em',
+                    fontFamily: '\'Courier New\', monospace',
+                    cursor: 'pointer',
+                    fontWeight: activeTab === tab.key ? 'bold' : 'normal',
+                    letterSpacing: '0.5px'
+                  }}
+                >
+                  {tab.label}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Content */}
+        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', padding: '8px 10px' }}>
+          {!data ? (
+            <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+          ) : hasJourney ? (
+            <JourneySection journey={data.current_journey!} onCommand={onCommand} />
+          ) : availableTabs.length === 0 ? (
+            <div style={{ color: '#555', fontSize: '0.8em' }}>No transit options available here.</div>
+          ) : (
+            <>
+              {activeTab === 'local' && (
+                <LocalSection routes={data.local_routes} onCommand={onCommand} />
+              )}
+              {activeTab === 'private' && (
+                <PrivateSection
+                  types={data.private_types}
+                  destinations={data.private_destinations}
+                  onCommand={onCommand}
+                />
+              )}
+              {activeTab === 'slipstream' && (
+                <SlipstreamSection
+                  routes={data.slipstream_routes.filter(r => r.boardable)}
+                  heat={data.slipstream_heat}
+                  heatTier={data.slipstream_heat_tier}
+                  onCommand={onCommand}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+// --- Active Journey ---
+
+const JourneySection: React.FC<{
+  journey: TransitJourney
+  onCommand: (cmd: string) => void
+}> = ({ journey, onCommand }) => {
+  const isSlipstream = journey.journey_type === 'slipstream'
+  const isLocalPublic = journey.journey_type === 'local_public'
+  const typeColor = isSlipstream ? '#a78bfa' : '#34d399'
+  const typeLabel = isSlipstream ? 'SLIPSTREAM' : journey.journey_type === 'local_private' ? 'PRIVATE' : 'LOCAL'
+
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {/* Journey header */}
+      <div style={{ marginBottom: '10px' }}>
+        <span style={{ color: typeColor, fontWeight: 'bold', letterSpacing: '1px' }}>[{typeLabel}]</span>
+        {journey.route_name && (
+          <span style={{ color: '#d0d0d0', marginLeft: '8px' }}>{journey.route_name}</span>
+        )}
+        {!isSlipstream && journey.direction === 'reverse' && (
+          <span style={{ color: '#888', fontSize: '0.85em', marginLeft: '6px' }}>(REV)</span>
+        )}
+      </div>
+
+      {/* Breach mid-journey warning */}
+      {journey.breach_mid_journey && (
+        <div style={{
+          padding: '6px 8px',
+          marginBottom: '10px',
+          border: '1px solid #f87171',
+          borderRadius: '3px',
+          color: '#f87171',
+          fontSize: '0.9em'
+        }}>
+          BREACH IN PROGRESS — resolve before continuing transit
+        </div>
+      )}
+
+      {/* Slipstream leg progress */}
+      {isSlipstream && (
+        <div style={{ marginBottom: '10px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+            <span style={{ color: '#888' }}>Progress</span>
+            <span style={{ color: '#a78bfa' }}>{journey.legs_completed}/{journey.total_legs} legs</span>
+          </div>
+          <div style={{ height: 4, background: '#222', borderRadius: 2 }}>
+            <div style={{
+              width: journey.total_legs > 0 ? `${(journey.legs_completed / journey.total_legs) * 100}%` : '0%',
+              height: '100%',
+              background: '#a78bfa',
+              borderRadius: 2,
+              transition: 'width 0.3s'
+            }} />
+          </div>
+          {journey.current_leg && (
+            <div style={{ color: '#888', fontSize: '0.9em', marginTop: '4px' }}>
+              Current leg: <span style={{ color: '#d0d0d0' }}>{journey.current_leg.name}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Local transit current + next stop */}
+      {!isSlipstream && journey.current_stop && (
+        <div style={{ marginBottom: '10px' }}>
+          <div style={{ color: '#888' }}>
+            Current stop: <span style={{ color: '#d0d0d0' }}>{journey.current_stop.name}</span>
+          </div>
+          {journey.next_stop ? (
+            <div style={{ color: '#888', fontSize: '0.9em', marginTop: '2px' }}>
+              Next stop: <span style={{ color: '#22d3ee' }}>{journey.next_stop}</span>
+            </div>
+          ) : (
+            <div style={{ color: '#fbbf24', fontSize: '0.9em', marginTop: '2px' }}>
+              End of the line
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Slipstream fork choices */}
+      {isSlipstream && journey.pending_fork && journey.current_leg_forks && (
+        <div style={{
+          padding: '8px',
+          marginBottom: '10px',
+          border: '1px solid #fbbf24',
+          borderRadius: '3px',
+          background: '#1a1a0a'
+        }}>
+          <div style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: '6px' }}>FORK CHOICE</div>
+          {journey.current_leg_forks.map(fork => (
+            <div key={fork.key} style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              padding: '4px 0',
+              borderBottom: '1px solid #1a1a1a'
+            }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ color: '#d0d0d0' }}>{fork.label}</div>
+                {fork.description && (
+                  <div style={{ color: '#666', fontSize: '0.9em' }}>{fork.description}</div>
+                )}
+              </div>
+              <button
+                onClick={() => onCommand(`choose ${fork.key}`)}
+                style={actionBtnStyle('#fbbf24')}
+              >
+                CHOOSE
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+        {!journey.breach_mid_journey && (
+          <>
+            {isSlipstream && !journey.pending_fork && (
+              <button onClick={() => onCommand('advance')} style={actionBtnStyle('#a78bfa')}>
+                ADVANCE
+              </button>
+            )}
+            {!isSlipstream && (
+              <button onClick={() => onCommand('wait')} style={actionBtnStyle('#34d399')}>
+                WAIT
+              </button>
+            )}
+            {isLocalPublic && (
+              <button onClick={() => onCommand('disembark')} style={actionBtnStyle('#fbbf24')}>
+                DISEMBARK
+              </button>
+            )}
+          </>
+        )}
+        <button onClick={() => onCommand('abandon')} style={actionBtnStyle('#f87171')}>
+          ABANDON
+        </button>
+        <button onClick={() => onCommand('status')} style={actionBtnStyle('#888')}>
+          STATUS
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// --- Local Public Routes ---
+
+const LocalSection: React.FC<{
+  routes: TransitRoute[]
+  onCommand: (cmd: string) => void
+}> = ({ routes, onCommand }) => {
+  if (routes.length === 0) {
+    return <div style={{ color: '#555', fontSize: '0.8em' }}>No local routes at this stop.</div>
+  }
+
+  // Group routes by transit type
+  const grouped = routes.reduce<Record<string, TransitRoute[]>>((acc, r) => {
+    const key = r.transit_type.name
+    if (!acc[key]) acc[key] = []
+    acc[key].push(r)
+    return acc
+  }, {})
+
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {Object.entries(grouped).map(([typeName, typeRoutes]) => (
+        <div key={typeName} style={{ marginBottom: '10px' }}>
+          <div style={{ color: '#34d399', fontWeight: 'bold', marginBottom: '4px', fontSize: '0.9em' }}>
+            [{typeRoutes[0].transit_type.icon_key || 'TRANSIT'}] {typeName}
+          </div>
+          {typeRoutes.map(route => (
+            <RouteRow key={route.slug} route={route} onCommand={onCommand} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+const RouteRow: React.FC<{
+  route: TransitRoute
+  onCommand: (cmd: string) => void
+}> = ({ route, onCommand }) => {
+  const canForward = route.loop_route || !route.at_last_stop
+  const canReverse = !route.loop_route && !route.at_first_stop
+  const firstStop = route.stops[0]?.name
+  const lastStop = route.stops[route.stops.length - 1]?.name
+
+  return (
+    <div style={{ borderBottom: '1px solid #1a1a1a', padding: '4px 0' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <span style={{ color: '#22d3ee' }}>{route.name}</span>
+          <span style={{ color: '#666', marginLeft: '6px', fontSize: '0.9em' }}>
+            {route.stop_count} stops {route.loop_route ? '(loop)' : ''} | {route.transit_type.base_fare} CRED
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '3px', flexShrink: 0, alignItems: 'center' }}>
+          {canForward && (
+            <button
+              onClick={() => onCommand(`board ${route.slug}`)}
+              style={dirBtnStyle}
+            >
+              BOARD {'\u2192'} {lastStop}
+            </button>
+          )}
+          {canReverse && (
+            <button
+              onClick={() => onCommand(`board ${route.slug} reverse`)}
+              style={dirBtnStyle}
+            >
+              BOARD {'\u2192'} {firstStop}
+            </button>
+          )}
+        </div>
+      </div>
+      <div style={{ paddingLeft: '10px', paddingTop: '4px' }}>
+        {route.stops.map((stop, i) => (
+          <div key={i} style={{ padding: '2px 0', color: stop.is_terminus ? '#fbbf24' : '#888', fontSize: '0.9em' }}>
+            {stop.is_terminus ? '\u25C6' : '\u00B7'} {stop.name}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// --- Private Transit ---
+
+const PrivateSection: React.FC<{
+  types: PrivateTransitType[]
+  destinations: PrivateDestination[]
+  onCommand: (cmd: string) => void
+}> = ({ types, destinations, onCommand }) => {
+  const [selectedType, setSelectedType] = useState<string | null>(null)
+  const [selectedDest, setSelectedDest] = useState<string | null>(null)
+
+  // Auto-select first type if only one
+  const effectiveType = selectedType || (types.length === 1 ? types[0].slug : null)
+
+  const handleHail = useCallback(() => {
+    if (effectiveType && selectedDest) {
+      onCommand(`hail ${effectiveType} ${selectedDest}`)
+      setSelectedDest(null)
+    }
+  }, [effectiveType, selectedDest, onCommand])
+
+  if (types.length === 0) {
+    return <div style={{ color: '#555', fontSize: '0.8em' }}>No private transit available here.</div>
+  }
+
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {/* Type selector */}
+      {types.length > 1 && (
+        <div style={{ marginBottom: '10px' }}>
+          <div style={{ color: '#888', marginBottom: '4px', fontSize: '0.9em' }}>Select transport:</div>
+          <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+            {types.map(t => (
+              <button
+                key={t.slug}
+                onClick={() => setSelectedType(t.slug)}
+                style={{
+                  background: effectiveType === t.slug ? '#1a1a1a' : 'transparent',
+                  color: effectiveType === t.slug ? '#fbbf24' : '#888',
+                  border: `1px solid ${effectiveType === t.slug ? '#fbbf24' : '#333'}`,
+                  borderRadius: '3px',
+                  padding: '4px 10px',
+                  fontSize: '0.9em',
+                  cursor: 'pointer',
+                  fontFamily: '\'Courier New\', monospace'
+                }}
+              >
+                {t.name} ({t.base_fare} CRED)
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Single type info */}
+      {types.length === 1 && (
+        <div style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: '8px', fontSize: '0.9em' }}>
+          [{types[0].icon_key || 'PRIVATE'}] {types[0].name}
+          <span style={{ color: '#888', fontWeight: 'normal', marginLeft: '8px' }}>{types[0].base_fare} CRED</span>
+        </div>
+      )}
+
+      {/* Destination picker */}
+      {effectiveType && (
+        <>
+          <div style={{ color: '#888', marginBottom: '4px', fontSize: '0.9em' }}>Destination:</div>
+          {destinations.length === 0 ? (
+            <div style={{ color: '#555', fontSize: '0.9em' }}>No destinations available.</div>
+          ) : (
+            <div>
+              {destinations.map(dest => {
+                const isSelected = selectedDest === dest.name
+                return (
+                  <div key={dest.name} style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    padding: '4px 0',
+                    borderBottom: '1px solid #1a1a1a',
+                    cursor: 'pointer',
+                    background: isSelected ? '#1a1a1a' : 'transparent'
+                  }}
+                  onClick={() => setSelectedDest(dest.name)}
+                  >
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ color: isSelected ? '#fbbf24' : '#d0d0d0' }}>
+                        {dest.name}
+                      </span>
+                      <span style={{ color: '#555', marginLeft: '6px', fontSize: '0.9em' }}>({dest.zone_name})</span>
+                    </div>
+                    {isSelected && (
+                      <button onClick={handleHail} style={actionBtnStyle('#fbbf24')}>
+                        HAIL
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// --- Slipstream ---
+
+const SlipstreamSection: React.FC<{
+  routes: SlipstreamRoute[]
+  heat: number
+  heatTier: string
+  onCommand: (cmd: string) => void
+}> = ({ routes, heat, heatTier, onCommand }) => {
+  return (
+    <div style={{ fontSize: '0.75em' }}>
+      {/* Heat indicator */}
+      <div style={{ marginBottom: '10px', padding: '6px 8px', border: '1px solid #333', borderRadius: '3px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+          <span style={{ color: '#888' }}>Corridor Heat</span>
+          <span style={{ color: HEAT_COLORS[heatTier] || '#888', fontWeight: 'bold' }}>
+            {heat}/100 ({heatTier})
+          </span>
+        </div>
+        <div style={{ height: 4, background: '#222', borderRadius: 2 }}>
+          <div style={{
+            width: `${heat}%`,
+            height: '100%',
+            background: HEAT_COLORS[heatTier] || '#888',
+            borderRadius: 2,
+            transition: 'width 0.3s'
+          }} />
+        </div>
+      </div>
+
+      {/* Routes */}
+      {routes.length === 0 ? (
+        <div style={{ color: '#555' }}>No Slipstream corridors from this region.</div>
+      ) : (
+        routes.map(route => (
+          <div key={route.slug} style={{
+            padding: '6px 0',
+            borderBottom: '1px solid #1a1a1a'
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div>
+                  <span style={{ color: '#a78bfa', fontWeight: 'bold' }}>{route.name}</span>
+                  <span style={{ color: '#666', marginLeft: '8px', fontSize: '0.9em' }}>CL{route.min_clearance}+</span>
+                </div>
+                <div style={{ color: '#888', fontSize: '0.9em' }}>
+                  {route.origin_region.name} <span style={{ color: '#a78bfa' }}>{'\u2192'}</span> {route.destination_region.name}
+                  <span style={{ color: '#555', marginLeft: '8px' }}>{route.leg_count} legs</span>
+                </div>
+              </div>
+              <button
+                onClick={() => onCommand(`slipstream ${route.slug}`)}
+                style={actionBtnStyle('#a78bfa')}
+              >
+                BOARD
+              </button>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+
+// --- Shared ---
+
+function actionBtnStyle (color: string): React.CSSProperties {
+  return {
+    background: color,
+    color: '#0a0a0a',
+    border: 'none',
+    borderRadius: '3px',
+    padding: '3px 8px',
+    fontSize: '0.9em',
+    cursor: 'pointer',
+    fontWeight: 'bold',
+    fontFamily: '\'Courier New\', monospace',
+    flexShrink: 0
+  }
+}
+
+const dirBtnStyle: React.CSSProperties = {
+  background: '#1a1a1a',
+  color: '#34d399',
+  border: '1px solid #333',
+  borderRadius: '3px',
+  padding: '2px 8px',
+  fontSize: '0.8em',
+  cursor: 'pointer',
+  fontFamily: '\'Courier New\', monospace',
+  whiteSpace: 'nowrap',
+  flexShrink: 0
+}

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -62,6 +62,7 @@ export interface ZoneMapData {
   breach_encounters: BreachEncounter[]
   deck_status: DeckStatus
   has_vendor: boolean
+  has_transit: boolean
 }
 
 export interface InventoryItem {
@@ -110,4 +111,97 @@ export interface ShopData {
   shop_type: string
   balance: number
   listings: ShopListing[]
+}
+
+// --- Transit types ---
+
+export interface TransitType {
+  slug: string
+  name: string
+  category: string
+  base_fare: number
+  icon_key: string | null
+}
+
+export interface TransitStop {
+  position: number
+  name: string
+  room_slug: string
+  is_terminus: boolean
+}
+
+export interface TransitRoute {
+  slug: string
+  name: string
+  transit_type: TransitType
+  region: { slug: string; name: string }
+  loop_route: boolean
+  stop_count: number
+  stops: TransitStop[]
+  at_first_stop: boolean
+  at_last_stop: boolean
+}
+
+export interface SlipstreamLeg {
+  position: number
+  name: string
+  has_forks: boolean
+}
+
+export interface SlipstreamRoute {
+  slug: string
+  name: string
+  origin_region: { slug: string; name: string }
+  destination_region: { slug: string; name: string }
+  min_clearance: number
+  leg_count: number
+  legs: SlipstreamLeg[]
+  boardable: boolean
+}
+
+export interface TransitForkOption {
+  key: string
+  label: string
+  description: string
+}
+
+export interface TransitJourney {
+  id: number
+  journey_type: 'slipstream' | 'local_public' | 'local_private'
+  state: string
+  legs_completed: number
+  total_legs: number
+  pending_fork: boolean
+  breach_mid_journey: boolean
+  direction: 'forward' | 'reverse'
+  started_at: string | null
+  route_name: string | null
+  current_stop: { position: number; name: string } | null
+  next_stop: string | null
+  current_leg: { position: number; name: string } | null
+  current_leg_forks?: TransitForkOption[]
+}
+
+export interface PrivateTransitType {
+  slug: string
+  name: string
+  base_fare: number
+  icon_key: string | null
+}
+
+export interface PrivateDestination {
+  name: string
+  slug: string
+  zone_name: string
+}
+
+export interface TransitData {
+  slipstream_heat: number
+  slipstream_heat_tier: string
+  current_region: { slug: string; name: string } | null
+  current_journey: TransitJourney | null
+  local_routes: TransitRoute[]
+  slipstream_routes: SlipstreamRoute[]
+  private_types: PrivateTransitType[]
+  private_destinations: PrivateDestination[]
 }

--- a/app/models/concerns/grid_hackr/transit.rb
+++ b/app/models/concerns/grid_hackr/transit.rb
@@ -24,19 +24,25 @@ module GridHackr::Transit
   # to avoid recalculating on every access. This means API GET endpoints that
   # call slipstream_heat are not purely read-only.
   def slipstream_heat
+    return @slipstream_heat_cache if defined?(@slipstream_heat_cache)
+
     raw = stat("slipstream_heat").to_i
     last_at = stat("slipstream_heat_last_at").to_i
-    return raw if last_at.zero? || raw.zero?
+    if last_at.zero? || raw.zero?
+      return @slipstream_heat_cache = raw
+    end
 
     elapsed_minutes = ((Time.current.to_i - last_at) / 60.0).floor
-    return raw if elapsed_minutes <= 0
+    if elapsed_minutes <= 0
+      return @slipstream_heat_cache = raw
+    end
 
     decayed = [raw - elapsed_minutes, 0].max
     if decayed < raw
       set_stat!("slipstream_heat", decayed)
       set_stat!("slipstream_heat_last_at", Time.current.to_i) if decayed > 0
     end
-    decayed
+    @slipstream_heat_cache = decayed
   end
 
   def slipstream_heat_tier
@@ -53,6 +59,7 @@ module GridHackr::Transit
     current = slipstream_heat # triggers decay first
     new_level = [current + amount, 100].min
     set_stat!("slipstream_heat", new_level)
+    @slipstream_heat_cache = new_level # update memoized value
     set_stat!("slipstream_heat_last_at", Time.current.to_i)
     new_level
   end

--- a/app/models/grid_transit_route.rb
+++ b/app/models/grid_transit_route.rb
@@ -56,14 +56,28 @@ class GridTransitRoute < ApplicationRecord
     grid_transit_stops.find_by(grid_room_id: room.id)
   end
 
-  def next_stop_after(stop)
+  def next_stop_after(stop, direction: :forward)
     stops = grid_transit_stops.order(:position).to_a
     idx = stops.index { |s| s.id == stop.id }
     return nil if idx.nil?
-    if idx + 1 < stops.size
+
+    reverse = direction.to_sym == :reverse
+    if reverse && idx > 0
+      stops[idx - 1]
+    elsif reverse && loop_route
+      stops.last
+    elsif !reverse && idx + 1 < stops.size
       stops[idx + 1]
-    elsif loop_route
+    elsif !reverse && loop_route
       stops.first
     end
+  end
+
+  def first_stop
+    grid_transit_stops.order(:position).first
+  end
+
+  def last_stop
+    grid_transit_stops.order(:position).last
   end
 end

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -949,7 +949,23 @@ module Grid
     end
 
     def board_command(args)
-      route_slug = args&.join("-")
+      return "<span style='color: #fbbf24;'>Board what? Specify a route slug. Type <span style='color: #22d3ee;'>transit</span> to see available routes.</span>" unless args&.any?
+
+      # Parse optional direction: "board <route> reverse" or "board reverse <route>"
+      direction = nil
+      filtered = args.reject do |a|
+        if %w[reverse rev backward back].include?(a.downcase)
+          direction = "reverse"
+          true
+        elsif %w[forward fwd].include?(a.downcase)
+          direction = "forward"
+          true
+        else
+          false
+        end
+      end
+
+      route_slug = filtered.join("-")
       return "<span style='color: #fbbf24;'>Board what? Specify a route slug. Type <span style='color: #22d3ee;'>transit</span> to see available routes.</span>" unless route_slug.present?
 
       room = hackr.current_room
@@ -957,7 +973,7 @@ module Grid
       route = routes.find { |r| r.slug == route_slug }
       return "<span style='color: #f87171;'>Route '#{h(route_slug)}' not available here. Type <span style='color: #22d3ee;'>transit</span> to see routes.</span>" unless route
 
-      result = Grid::LocalTransitService.board!(hackr: hackr, route: route)
+      result = Grid::LocalTransitService.board!(hackr: hackr, route: route, direction: direction)
       result.display
     rescue Grid::LocalTransitService::AlreadyInJourney
       "<span style='color: #f87171;'>Already in transit.</span>"
@@ -965,6 +981,8 @@ module Grid
       "<span style='color: #f87171;'>Insufficient CRED for fare.</span>"
     rescue Grid::LocalTransitService::RouteNotAtStop
       "<span style='color: #f87171;'>This route doesn't stop here.</span>"
+    rescue Grid::LocalTransitService::EndOfLine
+      "<span style='color: #f87171;'>This is the end of the line. The route doesn't continue from here.</span>"
     end
 
     def hail_command(args)

--- a/app/services/grid/local_transit_service.rb
+++ b/app/services/grid/local_transit_service.rb
@@ -14,10 +14,11 @@ module Grid
     class InsufficientFunds < StandardError; end
     class DestinationNotOnRoute < StandardError; end
     class AlreadyAtDestination < StandardError; end
+    class EndOfLine < StandardError; end
     class NotInJourney < StandardError; end
 
-    def self.board!(hackr:, route:, destination_stop: nil)
-      new(hackr).board!(route, destination_stop)
+    def self.board!(hackr:, route:, destination_stop: nil, direction: nil)
+      new(hackr).board!(route, destination_stop, direction)
     end
 
     def self.wait!(hackr:)
@@ -92,7 +93,7 @@ module Grid
       @hackr = hackr
     end
 
-    def board!(route, destination_stop = nil)
+    def board!(route, destination_stop = nil, direction = nil)
       room = @hackr.current_room
       boarding_stop = route.stop_for_room(room)
       raise RouteNotAtStop unless boarding_stop
@@ -104,6 +105,21 @@ module Grid
         raise DestinationNotOnRoute unless destination_stop
         raise DestinationNotOnRoute unless destination_stop.grid_transit_route_id == route.id
         raise AlreadyAtDestination if destination_stop.id == boarding_stop.id
+      end
+
+      # Auto-detect travel direction for non-loop public routes
+      travel_direction = if route.loop_route || type.private_point?
+        "forward"
+      elsif direction.to_s == "reverse"
+        "reverse"
+      else
+        resolve_direction(route, boarding_stop, direction)
+      end
+
+      # Validate there's actually a next stop in the chosen direction
+      if !route.loop_route && !type.private_point? &&
+          route.next_stop_after(boarding_stop, direction: travel_direction.to_sym).nil?
+        raise EndOfLine
       end
 
       fare = compute_fare(route, boarding_stop, destination_stop)
@@ -132,7 +148,7 @@ module Grid
           current_stop: boarding_stop,
           fare_paid: fare,
           started_at: Time.current,
-          meta: {}
+          meta: {"direction" => travel_direction}
         )
 
         display = Grid::TransitRenderer.render_board(journey, route, boarding_stop)
@@ -204,7 +220,8 @@ module Grid
           end
         end
 
-        next_stop = route.next_stop_after(current)
+        direction = (journey.meta&.dig("direction") || "forward").to_sym
+        next_stop = route.next_stop_after(current, direction: direction)
 
         unless next_stop
           # End of line (non-loop) — auto-disembark at current stop
@@ -260,6 +277,17 @@ module Grid
     end
 
     private
+
+    # Auto-detect direction: first stop → forward, last stop → reverse, middle → forward (default)
+    def resolve_direction(route, boarding_stop, explicit_direction)
+      return explicit_direction.to_s if %w[forward reverse].include?(explicit_direction.to_s)
+
+      if boarding_stop.id == route.last_stop&.id
+        "reverse"
+      else
+        "forward"
+      end
+    end
 
     def compute_fare(route, boarding_stop, destination_stop)
       type = route.grid_transit_type

--- a/app/services/grid/zone_map_builder.rb
+++ b/app/services/grid/zone_map_builder.rb
@@ -137,9 +137,12 @@ module Grid
       room_ids = Set.new(rooms.map(&:id))
       exits_by_from = exits.group_by(&:from_room_id)
 
+      # Seed from hub or special room (surface-level anchors).
+      # Transit rooms are excluded — they're often underground and
+      # would shift the whole zone's z-levels if used as z=0 anchor.
       seed = rooms.find { |r| r.room_type == "hub" } ||
         rooms.find { |r| r.room_type == "special" } ||
-        rooms.find { |r| r.room_type == "transit" } ||
+        rooms.reject { |r| r.room_type == "transit" }.min_by(&:id) ||
         rooms.min_by(&:id)
       return {} unless seed
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -118,8 +118,10 @@ class Rack::Attack
 
   ### Throttle API requests ###
 
-  # General API throttle - 100 requests per minute per IP
-  throttle("api/ip", limit: 100, period: 1.minute) do |req|
+  # General API throttle - 300 requests per minute per IP
+  # The tactical UI fires 3-5 parallel fetches per command action
+  # (zone_map, transit, loadout, shop, etc.), so 100/min is too tight.
+  throttle("api/ip", limit: 300, period: 1.minute) do |req|
     if req.path.start_with?("/api/")
       req.ip
     end

--- a/data/world/exits.yml
+++ b/data/world/exits.yml
@@ -27920,3 +27920,145 @@ exits:
     direction: west
     locked: false
 
+  # --- Local Transit Stops (The Lakeshore) ---
+
+  # Lakefront Terminal — Elevated Platform ↔ Platform One
+  - from_room_slug: lakefront-el-platform
+    to_room_slug: platform-one
+    direction: south
+    locked: false
+  - from_room_slug: platform-one
+    to_room_slug: lakefront-el-platform
+    direction: north
+    locked: false
+
+  # Lakefront Terminal — Subway Platform ↔ Underground Passage
+  - from_room_slug: lakefront-subway-platform
+    to_room_slug: underground-passage
+    direction: up
+    locked: false
+  - from_room_slug: underground-passage
+    to_room_slug: lakefront-subway-platform
+    direction: down
+    locked: false
+
+  # Skyline — L Stop ↔ The Plaza
+  - from_room_slug: skyline-el-stop
+    to_room_slug: the-plaza
+    direction: down
+    locked: false
+  - from_room_slug: the-plaza
+    to_room_slug: skyline-el-stop
+    direction: up
+    locked: false
+
+  # Gold Mile — L Station ↔ The Boulevard
+  - from_room_slug: gold-mile-el-station
+    to_room_slug: the-boulevard
+    direction: down
+    locked: false
+  - from_room_slug: the-boulevard
+    to_room_slug: gold-mile-el-station
+    direction: up
+    locked: false
+
+  # Gold Mile — Taxi Stand ↔ Valet Circle
+  - from_room_slug: gold-mile-taxi-stand
+    to_room_slug: valet-circle
+    direction: east
+    locked: false
+  - from_room_slug: valet-circle
+    to_room_slug: gold-mile-taxi-stand
+    direction: west
+    locked: false
+
+  # Gold Mile — Marina Dock ↔ Private Marina
+  - from_room_slug: gold-mile-marina-dock
+    to_room_slug: private-marina
+    direction: east
+    locked: false
+  - from_room_slug: private-marina
+    to_room_slug: gold-mile-marina-dock
+    direction: west
+    locked: false
+
+  # Terrace — L Platform ↔ Tree-Lined Avenue
+  - from_room_slug: terrace-el-platform
+    to_room_slug: tree-lined-avenue
+    direction: down
+    locked: false
+  - from_room_slug: tree-lined-avenue
+    to_room_slug: terrace-el-platform
+    direction: up
+    locked: false
+
+  # Ward — L Junction ↔ Main Street
+  - from_room_slug: ward-el-junction
+    to_room_slug: the-ward-main-street
+    direction: down
+    locked: false
+  - from_room_slug: the-ward-main-street
+    to_room_slug: ward-el-junction
+    direction: up
+    locked: false
+
+  # Switchyard — L Platform ↔ Track One
+  - from_room_slug: switchyard-el-platform
+    to_room_slug: track-one
+    direction: east
+    locked: false
+  - from_room_slug: track-one
+    to_room_slug: switchyard-el-platform
+    direction: west
+    locked: false
+
+  # Stacks — Subway ↔ Basement Level
+  - from_room_slug: stacks-subway
+    to_room_slug: basement-level
+    direction: up
+    locked: false
+  - from_room_slug: basement-level
+    to_room_slug: stacks-subway
+    direction: down
+    locked: false
+
+  # Rust Row — Underground ↔ Corroded Alley
+  - from_room_slug: rust-row-subway
+    to_room_slug: corroded-alley
+    direction: up
+    locked: false
+  - from_room_slug: corroded-alley
+    to_room_slug: rust-row-subway
+    direction: down
+    locked: false
+
+  # Pump Station — Subway ↔ Discharge Tunnel
+  - from_room_slug: pump-station-subway
+    to_room_slug: discharge-tunnel
+    direction: north
+    locked: false
+  - from_room_slug: discharge-tunnel
+    to_room_slug: pump-station-subway
+    direction: south
+    locked: false
+
+  # Pier 7 — Ferry Dock ↔ Pier Head
+  - from_room_slug: pier-7-ferry-dock
+    to_room_slug: pier-head
+    direction: south
+    locked: false
+  - from_room_slug: pier-head
+    to_room_slug: pier-7-ferry-dock
+    direction: north
+    locked: false
+
+  # Breakwall — Harbor Dock ↔ Fisherman's Walk
+  - from_room_slug: breakwall-harbor-dock
+    to_room_slug: fishermans-walk
+    direction: east
+    locked: false
+  - from_room_slug: fishermans-walk
+    to_room_slug: breakwall-harbor-dock
+    direction: west
+    locked: false
+

--- a/data/world/rooms.yml
+++ b/data/world/rooms.yml
@@ -11517,6 +11517,103 @@ rooms:
     zone_slug: coal-run
     room_type: transit
 
+  # --- Local Transit Stops (The Lakeshore) ---
+
+  # ── Lakefront Terminal ───────────────────────────────────────────
+  - name: "Elevated Platform"
+    slug: lakefront-el-platform
+    description: "A steel-and-concrete platform cantilevered over the terminal's north end, exposed to lake wind on three sides. The tracks run on riveted girders thirty feet above street level, and the platform shakes when a traincar approaches. Benches are bolted to the deck, their slats weathered gray. A route map under scratched plexiglass shows the Lakeshore Elevated Line in faded amber."
+    zone_slug: lakefront-terminal
+    room_type: transit
+
+  - name: "Subway Platform"
+    slug: lakefront-subway-platform
+    description: "Two levels below the main concourse, tiled in white ceramic with a green stripe at eye height. The air is warm and still, pushed by trains that arrive with a pressure wave before the sound catches up. The platform edge is ribbed yellow, and a digital board overhead counts down arrivals in minutes that don't always correspond to reality."
+    zone_slug: lakefront-terminal
+    room_type: transit
+
+  # ── The Skyline ──────────────────────────────────────────────────
+  - name: "Skyline L Stop"
+    slug: skyline-el-stop
+    description: "An elevated platform wedged between two glass towers, the station structure bolted directly to the buildings on either side. The wind is channeled and constant. Below, the plaza is visible through the steel grate floor, pedestrians the size of chess pieces. A turnstile guards the stairwell down, and the fare reader blinks green whether or not it's reading."
+    zone_slug: the-skyline
+    room_type: transit
+
+  # ── Gold Mile ────────────────────────────────────────────────────
+  - name: "Gold Mile L Station"
+    slug: gold-mile-el-station
+    description: "The cleanest elevated stop on the line — brass handrails polished daily, the platform swept twice. A glass canopy arches overhead, keeping the weather off waiting passengers and their shopping bags. The station sits above The Boulevard, and the view from the platform takes in the lakefront condominiums to the east and the shopping district stretching south."
+    zone_slug: gold-mile
+    room_type: transit
+
+  - name: "Gold Mile Taxi Stand"
+    slug: gold-mile-taxi-stand
+    description: "A covered pull-off adjacent to Valet Circle, marked by a brass sign reading PRIVATE TRANSIT in block capitals. Black sedans idle at the curb in a queue that never seems to empty. A dispatcher in a fitted coat holds a tablet, matching passengers to vehicles with practiced efficiency. The fare is posted on a discreet placard — discreet because the people who use this service already know what it costs."
+    zone_slug: gold-mile
+    room_type: transit
+
+  - name: "Marina Transit Dock"
+    slug: gold-mile-marina-dock
+    description: "A floating dock at the marina's east end, separate from the private slips, with a boarding ramp that adjusts with the lake level. A covered waiting area with heated benches faces the water. The dock is marked with running lights — green starboard, red port — and a schedule board shows water taxi arrivals in fifteen-minute intervals that stretch to thirty after dark."
+    zone_slug: gold-mile
+    room_type: transit
+
+  # ── The Terrace ──────────────────────────────────────────────────
+  - name: "Terrace L Platform"
+    slug: terrace-el-platform
+    description: "The elevated line dips to its lowest point here, the platform barely clearing the treetops along Tree-Lined Avenue. The station is brick-faced to match the brownstones below, a concession to the neighborhood that the transit authority made once and never repeated. Flower boxes on the platform railing bloom in season — someone in the neighborhood tends them."
+    zone_slug: the-terrace
+    room_type: transit
+
+  # ── The Ward ─────────────────────────────────────────────────────
+  - name: "Ward L Junction"
+    slug: ward-el-junction
+    description: "A heavy steel platform on concrete pillars, the original rivets still visible in the support beams. The station shows its age — peeling paint, a cracked windscreen, benches with carved initials going back decades. But the trains still stop here every twelve minutes, and the turnstiles still take fares. The stairs down to Main Street are worn to bowls in the center."
+    zone_slug: the-ward
+    room_type: transit
+
+  # ── The Switchyard ───────────────────────────────────────────────
+  - name: "Switchyard L Platform"
+    slug: switchyard-el-platform
+    description: "The line's southern terminus, where the elevated track curves down to grade level alongside the freight rails. The platform is utilitarian — poured concrete, chain-link windbreaks, a single overhead light. Shift workers wait here at odd hours, and the platform smells of creosote and ozone. Beyond the end of the line, the switchyard's tracks fan out into the industrial sprawl."
+    zone_slug: the-switchyard
+    room_type: transit
+
+  # ── The Stacks ───────────────────────────────────────────────────
+  - name: "Stacks Subway Station"
+    slug: stacks-subway
+    description: "A deep-bore station two levels underground, the walls cut through bedrock and lined with poured concrete. The platform is long and narrow, lit by caged fixtures that cast hard shadows. A mosaic mural on the back wall depicts books and scrolls in blue and gold tile — the artist's interpretation of what happens in the building above. The air moves only when trains do."
+    zone_slug: the-stacks
+    room_type: transit
+
+  # ── Rust Row ─────────────────────────────────────────────────────
+  - name: "Rust Row Underground"
+    slug: rust-row-subway
+    description: "The station walls are stained with iron-rich groundwater that seeps through the concrete in rust-colored streaks. The platform is narrow, the ceiling low, and the lighting fights a losing battle against the dark. Half the tile has fallen from the walls, exposing the brick backing beneath. The trains come through fast here — this is not a stop where anyone lingers."
+    zone_slug: rust-row
+    room_type: transit
+
+  # ── The Pumping Station ──────────────────────────────────────────
+  - name: "Pump Station Subway"
+    slug: pump-station-subway
+    description: "The southern terminus of the underground line, built into the pumping station's substructure. The rumble of water infrastructure is a constant presence, and the station walls vibrate at a frequency just below hearing. The platform is damp year-round, and a dehumidifier in the corner runs without making a difference. Travelers heading further south surface here and walk."
+    zone_slug: the-pumping-station
+    room_type: transit
+
+  # ── Pier 7 ───────────────────────────────────────────────────────
+  - name: "Pier 7 Ferry Dock"
+    slug: pier-7-ferry-dock
+    description: "A dedicated transit dock at the pier's north face, reinforced with rubber fenders and steel cleats for the water taxi hulls. A gangway with grip-tread descends to the floating platform, which rises and falls with the swells. The boarding area is roped off with stanchions, and a weatherproof fare terminal bolted to a piling takes payment before you step aboard."
+    zone_slug: pier-7
+    room_type: transit
+
+  # ── The Breakwall ────────────────────────────────────────────────
+  - name: "Harbor Dock"
+    slug: breakwall-harbor-dock
+    description: "A small transit dock tucked into the lee side of the breakwall, sheltered from the worst of the lake's chop. The dock is concrete and steel, bolted to the breakwall's foundation, with a ladder down to the water taxi platform. Spray coats everything in a fine salt mist, and the mooring ropes are stiff with brine. The crossing to Pier 7 takes four minutes on a calm day."
+    zone_slug: the-breakwall
+    room_type: transit
+
   - name: "Slipstream Gate North"
     slug: hollows-slip-north
     description: "A service tunnel beneath the rail siding at Coal Run, where the narrow-gauge track connects to standard gauge infrastructure. The corridor climbs through mountain passes toward the harbor city. Signal dies in the hollows."

--- a/data/world/transit_routes.yml
+++ b/data/world/transit_routes.yml
@@ -1,0 +1,105 @@
+# Local Transit Routes — seeded by: rails data:transit_routes (after rooms, transit_types)
+# Public and private routes for intra-region transit.
+#
+# Public routes: hackrs board at a stop, wait through intermediate stops, disembark.
+# Private routes: stops define boarding points; destination is any transit room in the region.
+
+routes:
+  # ── The Lakeshore: Elevated Traincar (Public) ───────────────────
+  - slug: lakeshore-elevated-line
+    name: "Lakeshore Elevated Line"
+    transit_type_slug: elevated-traincar
+    region_slug: the-lakeshore
+    active: true
+    loop_route: true
+    position: 0
+    stops:
+      - room_slug: lakefront-el-platform
+        label: "Lakefront Terminal"
+        position: 0
+      - room_slug: skyline-el-stop
+        label: "Skyline"
+        position: 1
+      - room_slug: gold-mile-el-station
+        label: "Gold Mile"
+        position: 2
+      - room_slug: terrace-el-platform
+        label: "The Terrace"
+        position: 3
+      - room_slug: ward-el-junction
+        label: "The Ward"
+        position: 4
+      - room_slug: switchyard-el-platform
+        label: "Switchyard"
+        position: 5
+
+  # ── The Lakeshore: Underground Rail (Public) ────────────────────
+  - slug: lakeshore-underground
+    name: "Lakeshore Underground"
+    transit_type_slug: underground-rail
+    region_slug: the-lakeshore
+    active: true
+    loop_route: false
+    position: 1
+    stops:
+      - room_slug: lakefront-subway-platform
+        label: "Lakefront Terminal"
+        position: 0
+        is_terminus: true
+      - room_slug: stacks-subway
+        label: "The Stacks"
+        position: 1
+      - room_slug: rust-row-subway
+        label: "Rust Row"
+        position: 2
+      - room_slug: pump-station-subway
+        label: "Pump Station"
+        position: 3
+        is_terminus: true
+
+  # ── The Lakeshore: Taxi Service (Private) ───────────────────────
+  - slug: lakeshore-taxi
+    name: "Lakeshore Taxi"
+    transit_type_slug: taxi-car
+    region_slug: the-lakeshore
+    active: true
+    loop_route: false
+    position: 10
+    stops:
+      - room_slug: gold-mile-taxi-stand
+        label: "Gold Mile"
+        position: 0
+      - room_slug: gold-mile-el-station
+        label: "Gold Mile L Station"
+        position: 1
+      - room_slug: skyline-el-stop
+        label: "Skyline"
+        position: 2
+      - room_slug: lakefront-el-platform
+        label: "Lakefront Terminal"
+        position: 3
+      - room_slug: terrace-el-platform
+        label: "The Terrace"
+        position: 4
+      - room_slug: ward-el-junction
+        label: "The Ward"
+        position: 5
+
+  # ── The Lakeshore: Water Taxi (Private) ─────────────────────────
+  - slug: lakeshore-water-taxi
+    name: "Lakeshore Water Taxi"
+    transit_type_slug: water-taxi
+    region_slug: the-lakeshore
+    active: true
+    loop_route: false
+    position: 11
+    stops:
+      - room_slug: gold-mile-marina-dock
+        label: "Gold Mile Marina"
+        position: 0
+      - room_slug: pier-7-ferry-dock
+        label: "Pier 7"
+        position: 1
+      - room_slug: breakwall-harbor-dock
+        label: "Harbor Dock"
+        position: 2

--- a/spec/services/grid/local_transit_service_spec.rb
+++ b/spec/services/grid/local_transit_service_spec.rb
@@ -105,6 +105,116 @@ RSpec.describe Grid::LocalTransitService do
     end
   end
 
+  describe "bidirectional travel" do
+    it "auto-detects forward direction when boarding at first stop" do
+      result = described_class.board!(hackr: hackr, route: route)
+      expect(result.journey.meta["direction"]).to eq("forward")
+    end
+
+    it "auto-detects reverse direction when boarding at last stop" do
+      hackr.update!(current_room: room_c)
+      result = described_class.board!(hackr: hackr, route: route)
+      expect(result.journey.meta["direction"]).to eq("reverse")
+    end
+
+    it "defaults to forward when boarding at middle stop" do
+      hackr.update!(current_room: room_b)
+      result = described_class.board!(hackr: hackr, route: route)
+      expect(result.journey.meta["direction"]).to eq("forward")
+    end
+
+    it "accepts explicit reverse direction at middle stop" do
+      hackr.update!(current_room: room_b)
+      result = described_class.board!(hackr: hackr, route: route, direction: "reverse")
+      expect(result.journey.meta["direction"]).to eq("reverse")
+    end
+
+    it "raises EndOfLine when boarding forward at last stop" do
+      hackr.update!(current_room: room_c)
+      expect {
+        described_class.board!(hackr: hackr, route: route, direction: "forward")
+      }.to raise_error(Grid::LocalTransitService::EndOfLine)
+    end
+
+    it "raises EndOfLine when boarding reverse at first stop" do
+      expect {
+        described_class.board!(hackr: hackr, route: route, direction: "reverse")
+      }.to raise_error(Grid::LocalTransitService::EndOfLine)
+    end
+
+    it "travels in reverse from last stop to first" do
+      hackr.update!(current_room: room_c)
+      described_class.board!(hackr: hackr, route: route)
+
+      result = described_class.wait!(hackr: hackr) # C → B
+      expect(result.current_stop.grid_room).to eq(room_b)
+      expect(hackr.reload.current_room).to eq(room_b)
+
+      result = described_class.wait!(hackr: hackr) # B → A
+      expect(result.current_stop.grid_room).to eq(room_a)
+      expect(hackr.reload.current_room).to eq(room_a)
+    end
+
+    it "auto-completes at end of line in reverse" do
+      hackr.update!(current_room: room_c)
+      described_class.board!(hackr: hackr, route: route)
+
+      described_class.wait!(hackr: hackr) # C → B
+      described_class.wait!(hackr: hackr) # B → A
+      result = described_class.wait!(hackr: hackr) # A → end of line
+
+      expect(result.arrived).to be true
+      expect(result.journey.state).to eq("completed")
+    end
+  end
+
+  describe "next_stop_after with direction" do
+    it "returns next stop forward" do
+      stop_a = route.grid_transit_stops.find_by(position: 0)
+      expect(route.next_stop_after(stop_a, direction: :forward).grid_room).to eq(room_b)
+    end
+
+    it "returns previous stop in reverse" do
+      stop_c = route.grid_transit_stops.find_by(position: 2)
+      expect(route.next_stop_after(stop_c, direction: :reverse).grid_room).to eq(room_b)
+    end
+
+    it "returns nil at first stop in reverse (non-loop)" do
+      stop_a = route.grid_transit_stops.find_by(position: 0)
+      expect(route.next_stop_after(stop_a, direction: :reverse)).to be_nil
+    end
+
+    it "returns nil at last stop forward (non-loop)" do
+      stop_c = route.grid_transit_stops.find_by(position: 2)
+      expect(route.next_stop_after(stop_c, direction: :forward)).to be_nil
+    end
+
+    context "with loop route" do
+      let(:loop_route) do
+        create(:grid_transit_route, grid_transit_type: transit_type, grid_region: region, loop_route: true).tap do |r|
+          create(:grid_transit_stop, grid_transit_route: r, grid_room: room_a, position: 0)
+          create(:grid_transit_stop, grid_transit_route: r, grid_room: room_b, position: 1)
+          create(:grid_transit_stop, grid_transit_route: r, grid_room: room_c, position: 2)
+        end
+      end
+
+      it "wraps forward from last to first" do
+        stop_c = loop_route.grid_transit_stops.find_by(position: 2)
+        expect(loop_route.next_stop_after(stop_c, direction: :forward).grid_room).to eq(room_a)
+      end
+
+      it "wraps reverse from first to last" do
+        stop_a = loop_route.grid_transit_stops.find_by(position: 0)
+        expect(loop_route.next_stop_after(stop_a, direction: :reverse).grid_room).to eq(room_c)
+      end
+    end
+
+    it "accepts string direction" do
+      stop_c = route.grid_transit_stops.find_by(position: 2)
+      expect(route.next_stop_after(stop_c, direction: "reverse").grid_room).to eq(room_b)
+    end
+  end
+
   describe ".disembark!" do
     before { described_class.board!(hackr: hackr, route: route) }
 


### PR DESCRIPTION
Slide-down transit panel on tactical map for public, private, and slipstream transit. Bidirectional travel for non-loop public routes. Compass rose nav buttons on map.

Transit Panel: Slide-down from top edge, 50% map height, cyan accent. Smart tabs — LOCAL/PRIVATE/SLIPSTREAM shown
only when data exists at current room. LOCAL: route list with stops, BOARD → <terminus> buttons. PRIVATE: type
selector + destination picker + HAIL. SLIPSTREAM: boardable routes only + heat bar + BOARD. Active journey replaces
tabs with status + controls (WAIT/DISEMBARK/ABANDON for local; ADVANCE/CHOOSE/ABANDON for slipstream). Shows current + next stop. Auto-closes on journey end. Handle hidden during BREACH and when vendor panel open. Backend: has_transit in zone_map, private_types/private_destinations/current_leg_forks/next_stop/boardable in transit API.

Bidirectional Transit: next_stop_after gains direction: param. Auto-detects from boarding position (last stop → reverse, otherwise forward). board <route> reverse command. EndOfLine guard when no next stop in chosen direction. Loop routes unaffected.

Nav Buttons: 8-direction compass rose + up/down in bottom-left of map. Enabled per available exits. Up purple, down orange (matching z-connector colors).

Fixes: Z-level seed excludes transit rooms (underground stops no longer anchor z=0). Rate limit 100→300 req/min (tactical UI fires 3-5 fetches/action). Error messages HTML-escaped and surfaced instead of generic "Network error." slipstream_heat memoized per-request to avoid double write-on-read.