### PR TITLE
[TPG] Prevent double-fire on tactical UI command buttons

### DIFF
--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -75,12 +75,15 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [npcMobs, setNpcMobs] = useState<NpcMobStub[]>([])
   const commandInputRef = useRef<CommandInputHandle | null>(null)
   const inBreachRef = useRef(false)
+  const executingRef = useRef(false)
 
   const sendCommand = useCallback(async (command: string) => {
     if (['clear', 'cls', 'cl'].includes(command.toLowerCase())) {
       setOutput([])
       return
     }
+
+    if (executingRef.current) return
 
     const echoLines = [
       '<div style="height: 1px; background: #444; margin-top: 16px; margin-bottom: 12px; overflow: hidden;"></div>',
@@ -89,6 +92,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
 
     setOutput(prev => [...prev, ...echoLines])
 
+    executingRef.current = true
     setExecuting(true)
 
     try {
@@ -140,6 +144,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
       const safe = raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
       setOutput(prev => [...prev, `<span style="color: #f87171;">Error: ${safe}</span>`])
     } finally {
+      executingRef.current = false
       setExecuting(false)
     }
   }, [])

--- a/app/javascript/components/tactical/breach/BreachConfirmModal.tsx
+++ b/app/javascript/components/tactical/breach/BreachConfirmModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { BreachEncounter } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
 import { TIER_COLORS } from './breachConstants'
 
 interface BreachConfirmModalProps {
@@ -11,6 +12,7 @@ interface BreachConfirmModalProps {
 export const BreachConfirmModal: React.FC<BreachConfirmModalProps> = ({
   encounter, onConfirm, onCancel
 }) => {
+  const { executing } = useTactical()
   const tierColor = TIER_COLORS[encounter.tier_label.toLowerCase()] || '#9ca3af'
 
   return (
@@ -78,13 +80,14 @@ export const BreachConfirmModal: React.FC<BreachConfirmModalProps> = ({
           </button>
           <button
             onClick={onConfirm}
+            disabled={executing}
             style={{
-              background: '#22d3ee',
-              color: '#0a0a0a',
+              background: executing ? '#333' : '#22d3ee',
+              color: executing ? '#666' : '#0a0a0a',
               border: 'none',
               padding: '8px 20px',
               fontSize: '0.9em',
-              cursor: 'pointer',
+              cursor: executing ? 'not-allowed' : 'pointer',
               borderRadius: '3px',
               fontWeight: 'bold',
               fontFamily: '\'Courier New\', monospace'

--- a/app/javascript/components/tactical/breach/BreachPanel.tsx
+++ b/app/javascript/components/tactical/breach/BreachPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { apiJson } from '~/utils/apiClient'
-import { BreachMeta, BreachProtocolMeta } from '../TacticalContext'
+import { BreachMeta, BreachProtocolMeta, useTactical } from '../TacticalContext'
 import { sanitizeHtml } from '~/utils/sanitizeHtml'
 
 interface DeckData {
@@ -41,7 +41,8 @@ const TargetSelector: React.FC<{
   label: string
   onSelect: (position: number) => void
   onCancel: () => void
-}> = ({ protocols, label, onSelect, onCancel }) => {
+  disabled: boolean
+}> = ({ protocols, label, onSelect, onCancel, disabled }) => {
   const aliveProtocols = protocols.filter(p => p.alive)
 
   return (
@@ -56,14 +57,15 @@ const TargetSelector: React.FC<{
           <button
             key={p.position}
             onClick={() => onSelect(p.position + 1)}
+            disabled={disabled}
             style={{
               background: '#222',
               border: '1px solid #555',
               borderRadius: '3px',
               padding: '4px 10px',
-              color: '#d0d0d0',
+              color: disabled ? '#666' : '#d0d0d0',
               fontSize: '0.8em',
-              cursor: 'pointer',
+              cursor: disabled ? 'not-allowed' : 'pointer',
               fontFamily: '\'Courier New\', monospace'
             }}
           >
@@ -88,6 +90,7 @@ const TargetSelector: React.FC<{
 export const BreachPanel: React.FC<BreachPanelProps> = ({
   visible, breachMeta, breachOutput, refreshToken, onCommand
 }) => {
+  const { executing } = useTactical()
   const [deckData, setDeckData] = useState<DeckData | null>(null)
   const [isRendered, setIsRendered] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
@@ -257,6 +260,7 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
                         : { type: 'exec', softwareName: sw.name }
                     )
                   }}
+                  disabled={executing}
                   style={{
                     background: '#1a1a1a',
                     border: `1px solid ${catColor}44`,
@@ -264,7 +268,8 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
                     padding: '3px 8px',
                     color: sw.rarity_color,
                     fontSize: '0.65em',
-                    cursor: 'pointer',
+                    cursor: executing ? 'not-allowed' : 'pointer',
+                    opacity: executing ? 0.5 : 1,
                     fontFamily: '\'Courier New\', monospace',
                     whiteSpace: 'nowrap'
                   }}
@@ -281,6 +286,7 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
                     label={`EXEC ${sw.name} →`}
                     onSelect={(pos) => { onCommand(`exec ${sw.name} ${pos}`); setActiveSelector(null) }}
                     onCancel={() => setActiveSelector(null)}
+                    disabled={executing}
                   />
                 )}
               </div>
@@ -296,9 +302,12 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
                   e.stopPropagation()
                   setActiveSelector(activeSelector?.type === cmd ? null : { type: cmd })
                 }}
+                disabled={executing}
                 style={{
                   background: '#1a1a1a', border: '1px solid #333', borderRadius: '3px',
-                  padding: '3px 8px', color: '#22d3ee', fontSize: '0.65em', cursor: 'pointer',
+                  padding: '3px 8px', color: '#22d3ee', fontSize: '0.65em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
+                  opacity: executing ? 0.5 : 1,
                   fontFamily: '\'Courier New\', monospace'
                 }}
               >
@@ -310,6 +319,7 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
                   label={`${cmd.toUpperCase()} \u2192`}
                   onSelect={(pos) => { onCommand(`${cmd} ${pos}`); setActiveSelector(null) }}
                   onCancel={() => setActiveSelector(null)}
+                  disabled={executing}
                 />
               )}
             </div>
@@ -392,9 +402,12 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
               </button>
               <button
                 onClick={() => { onCommand('jackout'); setJackoutConfirm(false) }}
+                disabled={executing}
                 style={{
-                  background: '#dc2626', color: 'white', border: 'none',
-                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  background: executing ? '#333' : '#dc2626',
+                  color: executing ? '#666' : 'white', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >

--- a/app/javascript/components/tactical/npc/DialogueSection.tsx
+++ b/app/javascript/components/tactical/npc/DialogueSection.tsx
@@ -7,9 +7,10 @@ interface DialogueSectionProps {
   mobName: string
   dialogueOutput: string | null
   onCommand: (cmd: string) => void
+  executing: boolean
 }
 
-export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobName, dialogueOutput, onCommand }) => {
+export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobName, dialogueOutput, onCommand, executing }) => {
   if (!dialogue.greeting && dialogue.current_topics.length === 0) {
     return <div style={{ color: '#555', fontSize: '0.8em', padding: '8px 0' }}>This NPC has nothing to say.</div>
   }
@@ -50,6 +51,7 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
               <button
                 key={topic.key}
                 onClick={() => onCommand(`ask ${mobName} about ${topic.key}`)}
+                disabled={executing}
                 style={{
                   background: 'transparent',
                   border: '1px solid #c084fc',
@@ -57,11 +59,12 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
                   color: '#c084fc',
                   padding: '4px 10px',
                   fontSize: '0.9em',
-                  cursor: 'pointer',
+                  cursor: executing ? 'not-allowed' : 'pointer',
+                  opacity: executing ? 0.5 : 1,
                   fontFamily: '\'Courier New\', monospace',
                   transition: 'background 0.15s'
                 }}
-                onMouseEnter={e => { (e.target as HTMLElement).style.background = '#1a1a2e' }}
+                onMouseEnter={e => { if (!executing) (e.target as HTMLElement).style.background = '#1a1a2e' }}
                 onMouseLeave={e => { (e.target as HTMLElement).style.background = 'transparent' }}
               >
                 {topic.key}{topic.has_children ? ' \u203A' : ''}
@@ -76,6 +79,7 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
         {!dialogue.at_root && (
           <button
             onClick={() => onCommand(`ask ${mobName} about back`)}
+            disabled={executing}
             style={{
               background: 'transparent',
               border: '1px solid #444',
@@ -83,7 +87,8 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
               color: '#888',
               padding: '3px 10px',
               fontSize: '0.85em',
-              cursor: 'pointer',
+              cursor: executing ? 'not-allowed' : 'pointer',
+              opacity: executing ? 0.5 : 1,
               fontFamily: '\'Courier New\', monospace'
             }}
           >
@@ -93,6 +98,7 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
         {!dialogue.at_root && (
           <button
             onClick={() => onCommand(`talk to ${mobName} again`)}
+            disabled={executing}
             style={{
               background: 'transparent',
               border: '1px solid #444',
@@ -100,7 +106,8 @@ export const DialogueSection: React.FC<DialogueSectionProps> = ({ dialogue, mobN
               color: '#888',
               padding: '3px 10px',
               fontSize: '0.85em',
-              cursor: 'pointer',
+              cursor: executing ? 'not-allowed' : 'pointer',
+              opacity: executing ? 0.5 : 1,
               fontFamily: '\'Courier New\', monospace'
             }}
           >

--- a/app/javascript/components/tactical/npc/MissionsSection.tsx
+++ b/app/javascript/components/tactical/npc/MissionsSection.tsx
@@ -7,6 +7,7 @@ interface MissionsSectionProps {
   deliveryItems: NpcDeliveryItem[]
   mobName: string
   onCommand: (cmd: string) => void
+  executing: boolean
 }
 
 interface ConfirmAction {
@@ -16,7 +17,7 @@ interface ConfirmAction {
 }
 
 export const MissionsSection: React.FC<MissionsSectionProps> = ({
-  availableMissions, activeMissions, deliveryItems, mobName, onCommand
+  availableMissions, activeMissions, deliveryItems, mobName, onCommand, executing
 }) => {
   const [confirm, setConfirm] = useState<ConfirmAction | null>(null)
 
@@ -50,6 +51,7 @@ export const MissionsSection: React.FC<MissionsSectionProps> = ({
               deliveryByObj={deliveryByObj}
               onCommand={onCommand}
               onConfirm={setConfirm}
+              executing={executing}
             />
           ))}
         </div>
@@ -66,6 +68,7 @@ export const MissionsSection: React.FC<MissionsSectionProps> = ({
               key={m.slug}
               mission={m}
               onConfirm={setConfirm}
+              executing={executing}
             />
           ))}
         </div>
@@ -115,10 +118,12 @@ export const MissionsSection: React.FC<MissionsSectionProps> = ({
               >CANCEL</button>
               <button
                 onClick={handleConfirm}
+                disabled={executing}
                 style={{
-                  background: confirm.type === 'abandon' ? '#f87171' : '#c084fc',
-                  color: '#0a0a0a', border: 'none',
-                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  background: executing ? '#333' : (confirm.type === 'abandon' ? '#f87171' : '#c084fc'),
+                  color: executing ? '#666' : '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >
@@ -142,7 +147,8 @@ const ActiveMissionRow: React.FC<{
   deliveryByObj: Map<number, NpcDeliveryItem>
   onCommand: (cmd: string) => void
   onConfirm: (action: ConfirmAction) => void
-}> = ({ mission, mobName, deliveryByObj, onCommand, onConfirm }) => {
+  executing: boolean
+}> = ({ mission, mobName, deliveryByObj, onCommand, onConfirm, executing }) => {
   const objectives = mission.mission.objectives
   const progressMap = new Map(mission.objective_progress.map(p => [p.objective_id, p]))
 
@@ -180,10 +186,10 @@ const ActiveMissionRow: React.FC<{
               {delivery && !done && (
                 <button
                   onClick={() => onCommand(`give ${delivery.item_name} to ${mobName}`)}
-                  disabled={!delivery.in_inventory}
+                  disabled={!delivery.in_inventory || executing}
                   style={{
-                    background: delivery.in_inventory ? '#c084fc' : '#333',
-                    color: delivery.in_inventory ? '#0a0a0a' : '#666',
+                    background: delivery.in_inventory && !executing ? '#c084fc' : '#333',
+                    color: delivery.in_inventory && !executing ? '#0a0a0a' : '#666',
                     border: 'none',
                     borderRadius: '3px',
                     padding: '2px 8px',
@@ -207,19 +213,25 @@ const ActiveMissionRow: React.FC<{
         {mission.ready_to_turn_in && mission.at_giver && (
           <button
             onClick={() => onConfirm({ type: 'turn_in', slug: mission.slug, name: mission.name })}
+            disabled={executing}
             style={{
-              background: '#34d399', color: '#0a0a0a', border: 'none',
+              background: executing ? '#333' : '#34d399',
+              color: executing ? '#666' : '#0a0a0a', border: 'none',
               borderRadius: '3px', padding: '3px 10px', fontSize: '0.8em',
-              cursor: 'pointer', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
+              cursor: executing ? 'not-allowed' : 'pointer',
+              fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
             }}
           >TURN IN</button>
         )}
         <button
           onClick={() => onConfirm({ type: 'abandon', slug: mission.slug, name: mission.name })}
+          disabled={executing}
           style={{
             background: 'transparent', color: '#f87171', border: '1px solid #f87171',
             borderRadius: '3px', padding: '2px 8px', fontSize: '0.75em',
-            cursor: 'pointer', fontFamily: '\'Courier New\', monospace'
+            cursor: executing ? 'not-allowed' : 'pointer',
+            opacity: executing ? 0.5 : 1,
+            fontFamily: '\'Courier New\', monospace'
           }}
         >ABANDON</button>
       </div>
@@ -232,7 +244,8 @@ const ActiveMissionRow: React.FC<{
 const AvailableMissionRow: React.FC<{
   mission: NpcAvailableMission
   onConfirm: (action: ConfirmAction) => void
-}> = ({ mission, onConfirm }) => {
+  executing: boolean
+}> = ({ mission, onConfirm, executing }) => {
   const gates = mission.gates
 
   return (
@@ -289,10 +302,10 @@ const AvailableMissionRow: React.FC<{
 
       <button
         onClick={() => onConfirm({ type: 'accept', slug: mission.slug, name: mission.name })}
-        disabled={!mission.can_accept}
+        disabled={!mission.can_accept || executing}
         style={{
-          background: mission.can_accept ? '#34d399' : '#333',
-          color: mission.can_accept ? '#0a0a0a' : '#666',
+          background: mission.can_accept && !executing ? '#34d399' : '#333',
+          color: mission.can_accept && !executing ? '#0a0a0a' : '#666',
           border: 'none',
           borderRadius: '3px',
           padding: '3px 10px',

--- a/app/javascript/components/tactical/npc/NpcPanel.tsx
+++ b/app/javascript/components/tactical/npc/NpcPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { apiJson } from '~/utils/apiClient'
 import { NpcData } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
 import { DialogueSection } from './DialogueSection'
 import { MissionsSection } from './MissionsSection'
 
@@ -17,6 +18,7 @@ type PanelSection = 'dialogue' | 'missions'
 export const NpcPanel: React.FC<NpcPanelProps> = ({
   visible, refreshToken, onCommand, onClose, selectedMobId
 }) => {
+  const { executing } = useTactical()
   const [isRendered, setIsRendered] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [npcData, setNpcData] = useState<NpcData | null>(null)
@@ -209,6 +211,7 @@ export const NpcPanel: React.FC<NpcPanelProps> = ({
               mobName={npcData.mob_name}
               dialogueOutput={dialogueOutput}
               onCommand={handleDialogueCommand}
+              executing={executing}
             />
           )}
           {npcData && section === 'missions' && (
@@ -218,6 +221,7 @@ export const NpcPanel: React.FC<NpcPanelProps> = ({
               deliveryItems={npcData.delivery_items}
               mobName={npcData.mob_name}
               onCommand={onCommand}
+              executing={executing}
             />
           )}
         </div>

--- a/app/javascript/components/tactical/tabs/CredTab.tsx
+++ b/app/javascript/components/tactical/tabs/CredTab.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
+import { useTactical } from '../TacticalContext'
 
 interface CacheData {
   address: string
@@ -20,6 +21,7 @@ function formatCred (amount: number): string {
 }
 
 export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+  const { executing } = useTactical()
   const [data, setData] = useState<CredResponse | null>(null)
   const [nicknameTarget, setNicknameTarget] = useState<string | null>(null)
   const [nicknameInput, setNicknameInput] = useState('')
@@ -52,6 +54,7 @@ export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string)
       {/* Create cache button */}
       <button
         onClick={() => onCommand?.('cache create')}
+        disabled={executing}
         style={{
           background: '#1a1a1a',
           border: '1px solid #34d399',
@@ -59,7 +62,8 @@ export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string)
           padding: '3px 10px',
           color: '#34d399',
           fontSize: '0.85em',
-          cursor: 'pointer',
+          cursor: executing ? 'not-allowed' : 'pointer',
+          opacity: executing ? 0.5 : 1,
           fontFamily: '\'Courier New\', monospace',
           marginBottom: '8px'
         }}
@@ -211,9 +215,12 @@ export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string)
                     setNicknameTarget(null)
                   }
                 }}
+                disabled={executing}
                 style={{
-                  background: '#a78bfa', color: '#0a0a0a', border: 'none',
-                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  background: executing ? '#333' : '#a78bfa',
+                  color: executing ? '#666' : '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >
@@ -327,17 +334,17 @@ export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string)
                 CANCEL
               </button>
               <button
-                disabled={!transferAmount || !transferTo}
+                disabled={!transferAmount || !transferTo || executing}
                 onClick={() => {
                   const fromArg = transferFrom.is_default ? '' : ` from ${transferFrom.nickname || transferFrom.address}`
                   onCommand?.(`cache send ${transferAmount} ${transferTo}${fromArg}`)
                   setTransferFrom(null)
                 }}
                 style={{
-                  background: (!transferAmount || !transferTo) ? '#333' : '#fbbf24',
+                  background: (!transferAmount || !transferTo || executing) ? '#333' : '#fbbf24',
                   color: '#0a0a0a', border: 'none',
                   padding: '8px 20px', fontSize: '0.9em',
-                  cursor: (!transferAmount || !transferTo) ? 'not-allowed' : 'pointer',
+                  cursor: (!transferAmount || !transferTo || executing) ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >

--- a/app/javascript/components/tactical/tabs/InventoryTab.tsx
+++ b/app/javascript/components/tactical/tabs/InventoryTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
 import { InventoryItem, InventoryResponse } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
 
 const ITEM_TYPE_LABELS: Record<string, string> = {
   gear: 'Gear', software: 'Software', module: 'Module', firmware: 'Firmware',
@@ -69,6 +70,7 @@ function humanizeProperties (props: Record<string, unknown>): { label: string; v
 }
 
 export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void; hasVendor?: boolean }> = ({ refreshToken, onCommand, hasVendor }) => {
+  const { executing } = useTactical()
   const [data, setData] = useState<InventoryResponse | null>(null)
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null)
   const [pendingAction, setPendingAction] = useState<{ item: InventoryItem; action: string } | null>(null)
@@ -118,9 +120,12 @@ export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: st
                 {canSell && (
                   <button
                     onClick={(e) => { e.stopPropagation(); setPendingAction({ item, action: 'sell' }) }}
+                    disabled={executing}
                     style={{
-                      background: '#fbbf24', color: '#0a0a0a', border: 'none', borderRadius: '2px',
-                      padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+                      background: executing ? '#333' : '#fbbf24',
+                      color: executing ? '#666' : '#0a0a0a', border: 'none', borderRadius: '2px',
+                      padding: '1px 5px', fontSize: '0.8em',
+                      cursor: executing ? 'not-allowed' : 'pointer', fontWeight: 'bold',
                       fontFamily: '\'Courier New\', monospace', lineHeight: 1, flexShrink: 0
                     }}
                   >SELL</button>
@@ -243,10 +248,11 @@ export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: st
               <button onClick={() => {
                 onCommand?.(`${pendingAction.action} ${pendingAction.item.name}`)
                 setPendingAction(null)
-              }} style={{
-                background: ACTION_CONFIG[pendingAction.action]?.color || '#34d399',
-                color: '#0a0a0a', border: 'none',
-                padding: '8px 20px', fontSize: '0.95em', cursor: 'pointer',
+              }} disabled={executing} style={{
+                background: executing ? '#333' : (ACTION_CONFIG[pendingAction.action]?.color || '#34d399'),
+                color: executing ? '#666' : '#0a0a0a', border: 'none',
+                padding: '8px 20px', fontSize: '0.95em',
+                cursor: executing ? 'not-allowed' : 'pointer',
                 borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
               }}>{ACTION_CONFIG[pendingAction.action]?.label || pendingAction.action.toUpperCase()}</button>
             </div>

--- a/app/javascript/components/tactical/tabs/MissionsTab.tsx
+++ b/app/javascript/components/tactical/tabs/MissionsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
+import { useTactical } from '../TacticalContext'
 
 interface ObjectiveDefinition {
   id: number
@@ -32,6 +33,7 @@ interface MissionsResponse {
 }
 
 export const MissionsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+  const { executing } = useTactical()
   const [data, setData] = useState<MissionsResponse | null>(null)
 
   useEffect(() => {
@@ -76,15 +78,16 @@ export const MissionsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: str
                 {hm.ready_to_turn_in && (
                   <button
                     onClick={() => onCommand?.(`turn_in ${hm.mission.slug}`)}
+                    disabled={executing}
                     style={{
                       marginTop: '4px',
-                      background: '#34d399',
-                      color: '#0a0a0a',
+                      background: executing ? '#333' : '#34d399',
+                      color: executing ? '#666' : '#0a0a0a',
                       border: 'none',
                       padding: '3px 10px',
                       fontSize: '0.85em',
                       fontWeight: 'bold',
-                      cursor: 'pointer',
+                      cursor: executing ? 'not-allowed' : 'pointer',
                       borderRadius: '3px',
                       fontFamily: '\'Courier New\', monospace'
                     }}

--- a/app/javascript/components/tactical/tabs/SchematicsTab.tsx
+++ b/app/javascript/components/tactical/tabs/SchematicsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { apiJson } from '~/utils/apiClient'
+import { useTactical } from '../TacticalContext'
 
 interface Ingredient {
   item_name: string
@@ -66,6 +67,7 @@ function humanizeProperties (props: Record<string, unknown>): { label: string; v
 }
 
 export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+  const { executing } = useTactical()
   const [data, setData] = useState<SchematicsResponse | null>(null)
   const [confirm, setConfirm] = useState<Schematic | null>(null)
   const [detail, setDetail] = useState<OutputDef | null>(null)
@@ -87,9 +89,11 @@ export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: s
           <div style={{ color: '#34d399', fontSize: '0.85em', marginBottom: '4px' }}>READY ({ready.length})</div>
           {ready.map(s => (
             <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0', breakInside: 'avoid' }}>
-              <button onClick={() => setConfirm(s)} style={{
-                background: '#34d399', color: '#0a0a0a', border: 'none', borderRadius: '2px',
-                padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+              <button onClick={() => setConfirm(s)} disabled={executing} style={{
+                background: executing ? '#333' : '#34d399', color: executing ? '#666' : '#0a0a0a',
+                border: 'none', borderRadius: '2px',
+                padding: '1px 5px', fontSize: '0.8em',
+                cursor: executing ? 'not-allowed' : 'pointer', fontWeight: 'bold',
                 fontFamily: '\'Courier New\', monospace', lineHeight: 1
               }}>FAB</button>
               <span onClick={() => setDetail(s.output)}
@@ -106,9 +110,11 @@ export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: s
           </div>
           {available.map(s => (
             <div key={s.slug} style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0', breakInside: 'avoid' }}>
-              <button onClick={() => setConfirm(s)} style={{
-                background: 'transparent', color: '#fbbf24', border: '1px solid #fbbf24', borderRadius: '2px',
-                padding: '1px 5px', fontSize: '0.8em', cursor: 'pointer', fontWeight: 'bold',
+              <button onClick={() => setConfirm(s)} disabled={executing} style={{
+                background: 'transparent', color: executing ? '#666' : '#fbbf24',
+                border: `1px solid ${executing ? '#444' : '#fbbf24'}`, borderRadius: '2px',
+                padding: '1px 5px', fontSize: '0.8em',
+                cursor: executing ? 'not-allowed' : 'pointer', fontWeight: 'bold',
                 fontFamily: '\'Courier New\', monospace', lineHeight: 1
               }}>FAB</button>
               <span onClick={() => setDetail(s.output)}
@@ -217,9 +223,12 @@ export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: s
               </button>
               <button
                 onClick={() => { onCommand?.(`fab ${confirm.slug}`); setConfirm(null) }}
+                disabled={executing}
                 style={{
-                  background: '#34d399', color: '#0a0a0a', border: 'none',
-                  padding: '8px 20px', fontSize: '0.95em', cursor: 'pointer',
+                  background: executing ? '#333' : '#34d399',
+                  color: executing ? '#666' : '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.95em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >

--- a/app/javascript/components/tactical/transit/TransitPanel.tsx
+++ b/app/javascript/components/tactical/transit/TransitPanel.tsx
@@ -4,6 +4,7 @@ import {
   TransitData, TransitRoute, SlipstreamRoute,
   PrivateTransitType, PrivateDestination, TransitJourney
 } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
 
 interface TransitPanelProps {
   visible: boolean
@@ -24,6 +25,7 @@ const HEAT_COLORS: Record<string, string> = {
 export const TransitPanel: React.FC<TransitPanelProps> = ({
   visible, refreshToken, onCommand, onClose
 }) => {
+  const { executing } = useTactical()
   const [isRendered, setIsRendered] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [data, setData] = useState<TransitData | null>(null)
@@ -204,19 +206,20 @@ export const TransitPanel: React.FC<TransitPanelProps> = ({
           {!data ? (
             <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
           ) : hasJourney ? (
-            <JourneySection journey={data.current_journey!} onCommand={onCommand} />
+            <JourneySection journey={data.current_journey!} onCommand={onCommand} executing={executing} />
           ) : availableTabs.length === 0 ? (
             <div style={{ color: '#555', fontSize: '0.8em' }}>No transit options available here.</div>
           ) : (
             <>
               {activeTab === 'local' && (
-                <LocalSection routes={data.local_routes} onCommand={onCommand} />
+                <LocalSection routes={data.local_routes} onCommand={onCommand} executing={executing} />
               )}
               {activeTab === 'private' && (
                 <PrivateSection
                   types={data.private_types}
                   destinations={data.private_destinations}
                   onCommand={onCommand}
+                  executing={executing}
                 />
               )}
               {activeTab === 'slipstream' && (
@@ -225,6 +228,7 @@ export const TransitPanel: React.FC<TransitPanelProps> = ({
                   heat={data.slipstream_heat}
                   heatTier={data.slipstream_heat_tier}
                   onCommand={onCommand}
+                  executing={executing}
                 />
               )}
             </>
@@ -240,7 +244,8 @@ export const TransitPanel: React.FC<TransitPanelProps> = ({
 const JourneySection: React.FC<{
   journey: TransitJourney
   onCommand: (cmd: string) => void
-}> = ({ journey, onCommand }) => {
+  executing: boolean
+}> = ({ journey, onCommand, executing }) => {
   const isSlipstream = journey.journey_type === 'slipstream'
   const isLocalPublic = journey.journey_type === 'local_public'
   const typeColor = isSlipstream ? '#a78bfa' : '#34d399'
@@ -341,7 +346,8 @@ const JourneySection: React.FC<{
               </div>
               <button
                 onClick={() => onCommand(`choose ${fork.key}`)}
-                style={actionBtnStyle('#fbbf24')}
+                disabled={executing}
+                style={actionBtnStyle('#fbbf24', executing)}
               >
                 CHOOSE
               </button>
@@ -355,26 +361,26 @@ const JourneySection: React.FC<{
         {!journey.breach_mid_journey && (
           <>
             {isSlipstream && !journey.pending_fork && (
-              <button onClick={() => onCommand('advance')} style={actionBtnStyle('#a78bfa')}>
+              <button onClick={() => onCommand('advance')} disabled={executing} style={actionBtnStyle('#a78bfa', executing)}>
                 ADVANCE
               </button>
             )}
             {!isSlipstream && (
-              <button onClick={() => onCommand('wait')} style={actionBtnStyle('#34d399')}>
+              <button onClick={() => onCommand('wait')} disabled={executing} style={actionBtnStyle('#34d399', executing)}>
                 WAIT
               </button>
             )}
             {isLocalPublic && (
-              <button onClick={() => onCommand('disembark')} style={actionBtnStyle('#fbbf24')}>
+              <button onClick={() => onCommand('disembark')} disabled={executing} style={actionBtnStyle('#fbbf24', executing)}>
                 DISEMBARK
               </button>
             )}
           </>
         )}
-        <button onClick={() => onCommand('abandon')} style={actionBtnStyle('#f87171')}>
+        <button onClick={() => onCommand('abandon')} disabled={executing} style={actionBtnStyle('#f87171', executing)}>
           ABANDON
         </button>
-        <button onClick={() => onCommand('status')} style={actionBtnStyle('#888')}>
+        <button onClick={() => onCommand('status')} disabled={executing} style={actionBtnStyle('#888', executing)}>
           STATUS
         </button>
       </div>
@@ -387,7 +393,8 @@ const JourneySection: React.FC<{
 const LocalSection: React.FC<{
   routes: TransitRoute[]
   onCommand: (cmd: string) => void
-}> = ({ routes, onCommand }) => {
+  executing: boolean
+}> = ({ routes, onCommand, executing }) => {
   if (routes.length === 0) {
     return <div style={{ color: '#555', fontSize: '0.8em' }}>No local routes at this stop.</div>
   }
@@ -408,7 +415,7 @@ const LocalSection: React.FC<{
             [{typeRoutes[0].transit_type.icon_key || 'TRANSIT'}] {typeName}
           </div>
           {typeRoutes.map(route => (
-            <RouteRow key={route.slug} route={route} onCommand={onCommand} />
+            <RouteRow key={route.slug} route={route} onCommand={onCommand} executing={executing} />
           ))}
         </div>
       ))}
@@ -419,7 +426,8 @@ const LocalSection: React.FC<{
 const RouteRow: React.FC<{
   route: TransitRoute
   onCommand: (cmd: string) => void
-}> = ({ route, onCommand }) => {
+  executing: boolean
+}> = ({ route, onCommand, executing }) => {
   const canForward = route.loop_route || !route.at_last_stop
   const canReverse = !route.loop_route && !route.at_first_stop
   const firstStop = route.stops[0]?.name
@@ -438,7 +446,8 @@ const RouteRow: React.FC<{
           {canForward && (
             <button
               onClick={() => onCommand(`board ${route.slug}`)}
-              style={dirBtnStyle}
+              disabled={executing}
+              style={{ ...dirBtnStyle, ...(executing ? { opacity: 0.5, cursor: 'not-allowed' } : {}) }}
             >
               BOARD {'\u2192'} {lastStop}
             </button>
@@ -446,7 +455,8 @@ const RouteRow: React.FC<{
           {canReverse && (
             <button
               onClick={() => onCommand(`board ${route.slug} reverse`)}
-              style={dirBtnStyle}
+              disabled={executing}
+              style={{ ...dirBtnStyle, ...(executing ? { opacity: 0.5, cursor: 'not-allowed' } : {}) }}
             >
               BOARD {'\u2192'} {firstStop}
             </button>
@@ -470,7 +480,8 @@ const PrivateSection: React.FC<{
   types: PrivateTransitType[]
   destinations: PrivateDestination[]
   onCommand: (cmd: string) => void
-}> = ({ types, destinations, onCommand }) => {
+  executing: boolean
+}> = ({ types, destinations, onCommand, executing }) => {
   const [selectedType, setSelectedType] = useState<string | null>(null)
   const [selectedDest, setSelectedDest] = useState<string | null>(null)
 
@@ -554,7 +565,7 @@ const PrivateSection: React.FC<{
                       <span style={{ color: '#555', marginLeft: '6px', fontSize: '0.9em' }}>({dest.zone_name})</span>
                     </div>
                     {isSelected && (
-                      <button onClick={handleHail} style={actionBtnStyle('#fbbf24')}>
+                      <button onClick={handleHail} disabled={executing} style={actionBtnStyle('#fbbf24', executing)}>
                         HAIL
                       </button>
                     )}
@@ -576,7 +587,8 @@ const SlipstreamSection: React.FC<{
   heat: number
   heatTier: string
   onCommand: (cmd: string) => void
-}> = ({ routes, heat, heatTier, onCommand }) => {
+  executing: boolean
+}> = ({ routes, heat, heatTier, onCommand, executing }) => {
   return (
     <div style={{ fontSize: '0.75em' }}>
       {/* Heat indicator */}
@@ -620,7 +632,8 @@ const SlipstreamSection: React.FC<{
               </div>
               <button
                 onClick={() => onCommand(`slipstream ${route.slug}`)}
-                style={actionBtnStyle('#a78bfa')}
+                disabled={executing}
+                style={actionBtnStyle('#a78bfa', executing)}
               >
                 BOARD
               </button>
@@ -634,15 +647,15 @@ const SlipstreamSection: React.FC<{
 
 // --- Shared ---
 
-function actionBtnStyle (color: string): React.CSSProperties {
+function actionBtnStyle (color: string, disabled?: boolean): React.CSSProperties {
   return {
-    background: color,
-    color: '#0a0a0a',
+    background: disabled ? '#333' : color,
+    color: disabled ? '#666' : '#0a0a0a',
     border: 'none',
     borderRadius: '3px',
     padding: '3px 8px',
     fontSize: '0.9em',
-    cursor: 'pointer',
+    cursor: disabled ? 'not-allowed' : 'pointer',
     fontWeight: 'bold',
     fontFamily: '\'Courier New\', monospace',
     flexShrink: 0

--- a/app/javascript/components/tactical/vendor/VendorPanel.tsx
+++ b/app/javascript/components/tactical/vendor/VendorPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { apiJson } from '~/utils/apiClient'
 import { ShopData, ShopListing, InventoryItem, InventoryResponse } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
 
 interface VendorPanelProps {
   visible: boolean
@@ -23,6 +24,7 @@ interface PendingTx {
 export const VendorPanel: React.FC<VendorPanelProps> = ({
   visible, refreshToken, onCommand, onClose
 }) => {
+  const { executing } = useTactical()
   const [isRendered, setIsRendered] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const [shopData, setShopData] = useState<ShopData | null>(null)
@@ -233,11 +235,13 @@ export const VendorPanel: React.FC<VendorPanelProps> = ({
               buyQty={buyQty}
               setBuyQty={setBuyQty}
               onBuy={handleBuyClick}
+              executing={executing}
             />
           ) : (
             <SellSection
               items={inventoryData}
               onSell={handleSellClick}
+              executing={executing}
             />
           )}
         </div>
@@ -329,10 +333,12 @@ export const VendorPanel: React.FC<VendorPanelProps> = ({
               >CANCEL</button>
               <button
                 onClick={handleConfirm}
+                disabled={executing}
                 style={{
-                  background: pendingTx.type === 'buy' ? '#34d399' : '#fbbf24',
-                  color: '#0a0a0a', border: 'none',
-                  padding: '8px 20px', fontSize: '0.9em', cursor: 'pointer',
+                  background: executing ? '#333' : (pendingTx.type === 'buy' ? '#34d399' : '#fbbf24'),
+                  color: executing ? '#666' : '#0a0a0a', border: 'none',
+                  padding: '8px 20px', fontSize: '0.9em',
+                  cursor: executing ? 'not-allowed' : 'pointer',
                   borderRadius: '3px', fontWeight: 'bold', fontFamily: '\'Courier New\', monospace'
                 }}
               >{pendingTx.type === 'buy' ? 'BUY' : 'SELL'}</button>
@@ -351,7 +357,8 @@ const BuySection: React.FC<{
   buyQty: Record<number, number>
   setBuyQty: React.Dispatch<React.SetStateAction<Record<number, number>>>
   onBuy: (listing: ShopListing) => void
-}> = ({ shopData, buyQty, setBuyQty, onBuy }) => {
+  executing: boolean
+}> = ({ shopData, buyQty, setBuyQty, onBuy, executing }) => {
   if (!shopData) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
   if (shopData.listings.length === 0) return <div style={{ color: '#555', fontSize: '0.8em' }}>Nothing for sale.</div>
 
@@ -406,10 +413,10 @@ const BuySection: React.FC<{
                 )}
                 <button
                   onClick={() => onBuy(listing)}
-                  disabled={!canAfford}
+                  disabled={!canAfford || executing}
                   style={{
-                    background: canAfford ? '#34d399' : '#333',
-                    color: canAfford ? '#0a0a0a' : '#666',
+                    background: canAfford && !executing ? '#34d399' : '#333',
+                    color: canAfford && !executing ? '#0a0a0a' : '#666',
                     border: 'none',
                     borderRadius: '3px',
                     padding: '3px 8px',
@@ -438,7 +445,8 @@ const BuySection: React.FC<{
 const SellSection: React.FC<{
   items: InventoryItem[]
   onSell: (item: InventoryItem) => void
-}> = ({ items, onSell }) => {
+  executing: boolean
+}> = ({ items, onSell, executing }) => {
   if (items.length === 0) return <div style={{ color: '#555', fontSize: '0.8em' }}>Nothing to sell.</div>
 
   return (
@@ -467,14 +475,15 @@ const SellSection: React.FC<{
 
           <button
             onClick={() => onSell(item)}
+            disabled={executing}
             style={{
-              background: '#fbbf24',
-              color: '#0a0a0a',
+              background: executing ? '#333' : '#fbbf24',
+              color: executing ? '#666' : '#0a0a0a',
               border: 'none',
               borderRadius: '3px',
               padding: '3px 8px',
               fontSize: '0.9em',
-              cursor: 'pointer',
+              cursor: executing ? 'not-allowed' : 'pointer',
               fontWeight: 'bold',
               fontFamily: '\'Courier New\', monospace',
               flexShrink: 0


### PR DESCRIPTION
  sendCommand in TacticalContext now guards against concurrent execution via
  executingRef — a second call while one is in-flight is silently dropped.
  This prevents duplicate commands (e.g. double-click ACCEPT) regardless of
  UI state.

  All ~30 command-dispatching buttons across tactical panels and status tabs
  now show a disabled state while a command is executing. Panels read
  `executing` from useTactical(); leaf sub-components receive it as a
  required prop.

  Disabled pattern: solid-bg buttons swap to #333/#666, outline/transparent
  buttons use opacity 0.5. Matches existing convention for pre-existing
  disabled conditions (canAfford, can_accept, in_inventory).