### PR TITLE
[TPG] Image Avatars for Mobs via Active Storage

### DIFF
--- a/app/controllers/admin/grid_mobs_controller.rb
+++ b/app/controllers/admin/grid_mobs_controller.rb
@@ -3,7 +3,7 @@ class Admin::GridMobsController < Admin::ApplicationController
 
   versionable GridMob
 
-  before_action :set_mob, only: %i[edit update destroy add_listing remove_listing]
+  before_action :set_mob, only: %i[edit update destroy add_listing remove_listing purge_avatar]
 
   def index
     @mobs = GridMob.includes(:grid_room, :grid_faction).order(:name)
@@ -72,6 +72,12 @@ class Admin::GridMobsController < Admin::ApplicationController
     redirect_to edit_admin_grid_mob_path(@mob)
   end
 
+  def purge_avatar
+    @mob.avatar.purge
+    set_flash_success("Avatar removed.")
+    redirect_to edit_admin_grid_mob_path(@mob)
+  end
+
   private
 
   def set_mob
@@ -97,7 +103,8 @@ class Admin::GridMobsController < Admin::ApplicationController
 
   def mob_params
     permitted = params.require(:grid_mob).permit(
-      :name, :description, :mob_type, :grid_room_id, :grid_faction_id
+      :name, :description, :mob_type, :grid_room_id, :grid_faction_id,
+      :avatar
     )
     # Parse JSON fields
     %w[dialogue_tree vendor_config].each do |json_field|

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -227,6 +227,7 @@ class Api::GridController < ApplicationController
       vendor_name: vendor.name,
       shop_type: vendor.shop_type,
       balance: balance,
