### PR TITLE
[TPG] Offer Command, Fix Shop Table Rendering

### DIFF
--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -1236,12 +1236,7 @@ class Api::GridController < ApplicationController
 
   def sell_price_for(item, vendor_listings_by_def)
     listing = vendor_listings_by_def[item.grid_item_definition_id]
-    price = if listing
-      listing.sell_price
-    else
-      (item.value * Grid::EconomyConfig::SELL_PRICE_RATIO).ceil
-    end
-    [price, 1].max
+    Grid::ShopService.sell_price_for(item: item, listing: listing)
   end
 
   def transit_journey_json(journey)

--- a/app/javascript/utils/sanitizeHtml.ts
+++ b/app/javascript/utils/sanitizeHtml.ts
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify'
 // standard formatting tags. Strips scripts, event handlers, etc.
 export function sanitizeHtml (html: string): string {
   return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['span', 'div', 'br', 'b', 'i', 'em', 'strong', 'a', 'p', 'svg', 'path', 'rect', 'circle', 'g'],
-    ALLOWED_ATTR: ['style', 'class', 'href', 'target', 'rel', 'viewBox', 'xmlns', 'd', 'fill', 'width', 'height', 'x', 'y', 'rx', 'ry', 'transform']
+    ALLOWED_TAGS: ['span', 'div', 'br', 'b', 'i', 'em', 'strong', 'a', 'p', 'table', 'tr', 'td', 'th', 'svg', 'path', 'rect', 'circle', 'g'],
+    ALLOWED_ATTR: ['style', 'class', 'href', 'target', 'rel', 'viewBox', 'xmlns', 'd', 'fill', 'width', 'height', 'x', 'y', 'rx', 'ry', 'transform', 'colspan', 'rowspan']
   })
 }

--- a/app/services/grid/command_parser.rb
+++ b/app/services/grid/command_parser.rb
@@ -119,6 +119,8 @@ module Grid
         buy_command(args&.join(" "))
       when "sell"
         sell_command(args&.join(" "))
+      when "offer", "appraise"
+        offer_command(args&.join(" "))
       when "missions", "quests"
         missions_command
       when "mission", "quest"
@@ -1135,6 +1137,7 @@ module Grid
           <span style='color: #34d399;'>shop, browse</span>               - View vendor inventory &amp; prices
           <span style='color: #34d399;'>buy [qty] &lt;item&gt;</span>            - Purchase item(s) from vendor
           <span style='color: #34d399;'>sell [qty|all] &lt;item&gt;</span>      - Sell item(s) to vendor
+          <span style='color: #34d399;'>offer &lt;item&gt;, appraise</span>     - Check what vendor will pay for an item
 
         <span style='color: #fbbf24;'>Economy:</span>
           <span style='color: #34d399;'>cache</span>                      - List your caches
@@ -2443,6 +2446,35 @@ module Grid
       "<span style='color: #fbbf24;'>#{h(e.message)}</span>"
     rescue Grid::TransactionService::InsufficientBalance
       "<span style='color: #f87171;'>The vendor can't afford to buy that right now.</span>"
+    end
+
+    def offer_command(item_name)
+      return "<span style='color: #fbbf24;'>Appraise what? Usage: offer &lt;item&gt;</span>" if item_name.blank?
+
+      room = hackr.current_room
+      return "<span style='color: #f87171;'>You are nowhere!</span>" unless room
+
+      vendor = room.grid_mobs.find_by(mob_type: "vendor")
+      return "<span style='color: #9ca3af;'>There's no vendor here.</span>" unless vendor
+
+      item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
+      return equipped_item_hint(item_name) || "<span style='color: #f87171;'>You don't have '#{h(item_name)}'.</span>" unless item
+
+      if item.unicorn? || item.value.to_i <= 0
+        return "<span style='color: #9ca3af;'>#{h(vendor.name)} has no interest in <span style='color: #{item.rarity_color};'>#{h(item.name)}</span>.</span>"
+      end
+
+      unit_sell_price = Grid::ShopService.sell_price_for(item: item, mob: vendor)
+
+      color = item.rarity_color
+      name_display = "<span style='color: #{color};'>#{h(item.name)}</span>"
+      qty_note = if item.quantity > 1
+        " <span style='color: #6b7280;'>(×#{item.quantity} = #{format_cred(unit_sell_price * item.quantity)} CRED)</span>"
+      else
+        ""
+      end
+
+      "<span style='color: #22d3ee;'>#{h(vendor.name)}</span> offers <span style='color: #fbbf24;'>#{format_cred(unit_sell_price)} CRED</span> for #{name_display}.#{qty_note}"
     end
 
     # --- Economy commands ---

--- a/app/services/grid/shop_service.rb
+++ b/app/services/grid/shop_service.rb
@@ -97,16 +97,10 @@ module Grid
       item = Grid::NameResolver.resolve(hackr.grid_items.in_inventory(hackr), item_name)
       raise ItemNotFound, "You don't have '#{item_name}'" unless item
 
-      # Find matching listing for sell price, or use item.value * SELL_PRICE_RATIO
       listing = mob.grid_shop_listings.joins(:grid_item_definition)
         .where("LOWER(grid_item_definitions.name) = ?", item.name.downcase)
         .first
-      unit_sell_price = if listing
-        listing.sell_price
-      else
-        (item.value * EconomyConfig::SELL_PRICE_RATIO).ceil
-      end
-      unit_sell_price = [unit_sell_price, 1].max # minimum 1 CRED
+      unit_sell_price = sell_price_for(item: item, listing: listing)
 
       cache = hackr.default_cache
       raise AccessDenied, "You need a cache to receive CRED" unless cache
@@ -163,6 +157,19 @@ module Grid
       else
         listing.base_price
       end
+    end
+
+    # Compute what a vendor would pay for an item.
+    # Pass listing: if already fetched, or mob: to look it up.
+    def self.sell_price_for(item:, listing: nil, mob: nil)
+      if listing.nil? && mob
+        listing = mob.grid_shop_listings.joins(:grid_item_definition)
+          .where("LOWER(grid_item_definitions.name) = ?", item.name.downcase)
+          .first
+      end
+
+      price = listing ? listing.sell_price : (item.value * EconomyConfig::SELL_PRICE_RATIO).ceil
+      [price, 1].max
     end
 
     # Restock a vendor's limited-stock listings


### PR DESCRIPTION
DOMPurify was stripping `<table>` tags from shop output — added table/tr/td/th to sanitizeHtml allowlist. New `offer`/`appraise` command shows what a vendor will pay for an item before committing to sell. Extracted sell-price logic into ShopService.sell_price_for to eliminate three-way duplication.