### PR TITLE
[TPG] Rest Pod System: pay CRED to restore vitals

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,9 +2,9 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index shop_index npc_index stats_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index shop_index npc_index rest_pod_index stats_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
-  before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: %i[zone_map shop_index npc_index stats_index]
+  before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: %i[zone_map shop_index npc_index rest_pod_index stats_index]
   before_action :require_admin_api, only: [:debit]
 
   INVENTORY_TYPE_ORDER = %w[gear consumable tool software module firmware material data rig_component fixture collectible faction].freeze
@@ -352,6 +352,25 @@ class Api::GridController < ApplicationController
           aggregate: s[:aggregate],
           depth: entry[:depth]
         }
+      }
+    }
+  end
+
+  # GET /api/grid/rest_pod - Rest Pod panel data for tactical UI
+  def rest_pod_index
+    room = current_hackr.current_room
+    return render(json: {error: "No current room."}, status: :unprocessable_entity) unless room
+    return render(json: {error: "No Rest Pod here."}, status: :not_found) unless room.room_type == "rest_pod"
+
+    rate = Grid::RestPodService.rate_for(current_hackr)
+
+    render json: {
+      rate: rate,
+      balance: current_hackr.default_cache&.balance || 0,
+      vitals: {
+        health: {current: current_hackr.stat("health"), max: current_hackr.effective_max("health")},
+        energy: {current: current_hackr.stat("energy"), max: current_hackr.effective_max("energy")},
+        psyche: {current: current_hackr.stat("psyche"), max: current_hackr.effective_max("psyche")}
       }
     }
   end
@@ -1032,7 +1051,8 @@ class Api::GridController < ApplicationController
         GridSlipstreamRoute.active.where(origin_room_id: room.id).exists? ||
         current_hackr.in_transit?,
       has_npc: npc_mobs.any?,
-      npc_mobs: npc_mobs
+      npc_mobs: npc_mobs,
+      has_rest_pod: room.room_type == "rest_pod"
     }
   end
 

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -17,6 +17,8 @@ import { TransitHandle } from '~/components/tactical/transit/TransitHandle'
 import { TransitPanel } from '~/components/tactical/transit/TransitPanel'
 import { NpcHandle } from '~/components/tactical/npc/NpcHandle'
 import { NpcPanel } from '~/components/tactical/npc/NpcPanel'