+      avatar_url: vendor.avatar.attached? ? url_for(vendor.avatar_panel) : nil,
       listings: listings.map { |entry|
         listing = entry[:listing]
         {
@@ -290,6 +291,7 @@ class Api::GridController < ApplicationController
       mob_name: mob.name,
       mob_type: mob.mob_type,
       faction_name: mob.grid_faction&.display_name,
+      avatar_url: mob.avatar.attached? ? url_for(mob.avatar_panel) : nil,
       dialogue: {
         greeting: navigator.greeting,
         current_response: navigator.at_root? ? nil : navigator.node_at(navigator.current_path)&.dig("response"),

--- a/app/javascript/components/tactical/npc/NpcPanel.tsx
+++ b/app/javascript/components/tactical/npc/NpcPanel.tsx
@@ -24,6 +24,7 @@ export const NpcPanel: React.FC<NpcPanelProps> = ({
   const [npcData, setNpcData] = useState<NpcData | null>(null)
   const [section, setSection] = useState<PanelSection>('dialogue')
   const [dialogueOutput, setDialogueOutput] = useState<string | null>(null)
+  const [avatarLoaded, setAvatarLoaded] = useState(false)
   const initialTalkFired = useRef<number | null>(null)
 
   // Slide animation: mount first, then open; close first, then unmount
@@ -45,6 +46,7 @@ export const NpcPanel: React.FC<NpcPanelProps> = ({
   useEffect(() => {
     setNpcData(null)
     setDialogueOutput(null)
+    setAvatarLoaded(false)
     initialTalkFired.current = null
   }, [visible, selectedMobId])
 
@@ -125,6 +127,37 @@ export const NpcPanel: React.FC<NpcPanelProps> = ({
           fontFamily: '\'Courier New\', monospace'
         }}
       >
+        {/* Avatar fly-out wing — extends above panel */}
+        {npcData?.avatar_url && (
+          <div style={{
+            position: 'absolute',
+            bottom: '100%',
+            right: '0',
+            background: '#0d0d0d',
+            border: '2px solid #c084fc',
+            borderBottom: 'none',
+            borderRadius: '6px 6px 0 0',
+            padding: '8px',
+            display: 'flex',
+            alignItems: 'center'
+          }}>
+            <img
+              src={npcData.avatar_url}
+              alt={npcData.mob_name}
+              onLoad={() => setAvatarLoaded(true)}
+              style={{
+                width: '180px',
+                height: '180px',
+                objectFit: 'cover',
+                borderRadius: '4px',
+                border: '1px solid #333',
+                opacity: avatarLoaded ? 1 : 0,
+                transition: 'opacity 300ms ease-in'
+              }}
+            />
+          </div>
+        )}
+
         {/* Header */}
         <div style={{
           display: 'flex',

--- a/app/javascript/components/tactical/vendor/VendorPanel.tsx
+++ b/app/javascript/components/tactical/vendor/VendorPanel.tsx
@@ -32,6 +32,7 @@ export const VendorPanel: React.FC<VendorPanelProps> = ({
   const [section, setSection] = useState<PanelSection>('buy')
   const [pendingTx, setPendingTx] = useState<PendingTx | null>(null)
   const [buyQty, setBuyQty] = useState<Record<number, number>>({})
+  const [avatarLoaded, setAvatarLoaded] = useState(false)
 
   // Slide animation: mount first, then open; close first, then unmount
   // Double-rAF ensures browser paints the closed state before transitioning to open
@@ -68,9 +69,12 @@ export const VendorPanel: React.FC<VendorPanelProps> = ({
     }
   }, [refreshToken, isRendered])
 
-  // Reset buy quantities when panel closes or shop data refreshes
+  // Reset buy quantities and avatar state when panel closes
   useEffect(() => {
-    if (!visible) setBuyQty({})
+    if (!visible) {
+      setBuyQty({})
+      setAvatarLoaded(false)
+    }
   }, [visible])
 
   useEffect(() => {
@@ -149,6 +153,37 @@ export const VendorPanel: React.FC<VendorPanelProps> = ({
           fontFamily: '\'Courier New\', monospace'
         }}
       >
+        {/* Avatar fly-out wing — extends left from panel */}
+        {shopData?.avatar_url && (
+          <div style={{
+            position: 'absolute',
+            right: '100%',
+            top: '0',
+            background: '#0d0d0d',
+            border: '2px solid #fbbf24',
+            borderRight: 'none',
+            borderRadius: '6px 0 0 6px',
+            padding: '8px',
+            display: 'flex',
+            alignItems: 'center'
+          }}>
+            <img
+              src={shopData.avatar_url}
+              alt={shopData.vendor_name}
+              onLoad={() => setAvatarLoaded(true)}
+              style={{
+                width: '180px',
+                height: '180px',
+                objectFit: 'cover',
+                borderRadius: '4px',
+                border: '1px solid #333',
+                opacity: avatarLoaded ? 1 : 0,
+                transition: 'opacity 300ms ease-in'
+              }}
+            />
+          </div>
+        )}
+
         {/* Header */}
         <div style={{
           display: 'flex',

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -118,6 +118,7 @@ export interface ShopData {
   vendor_name: string
   shop_type: string
   balance: number
+  avatar_url: string | null
   listings: ShopListing[]
 }
 
@@ -299,6 +300,7 @@ export interface NpcData {
   mob_name: string
   mob_type: string
   faction_name: string | null
+  avatar_url: string | null
   dialogue: NpcDialogueState
   available_missions: NpcAvailableMission[]
   active_missions: NpcActiveMission[]

--- a/app/models/grid_mob.rb
+++ b/app/models/grid_mob.rb
@@ -26,14 +26,20 @@ class GridMob < ApplicationRecord
   # When a giver mob is deleted, the missions lose their giver (FK nullified
   # at the DB level). Missions are world data — an admin can reassign.
   has_many :given_missions, class_name: "GridMission", foreign_key: :giver_mob_id, dependent: :nullify
+  has_one_attached :avatar
 
   validates :name, presence: true
   validates :mob_type, inclusion: {in: %w[quest_giver vendor lore special], allow_nil: true}
   validate :faction_not_aggregate
+  validate :avatar_file_valid, if: -> { avatar.attached? && avatar.blob&.new_record? }
   validate :dialogue_tree_depth_within_limit
   validate :dialogue_tree_keys_unique
 
   before_validation :normalize_dialogue_tree
+
+  def avatar_panel
+    avatar.variant(resize_to_fill: [180, 180], format: :webp, saver: {quality: 85})
+  end
 
   def vendor?
     mob_type == "vendor"
@@ -60,6 +66,19 @@ class GridMob < ApplicationRecord
   end
 
   private
+
+  AVATAR_CONTENT_TYPES = %w[image/jpeg image/png image/webp].freeze
+  AVATAR_MAX_SIZE = 5.megabytes
+
+  def avatar_file_valid
+    blob = avatar.blob
+    unless AVATAR_CONTENT_TYPES.include?(blob.content_type)
+      errors.add(:avatar, "must be a JPEG, PNG, or WebP image")
+    end
+    if blob.byte_size > AVATAR_MAX_SIZE
+      errors.add(:avatar, "must be less than 5 MB")
+    end
+  end
 
   # Upgrade flat dialogue format (topic: "string") to nested format
   # (topic: { response: "string" }) so all downstream code can assume

--- a/app/views/admin/grid_mobs/_form.html.erb
+++ b/app/views/admin/grid_mobs/_form.html.erb
@@ -112,6 +112,42 @@
   <div id="vendor-raw-error" class="red-255-text" style="margin-top: 5px; display: none;"></div>
 </div>
 
+<%# ===================== AVATAR IMAGE ===================== %>
+<h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: AVATAR ::]</h3>
+
+<div style="display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap;">
+  <div>
+    <% if @mob.avatar.attached? %>
+      <%= image_tag @mob.avatar_panel, style: "width: 180px; height: 180px; object-fit: cover; border: 1px solid #333; border-radius: 4px;" %>
+    <% else %>
+      <div style="width: 180px; height: 180px; background: #1a1a1a; border: 1px solid #333; border-radius: 4px; display: flex; align-items: center; justify-content: center; color: #555; font-size: 0.85em;">
+        NO AVATAR
+      </div>
+    <% end %>
+  </div>
+  <div style="flex: 1; min-width: 200px;">
+    <label class="white-text" style="display: block; margin-bottom: 8px; font-weight: bold;">
+      <%= @mob.avatar.attached? ? "REPLACE AVATAR" : "UPLOAD AVATAR" %>
+    </label>
+    <%= f.file_field :avatar, accept: "image/jpeg,image/png,image/webp",
+          id: "avatar-image-input", style: "display: none;" %>
+    <label for="avatar-image-input" class="tui-button purple-168"
+           style="padding: 8px 20px; font-size: 0.85em; cursor: pointer; display: inline-block;">
+      CHOOSE FILE
+    </label>
+    <span id="avatar-file-name" style="color: #888; margin-left: 10px; font-size: 0.85em;"></span>
+    <p style="color: #666; margin-top: 8px; font-size: 0.8em;">
+      Recommended: 1:1 aspect ratio (square). JPG, PNG, or WebP.
+    </p>
+    <% if @mob.avatar.attached? %>
+      <%= button_to "Remove Avatar", purge_avatar_admin_grid_mob_path(@mob), method: :delete,
+            class: "tui-button red-168",
+            style: "padding: 6px 16px; font-size: 0.85em; margin-top: 10px;",
+            data: { confirm: "Remove avatar image?" } %>
+    <% end %>
+  </div>
+</div>
+
 <div style="margin-top: 30px; display: flex; gap: 10px;">
   <%= f.submit @mob.new_record? ? "Create Mob" : "Update Mob", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
   <%= link_to "Cancel", admin_grid_mobs_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
@@ -358,6 +394,15 @@
     vBtnRaw.classList.remove('green-168');
     vendorMode = 'structured';
   });
+
+  // === Avatar File Name Display ===
+  var avatarInput = document.getElementById('avatar-image-input');
+  var avatarFileName = document.getElementById('avatar-file-name');
+  if (avatarInput) {
+    avatarInput.addEventListener('change', function() {
+      avatarFileName.textContent = avatarInput.files.length ? avatarInput.files[0].name : '';
+    });
+  }
 
   // === Room Combobox ===
   AdminCombobox.init({

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,7 @@ Rails.application.routes.draw do
         get :history
         post :add_listing
         delete :remove_listing
+        delete :purge_avatar
       end
     end
     resources :grid_exits do


### PR DESCRIPTION
  Mob avatar system using Active Storage uploads with processed
  variants. Renders as fly-out "wing" panels on the tactical UI -
  extending above the NPC dialogue panel and left of the vendor
  shop panel, riding their existing slide animations.

  Backend: has_one_attached :avatar on GridMob with avatar_panel
  variant (180x180 WebP). Server-side validation: JPEG/PNG/WebP
  only, <5MB. avatar_url added to both /api/grid/npc and
  /api/grid/shop responses. Admin CRUD: file upload with preview,
  purge button, purge_avatar route.

  Frontend: Avatar fly-out wings on NpcPanel (top, purple border)
  and VendorPanel (left, amber border). Fade-in on image load to
  prevent pop-in. Wings only render when avatar is attached.