+import { RestPodHandle } from '~/components/tactical/rest_pod/RestPodHandle'
+import { RestPodPanel } from '~/components/tactical/rest_pod/RestPodPanel'
 
 const TacticalInner: React.FC = () => {
   const { hackr } = useGridAuth()
@@ -26,7 +28,8 @@ const TacticalInner: React.FC = () => {
     inBreach, breachMeta, breachOutput,
     hasVendor, setHasVendor,
     hasTransit, setHasTransit,
-    hasNpc, setHasNpc, npcMobs, setNpcMobs
+    hasNpc, setHasNpc, npcMobs, setNpcMobs,
+    hasRestPod, setHasRestPod
   } = useTactical()
   const initialLoadDoneRef = useRef(false)
   const [breachEncounters, setBreachEncounters] = useState<BreachEncounter[]>([])
@@ -35,6 +38,7 @@ const TacticalInner: React.FC = () => {
   const [vendorOpen, setVendorOpen] = useState(false)
   const [transitOpen, setTransitOpen] = useState(false)
   const [npcOpen, setNpcOpen] = useState(false)
+  const [restPodOpen, setRestPodOpen] = useState(false)
   const [selectedNpcId, setSelectedNpcId] = useState<number | null>(null)
 
   const handleBreachEncountersChange = useCallback((encounters: BreachEncounter[], ds: DeckStatus) => {
@@ -58,12 +62,18 @@ const TacticalInner: React.FC = () => {
     if (!has) { setNpcOpen(false); setSelectedNpcId(null) }
   }, [setHasNpc, setNpcMobs])
 
+  const handleRestPodPresenceChange = useCallback((v: boolean) => {
+    setHasRestPod(v)
+    if (!v) setRestPodOpen(false)
+  }, [setHasRestPod])
+
   // Close panels when breach starts
   useEffect(() => {
     if (inBreach) {
       setVendorOpen(false)
       setTransitOpen(false)
       setNpcOpen(false)
+      setRestPodOpen(false)
     }
   }, [inBreach])
 
@@ -179,6 +189,7 @@ const TacticalInner: React.FC = () => {
           onVendorPresenceChange={handleVendorPresenceChange}
           onTransitPresenceChange={handleTransitPresenceChange}
           onNpcPresenceChange={handleNpcPresenceChange}
+          onRestPodPresenceChange={handleRestPodPresenceChange}
         />
         {!inBreach && breachEncounters.length > 0 && (
           <BreachTargetButtons
@@ -194,7 +205,7 @@ const TacticalInner: React.FC = () => {
           refreshToken={refreshToken}
           onCommand={sendCommand}
         />
-        {hasTransit && !inBreach && !vendorOpen && !transitOpen && !npcOpen && (
+        {hasTransit && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
           <TransitHandle onClick={() => setTransitOpen(true)} />
         )}
         <TransitPanel
@@ -203,7 +214,7 @@ const TacticalInner: React.FC = () => {
           onCommand={sendCommand}
           onClose={() => setTransitOpen(false)}
         />
-        {hasVendor && !inBreach && !vendorOpen && !transitOpen && !npcOpen && (
+        {hasVendor && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
           <VendorHandle onClick={() => setVendorOpen(true)} />
         )}
         <VendorPanel
@@ -212,7 +223,7 @@ const TacticalInner: React.FC = () => {
           onCommand={sendCommand}
           onClose={() => setVendorOpen(false)}
         />
-        {hasNpc && !inBreach && !vendorOpen && !transitOpen && !npcOpen &&
+        {hasNpc && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen &&
           npcMobs.map((mob, i) => {
             const total = npcMobs.length
             const offsetX = total === 1 ? 0 : (i - (total - 1) / 2) * 72
@@ -232,6 +243,15 @@ const TacticalInner: React.FC = () => {
           onCommand={sendCommand}
           onClose={() => setNpcOpen(false)}
           selectedMobId={selectedNpcId}
+        />
+        {hasRestPod && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
+          <RestPodHandle onClick={() => setRestPodOpen(true)} />
+        )}
+        <RestPodPanel
+          visible={restPodOpen && !inBreach}
+          refreshToken={refreshToken}
+          onCommand={sendCommand}
+          onClose={() => setRestPodOpen(false)}
         />
       </div>
 

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -42,6 +42,7 @@ interface TacticalContextValue {
   hasVendor: boolean
   hasTransit: boolean
   hasNpc: boolean
+  hasRestPod: boolean
   npcMobs: NpcMobStub[]
   sendCommand: (command: string) => Promise<string | undefined>
   setOutput: React.Dispatch<React.SetStateAction<string[]>>
@@ -49,6 +50,7 @@ interface TacticalContextValue {
   setHasVendor: React.Dispatch<React.SetStateAction<boolean>>
   setHasTransit: React.Dispatch<React.SetStateAction<boolean>>
   setHasNpc: React.Dispatch<React.SetStateAction<boolean>>
+  setHasRestPod: React.Dispatch<React.SetStateAction<boolean>>
   setNpcMobs: React.Dispatch<React.SetStateAction<NpcMobStub[]>>
   commandInputRef: React.RefObject<CommandInputHandle | null>
 }
@@ -72,6 +74,7 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [hasVendor, setHasVendor] = useState(false)
   const [hasTransit, setHasTransit] = useState(false)
   const [hasNpc, setHasNpc] = useState(false)
+  const [hasRestPod, setHasRestPod] = useState(false)
   const [npcMobs, setNpcMobs] = useState<NpcMobStub[]>([])
   const commandInputRef = useRef<CommandInputHandle | null>(null)
   const inBreachRef = useRef(false)
@@ -152,8 +155,8 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   return (
     <TacticalContext.Provider value={{
       output, currentRoomId, executing, refreshToken,
-      inBreach, breachMeta, breachOutput, hasVendor, hasTransit, hasNpc, npcMobs,
-      sendCommand, setOutput, setCurrentRoomId, setHasVendor, setHasTransit, setHasNpc, setNpcMobs, commandInputRef
+      inBreach, breachMeta, breachOutput, hasVendor, hasTransit, hasNpc, hasRestPod, npcMobs,
+      sendCommand, setOutput, setCurrentRoomId, setHasVendor, setHasTransit, setHasNpc, setHasRestPod, setNpcMobs, commandInputRef
     }}>
       {children}
     </TacticalContext.Provider>

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -16,6 +16,7 @@ interface ZoneMapProps {
   onVendorPresenceChange?: (hasVendor: boolean) => void
   onTransitPresenceChange?: (hasTransit: boolean) => void
   onNpcPresenceChange?: (hasNpc: boolean, mobs: NpcMobStub[]) => void
+  onRestPodPresenceChange?: (hasRestPod: boolean) => void
 }
 
 interface Tooltip {
@@ -26,7 +27,7 @@ interface Tooltip {
 
 const Z_DIRS = new Set(['up', 'down'])
 
-export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange, onVendorPresenceChange, onTransitPresenceChange, onNpcPresenceChange }) => {
+export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, onNavigate, onBreachEncountersChange, onVendorPresenceChange, onTransitPresenceChange, onNpcPresenceChange, onRestPodPresenceChange }) => {
   const [mapData, setMapData] = useState<ZoneMapData | null>(null)
   const [tooltip, setTooltip] = useState<Tooltip | null>(null)
   const [zoom, setZoom] = useState(1.25)
@@ -47,6 +48,7 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
         onVendorPresenceChange?.(data.has_vendor ?? false)
         onTransitPresenceChange?.(data.has_transit ?? false)
         onNpcPresenceChange?.(data.has_npc ?? false, data.npc_mobs ?? [])
+        onRestPodPresenceChange?.(data.has_rest_pod ?? false)
       })
       .catch(err => console.error('Zone map fetch failed:', err))
   // eslint-disable-next-line react-hooks/exhaustive-deps -- callback ref change should not re-trigger fetch; refreshToken controls cadence

--- a/app/javascript/components/tactical/rest_pod/RestPodHandle.tsx
+++ b/app/javascript/components/tactical/rest_pod/RestPodHandle.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+
+interface RestPodHandleProps {
+  onClick: () => void
+}
+
+export const RestPodHandle: React.FC<RestPodHandleProps> = ({ onClick }) => {
+  const [hover, setHover] = useState(false)
+
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick() }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: 'absolute',
+        right: 0,
+        bottom: '25%',
+        transform: 'translateY(50%)',
+        zIndex: 25,
+        background: hover ? '#1a1a1a' : '#111',
+        border: '1px solid #34d399',
+        borderRight: 'none',
+        borderRadius: '6px 0 0 6px',
+        padding: '12px 6px',
+        cursor: 'pointer',
+        writingMode: 'vertical-rl',
+        textOrientation: 'mixed',
+        fontFamily: '\'Courier New\', monospace',
+        fontSize: '0.7em',
+        fontWeight: 'bold',
+        letterSpacing: '2px',
+        color: '#34d399',
+        transition: 'background 0.2s, box-shadow 0.2s',
+        boxShadow: hover ? '0 0 10px rgba(52, 211, 153, 0.3)' : 'none'
+      }}
+    >
+      REST POD
+    </button>
+  )
+}

--- a/app/javascript/components/tactical/rest_pod/RestPodPanel.tsx
+++ b/app/javascript/components/tactical/rest_pod/RestPodPanel.tsx
@@ -1,0 +1,299 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { apiJson } from '~/utils/apiClient'
+import { RestPodData } from '~/types/zoneMap'
+import { useTactical } from '../TacticalContext'
+
+interface RestPodPanelProps {
+  visible: boolean
+  refreshToken: number
+  onCommand: (cmd: string) => void
+  onClose: () => void
+}
+
+const VITALS = ['health', 'energy', 'psyche'] as const
+type VitalKey = typeof VITALS[number]
+
+const VITAL_LABELS: Record<VitalKey, string> = {
+  health: 'HEALTH',
+  energy: 'ENERGY',
+  psyche: 'PSYCHE'
+}
+
+const VITAL_COLORS: Record<VitalKey, string> = {
+  health: '#34d399',
+  energy: '#60a5fa',
+  psyche: '#c084fc'
+}
+
+export const RestPodPanel: React.FC<RestPodPanelProps> = ({
+  visible, refreshToken, onCommand, onClose
+}) => {
+  const { executing } = useTactical()
+  const [isRendered, setIsRendered] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const [podData, setPodData] = useState<RestPodData | null>(null)
+  const [allocs, setAllocs] = useState<Record<VitalKey, string>>({
+    health: '', energy: '', psyche: ''
+  })
+
+  // Slide animation: mount first, then open; close first, then unmount
+  useEffect(() => {
+    if (visible) {
+      setIsRendered(true)
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setIsOpen(true))
+      })
+      return () => cancelAnimationFrame(raf)
+    } else {
+      setIsOpen(false)
+      const timer = setTimeout(() => setIsRendered(false), 300)
+      return () => clearTimeout(timer)
+    }
+  }, [visible])
+
+  // Fetch data when panel renders or refreshToken changes
+  useEffect(() => {
+    if (isRendered) {
+      apiJson<RestPodData>('/api/grid/rest_pod').then(setPodData).catch(console.error)
+    }
+  }, [refreshToken, isRendered])
+
+  // Reset allocations when panel closes
+  useEffect(() => {
+    if (!visible) {
+      setAllocs({ health: '', energy: '', psyche: '' })
+    }
+  }, [visible])
+
+  const getDeficit = (vital: VitalKey): number => {
+    if (!podData) return 0
+    const v = podData.vitals[vital]
+    return Math.max(0, v.max - v.current)
+  }
+
+  const getPoints = (vital: VitalKey): number => {
+    const raw = parseInt(allocs[vital], 10)
+    if (!raw || raw <= 0) return 0
+    return Math.min(raw, getDeficit(vital))
+  }
+
+  const totalPoints = VITALS.reduce((sum, v) => sum + getPoints(v), 0)
+  const totalCred = podData ? Math.ceil(totalPoints / podData.rate) : 0
+  const canAfford = podData ? totalCred <= podData.balance : false
+  const hasAllocation = totalPoints > 0
+
+  const handleFill = useCallback((vital: VitalKey) => {
+    const deficit = getDeficit(vital)
+    setAllocs(prev => ({ ...prev, [vital]: deficit > 0 ? String(deficit) : '' }))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [podData])
+
+  const handleFillAll = useCallback(() => {
+    const next: Record<VitalKey, string> = { health: '', energy: '', psyche: '' }
+    for (const v of VITALS) {
+      const deficit = getDeficit(v)
+      if (deficit > 0) next[v] = String(deficit)
+    }
+    setAllocs(next)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [podData])
+
+  const handleConfirm = useCallback(() => {
+    if (!podData || !canAfford || !hasAllocation) return
+    const parts: string[] = []
+    for (const v of VITALS) {
+      const pts = getPoints(v)
+      if (pts > 0) parts.push(`${pts} ${v}`)
+    }
+    if (parts.length === 0) return
+    onCommand(`rest ${parts.join(' ')}`)
+    onClose()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allocs, podData, canAfford, hasAllocation, onCommand, onClose])
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    onClose()
+  }, [onClose])
+
+  if (!isRendered) return null
+
+  return (
+    <>
+      <div
+        onClick={handleBackdropClick}
+        style={{
+          position: 'absolute', inset: 0, zIndex: 29,
+          background: isOpen ? 'rgba(0,0,0,0.2)' : 'transparent',
+          transition: 'background 300ms ease-out'
+        }}
+      />
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute', top: 0, right: 0, bottom: 0, width: '50%',
+          zIndex: 30,
+          transform: isOpen ? 'translateX(0%)' : 'translateX(100%)',
+          transition: 'transform 300ms ease-out',
+          display: 'flex', flexDirection: 'column',
+          background: '#0d0d0d',
+          borderLeft: '2px solid #34d399',
+          fontFamily: '\'Courier New\', monospace'
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          padding: '8px 12px', background: '#111',
+          borderBottom: '1px solid #333', flexShrink: 0
+        }}>
+          <div>
+            <span style={{ color: '#34d399', fontWeight: 'bold', fontSize: '0.8em', letterSpacing: '1px' }}>
+              REST POD
+            </span>
+            {podData && (
+              <>
+                <span style={{ color: '#444', margin: '0 8px' }}>::</span>
+                <span style={{ color: '#fbbf24', fontSize: '0.7em' }}>{podData.balance} CRED</span>
+                <span style={{ color: '#666', fontSize: '0.65em', marginLeft: '8px' }}>
+                  {podData.rate} pts/CRED
+                </span>
+              </>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'transparent', color: '#888', border: '1px solid #444',
+              padding: '3px 10px', fontSize: '0.7em', cursor: 'pointer',
+              borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+            }}
+          >CLOSE</button>
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '12px 14px' }}>
+          {!podData ? (
+            <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
+          ) : (
+            <>
+              {VITALS.map(v => {
+                const vi = podData.vitals[v]
+                const deficit = getDeficit(v)
+                const pts = getPoints(v)
+                const color = VITAL_COLORS[v]
+                const pct = vi.max > 0 ? (vi.current / vi.max) * 100 : 0
+
+                return (
+                  <div key={v} style={{ marginBottom: '18px' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
+                      <span style={{ color, fontSize: '0.75em', fontWeight: 'bold', letterSpacing: '1px' }}>
+                        {VITAL_LABELS[v]}
+                      </span>
+                      <span style={{ color: '#888', fontSize: '0.7em' }}>
+                        {vi.current} / {vi.max}
+                        {deficit > 0 && <span style={{ color: '#555' }}> ({deficit} missing)</span>}
+                      </span>
+                    </div>
+                    {/* Bar */}
+                    <div style={{ height: '4px', background: '#222', borderRadius: '2px', marginBottom: '8px', position: 'relative' }}>
+                      <div style={{
+                        height: '100%', borderRadius: '2px',
+                        background: color,
+                        width: `${pct}%`,
+                        transition: 'width 300ms'
+                      }} />
+                      {pts > 0 && (
+                        <div style={{
+                          position: 'absolute', top: 0, height: '100%',
+                          borderRadius: '2px',
+                          background: color,
+                          opacity: 0.35,
+                          left: `${pct}%`,
+                          width: `${(pts / vi.max) * 100}%`,
+                          transition: 'width 300ms, left 300ms'
+                        }} />
+                      )}
+                    </div>
+                    {deficit > 0 ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <input
+                          type="number"
+                          min={0}
+                          max={deficit}
+                          placeholder="pts"
+                          value={allocs[v]}
+                          onChange={(e) => setAllocs(prev => ({ ...prev, [v]: e.target.value }))}
+                          style={{
+                            width: '72px', background: '#1a1a1a', border: '1px solid #333',
+                            color: '#d0d0d0', padding: '4px 6px', fontSize: '0.75em',
+                            fontFamily: '\'Courier New\', monospace', borderRadius: '3px',
+                            outline: 'none'
+                          }}
+                        />
+                        <span style={{ color: '#555', fontSize: '0.7em' }}>pts</span>
+                        <button
+                          onClick={() => handleFill(v)}
+                          style={{
+                            background: 'transparent', border: `1px solid ${color}`,
+                            color, padding: '2px 8px', fontSize: '0.65em', cursor: 'pointer',
+                            borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                          }}
+                        >FULL</button>
+                        {pts > 0 && (
+                          <span style={{ color, fontSize: '0.7em' }}>
+                            +{pts} → {vi.current + pts}/{vi.max}
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <span style={{ color: '#34d399', fontSize: '0.7em' }}>FULL</span>
+                    )}
+                  </div>
+                )
+              })}
+
+              {/* Footer: cost + buttons */}
+              <div style={{ borderTop: '1px solid #222', paddingTop: '12px', marginTop: '8px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <span style={{ color: '#888', fontSize: '0.75em' }}>
+                      Total: <span style={{ color: hasAllocation ? (canAfford ? '#fbbf24' : '#f87171') : '#555' }}>
+                        {totalPoints} pts → {totalCred} CRED
+                      </span>
+                    </span>
+                    {!canAfford && totalCred > 0 && (
+                      <div style={{ color: '#f87171', fontSize: '0.65em', marginTop: '4px' }}>Insufficient CRED</div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <button
+                      onClick={handleFillAll}
+                      style={{
+                        background: 'transparent', border: '1px solid #555',
+                        color: '#888', padding: '5px 12px', fontSize: '0.7em', cursor: 'pointer',
+                        borderRadius: '3px', fontFamily: '\'Courier New\', monospace'
+                      }}
+                    >FILL ALL</button>
+                    <button
+                      onClick={handleConfirm}
+                      disabled={!canAfford || !hasAllocation || executing}
+                      style={{
+                        background: canAfford && hasAllocation && !executing ? '#34d399' : '#333',
+                        color: canAfford && hasAllocation && !executing ? '#0a0a0a' : '#666',
+                        border: 'none', borderRadius: '3px', padding: '5px 16px',
+                        fontSize: '0.8em', fontWeight: 'bold',
+                        cursor: canAfford && hasAllocation && !executing ? 'pointer' : 'not-allowed',
+                        fontFamily: '\'Courier New\', monospace'
+                      }}
+                    >RESTORE</button>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/javascript/types/zoneMap.ts
+++ b/app/javascript/types/zoneMap.ts
@@ -71,6 +71,7 @@ export interface ZoneMapData {
   has_transit: boolean
   has_npc: boolean
   npc_mobs: NpcMobStub[]
+  has_rest_pod: boolean
 }
 
 export interface InventoryItem {
@@ -293,6 +294,23 @@ export interface NpcDeliveryItem {
   in_inventory: boolean
   quantity_held: number
   quantity_needed: number
+}
+
+// --- Rest Pod types ---
+
+export interface RestPodVital {
+  current: number
+  max: number
+}
+
+export interface RestPodData {
+  rate: number
+  balance: number
+  vitals: {
+    health: RestPodVital
+    energy: RestPodVital
+    psyche: RestPodVital
+  }
 }
 
 export interface NpcData {

--- a/app/models/grid_room.rb
+++ b/app/models/grid_room.rb
@@ -49,7 +49,7 @@ class GridRoom < ApplicationRecord
   validates :name, presence: true
   validates :name, length: {maximum: 80}, if: :den?
   validates :room_type, inclusion: {
-    in: %w[standard hub faction_base govcorp special safe_zone transit shop danger_zone den hospital firmware_vendor repair_service containment impound sally_port sally_port_anteroom]
+    in: %w[standard hub faction_base govcorp special safe_zone transit shop danger_zone den hospital firmware_vendor repair_service containment impound sally_port sally_port_anteroom rest_pod]
   }
   validates :min_clearance, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validates :owner_id, uniqueness: {allow_nil: true}

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -3,6 +3,8 @@ module Grid
     include CodexHelper
     include ItemEffectApplier
 
+    VITAL_SHORTCUTS = {"hp" => "health", "en" => "energy", "ps" => "psyche"}.freeze
+
     attr_reader :hackr, :input, :event
 
     def initialize(hackr, input)
@@ -157,6 +159,8 @@ module Grid
         breach_initiate_command(args&.join(" "))
       when "repair"
         repair_command
+      when "rest"
+        rest_command(args)
       when "den"
         den_command(args)
       when "out"
@@ -229,6 +233,16 @@ module Grid
           end
           output << "<span style='color: #6b7280;'>  Type 'breach &lt;name or #&gt;' to initiate.</span>"
         end
+      end
+
+      # Rest Pod indicator
+      if room.room_type == "rest_pod"
+        rate = Grid::RestPodService.rate_for(hackr)
+        output << ""
+        output << "<span style='color: #34d399; font-weight: bold;'>[ REST POD ]</span>"
+        output << "<span style='color: #6b7280;'>  Restore vitals for CRED. Rate: #{rate} pts/CRED.</span>"
+        output << "<span style='color: #6b7280;'>  Type 'rest &lt;amount&gt; &lt;vital&gt; [...]' — e.g., rest 50 hp 30 en</span>"
+        output << "<span style='color: #6b7280;'>  Use 'full' for max: rest full hp full en full ps</span>"
       end
 
       # Slipstream access indicator — show destinations available from this room
@@ -1546,6 +1560,56 @@ module Grid
     rescue Grid::DeckRepairService::DeckNotFried => e
       "<span style='color: #9ca3af;'>#{h(e.message)}</span>"
     rescue Grid::DeckRepairService::InsufficientBalance => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    end
+
+    def rest_command(args)
+      if args.nil? || args.empty?
+        return "<span style='color: #f87171;'>Usage: rest &lt;amount&gt; &lt;vital&gt; [...] — e.g., rest 50 hp 30 en</span>" \
+               "\n<span style='color: #6b7280;'>  Vitals: health/hp, energy/en, psyche/ps. Use 'full' for max.</span>"
+      end
+
+      # Parse amount/vital pairs, merge duplicates (e.g., "10 hp 20 hp" → health: 30)
+      merged = {}
+      i = 0
+      while i < args.length
+        amount_str = args[i]
+        vital_raw = args[i + 1]
+        i += 2
+
+        unless vital_raw
+          return "<span style='color: #f87171;'>Missing vital name after '#{h(amount_str)}'. Use health/hp, energy/en, psyche/ps.</span>"
+        end
+
+        vital = VITAL_SHORTCUTS.fetch(vital_raw.downcase, vital_raw.downcase)
+        unless Grid::RestPodService::VITALS.include?(vital)
+          return "<span style='color: #f87171;'>Unknown vital: #{h(vital_raw)}. Use health/hp, energy/en, psyche/ps.</span>"
+        end
+
+        points = if amount_str.downcase == "full"
+          hackr.effective_max(vital) - hackr.stat(vital).to_i
+        else
+          amount_str.to_i
+        end
+
+        merged[vital] = (merged[vital] || 0) + points if points > 0
+      end
+
+      allocs = merged.map { |vital, points| {vital: vital, points: points} }
+
+      if allocs.empty?
+        return "<span style='color: #9ca3af;'>Nothing to restore — vitals are already full.</span>"
+      end
+
+      result = Grid::RestPodService.restore!(hackr: hackr, allocs: allocs)
+      result.display
+    rescue Grid::RestPodService::NotAtRestPod => e
+      "<span style='color: #9ca3af;'>#{h(e.message)}</span>"
+    rescue Grid::RestPodService::InvalidAllocation => e
+      "<span style='color: #f87171;'>#{h(e.message)}</span>"
+    rescue Grid::RestPodService::NothingToRestore => e
+      "<span style='color: #9ca3af;'>#{h(e.message)}</span>"
+    rescue Grid::RestPodService::InsufficientBalance => e
       "<span style='color: #f87171;'>#{h(e.message)}</span>"
     end
 

--- a/app/services/grid/rest_pod_service.rb
+++ b/app/services/grid/rest_pod_service.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Grid
+  class RestPodService
+    Result = Data.define(:allocations, :total_cred_paid, :display)
+
+    class NotAtRestPod < StandardError; end
+    class InvalidAllocation < StandardError; end
+    class InsufficientBalance < StandardError; end
+    class NothingToRestore < StandardError; end
+
+    VITALS = %w[health energy psyche].freeze
+    CL_THRESHOLD = 30
+    RATE_DISCOUNTED = 2 # points per CRED (CL < 30)
+    RATE_STANDARD = 1   # points per CRED (CL >= 30)
+
+    # allocs: Array of { vital: "health"|"energy"|"psyche", points: Integer }
+    def self.restore!(hackr:, allocs:)
+      new(hackr).restore!(allocs)
+    end
+
+    def self.rate_for(hackr)
+      (hackr.stat("clearance").to_i >= CL_THRESHOLD) ? RATE_STANDARD : RATE_DISCOUNTED
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def restore!(allocs)
+      room = @hackr.current_room
+      raise NotAtRestPod, "There's no Rest Pod here." unless room&.room_type == "rest_pod"
+      raise InvalidAllocation, "No allocation specified." if allocs.empty?
+
+      allocs.each do |a|
+        raise InvalidAllocation, "Unknown vital: #{a[:vital]}" unless VITALS.include?(a[:vital])
+        raise InvalidAllocation, "Points must be positive." unless a[:points].to_i > 0
+      end
+
+      rate = self.class.rate_for(@hackr)
+
+      # Pre-check balance (fast-fail before locking)
+      cache = @hackr.default_cache
+      max_points = allocs.sum { |a| a[:points].to_i }
+      max_cost = (max_points.to_f / rate).ceil
+      raise InsufficientBalance, "Insufficient CRED." unless cache&.balance.to_i >= max_cost
+
+      final_allocs = nil
+      total_cred = nil
+
+      ActiveRecord::Base.transaction do
+        @hackr.lock!
+
+        # Snapshot vitals under lock for deficit computation
+        prior_vitals = VITALS.each_with_object({}) { |v, h| h[v] = @hackr.stat(v).to_i }
+
+        # Clamp each allocation to actual deficit under lock
+        final_allocs = allocs.filter_map do |a|
+          vital = a[:vital]
+          current = prior_vitals[vital]
+          max = @hackr.effective_max(vital)
+          deficit = max - current
+          next nil if deficit <= 0
+
+          clamped = [a[:points].to_i, deficit].min
+          {vital: vital, points: clamped, new_val: current + clamped, max_val: max}
+        end
+
+        raise NothingToRestore, "Your vitals are already full." if final_allocs.empty?
+
+        total_points = final_allocs.sum { |a| a[:points] }
+        total_cred = (total_points.to_f / rate).ceil
+
+        # Re-fetch balance after lock (TOCTOU guard)
+        cache = @hackr.default_cache
+        raise InsufficientBalance, "Need #{total_cred} CRED. You have #{cache&.balance || 0}." unless cache&.balance.to_i >= total_cred
+
+        # Apply vital restorations (adjust_vital! re-clamps, belt-and-suspenders
+        # with the deficit clamp above — both safe because lock prevents changes)
+        final_allocs.each do |a|
+          @hackr.adjust_vital!(a[:vital], a[:points])
+        end
+      end
+
+      # CRED payment outside transaction (TransactionService has its own mutex).
+      # If payment fails, subtract what we added — preserves any concurrent changes.
+      begin
+        split_payment!(from_cache: cache, amount: total_cred)
+      rescue => e
+        final_allocs.each { |a| @hackr.adjust_vital!(a[:vital], -a[:points]) }
+        raise InsufficientBalance, "Payment failed — restoration reversed. #{e.message}"
+      end
+
+      display = render_result(final_allocs, total_cred, rate)
+      Result.new(allocations: final_allocs, total_cred_paid: total_cred, display: display)
+    end
+
+    private
+
+    def split_payment!(from_cache:, amount:)
+      burn_amt = (amount * EconomyConfig::SHOP_BURN_RATIO).floor
+      recycle_amt = amount - burn_amt
+
+      if burn_amt > 0
+        Grid::TransactionService.burn!(
+          from_cache: from_cache,
+          amount: burn_amt,
+          memo: "Rest Pod restoration"
+        )
+      end
+
+      if recycle_amt > 0
+        Grid::TransactionService.recycle!(
+          from_cache: from_cache,
+          amount: recycle_amt,
+          memo: "Rest Pod restoration"
+        )
+      end
+    end
+
+    def render_result(allocs, total_cred, rate)
+      vital_colors = {"health" => "#34d399", "energy" => "#60a5fa", "psyche" => "#c084fc"}
+      lines = []
+      lines << ""
+      lines << "<span style='color: #34d399; font-weight: bold;'>[ REST POD — VITALS RESTORED ]</span>"
+      allocs.each do |a|
+        color = vital_colors.fetch(a[:vital], "#d0d0d0")
+        lines << "<span style='color: #{color};'>  #{a[:vital].upcase}: +#{a[:points]} (#{a[:new_val]}/#{a[:max_val]})</span>"
+      end
+      rate_label = (rate == RATE_DISCOUNTED) ? "discounted" : "standard"
+      lines << "<span style='color: #fbbf24;'>  Cost: #{total_cred} CRED (#{rate_label} rate: #{rate} pts/CRED)</span>"
+      lines.join("\n")
+    end
+  end
+end

--- a/app/views/admin/grid_map_editor/show.html.erb
+++ b/app/views/admin/grid_map_editor/show.html.erb
@@ -1666,7 +1666,7 @@
     html += '<div style="flex: 1;">';
     html += '<label class="white-text" style="display: block; margin-bottom: 4px; font-size: 0.85em;">Type:</label>';
     html += '<select id="me-p-type" class="tui-input" style="width: 100%; padding: 4px; font-size: 0.85em;">';
-    var types = ['standard','hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','hospital','firmware_vendor','repair_service','containment','impound','sally_port_anteroom','sally_port'];
+    var types = ['standard','hub','faction_base','govcorp','special','safe_zone','transit','shop','danger_zone','hospital','firmware_vendor','repair_service','rest_pod','containment','impound','sally_port_anteroom','sally_port'];
     types.forEach(function(t) {
       html += '<option value="' + t + '"' + (room.room_type === t ? ' selected' : '') + '>' + t + '</option>';
     });

--- a/app/views/admin/grid_mobs/index.html.erb
+++ b/app/views/admin/grid_mobs/index.html.erb
@@ -15,13 +15,17 @@
         </div>
       <% end %>
 
-      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px; flex-wrap: wrap;">
         <%= link_to "+ New Mob", new_admin_grid_mob_path, class: "tui-button green-168" %>
+        <span style="color: #333;">|</span>
+        <label class="white-text" style="font-weight: bold;">FILTER:</label>
+        <input type="text" id="mob-filter" class="tui-input" style="padding: 6px 10px; width: 250px;" placeholder="name, type, room, faction..." autocomplete="off">
+        <span id="mob-filter-status" style="color: #666; font-size: 0.85em;"><%= @mobs.size %> mobs</span>
       </div>
 
       <% if @mobs.any? %>
         <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
-          <table class="tui-table" style="width: 100%;">
+          <table id="mob-table" class="tui-table" style="width: 100%;">
             <thead>
               <tr>
                 <th style="text-align: left;">Name</th>
@@ -63,3 +67,27 @@
     </div>
   </fieldset>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var input = document.getElementById('mob-filter');
+    var status = document.getElementById('mob-filter-status');
+    var rows = document.querySelectorAll('#mob-table tbody tr');
+    if (!input || !rows.length) return;
+    var total = rows.length;
+
+    input.addEventListener('input', function() {
+      var q = this.value.toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var cells = rows[i].querySelectorAll('td');
+        var text = '';
+        for (var c = 0; c < cells.length - 1; c++) text += cells[c].textContent + ' ';
+        var show = !q || text.toLowerCase().indexOf(q) !== -1;
+        rows[i].style.display = show ? '' : 'none';
+        if (show) visible++;
+      }
+      status.textContent = visible + ' of ' + total + ' mob' + (total === 1 ? '' : 's');
+    });
+  })();
+</script>

--- a/app/views/admin/grid_rooms/_form.html.erb
+++ b/app/views/admin/grid_rooms/_form.html.erb
@@ -31,7 +31,7 @@
   <div style="flex: 1; min-width: 200px;">
     <%= f.label :room_type, "ROOM TYPE", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
     <%= f.select :room_type,
-          [["Standard", "standard"], ["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
+          [["Standard", "standard"], ["Hub", "hub"], ["Faction Base", "faction_base"], ["GovCorp", "govcorp"], ["Special", "special"], ["Safe Zone", "safe_zone"], ["Transit", "transit"], ["Shop", "shop"], ["Danger Zone", "danger_zone"], ["Den", "den"], ["Hospital", "hospital"], ["Firmware Vendor", "firmware_vendor"], ["Repair Service", "repair_service"], ["Rest Pod", "rest_pod"], ["Containment", "containment"], ["Impound", "impound"], ["Sally Port Anteroom", "sally_port_anteroom"], ["Sally Port", "sally_port"]],
           { selected: @room.room_type || "standard" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
   </div>
   <div style="flex: 1; min-width: 200px;">

--- a/app/views/admin/grid_rooms/index.html.erb
+++ b/app/views/admin/grid_rooms/index.html.erb
@@ -15,14 +15,18 @@
         </div>
       <% end %>
 
-      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px;">
+      <div style="display: flex; gap: 15px; align-items: center; margin-bottom: 20px; flex-wrap: wrap;">
         <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
         <%= link_to "+ New Room", new_admin_grid_room_path, class: "tui-button green-168" %>
+        <span style="color: #333;">|</span>
+        <label class="white-text" style="font-weight: bold;">FILTER:</label>
+        <input type="text" id="room-filter" class="tui-input" style="padding: 6px 10px; width: 250px;" placeholder="name, slug, zone, type..." autocomplete="off">
+        <span id="room-filter-status" style="color: #666; font-size: 0.85em;"><%= @rooms.size %> rooms</span>
       </div>
 
       <% if @rooms.any? %>
         <div class="tui-window white-text" style="display: block; background: #0a0a0a; overflow-x: auto;">
-          <table class="tui-table" style="width: 100%;">
+          <table id="room-table" class="tui-table" style="width: 100%;">
             <thead>
               <tr>
                 <th style="text-align: left;">Name</th>
@@ -71,3 +75,27 @@
     </div>
   </fieldset>
 </div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  (function() {
+    var input = document.getElementById('room-filter');
+    var status = document.getElementById('room-filter-status');
+    var rows = document.querySelectorAll('#room-table tbody tr');
+    if (!input || !rows.length) return;
+    var total = rows.length;
+
+    input.addEventListener('input', function() {
+      var q = this.value.toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var cells = rows[i].querySelectorAll('td');
+        var text = '';
+        for (var c = 0; c < cells.length - 1; c++) text += cells[c].textContent + ' ';
+        var show = !q || text.toLowerCase().indexOf(q) !== -1;
+        rows[i].style.display = show ? '' : 'none';
+        if (show) visible++;
+      }
+      status.textContent = visible + ' of ' + total + ' room' + (total === 1 ? '' : 's');
+    });
+  })();
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Rails.application.routes.draw do
     get "grid/cred", to: "grid#cred_index"
     get "grid/shop", to: "grid#shop_index"
     get "grid/npc", to: "grid#npc_index"
+    get "grid/rest_pod", to: "grid#rest_pod_index"
     get "grid/transit", to: "grid#transit_index"
     post "grid/login", to: "grid#login"
     post "grid/register", to: "grid#register"

--- a/spec/factories/grid_rooms.rb
+++ b/spec/factories/grid_rooms.rb
@@ -63,6 +63,10 @@ FactoryBot.define do
       room_type { "standard" }
     end
 
+    trait :rest_pod do
+      room_type { "rest_pod" }
+    end
+
     trait :den do
       room_type { "den" }
       sequence(:name) { |n| "Den #{n}" }

--- a/spec/services/grid/rest_pod_service_spec.rb
+++ b/spec/services/grid/rest_pod_service_spec.rb
@@ -1,0 +1,212 @@
+require "rails_helper"
+
+RSpec.describe Grid::RestPodService do
+  let(:zone) { create(:grid_zone) }
+  let(:rest_room) { create(:grid_room, :rest_pod, grid_zone: zone) }
+  let(:standard_room) { create(:grid_room, :standard, grid_zone: zone) }
+  let(:hackr) { create(:grid_hackr, current_room: rest_room) }
+  let(:cache) { create(:grid_cache, :default, grid_hackr: hackr) }
+  let(:gameplay_pool) { create(:grid_cache, :gameplay_pool) }
+  let(:burn_cache) { create(:grid_cache, :burn) }
+
+  def fund_cache(target_cache, amount)
+    source = create(:grid_cache)
+    GridTransaction.create!(
+      from_cache: source, to_cache: target_cache, amount: amount,
+      tx_type: "genesis", tx_hash: SecureRandom.hex(32), created_at: Time.current
+    )
+  end
+
+  before do
+    cache
+    gameplay_pool
+    burn_cache
+  end
+
+  describe ".rate_for" do
+    it "returns discounted rate (2) for CL < 30" do
+      hackr.set_stat!("clearance", 0)
+      expect(described_class.rate_for(hackr)).to eq(2)
+
+      hackr.set_stat!("clearance", 29)
+      expect(described_class.rate_for(hackr)).to eq(2)
+    end
+
+    it "returns standard rate (1) for CL >= 30" do
+      hackr.set_stat!("clearance", 30)
+      expect(described_class.rate_for(hackr)).to eq(1)
+
+      hackr.set_stat!("clearance", 99)
+      expect(described_class.rate_for(hackr)).to eq(1)
+    end
+  end
+
+  describe ".restore!" do
+    before { fund_cache(cache, 5000) }
+
+    context "room gate" do
+      it "raises NotAtRestPod when not in a rest_pod room" do
+        hackr.update!(current_room: standard_room)
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 10}])
+        }.to raise_error(described_class::NotAtRestPod)
+      end
+    end
+
+    context "validation" do
+      it "raises InvalidAllocation for empty allocs" do
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [])
+        }.to raise_error(described_class::InvalidAllocation, /No allocation/)
+      end
+
+      it "raises InvalidAllocation for unknown vital" do
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [{vital: "mana", points: 10}])
+        }.to raise_error(described_class::InvalidAllocation, /Unknown vital/)
+      end
+
+      it "raises InvalidAllocation for non-positive points" do
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 0}])
+        }.to raise_error(described_class::InvalidAllocation, /Points must be positive/)
+      end
+    end
+
+    context "full vitals" do
+      it "raises NothingToRestore when all vitals are at max" do
+        hackr.set_stat!("health", 100)
+        hackr.set_stat!("energy", 100)
+        hackr.set_stat!("psyche", 100)
+
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 50}])
+        }.to raise_error(described_class::NothingToRestore)
+      end
+    end
+
+    context "insufficient balance" do
+      it "raises InsufficientBalance pre-check when CRED is clearly short" do
+        hackr.set_stat!("health", 0)
+        # Fund only 10 CRED, try to restore 100 HP at rate 2 = 50 CRED
+        cache # already funded with 5000 above, re-fund low
+        # Drain all but 10
+        Grid::TransactionService.burn!(from_cache: cache, amount: 4990, memo: "drain")
+
+        expect {
+          described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 100}])
+        }.to raise_error(described_class::InsufficientBalance)
+      end
+    end
+
+    context "successful restoration" do
+      before do
+        hackr.set_stat!("health", 50)
+        hackr.set_stat!("energy", 70)
+        hackr.set_stat!("psyche", 40)
+        hackr.set_stat!("clearance", 10) # discounted rate: 2 pts/CRED
+      end
+
+      it "restores vitals and charges CRED" do
+        result = described_class.restore!(hackr: hackr, allocs: [
+          {vital: "health", points: 30},
+          {vital: "energy", points: 20}
+        ])
+
+        expect(hackr.stat("health")).to eq(80)
+        expect(hackr.stat("energy")).to eq(90)
+        expect(hackr.stat("psyche")).to eq(40) # unchanged
+
+        # 50 total points / rate 2 = 25 CRED
+        expect(result.total_cred_paid).to eq(25)
+      end
+
+      it "returns a Result with display HTML" do
+        result = described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 10}])
+        expect(result.display).to include("REST POD")
+        expect(result.display).to include("HEALTH")
+        expect(result.display).to include("+10")
+      end
+
+      it "burns 70% and recycles 30% of cost" do
+        described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 20}])
+        # 20 pts / rate 2 = 10 CRED. Burn = 7, recycle = 3
+        expect(burn_cache.balance).to eq(7)
+        expect(gameplay_pool.balance).to eq(3)
+      end
+
+      it "clamps allocation to actual deficit" do
+        hackr.set_stat!("health", 95) # only 5 missing
+        result = described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 50}])
+
+        expect(hackr.stat("health")).to eq(100)
+        # Clamped to 5 pts / rate 2 = ceil(2.5) = 3 CRED
+        expect(result.total_cred_paid).to eq(3)
+      end
+
+      it "skips vitals that are already full" do
+        hackr.set_stat!("health", 100)
+        hackr.set_stat!("energy", 80)
+
+        result = described_class.restore!(hackr: hackr, allocs: [
+          {vital: "health", points: 50},
+          {vital: "energy", points: 10}
+        ])
+
+        expect(hackr.stat("health")).to eq(100) # unchanged
+        expect(hackr.stat("energy")).to eq(90)
+        # Only 10 energy pts counted, health alloc skipped
+        expect(result.total_cred_paid).to eq(5) # 10 / 2
+      end
+    end
+
+    context "veteran rate (CL >= 30)" do
+      before do
+        hackr.set_stat!("health", 50)
+        hackr.set_stat!("clearance", 30) # standard rate: 1 pt/CRED
+      end
+
+      it "charges 1:1 rate" do
+        result = described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 30}])
+        expect(result.total_cred_paid).to eq(30) # 30 pts / rate 1 = 30 CRED
+        expect(hackr.stat("health")).to eq(80)
+      end
+    end
+
+    context "multi-vital allocation" do
+      before do
+        hackr.set_stat!("health", 50)
+        hackr.set_stat!("energy", 60)
+        hackr.set_stat!("psyche", 70)
+        hackr.set_stat!("clearance", 0) # rate 2
+      end
+
+      it "restores all three vitals in one call" do
+        result = described_class.restore!(hackr: hackr, allocs: [
+          {vital: "health", points: 50},
+          {vital: "energy", points: 40},
+          {vital: "psyche", points: 30}
+        ])
+
+        expect(hackr.stat("health")).to eq(100)
+        expect(hackr.stat("energy")).to eq(100)
+        expect(hackr.stat("psyche")).to eq(100)
+        # 120 total pts / rate 2 = 60 CRED
+        expect(result.total_cred_paid).to eq(60)
+      end
+    end
+
+    context "cost rounding" do
+      before do
+        hackr.set_stat!("health", 99) # 1 point deficit
+        hackr.set_stat!("clearance", 0) # rate 2
+      end
+
+      it "rounds cost up (no free healing)" do
+        result = described_class.restore!(hackr: hackr, allocs: [{vital: "health", points: 1}])
+        # 1 pt / rate 2 = ceil(0.5) = 1 CRED
+        expect(result.total_cred_paid).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
  New rest_pod room type for THE PULSE GRID. Players pay CRED to restore
  HP/EN/PS with full control over allocation. Rate: CL<30 = 2 pts/CRED
  (discounted), CL>=30 = 1 pt/CRED (standard). Auto-clamps to deficit,
  reduces cost proportionally. 70/30 burn/recycle economy split.

  Backend: Grid::RestPodService with room-type gate, TOCTOU-safe
  locking, split payment with adjust_vital rollback guard. Terminal command
  rest <amount> <vital> [...] with hp/en/ps shortcuts and full keyword
  (e.g., rest full hp full en full ps). Duplicate vital args merged.
  look shows [ REST POD ] indicator with rate. New GET /api/grid/rest_pod
  endpoint for tactical panel data. has_rest_pod in zone_map response.

  Frontend: RestPodHandle (right-edge, green #34d399) + RestPodPanel
  (slide-in, per-vital bars with point inputs, FULL/FILL ALL buttons, live
  cost preview, RESTORE confirms via terminal command). Mutual exclusion
  with vendor/transit/NPC panels.

  Admin: rest_pod added to room form select + map editor type dropdown.
  Client-side instant filter added to Rooms and Mobs index pages.