### PR TITLE
Observability: err tracking, struct'd log, perf monitoring, analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "paper_trail"
 # Rate limiting and request throttling
 gem "rack-attack"
 
+# Structured request logging (single-line JSON per request)
+gem "lograge"
+
 # AWS S3 for audio file imports
 gem "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,11 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -445,6 +450,7 @@ DEPENDENCIES
   faraday-retry
   image_processing (~> 1.2)
   jbuilder
+  lograge
   obscenity
   octokit
   paper_trail

--- a/app/controllers/admin/analytics_dashboard_controller.rb
+++ b/app/controllers/admin/analytics_dashboard_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Admin::AnalyticsDashboardController < Admin::ApplicationController
+  VALID_RANGES = {"7" => 7, "30" => 30, "90" => 90, "0" => 0}.freeze
+  DEFAULT_RANGE = 30
+
+  def index
+    range_days = VALID_RANGES.fetch(params[:range], DEFAULT_RANGE)
+    svc = Analytics::GridMetricsService.new(range_days: range_days)
+
+    @range_days = range_days
+    @user_metrics = svc.user_metrics
+    @feature_usage = svc.feature_usage
+    @tutorial_funnel = svc.tutorial_funnel
+    @session_metrics = svc.session_metrics
+    @registrations_by_day = svc.registrations_by_day(days: [range_days, 30].max.clamp(7, 90))
+    @activity_by_day = svc.activity_by_day(days: [range_days, 30].max.clamp(7, 90))
+    @analytics_event_count = svc.analytics_event_count
+    @perf_summary = svc.perf_summary
+  end
+end

--- a/app/controllers/admin/error_groups_controller.rb
+++ b/app/controllers/admin/error_groups_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Admin::ErrorGroupsController < Admin::ApplicationController
+  PER_PAGE = 50
+
+  before_action :set_error_group, only: %i[show resolve ignore reopen]
+
+  # GET /root/error_groups
+  def index
+    @error_groups = ErrorGroup.newest_first
+
+    # Filters
+    if params[:status].present? && ErrorGroup::STATUSES.include?(params[:status])
+      @error_groups = @error_groups.where(status: params[:status])
+    end
+    @error_groups = @error_groups.for_component(params[:component])
+    @error_groups = @error_groups.for_severity(params[:severity])
+
+    if params[:search].present?
+      escaped = ActiveRecord::Base.sanitize_sql_like(params[:search])
+      @error_groups = @error_groups.where("title LIKE ?", "%#{escaped}%")
+    end
+
+    # Pagination
+    @per_page = PER_PAGE
+    @offset = [params[:offset].to_i, 0].max
+    @total_count = @error_groups.count
+    @error_groups = @error_groups.offset(@offset).limit(@per_page)
+
+    # Trend data: occurrence counts in last 24h for displayed groups
+    group_ids = @error_groups.map(&:id)
+    @trends_24h = ErrorOccurrence
+      .where(error_group_id: group_ids)
+      .where("occurred_at >= ?", 24.hours.ago)
+      .group(:error_group_id)
+      .count
+  end
+
+  # GET /root/error_groups/:id
+  def show
+    @per_page = 50
+    @offset = [params[:offset].to_i, 0].max
+    @occurrences = @error_group.error_occurrences.newest_first
+    @total_occurrences = @occurrences.count
+    @occurrences = @occurrences.offset(@offset).limit(@per_page)
+  end
+
+  # POST /root/error_groups/:id/resolve
+  def resolve
+    @error_group.resolve!(current_hackr)
+    set_flash_success "Error group resolved."
+    redirect_to admin_error_groups_path
+  end
+
+  # POST /root/error_groups/:id/ignore
+  def ignore
+    duration = params[:duration].to_s
+    until_time = case duration
+    when "1h" then 1.hour.from_now
+    when "24h" then 24.hours.from_now
+    when "7d" then 7.days.from_now
+    when "30d" then 30.days.from_now
+    when "forever" then nil
+    else 24.hours.from_now
+    end
+
+    @error_group.ignore!(until_time)
+    label = until_time ? "until #{until_time.strftime("%Y-%m-%d %H:%M")}" : "permanently"
+    set_flash_success "Error group ignored #{label}."
+    redirect_to admin_error_groups_path
+  end
+
+  # POST /root/error_groups/:id/reopen
+  def reopen
+    @error_group.reopen!
+    set_flash_success "Error group reopened."
+    redirect_to admin_error_groups_path
+  end
+
+  private
+
+  def set_error_group
+    @error_group = ErrorGroup.find(params[:id])
+  end
+end

--- a/app/controllers/admin/pulse_wire_controller.rb
+++ b/app/controllers/admin/pulse_wire_controller.rb
@@ -26,12 +26,20 @@ class Admin::PulseWireController < Admin::ApplicationController
       @pulses = @pulses.where("content LIKE ?", "%#{params[:search]}%")
     end
 
-    # Filter by date range
+    # Filter by date range (use beginning/end of day for timezone-safe boundaries)
     if params[:start_date].present?
-      @pulses = @pulses.where("pulsed_at >= ?", params[:start_date])
+      begin
+        @pulses = @pulses.where("pulsed_at >= ?", Date.parse(params[:start_date]).beginning_of_day)
+      rescue ArgumentError
+        # ignore malformed date
+      end
     end
     if params[:end_date].present?
-      @pulses = @pulses.where("pulsed_at <= ?", params[:end_date])
+      begin
+        @pulses = @pulses.where("pulsed_at <= ?", Date.parse(params[:end_date]).end_of_day)
+      rescue ArgumentError
+        # ignore malformed date
+      end
     end
   end
 

--- a/app/controllers/api/analytics_controller.rb
+++ b/app/controllers/api/analytics_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  class AnalyticsController < ApplicationController
+    # sendBeacon does not send CSRF tokens
+    protect_from_forgery with: :null_session
+
+    MAX_BATCH_SIZE = 50
+
+    # POST /api/analytics/events
+    def create_batch
+      events = params[:events]
+
+      unless events.is_a?(Array) && events.size.between?(1, MAX_BATCH_SIZE)
+        return head :bad_request
+      end
+
+      now = Time.current
+      rows = events.first(MAX_BATCH_SIZE).filter_map do |e|
+        event_type = e[:event_type].to_s
+        next unless AnalyticsEvent::EVENT_TYPES.include?(event_type)
+
+        {
+          event_type: event_type,
+          event_name: e[:event_name].to_s.first(100),
+          hackr_id: current_hackr&.id,
+          session_id: e[:session_id].to_s.first(36),
+          properties: (e[:properties].respond_to?(:to_unsafe_h) ? e[:properties].to_unsafe_h.to_json : e[:properties].to_s).truncate(2000),
+          created_at: now
+        }
+      end
+
+      AnalyticsEvent.insert_all(rows) if rows.any?
+
+      head :no_content
+    end
+  end
+end

--- a/app/controllers/api/error_reports_controller.rb
+++ b/app/controllers/api/error_reports_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  class ErrorReportsController < ApplicationController
+    # sendBeacon does not send CSRF tokens — null_session accepts the
+    # request without inheriting session state (current_hackr may be nil).
+    protect_from_forgery with: :null_session
+
+    # POST /api/error_report
+    def create
+      ErrorTracker.track_frontend(
+        payload: error_params,
+        request: request,
+        hackr: current_hackr
+      )
+
+      # Always return success — never expose internal state to callers
+      render json: {success: true}, status: :ok
+    end
+
+    private
+
+    def error_params
+      params.permit(:message, :source, :lineno, :colno, :stack, :type, :url)
+    end
+  end
+end

--- a/app/controllers/api/perf_controller.rb
+++ b/app/controllers/api/perf_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  class PerfController < ApplicationController
+    # sendBeacon does not send CSRF tokens
+    protect_from_forgery with: :null_session
+
+    MAX_BATCH_SIZE = 50
+
+    # POST /api/perf/metrics
+    def create
+      metrics = params[:metrics]
+
+      unless metrics.is_a?(Array) && metrics.size.between?(1, MAX_BATCH_SIZE)
+        return render json: {error: "invalid payload"}, status: :bad_request
+      end
+
+      rows = metrics.filter_map do |m|
+        name = m[:metric_name].to_s
+        type = m[:metric_type].to_s
+        next unless PerformanceMetric::VALID_METRIC_NAMES.include?(name)
+        next unless PerformanceMetric::VALID_METRIC_TYPES.include?(type)
+
+        {
+          metric_name: name,
+          metric_type: type,
+          value: m[:value].to_f,
+          unit: m[:unit].to_s.presence_in(%w[ms score]) || "ms",
+          page_path: m[:page_path].to_s.first(255),
+          session_id: m[:session_id].to_s.first(64),
+          hackr_id: current_hackr&.id,
+          connection_type: m[:connection_type].to_s.first(32).presence,
+          device_class: m[:device_class].to_s.first(16).presence,
+          created_at: Time.current,
+          updated_at: Time.current
+        }
+      end
+
+      PerformanceMetric.insert_all(rows) if rows.any?
+
+      render json: {received: rows.size}, status: :created
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include RequestAnalysis
   include GridAuthentication
   include CoverUrlHelpers
+  include StructuredLogging
 
   protect_from_forgery with: :exception, unless: :api_token_request?
 

--- a/app/controllers/concerns/structured_logging.rb
+++ b/app/controllers/concerns/structured_logging.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StructuredLogging
+  extend ActiveSupport::Concern
+
+  # Injects hackr identity into the lograge payload via the standard
+  # Rails append_info_to_payload hook. This data is available in
+  # event.payload inside lograge's custom_options block.
+  def append_info_to_payload(payload)
+    super
+    hackr = current_hackr
+    payload[:hackr_id] = hackr&.id
+    payload[:hackr_alias] = hackr&.hackr_alias
+  end
+end

--- a/app/javascript/components/errors/ErrorBoundary.tsx
+++ b/app/javascript/components/errors/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, ReactNode } from 'react'
+import { reportError } from '~/services/errorReporter'
 
 interface Props {
   children: ReactNode
@@ -27,6 +28,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch (error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
+    reportError(error, errorInfo)
     this.setState({
       error,
       errorInfo

--- a/app/javascript/entrypoints/application.tsx
+++ b/app/javascript/entrypoints/application.tsx
@@ -9,9 +9,15 @@ import { GridAuthProvider } from '~/contexts/GridAuthContext'
 import { AppLayout } from '~/components/layouts/AppLayout'
 import { ErrorBoundary } from '~/components/errors/ErrorBoundary'
 import { LowercaseRedirect } from '~/components/routing/LowercaseRedirect'
+import { initErrorReporter } from '~/services/errorReporter'
+import { initPerfCollector } from '~/utils/perfCollector'
+import { startAnalyticsCollector } from '~/utils/analyticsCollector'
 
 // Mount React SPA when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
+  initErrorReporter()
+  initPerfCollector()
+  startAnalyticsCollector()
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content')
   if (csrfToken) {
     const originalFetch = window.fetch.bind(window)

--- a/app/javascript/services/errorReporter.ts
+++ b/app/javascript/services/errorReporter.ts
@@ -1,0 +1,96 @@
+// Frontend error reporter. Captures unhandled JS errors, unhandled Promise
+// rejections, and React ErrorBoundary catches. Reports to /api/error_report.
+//
+// Usage:
+//   import { initErrorReporter, reportError } from '~/services/errorReporter'
+//   initErrorReporter()                    // once, in application.tsx
+//   reportError(error, errorInfo)          // from ErrorBoundary.componentDidCatch
+
+const ENDPOINT = '/api/error_report'
+const MAX_IDENTICAL_REPORTS = 5
+
+interface ErrorReport {
+  message: string
+  source?: string
+  lineno?: number
+  colno?: number
+  stack?: string
+  type: 'global' | 'unhandled_rejection' | 'boundary'
+  url: string
+}
+
+const recentFingerprints = new Map<string, number>()
+
+function fingerprint (message: string, source?: string, lineno?: number): string {
+  return `${message}:${source || ''}:${lineno || 0}`
+}
+
+function shouldReport (fp: string): boolean {
+  const count = recentFingerprints.get(fp) || 0
+  if (count >= MAX_IDENTICAL_REPORTS) return false
+  recentFingerprints.set(fp, count + 1)
+
+  // Cap map size to prevent unbounded growth in long sessions
+  if (recentFingerprints.size > 100) {
+    const firstKey = recentFingerprints.keys().next().value
+    if (firstKey !== undefined) recentFingerprints.delete(firstKey)
+  }
+
+  return true
+}
+
+function send (report: ErrorReport): void {
+  const fp = fingerprint(report.message, report.source, report.lineno)
+  if (!shouldReport(fp)) return
+
+  try {
+    fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(report),
+      keepalive: true
+    }).catch(() => {
+      // Silently ignore — error reporting must never cause errors
+    })
+  } catch {
+    // fetch itself may throw in some environments
+  }
+}
+
+export function initErrorReporter (): void {
+  // Global JS errors
+  window.onerror = (message, source, lineno, colno, error) => {
+    send({
+      message: String(message),
+      source,
+      lineno: lineno || undefined,
+      colno: colno || undefined,
+      stack: error?.stack,
+      type: 'global',
+      url: window.location.href
+    })
+    return false // let default handler run
+  }
+
+  // Unhandled Promise rejections
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason
+    send({
+      message: reason?.message || String(reason),
+      stack: reason?.stack,
+      type: 'unhandled_rejection',
+      url: window.location.href
+    })
+  })
+}
+
+// Called from ErrorBoundary.componentDidCatch
+export function reportError (error: Error, errorInfo?: { componentStack?: string | null }): void {
+  send({
+    message: error.message,
+    stack: error.stack,
+    type: 'boundary',
+    url: window.location.href,
+    source: errorInfo?.componentStack?.split('\n')[1]?.trim()
+  })
+}

--- a/app/javascript/utils/analyticsCollector.ts
+++ b/app/javascript/utils/analyticsCollector.ts
@@ -1,0 +1,87 @@
+// Frontend analytics event collector. Batches events in memory and
+// sends them to /api/analytics/events every 45s or on page unload
+// via sendBeacon.
+//
+// Usage:
+//   import { trackEvent } from '~/utils/analyticsCollector'
+//   trackEvent('panel_open', 'breach_panel')
+//   trackEvent('command_entered', 'exec', { program: 'trace-killer' })
+
+const FLUSH_INTERVAL_MS = 45_000
+const BATCH_ENDPOINT = '/api/analytics/events'
+const SESSION_KEY = 'hackr_analytics_session_id'
+
+type EventType =
+  | 'page_view' | 'feature_click' | 'button_click'
+  | 'panel_open' | 'panel_close' | 'command_entered'
+  | 'session_start' | 'session_end'
+
+interface AnalyticsEvent {
+  event_type: EventType
+  event_name: string
+  session_id: string
+  properties?: Record<string, unknown>
+}
+
+const queue: AnalyticsEvent[] = []
+let initialized = false
+
+function getOrCreateSessionId (): string {
+  let id = sessionStorage.getItem(SESSION_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    sessionStorage.setItem(SESSION_KEY, id)
+  }
+  return id
+}
+
+export function trackEvent (
+  eventType: EventType,
+  eventName: string,
+  properties?: Record<string, unknown>
+): void {
+  queue.push({
+    event_type: eventType,
+    event_name: eventName,
+    session_id: getOrCreateSessionId(),
+    properties
+  })
+}
+
+function flushBeacon (): void {
+  while (queue.length > 0) {
+    const batch = queue.splice(0, 50)
+    try {
+      navigator.sendBeacon(
+        BATCH_ENDPOINT,
+        new Blob([JSON.stringify({ events: batch })], { type: 'application/json' })
+      )
+    } catch {
+      // sendBeacon may fail in some environments
+      break
+    }
+  }
+}
+
+function flushFetch (): void {
+  if (queue.length === 0) return
+  const batch = queue.splice(0, 50)
+  fetch(BATCH_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ events: batch }),
+    keepalive: true
+  }).catch(() => { /* telemetry failures are non-critical */ })
+}
+
+export function startAnalyticsCollector (): void {
+  if (initialized) return
+  initialized = true
+
+  trackEvent('session_start', 'app_loaded')
+  setInterval(flushFetch, FLUSH_INTERVAL_MS)
+  window.addEventListener('pagehide', flushBeacon, { once: true })
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flushBeacon()
+  })
+}

--- a/app/javascript/utils/perfCollector.ts
+++ b/app/javascript/utils/perfCollector.ts
@@ -1,0 +1,111 @@
+// Performance metrics collector. Captures Core Web Vitals via web-vitals
+// library and custom component render timing. Batches and sends to
+// /api/perf/metrics every 30s or on page unload via sendBeacon.
+
+import { onLCP, onINP, onCLS, onFCP, onTTFB } from 'web-vitals'
+
+interface PerfMetric {
+  metric_name: string
+  metric_type: 'web_vital' | 'component' | 'navigation'
+  value: number
+  unit: 'ms' | 'score'
+  page_path: string
+  session_id: string
+  connection_type?: string
+  device_class?: string
+}
+
+const ENDPOINT = '/api/perf/metrics'
+const FLUSH_INTERVAL_MS = 30_000
+const MAX_BUFFER = 100
+
+let buffer: PerfMetric[] = []
+let initialized = false
+const sessionId = generateSessionId()
+
+function generateSessionId (): string {
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36)
+}
+
+function getConnectionType (): string | undefined {
+  const nav = navigator as Navigator & { connection?: { effectiveType?: string } }
+  return nav.connection?.effectiveType
+}
+
+function getDeviceClass (): 'mobile' | 'desktop' {
+  return /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop'
+}
+
+function enqueue (metric: Omit<PerfMetric, 'session_id' | 'page_path' | 'connection_type' | 'device_class'>): void {
+  if (buffer.length >= MAX_BUFFER) return
+  buffer.push({
+    ...metric,
+    page_path: window.location.pathname,
+    session_id: sessionId,
+    connection_type: getConnectionType(),
+    device_class: getDeviceClass()
+  })
+}
+
+function flush (useBeacon = false): void {
+  if (buffer.length === 0) return
+  const payload = JSON.stringify({ metrics: buffer.splice(0) })
+
+  if (useBeacon && navigator.sendBeacon) {
+    navigator.sendBeacon(ENDPOINT, new Blob([payload], { type: 'application/json' }))
+  } else {
+    fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true
+    }).catch(() => { /* perf data is non-critical */ })
+  }
+}
+
+export function initPerfCollector (): void {
+  if (initialized) return
+  initialized = true
+
+  // Core Web Vitals
+  onLCP(({ value }) => enqueue({ metric_name: 'LCP', metric_type: 'web_vital', value: Math.round(value), unit: 'ms' }))
+  onINP(({ value }) => enqueue({ metric_name: 'INP', metric_type: 'web_vital', value: Math.round(value), unit: 'ms' }))
+  onCLS(({ value }) => enqueue({ metric_name: 'CLS', metric_type: 'web_vital', value: parseFloat(value.toFixed(4)), unit: 'score' }))
+  onFCP(({ value }) => enqueue({ metric_name: 'FCP', metric_type: 'web_vital', value: Math.round(value), unit: 'ms' }))
+  onTTFB(({ value }) => enqueue({ metric_name: 'TTFB', metric_type: 'web_vital', value: Math.round(value), unit: 'ms' }))
+
+  // Periodic flush
+  setInterval(() => flush(), FLUSH_INTERVAL_MS)
+
+  // Flush on page unload/background
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flush(true)
+  })
+  window.addEventListener('pagehide', () => flush(true), { once: true })
+}
+
+// Measure component render/transition timing. Place performance.mark calls
+// around the operation, then call this to record it.
+//
+//   performance.mark('zone_map_render_start')
+//   // ... render ...
+//   performance.mark('zone_map_render_end')
+//   measureComponent('zone_map_render', 'zone_map_render_start', 'zone_map_render_end')
+//
+export function measureComponent (name: string, startMark: string, endMark: string): void {
+  try {
+    const measure = performance.measure(name, startMark, endMark)
+    enqueue({
+      metric_name: name,
+      metric_type: 'component',
+      value: Math.round(measure.duration),
+      unit: 'ms'
+    })
+    // Clean up marks
+    performance.clearMarks(startMark)
+    performance.clearMarks(endMark)
+    performance.clearMeasures(name)
+  } catch {
+    // marks may not exist in test environments
+  }
+}

--- a/app/jobs/error_tracker/retention_job.rb
+++ b/app/jobs/error_tracker/retention_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ErrorTracker
+  # Purges error occurrences older than the retention period.
+  # Groups are preserved — occurrence_count is a lifetime total (intentional).
+  # Errors propagate to Solid Queue for retry/reporting.
+  class RetentionJob < ApplicationJob
+    queue_as :default
+
+    MIN_RETENTION = 7
+
+    def perform
+      days = [ENV.fetch("ERROR_TRACKER_RETENTION_DAYS", "90").to_i, MIN_RETENTION].max
+      deleted = ErrorOccurrence.older_than(days).delete_all
+      Rails.logger.info "[ErrorTracker::RetentionJob] Purged #{deleted} occurrences older than #{days} days"
+    end
+  end
+end

--- a/app/jobs/telemetry_prune_job.rb
+++ b/app/jobs/telemetry_prune_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Prunes old performance metrics and analytics events from the telemetry DB.
+# Errors propagate to Solid Queue for retry/reporting.
+class TelemetryPruneJob < ApplicationJob
+  queue_as :default
+
+  MIN_RETENTION = 7
+
+  def perform
+    perf_days = [ENV.fetch("PERF_METRICS_RETENTION_DAYS", "30").to_i, MIN_RETENTION].max
+    analytics_days = [ENV.fetch("ANALYTICS_RETENTION_DAYS", "90").to_i, MIN_RETENTION].max
+
+    perf_deleted = PerformanceMetric.older_than(perf_days).delete_all
+    analytics_deleted = AnalyticsEvent.older_than(analytics_days).delete_all
+
+    Rails.logger.info "[TelemetryPruneJob] Purged #{perf_deleted} perf metrics (>#{perf_days}d), " \
+                      "#{analytics_deleted} analytics events (>#{analytics_days}d)"
+  end
+end

--- a/app/models/analytics_event.rb
+++ b/app/models/analytics_event.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: analytics_events
+# Database name: telemetry
+#
+#  id         :integer          not null, primary key
+#  event_name :string           not null
+#  event_type :string           not null
+#  properties :text
+#  created_at :datetime         not null
+#  hackr_id   :integer
+#  session_id :string(36)       not null
+#
+# Indexes
+#
+#  index_analytics_events_on_created_at  (created_at)
+#  index_analytics_events_on_event_type  (event_type)
+#  index_analytics_events_on_session_id  (session_id)
+#
+class AnalyticsEvent < TelemetryRecord
+  EVENT_TYPES = %w[page_view feature_click button_click panel_open panel_close
+    command_entered session_start session_end].freeze
+
+  validates :event_type, inclusion: {in: EVENT_TYPES}
+  validates :event_name, :session_id, presence: true
+
+  scope :older_than, ->(days) { where("created_at < ?", days.days.ago) }
+end

--- a/app/models/error_group.rb
+++ b/app/models/error_group.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: error_groups
+# Database name: primary
+#
+#  id                   :integer          not null, primary key
+#  component            :string           not null
+#  fingerprint          :string           not null
+#  first_seen_at        :datetime
+#  ignore_until         :datetime
+#  last_seen_at         :datetime
+#  occurrence_count     :integer          default(0), not null
+#  resolved_at          :datetime
+#  severity             :string           default("error"), not null
+#  status               :string           default("open"), not null
+#  title                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  resolved_by_hackr_id :integer
+#
+# Indexes
+#
+#  index_error_groups_on_component                (component)
+#  index_error_groups_on_fingerprint              (fingerprint) UNIQUE
+#  index_error_groups_on_severity                 (severity)
+#  index_error_groups_on_status_and_last_seen_at  (status,last_seen_at)
+#
+class ErrorGroup < ApplicationRecord
+  STATUSES = %w[open resolved ignored].freeze
+  COMPONENTS = %w[backend frontend].freeze
+  SEVERITIES = %w[error warning info].freeze
+
+  has_many :error_occurrences, dependent: :destroy
+  belongs_to :resolved_by_hackr, class_name: "GridHackr", optional: true
+
+  validates :fingerprint, presence: true, uniqueness: true
+  validates :title, presence: true
+  validates :component, inclusion: {in: COMPONENTS}
+  validates :severity, inclusion: {in: SEVERITIES}
+  validates :status, inclusion: {in: STATUSES}
+
+  scope :open_status, -> { where(status: "open") }
+  scope :resolved, -> { where(status: "resolved") }
+  scope :ignored, -> { where(status: "ignored") }
+  scope :for_component, ->(c) { where(component: c) if c.present? }
+  scope :for_severity, ->(s) { where(severity: s) if s.present? }
+  scope :newest_first, -> { order(last_seen_at: :desc) }
+
+  def effective_status
+    if status == "ignored" && ignore_until.present? && ignore_until < Time.current
+      "open"
+    else
+      status
+    end
+  end
+
+  def ignore_expired?
+    status == "ignored" && ignore_until.present? && ignore_until < Time.current
+  end
+
+  def resolve!(hackr)
+    update!(status: "resolved", resolved_at: Time.current, resolved_by_hackr: hackr)
+  end
+
+  def ignore!(until_time = nil)
+    update!(status: "ignored", ignore_until: until_time)
+  end
+
+  def reopen!
+    update!(status: "open", resolved_at: nil, resolved_by_hackr: nil, ignore_until: nil)
+  end
+end

--- a/app/models/error_occurrence.rb
+++ b/app/models/error_occurrence.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: error_occurrences
+# Database name: primary
+#
+#  id              :integer          not null, primary key
+#  backtrace       :text
+#  component       :string           not null
+#  exception_class :string
+#  hackr_alias     :string
+#  ip_address      :string
+#  message         :string           not null
+#  metadata        :text
+#  occurred_at     :datetime         not null
+#  rails_env       :string
+#  request_method  :string
+#  request_params  :text
+#  request_url     :string
+#  user_agent      :string
+#  created_at      :datetime         not null
+#  error_group_id  :integer          not null
+#  hackr_id        :integer
+#
+# Indexes
+#
+#  index_error_occurrences_on_error_group_id                  (error_group_id)
+#  index_error_occurrences_on_error_group_id_and_occurred_at  (error_group_id,occurred_at DESC)
+#  index_error_occurrences_on_occurred_at                     (occurred_at)
+#
+# Foreign Keys
+#
+#  error_group_id  (error_group_id => error_groups.id)
+#
+class ErrorOccurrence < ApplicationRecord
+  belongs_to :error_group
+
+  scope :newest_first, -> { order(occurred_at: :desc) }
+  scope :older_than, ->(days) { where("occurred_at < ?", days.days.ago) }
+
+  def parsed_backtrace
+    return [] if backtrace.blank?
+    JSON.parse(backtrace)
+  rescue JSON::ParserError
+    []
+  end
+
+  def parsed_metadata
+    return {} if metadata.blank?
+    JSON.parse(metadata)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def parsed_request_params
+    return {} if request_params.blank?
+    JSON.parse(request_params)
+  rescue JSON::ParserError
+    {}
+  end
+end

--- a/app/models/performance_metric.rb
+++ b/app/models/performance_metric.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: performance_metrics
+# Database name: telemetry
+#
+#  id              :integer          not null, primary key
+#  connection_type :string(32)
+#  device_class    :string(16)
+#  metric_name     :string           not null
+#  metric_type     :string           not null
+#  page_path       :string           not null
+#  unit            :string           not null
+#  value           :float            not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  hackr_id        :integer
+#  session_id      :string(64)
+#
+# Indexes
+#
+#  index_performance_metrics_on_created_at   (created_at)
+#  index_performance_metrics_on_metric_name  (metric_name)
+#
+class PerformanceMetric < TelemetryRecord
+  VALID_METRIC_NAMES = %w[LCP INP CLS FCP TTFB zone_map_render panel_open page_nav].freeze
+  VALID_METRIC_TYPES = %w[web_vital component navigation].freeze
+
+  validates :metric_name, inclusion: {in: VALID_METRIC_NAMES}
+  validates :metric_type, inclusion: {in: VALID_METRIC_TYPES}
+  validates :value, presence: true, numericality: true
+  validates :unit, inclusion: {in: %w[ms score]}
+  validates :page_path, presence: true, length: {maximum: 255}
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :web_vitals, -> { where(metric_type: "web_vital") }
+  scope :slow_renders, -> { where(metric_name: "zone_map_render").where("value > ?", 500) }
+  scope :older_than, ->(days) { where("created_at < ?", days.days.ago) }
+end

--- a/app/models/telemetry_record.rb
+++ b/app/models/telemetry_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Abstract base class for models stored in the telemetry SQLite database.
+# Isolates high-frequency perf + analytics writes from the primary DB.
+class TelemetryRecord < ApplicationRecord
+  self.abstract_class = true
+
+  connects_to database: {writing: :telemetry, reading: :telemetry}
+end

--- a/app/services/analytics/grid_metrics_service.rb
+++ b/app/services/analytics/grid_metrics_service.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+module Analytics
+  # Computes analytics metrics from existing hackr.tv data tables.
+  # All queries are cached via Solid Cache with configurable TTL.
+  class GridMetricsService
+    CACHE_TTL = ENV.fetch("ANALYTICS_CACHE_TTL_MINUTES", "10").to_i.minutes
+    CACHE_NS = "analytics_v1"
+
+    def initialize(range_days:)
+      @range_days = range_days
+      @since = (range_days == 0) ? nil : range_days.days.ago
+    end
+
+    def user_metrics
+      fetch_cached("user_metrics") { compute_user_metrics }
+    end
+
+    def feature_usage
+      fetch_cached("feature_usage") { compute_feature_usage }
+    end
+
+    def tutorial_funnel
+      fetch_cached("tutorial_funnel") { compute_tutorial_funnel }
+    end
+
+    def session_metrics
+      fetch_cached("session_metrics") { compute_session_metrics }
+    end
+
+    def registrations_by_day(days: 30)
+      fetch_cached("registrations_by_day_#{days}") { compute_time_series(:created_at, days) }
+    end
+
+    def activity_by_day(days: 30)
+      fetch_cached("activity_by_day_#{days}") { compute_time_series(:last_activity_at, days) }
+    end
+
+    def analytics_event_count
+      fetch_cached("analytics_event_count") { AnalyticsEvent.count }
+    end
+
+    def perf_summary
+      fetch_cached("perf_summary") { compute_perf_summary }
+    end
+
+    private
+
+    def fetch_cached(key, &block)
+      Rails.cache.fetch("#{CACHE_NS}/#{key}/#{@since&.to_i || 0}", expires_in: CACHE_TTL, &block)
+    end
+
+    def compute_user_metrics
+      dau = GridHackr.where("last_activity_at >= ?", 1.day.ago).count
+      wau = GridHackr.where("last_activity_at >= ?", 7.days.ago).count
+      mau = GridHackr.where("last_activity_at >= ?", 30.days.ago).count
+      total = GridHackr.count
+
+      returning = GridHackr
+        .where("last_activity_at >= ?", 30.days.ago)
+        .where("created_at < ?", 30.days.ago)
+        .count
+      new_30d = GridHackr.where("created_at >= ?", 30.days.ago).count
+
+      {dau: dau, wau: wau, mau: mau, total: total, returning_30d: returning, new_30d: new_30d}
+    end
+
+    def compute_feature_usage
+      top_rooms = GridRoomVisit
+        .joins("INNER JOIN grid_rooms ON grid_rooms.id = grid_room_visits.grid_room_id")
+        .joins("INNER JOIN grid_zones ON grid_zones.id = grid_rooms.grid_zone_id")
+        .select("grid_rooms.name AS room_name, grid_zones.name AS zone_name, COUNT(*) AS visit_count")
+        .then { |q| @since ? q.where("grid_room_visits.first_visited_at >= ?", @since) : q }
+        .group("grid_room_visits.grid_room_id")
+        .order("visit_count DESC")
+        .limit(10)
+        .map { |r| {name: "#{r.room_name} (#{r.zone_name})", count: r.visit_count} }
+
+      top_tracks = GridHackrTrackPlay
+        .joins("INNER JOIN tracks ON tracks.id = grid_hackr_track_plays.track_id")
+        .joins("INNER JOIN artists ON artists.id = tracks.artist_id")
+        .select("tracks.title, artists.name AS artist_name, SUM(grid_hackr_track_plays.play_count) AS total_plays")
+        .then { |q| @since ? q.where("grid_hackr_track_plays.first_played_at >= ?", @since) : q }
+        .group("grid_hackr_track_plays.track_id")
+        .order("total_plays DESC")
+        .limit(10)
+        .map { |r| {name: "#{r.title} — #{r.artist_name}", count: r.total_plays} }
+
+      breach_scope = GridHackrBreach.then { |q| @since ? q.where("started_at >= ?", @since) : q }
+      breach_attempts = breach_scope.count
+      breach_successes = breach_scope.where(state: "success").count
+
+      shop_scope = GridShopTransaction.then { |q| @since ? q.where("created_at >= ?", @since) : q }
+      shop_buys = shop_scope.where(transaction_type: "buy").count
+      shop_sells = shop_scope.where(transaction_type: "sell").count
+
+      mission_scope = GridHackrMission.then { |q| @since ? q.where("accepted_at >= ?", @since) : q }
+      mission_accepted = mission_scope.count
+      mission_completions = mission_scope.where(status: "completed").count
+
+      {
+        top_rooms: top_rooms,
+        top_tracks: top_tracks,
+        breach_attempts: breach_attempts,
+        breach_successes: breach_successes,
+        breach_success_rate: (breach_attempts > 0) ? (breach_successes.to_f / breach_attempts * 100).round(1) : 0,
+        shop_buys: shop_buys,
+        shop_sells: shop_sells,
+        mission_accepted: mission_accepted,
+        mission_completions: mission_completions,
+        mission_completion_rate: (mission_accepted > 0) ? (mission_completions.to_f / mission_accepted * 100).round(1) : 0
+      }
+    end
+
+    def compute_tutorial_funnel
+      hackrs_with_tutorial = GridHackr.where("json_extract(stats, '$.tutorial_step') IS NOT NULL")
+      total_started = hackrs_with_tutorial.count
+      return {total_started: 0, step_counts: [], drop_off_step: nil} if total_started.zero?
+
+      step_counts = GridHackr
+        .where("json_extract(stats, '$.tutorial_step') IS NOT NULL")
+        .group("json_extract(stats, '$.tutorial_step')")
+        .order(Arel.sql("json_extract(stats, '$.tutorial_step') ASC"))
+        .count("id")
+        .transform_keys { |k| k.to_i }
+        .sort_by { |step, _| step }
+
+      # Completed = step 53 (final step)
+      completed = step_counts.find { |s, _| s >= 53 }&.last || 0
+
+      # Largest step-over-step drop: find consecutive pair with biggest count decrease
+      drop_off_step = nil
+      if step_counts.size > 1
+        max_drop = 0
+        step_counts.each_cons(2) do |(step_a, count_a), (step_b, count_b)|
+          next if step_a >= 53
+          drop = count_a - count_b
+          if drop > max_drop
+            max_drop = drop
+            drop_off_step = step_a
+          end
+        end
+      end
+
+      {total_started: total_started, completed: completed, step_counts: step_counts, drop_off_step: drop_off_step}
+    end
+
+    def compute_session_metrics
+      base = TerminalSession.where.not(duration_seconds: nil)
+      base = base.where("connected_at >= ?", @since) if @since
+
+      avg_duration = base.average(:duration_seconds)&.to_i || 0
+      total_sessions = base.count
+      unique_users = base.where.not(grid_hackr_id: nil).distinct.count(:grid_hackr_id)
+      avg_sessions_per_user = (unique_users > 0) ? (total_sessions.to_f / unique_users).round(1) : 0
+
+      {avg_duration_seconds: avg_duration, total_sessions: total_sessions,
+       unique_users: unique_users, avg_sessions_per_user: avg_sessions_per_user}
+    end
+
+    ALLOWED_TIME_SERIES_COLUMNS = %w[created_at last_activity_at].freeze
+
+    def compute_time_series(column, days)
+      col = column.to_s
+      raise ArgumentError, "Invalid column: #{col}" unless ALLOWED_TIME_SERIES_COLUMNS.include?(col)
+
+      buckets = days.times.map { |i|
+        date = i.days.ago.to_date
+        [date.iso8601, 0]
+      }.to_h
+
+      GridHackr
+        .where("#{col} >= ?", days.days.ago) # rubocop:disable Rails/WhereEquals -- column is allowlisted above
+        .group("strftime('%Y-%m-%d', #{col})") # rubocop:disable Rails/GroupByAssociation -- raw SQLite strftime
+        .count
+        .each { |date, count| buckets[date] = count if buckets.key?(date) }
+
+      buckets.sort.map { |date, count| {date: date, count: count} }
+    end
+
+    def compute_perf_summary
+      {
+        total_metrics: PerformanceMetric.count,
+        web_vitals_24h: PerformanceMetric.web_vitals.where("created_at >= ?", 24.hours.ago).count,
+        slow_zone_renders_7d: PerformanceMetric.slow_renders.where("created_at >= ?", 7.days.ago).count
+      }
+    end
+  end
+end

--- a/app/services/error_tracker.rb
+++ b/app/services/error_tracker.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Public API for error tracking. All methods are safe to call from anywhere —
+# they never raise, never add latency to the request cycle beyond a single
+# SQLite insert (~1ms).
+#
+#   ErrorTracker.track(exception, context: { hackr_id: 42 })
+#   ErrorTracker.track_frontend(payload:, request:, hackr:)
+#
+module ErrorTracker
+  module_function
+
+  # Track a backend exception. Called from middleware (unhandled) or rescue blocks (manual).
+  def track(exception, context: {})
+    fingerprint = Fingerprinter.backend(exception)
+
+    Persister.record(
+      fingerprint: fingerprint,
+      title: exception.class.name,
+      component: "backend",
+      severity: "error",
+      occurred_at: Time.current,
+      exception_class: exception.class.name,
+      message: exception.message.to_s.truncate(1000),
+      backtrace: exception.backtrace&.first(30)&.to_json,
+      rails_env: Rails.env,
+      hackr_id: context[:hackr_id],
+      hackr_alias: context[:hackr_alias],
+      request_url: context[:request_url],
+      request_method: context[:request_method],
+      request_params: context[:request_params],
+      ip_address: context[:ip_address],
+      user_agent: context[:user_agent],
+      metadata: context[:metadata]&.to_json
+    )
+  rescue => e
+    Rails.logger.error "[ErrorTracker] track failed: #{e.message}"
+  end
+
+  # Track a frontend error reported via API.
+  def track_frontend(payload:, request:, hackr:)
+    message = payload[:message].to_s.truncate(1000)
+    source = payload[:source].to_s
+    lineno = payload[:lineno].to_i
+    fingerprint = Fingerprinter.frontend(message: message, source: source, lineno: lineno)
+
+    Persister.record(
+      fingerprint: fingerprint,
+      title: message.truncate(200),
+      component: "frontend",
+      severity: "error",
+      occurred_at: Time.current,
+      exception_class: nil,
+      message: message,
+      backtrace: payload[:stack].present? ? payload[:stack].to_s.lines.first(20).to_json : nil,
+      rails_env: Rails.env,
+      hackr_id: hackr&.id,
+      hackr_alias: hackr&.hackr_alias,
+      request_url: payload[:url].to_s.truncate(2048),
+      request_method: nil,
+      request_params: nil,
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent&.truncate(500),
+      metadata: {
+        type: payload[:type],
+        source: source,
+        lineno: lineno,
+        colno: payload[:colno].to_i
+      }.to_json
+    )
+  rescue => e
+    Rails.logger.error "[ErrorTracker] track_frontend failed: #{e.message}"
+  end
+end

--- a/app/services/error_tracker/fingerprinter.rb
+++ b/app/services/error_tracker/fingerprinter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module ErrorTracker
+  # Generates deterministic fingerprints for error grouping.
+  # Backend: SHA256 of exception class + normalized backtrace.
+  # Frontend: SHA256 of message (numbers normalized) + source file + line number.
+  module Fingerprinter
+    module_function
+
+    def backend(exception)
+      trace = normalize_backtrace(exception.backtrace || [])
+      Digest::SHA256.hexdigest("#{exception.class.name}:#{trace}")
+    end
+
+    def frontend(message:, source:, lineno:)
+      normalized_message = message.to_s.gsub(/\b\d+\b/, "N")
+      Digest::SHA256.hexdigest("frontend:#{normalized_message}:#{source}:#{lineno}")
+    end
+
+    # Strip line numbers from backtrace frames but keep method names.
+    # "/app/services/grid/breach_service.rb:42:in `start!'" → "/app/services/grid/breach_service.rb:in `start!'"
+    def normalize_backtrace(backtrace)
+      backtrace
+        .first(10)
+        .map { |line| line.sub(/:\d+/, "") }
+        .join("|")
+    end
+  end
+end

--- a/app/services/error_tracker/persister.rb
+++ b/app/services/error_tracker/persister.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module ErrorTracker
+  # Synchronously persists an error occurrence and updates its group.
+  # Uses create_or_find_by! for race-safe group upsert and insert_all
+  # for the occurrence row. Two SQLite writes per error (~1ms each).
+  module Persister
+    module_function
+
+    def record(attrs)
+      now = Time.current
+
+      group = ErrorGroup.create_or_find_by!(fingerprint: attrs[:fingerprint]) do |g|
+        g.title = attrs[:title]
+        g.component = attrs[:component]
+        g.severity = attrs[:severity]
+        g.status = "open"
+        g.first_seen_at = now
+        g.last_seen_at = now
+        g.occurrence_count = 0
+      end
+
+      # Auto-reopen resolved groups on recurrence
+      if group.status == "resolved"
+        group.update!(status: "open", resolved_at: nil, resolved_by_hackr_id: nil)
+      end
+
+      # Skip if actively ignored (not expired)
+      if group.status == "ignored" && !group.ignore_expired?
+        return
+      end
+
+      # Reopen expired ignores
+      if group.ignore_expired?
+        group.update!(status: "open", ignore_until: nil)
+      end
+
+      # Insert occurrence
+      ErrorOccurrence.insert_all([{
+        error_group_id: group.id,
+        occurred_at: attrs[:occurred_at] || now,
+        component: attrs[:component],
+        exception_class: attrs[:exception_class],
+        message: attrs[:message],
+        backtrace: attrs[:backtrace],
+        request_url: attrs[:request_url],
+        request_method: attrs[:request_method],
+        request_params: attrs[:request_params],
+        ip_address: attrs[:ip_address],
+        user_agent: attrs[:user_agent],
+        hackr_id: attrs[:hackr_id],
+        hackr_alias: attrs[:hackr_alias],
+        rails_env: attrs[:rails_env],
+        metadata: attrs[:metadata],
+        created_at: now
+      }])
+
+      # Atomic counter increment
+      ErrorGroup.where(id: group.id).update_all(
+        ["occurrence_count = occurrence_count + 1, last_seen_at = MAX(COALESCE(last_seen_at, ?), ?), first_seen_at = MIN(COALESCE(first_seen_at, ?), ?)",
+          now, now, now, now]
+      )
+    end
+  end
+end

--- a/app/services/error_tracker/request_sanitizer.rb
+++ b/app/services/error_tracker/request_sanitizer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ErrorTracker
+  # Extracts and sanitizes request context from a Rack env hash.
+  # Strips sensitive parameters matching common credential patterns.
+  module RequestSanitizer
+    SENSITIVE_PATTERN = /password|token|secret|auth|key|cvv|ssn|otp/i
+    MAX_PARAMS_SIZE = 4096
+
+    module_function
+
+    def from_env(env)
+      request = ActionDispatch::Request.new(env)
+      params = sanitize_params(request.filtered_parameters.except("controller", "action", "format"))
+
+      {
+        request_url: request.original_url.to_s.truncate(2048),
+        request_method: request.method,
+        request_params: truncate_json(params),
+        ip_address: request.remote_ip,
+        user_agent: request.user_agent&.truncate(500)
+      }
+    end
+
+    def sanitize_params(params)
+      case params
+      when Hash
+        params.each_with_object({}) do |(key, value), result|
+          result[key] = if key.to_s.match?(SENSITIVE_PATTERN)
+            "[FILTERED]"
+          else
+            sanitize_params(value)
+          end
+        end
+      when Array
+        params.map { |v| sanitize_params(v) }
+      else
+        params
+      end
+    end
+
+    def truncate_json(params)
+      json = params.to_json
+      (json.size > MAX_PARAMS_SIZE) ? json.truncate(MAX_PARAMS_SIZE) : json
+    end
+  end
+end

--- a/app/views/admin/analytics_dashboard/index.html.erb
+++ b/app/views/admin/analytics_dashboard/index.html.erb
@@ -1,0 +1,215 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/analytics :: ANALYTICS DASHBOARD</legend>
+
+    <div style="padding: 20px;">
+      <%# Date range selector %>
+      <div style="margin-bottom: 20px; display: flex; gap: 10px;">
+        <% { "7" => "7d", "30" => "30d", "90" => "90d", "0" => "ALL" }.each do |val, label| %>
+          <% active = @range_days.to_s == val %>
+          <%= link_to label, admin_analytics_dashboard_path(range: val),
+              class: "tui-button #{active ? 'green-168' : ''}",
+              style: "padding: 6px 14px; #{active ? 'font-weight: bold;' : ''}" %>
+        <% end %>
+      </div>
+
+      <%# USER METRICS %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: USER METRICS ::]</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 15px; margin-bottom: 30px;">
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">DAU</div>
+          <div style="font-size: 1.8em; color: #00ff9f;"><%= @user_metrics[:dau] %></div>
+        </div>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">WAU</div>
+          <div style="font-size: 1.8em; color: #22d3ee;"><%= @user_metrics[:wau] %></div>
+        </div>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">MAU</div>
+          <div style="font-size: 1.8em; color: #a78bfa;"><%= @user_metrics[:mau] %></div>
+        </div>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">TOTAL</div>
+          <div style="font-size: 1.8em; color: #d0d0d0;"><%= @user_metrics[:total] %></div>
+        </div>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">NEW (30d)</div>
+          <div style="font-size: 1.8em; color: #fbbf24;"><%= @user_metrics[:new_30d] %></div>
+        </div>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.8em;">RETURNING (30d)</div>
+          <div style="font-size: 1.8em; color: #34d399;"><%= @user_metrics[:returning_30d] %></div>
+        </div>
+      </div>
+
+      <%# REGISTRATIONS CHART %>
+      <h3 class="cyan-255-text" style="margin-bottom: 10px;">[:: REGISTRATIONS ::]</h3>
+      <% max_reg = @registrations_by_day.map { |b| b[:count] }.max.to_f %>
+      <div style="display: flex; align-items: flex-end; gap: 2px; height: 80px; margin-bottom: 5px; padding: 0 5px;">
+        <% @registrations_by_day.each do |bucket| %>
+          <% pct = max_reg > 0 ? (bucket[:count] / max_reg * 100).round : 0 %>
+          <div title="<%= bucket[:date] %>: <%= bucket[:count] %>"
+               style="flex: 1; height: <%= [pct, 2].max %>%; background: #00ff9f; min-height: 1px;"></div>
+        <% end %>
+      </div>
+      <div style="display: flex; justify-content: space-between; color: #555; font-size: 0.7em; margin-bottom: 30px; padding: 0 5px;">
+        <span><%= @registrations_by_day.first&.dig(:date) %></span>
+        <span><%= @registrations_by_day.last&.dig(:date) %></span>
+      </div>
+
+      <%# ACTIVITY CHART %>
+      <h3 class="cyan-255-text" style="margin-bottom: 10px;">[:: DAILY ACTIVE HACKRS ::]</h3>
+      <% max_act = @activity_by_day.map { |b| b[:count] }.max.to_f %>
+      <div style="display: flex; align-items: flex-end; gap: 2px; height: 80px; margin-bottom: 5px; padding: 0 5px;">
+        <% @activity_by_day.each do |bucket| %>
+          <% pct = max_act > 0 ? (bucket[:count] / max_act * 100).round : 0 %>
+          <div title="<%= bucket[:date] %>: <%= bucket[:count] %>"
+               style="flex: 1; height: <%= [pct, 2].max %>%; background: #22d3ee; min-height: 1px;"></div>
+        <% end %>
+      </div>
+      <div style="display: flex; justify-content: space-between; color: #555; font-size: 0.7em; margin-bottom: 30px; padding: 0 5px;">
+        <span><%= @activity_by_day.first&.dig(:date) %></span>
+        <span><%= @activity_by_day.last&.dig(:date) %></span>
+      </div>
+
+      <%# FEATURE USAGE %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: FEATURE USAGE ::]</h3>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px;">
+        <%# Top Rooms %>
+        <div style="border: 1px solid #333; background: #0a0a0a; padding: 15px;">
+          <h4 style="color: #888; margin-bottom: 10px;">Top 10 Rooms</h4>
+          <% @feature_usage[:top_rooms].each_with_index do |room, i| %>
+            <div style="display: flex; justify-content: space-between; padding: 3px 0; border-bottom: 1px solid #1a1a1a;">
+              <span style="color: #d0d0d0; font-size: 0.85em;"><%= i + 1 %>. <%= room[:name] %></span>
+              <span style="color: #00ff9f; font-family: monospace;"><%= room[:count] %></span>
+            </div>
+          <% end %>
+          <% if @feature_usage[:top_rooms].empty? %>
+            <span style="color: #555;">No data</span>
+          <% end %>
+        </div>
+
+        <%# Top Tracks %>
+        <div style="border: 1px solid #333; background: #0a0a0a; padding: 15px;">
+          <h4 style="color: #888; margin-bottom: 10px;">Top 10 Tracks</h4>
+          <% @feature_usage[:top_tracks].each_with_index do |track, i| %>
+            <div style="display: flex; justify-content: space-between; padding: 3px 0; border-bottom: 1px solid #1a1a1a;">
+              <span style="color: #d0d0d0; font-size: 0.85em;"><%= i + 1 %>. <%= track[:name] %></span>
+              <span style="color: #fbbf24; font-family: monospace;"><%= track[:count] %></span>
+            </div>
+          <% end %>
+          <% if @feature_usage[:top_tracks].empty? %>
+            <span style="color: #555;">No data</span>
+          <% end %>
+        </div>
+      </div>
+
+      <%# Feature stats grid %>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 15px; margin-bottom: 30px;">
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">BREACH ATTEMPTS</div>
+          <div style="font-size: 1.4em; color: #ff6b6b;"><%= @feature_usage[:breach_attempts] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">BREACH SUCCESS</div>
+          <div style="font-size: 1.4em; color: #00ff9f;"><%= @feature_usage[:breach_success_rate] %>%</div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">SHOP BUYS</div>
+          <div style="font-size: 1.4em; color: #fbbf24;"><%= @feature_usage[:shop_buys] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">SHOP SELLS</div>
+          <div style="font-size: 1.4em; color: #34d399;"><%= @feature_usage[:shop_sells] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">MISSIONS ACCEPTED</div>
+          <div style="font-size: 1.4em; color: #22d3ee;"><%= @feature_usage[:mission_accepted] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">MISSION COMPLETE</div>
+          <div style="font-size: 1.4em; color: #a78bfa;"><%= @feature_usage[:mission_completion_rate] %>%</div>
+        </div>
+      </div>
+
+      <%# TUTORIAL FUNNEL %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: TUTORIAL FUNNEL ::]</h3>
+      <div style="margin-bottom: 30px; padding: 15px; border: 1px solid #333; background: #0a0a0a;">
+        <div style="margin-bottom: 10px;">
+          <span style="color: #888;">Started:</span> <span style="color: #d0d0d0;"><%= @tutorial_funnel[:total_started] %></span>
+          <span style="color: #555; margin: 0 10px;">|</span>
+          <span style="color: #888;">Completed:</span> <span style="color: #00ff9f;"><%= @tutorial_funnel[:completed] || 0 %></span>
+          <% if @tutorial_funnel[:drop_off_step] %>
+            <span style="color: #555; margin: 0 10px;">|</span>
+            <span style="color: #888;">Biggest drop-off:</span> <span style="color: #ff6b6b;">Step <%= @tutorial_funnel[:drop_off_step] %></span>
+          <% end %>
+        </div>
+
+        <% if @tutorial_funnel[:step_counts].any? %>
+          <% max_step = @tutorial_funnel[:step_counts].map(&:last).max.to_f %>
+          <div style="display: flex; align-items: flex-end; gap: 1px; height: 60px;">
+            <% @tutorial_funnel[:step_counts].each do |step, count| %>
+              <% pct = max_step > 0 ? (count / max_step * 100).round : 0 %>
+              <% is_drop = step == @tutorial_funnel[:drop_off_step] %>
+              <div title="Step <%= step %>: <%= count %> hackrs"
+                   style="flex: 1; height: <%= [pct, 2].max %>%; background: <%= is_drop ? '#ff6b6b' : '#a78bfa' %>; min-height: 1px;"></div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <%# SESSION METRICS %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SESSION METRICS ::]</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 15px; margin-bottom: 30px;">
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">AVG SESSION</div>
+          <% mins = @session_metrics[:avg_duration_seconds].to_i / 60 %>
+          <div style="font-size: 1.4em; color: #d0d0d0;"><%= mins %>m</div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">TOTAL SESSIONS</div>
+          <div style="font-size: 1.4em; color: #d0d0d0;"><%= @session_metrics[:total_sessions] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">UNIQUE USERS</div>
+          <div style="font-size: 1.4em; color: #d0d0d0;"><%= @session_metrics[:unique_users] %></div>
+        </div>
+        <div style="padding: 12px; border: 1px solid #333; background: #0a0a0a; text-align: center;">
+          <div style="color: #888; font-size: 0.75em;">SESSIONS/USER</div>
+          <div style="font-size: 1.4em; color: #d0d0d0;"><%= @session_metrics[:avg_sessions_per_user] %></div>
+        </div>
+      </div>
+
+      <%# TELEMETRY STATUS %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: TELEMETRY STATUS ::]</h3>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 30px;">
+        <%# Performance metrics %>
+        <div style="padding: 15px; border: 1px solid #333; background: #0a0a0a;">
+          <h4 style="color: #888; margin-bottom: 10px;">Performance Metrics</h4>
+          <div style="color: #d0d0d0;">Total: <span style="color: #22d3ee;"><%= @perf_summary[:total_metrics] %></span></div>
+          <div style="color: #d0d0d0;">Web Vitals (24h): <span style="color: #22d3ee;"><%= @perf_summary[:web_vitals_24h] %></span></div>
+          <div style="color: #d0d0d0;">Slow ZoneMap Renders (7d): <span style="color: <%= @perf_summary[:slow_zone_renders_7d] > 0 ? '#ff6b6b' : '#00ff9f' %>;"><%= @perf_summary[:slow_zone_renders_7d] %></span></div>
+        </div>
+
+        <%# Frontend events %>
+        <div style="padding: 15px; border: 1px solid #fbbf24; background: #1a1500;">
+          <h4 style="color: #fbbf24; margin-bottom: 10px;">Frontend Event Collection</h4>
+          <div style="color: #d0d0d0; margin-bottom: 8px;">
+            Frontend event collection is active. Reporting UI coming in a future update.
+          </div>
+          <div style="color: #888;">
+            Events collected: <span style="color: #fbbf24; font-size: 1.2em;"><%= @analytics_event_count %></span>
+          </div>
+          <div style="color: #555; font-size: 0.8em; margin-top: 8px;">
+            Tracking: page_view, feature_click, button_click, panel_open, panel_close, command_entered, session_start, session_end
+          </div>
+        </div>
+      </div>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Error Tracker", admin_error_groups_path, class: "tui-button red-168" %>
+        <%= link_to "← Admin Dashboard", admin_root_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/error_groups/index.html.erb
+++ b/app/views/admin/error_groups/index.html.erb
@@ -1,0 +1,135 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/error_groups :: ERROR TRACKER</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #002200; border: 2px solid #00ff00; padding: 10px 15px; margin-bottom: 15px;">
+          <span class="green-255-text"><%= flash[:success] %></span>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #220000; border: 2px solid #ff0000; padding: 10px 15px; margin-bottom: 15px;">
+          <span class="red-255-text"><%= flash[:error] %></span>
+        </div>
+      <% end %>
+
+      <%# Filter form %>
+      <div style="margin-bottom: 20px; padding: 15px; border: 1px solid #333; background: #0a0a0a;">
+        <%= form_tag admin_error_groups_path, method: :get, style: "display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;" do %>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Status</label>
+            <%= select_tag :status, options_for_select([["All", ""]] + ErrorGroup::STATUSES.map { |s| [s.upcase, s] }, params[:status]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Component</label>
+            <%= select_tag :component, options_for_select([["All", ""]] + ErrorGroup::COMPONENTS.map { |c| [c.upcase, c] }, params[:component]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Severity</label>
+            <%= select_tag :severity, options_for_select([["All", ""]] + ErrorGroup::SEVERITIES.map { |s| [s.upcase, s] }, params[:severity]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Search</label>
+            <%= text_field_tag :search, params[:search], style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;", placeholder: "error title..." %>
+          </div>
+          <div>
+            <button type="submit" class="tui-button cyan-168" style="padding: 6px 14px;">Filter</button>
+          </div>
+          <% if params.values_at(:status, :component, :severity, :search).any?(&:present?) %>
+            <div>
+              <%= link_to "Clear", admin_error_groups_path, class: "tui-button", style: "padding: 6px 14px;" %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: ERROR GROUPS (<%= @total_count %> total, showing <%= @offset + 1 %>–<%= [@offset + @per_page, @total_count].min %>) ::]</h3>
+
+      <% if @error_groups.any? %>
+        <style>.error-groups-table tbody tr td, .error-groups-table thead tr th { padding: 8px 10px; }</style>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table error-groups-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Status</th>
+                <th style="text-align: left;">Title</th>
+                <th style="text-align: center;">Component</th>
+                <th style="text-align: right;">Count</th>
+                <th style="text-align: right;">24h</th>
+                <th style="text-align: center;">First Seen</th>
+                <th style="text-align: center;">Last Seen</th>
+                <th style="text-align: center;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @error_groups.each_with_index do |group, i| %>
+                <% eff_status = group.effective_status %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td style="text-align: center;">
+                    <% color = case eff_status
+                      when "open" then "#ff0000"
+                      when "resolved" then "#00ff00"
+                      when "ignored" then "#888"
+                    end %>
+                    <span style="color: <%= color %>; font-weight: bold;"><%= eff_status.upcase %></span>
+                    <% if group.status == "ignored" && group.ignore_until %>
+                      <br><span style="color: #555; font-size: 0.75em;">until <%= group.ignore_until.strftime("%m/%d %H:%M") %></span>
+                    <% end %>
+                  </td>
+                  <td style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    <%= link_to group.title, admin_error_group_path(group), style: "color: #d0d0d0; text-decoration: none;", title: group.title %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% comp_color = group.component == "backend" ? "#a78bfa" : "#fbbf24" %>
+                    <span style="color: <%= comp_color %>; font-size: 0.85em;"><%= group.component.upcase %></span>
+                  </td>
+                  <td style="text-align: right; font-family: monospace;"><%= group.occurrence_count %></td>
+                  <td style="text-align: right; font-family: monospace;">
+                    <% trend = @trends_24h[group.id] || 0 %>
+                    <span style="color: <%= trend > 0 ? '#ff6b6b' : '#666' %>;"><%= trend %></span>
+                  </td>
+                  <td style="text-align: center; color: #666; white-space: nowrap; font-size: 0.85em;">
+                    <%= group.first_seen_at&.strftime("%Y-%m-%d %H:%M") || "—" %>
+                  </td>
+                  <td style="text-align: center; color: #666; white-space: nowrap; font-size: 0.85em;">
+                    <%= group.last_seen_at&.strftime("%Y-%m-%d %H:%M") || "—" %>
+                  </td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <% if eff_status == "open" %>
+                      <%= button_to "Resolve", resolve_admin_error_group_path(group), method: :post, class: "tui-button green-168", style: "padding: 2px 8px; font-size: 0.8em;", form: {style: "display: inline;"} %>
+                      <%= button_to "Ignore", ignore_admin_error_group_path(group, duration: "24h"), method: :post, class: "tui-button", style: "padding: 2px 8px; font-size: 0.8em;", form: {style: "display: inline;"} %>
+                    <% else %>
+                      <%= button_to "Reopen", reopen_admin_error_group_path(group), method: :post, class: "tui-button red-168", style: "padding: 2px 8px; font-size: 0.8em;", form: {style: "display: inline;"} %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <%# Pagination %>
+        <div style="display: flex; gap: 15px; align-items: center; margin-top: 15px;">
+          <% if @offset > 0 %>
+            <%= link_to "← Prev", admin_error_groups_path(request.query_parameters.merge("offset" => [@offset - @per_page, 0].max)), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+          <span style="color: #888;">
+            Page <%= (@offset / @per_page) + 1 %> of <%= [(@total_count.to_f / @per_page).ceil, 1].max %>
+          </span>
+          <% if @offset + @per_page < @total_count %>
+            <%= link_to "Next →", admin_error_groups_path(request.query_parameters.merge("offset" => @offset + @per_page)), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666;">No error groups found.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Admin Dashboard", admin_root_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/error_groups/show.html.erb
+++ b/app/views/admin/error_groups/show.html.erb
@@ -1,0 +1,149 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/error_groups/<%= @error_group.id %> :: ERROR DETAIL</legend>
+
+    <div style="padding: 20px;">
+      <%# Group summary %>
+      <div style="margin-bottom: 20px; padding: 15px; border: 1px solid #333; background: #0a0a0a;">
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px;">
+          <div>
+            <span style="color: #888; font-size: 0.8em;">STATUS</span><br>
+            <% eff_status = @error_group.effective_status %>
+            <% color = case eff_status
+              when "open" then "#ff0000"
+              when "resolved" then "#00ff00"
+              when "ignored" then "#888"
+            end %>
+            <span style="color: <%= color %>; font-weight: bold; font-size: 1.2em;"><%= eff_status.upcase %></span>
+            <% if @error_group.status == "ignored" && @error_group.ignore_until %>
+              <br><span style="color: #555; font-size: 0.8em;">until <%= @error_group.ignore_until.strftime("%Y-%m-%d %H:%M") %></span>
+            <% end %>
+          </div>
+          <div>
+            <span style="color: #888; font-size: 0.8em;">COMPONENT</span><br>
+            <% comp_color = @error_group.component == "backend" ? "#a78bfa" : "#fbbf24" %>
+            <span style="color: <%= comp_color %>;"><%= @error_group.component.upcase %></span>
+          </div>
+          <div>
+            <span style="color: #888; font-size: 0.8em;">SEVERITY</span><br>
+            <span style="color: #d0d0d0;"><%= @error_group.severity.upcase %></span>
+          </div>
+          <div>
+            <span style="color: #888; font-size: 0.8em;">OCCURRENCES</span><br>
+            <span style="color: #d0d0d0; font-size: 1.2em;"><%= @error_group.occurrence_count %></span>
+          </div>
+          <div>
+            <span style="color: #888; font-size: 0.8em;">FIRST SEEN</span><br>
+            <span style="color: #666;"><%= @error_group.first_seen_at&.strftime("%Y-%m-%d %H:%M:%S") || "—" %></span>
+          </div>
+          <div>
+            <span style="color: #888; font-size: 0.8em;">LAST SEEN</span><br>
+            <span style="color: #666;"><%= @error_group.last_seen_at&.strftime("%Y-%m-%d %H:%M:%S") || "—" %></span>
+          </div>
+        </div>
+
+        <div style="margin-top: 15px;">
+          <span style="color: #888; font-size: 0.8em;">TITLE</span><br>
+          <span style="color: #d0d0d0; word-break: break-all;"><%= @error_group.title %></span>
+        </div>
+
+        <div style="margin-top: 15px;">
+          <span style="color: #888; font-size: 0.8em;">FINGERPRINT</span><br>
+          <span style="color: #555; font-family: monospace; font-size: 0.8em;"><%= @error_group.fingerprint %></span>
+        </div>
+
+        <% if @error_group.resolved_by_hackr %>
+          <div style="margin-top: 10px;">
+            <span style="color: #888; font-size: 0.8em;">RESOLVED BY</span>
+            <span style="color: #00ff00;"><%= @error_group.resolved_by_hackr.hackr_alias %></span>
+            <span style="color: #555;">at <%= @error_group.resolved_at&.strftime("%Y-%m-%d %H:%M") %></span>
+          </div>
+        <% end %>
+      </div>
+
+      <%# Actions %>
+      <div style="margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap;">
+        <% if eff_status == "open" %>
+          <%= button_to "Resolve", resolve_admin_error_group_path(@error_group), method: :post, class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <%= button_to "Ignore 1h", ignore_admin_error_group_path(@error_group, duration: "1h"), method: :post, class: "tui-button", style: "padding: 6px 14px;" %>
+          <%= button_to "Ignore 24h", ignore_admin_error_group_path(@error_group, duration: "24h"), method: :post, class: "tui-button", style: "padding: 6px 14px;" %>
+          <%= button_to "Ignore 7d", ignore_admin_error_group_path(@error_group, duration: "7d"), method: :post, class: "tui-button", style: "padding: 6px 14px;" %>
+          <%= button_to "Ignore Forever", ignore_admin_error_group_path(@error_group, duration: "forever"), method: :post, class: "tui-button", style: "padding: 6px 14px;" %>
+        <% else %>
+          <%= button_to "Reopen", reopen_admin_error_group_path(@error_group), method: :post, class: "tui-button red-168", style: "padding: 6px 14px;" %>
+        <% end %>
+      </div>
+
+      <%# Occurrences %>
+      <h3 class="cyan-255-text" style="margin-bottom: 15px;">
+        [:: OCCURRENCES (<%= @total_occurrences %> total<%= @total_occurrences > 0 ? ", showing #{@offset + 1}–#{[@offset + @per_page, @total_occurrences].min}" : "" %>) ::]
+      </h3>
+
+      <% @occurrences.each do |occ| %>
+        <div style="margin-bottom: 15px; padding: 12px; border: 1px solid #333; background: #0a0a0a;">
+          <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+            <span style="color: #666; font-size: 0.85em;"><%= occ.occurred_at.strftime("%Y-%m-%d %H:%M:%S") %></span>
+            <span style="color: #555; font-size: 0.85em;">
+              <% if occ.hackr_alias.present? %>
+                <span style="color: #a78bfa;"><%= occ.hackr_alias %></span> |
+              <% end %>
+              <%= occ.ip_address %> |
+              <%= occ.request_method %> <%= occ.request_url %>
+            </span>
+          </div>
+
+          <div style="margin-bottom: 8px;">
+            <% if occ.exception_class.present? %>
+              <span style="color: #ff6b6b; font-weight: bold;"><%= occ.exception_class %></span>:
+            <% end %>
+            <span style="color: #d0d0d0; word-break: break-all;"><%= occ.message %></span>
+          </div>
+
+          <% bt = occ.parsed_backtrace %>
+          <% if bt.any? %>
+            <details style="margin-top: 8px;">
+              <summary style="cursor: pointer; color: #888; font-size: 0.85em;">Backtrace (<%= bt.size %> frames)</summary>
+              <pre style="margin-top: 5px; padding: 8px; background: #111; border: 1px solid #222; color: #888; font-size: 0.8em; overflow-x: auto; white-space: pre-wrap;"><%= bt.join("\n") %></pre>
+            </details>
+          <% end %>
+
+          <% meta = occ.parsed_metadata %>
+          <% if meta.any? %>
+            <details style="margin-top: 5px;">
+              <summary style="cursor: pointer; color: #888; font-size: 0.85em;">Metadata</summary>
+              <pre style="margin-top: 5px; padding: 8px; background: #111; border: 1px solid #222; color: #888; font-size: 0.8em; overflow-x: auto;"><%= JSON.pretty_generate(meta) %></pre>
+            </details>
+          <% end %>
+
+          <% req_params = occ.parsed_request_params %>
+          <% if req_params.any? %>
+            <details style="margin-top: 5px;">
+              <summary style="cursor: pointer; color: #888; font-size: 0.85em;">Request Params</summary>
+              <pre style="margin-top: 5px; padding: 8px; background: #111; border: 1px solid #222; color: #888; font-size: 0.8em; overflow-x: auto;"><%= JSON.pretty_generate(req_params) %></pre>
+            </details>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%# Pagination %>
+      <% if @total_occurrences > @per_page %>
+        <div style="display: flex; gap: 15px; align-items: center; margin-top: 15px;">
+          <% if @offset > 0 %>
+            <%= link_to "← Prev", admin_error_group_path(@error_group, offset: [@offset - @per_page, 0].max), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+          <span style="color: #888;">
+            Page <%= (@offset / @per_page) + 1 %> of <%= [(@total_occurrences.to_f / @per_page).ceil, 1].max %>
+          </span>
+          <% if @offset + @per_page < @total_occurrences %>
+            <%= link_to "Next →", admin_error_group_path(@error_group, offset: @offset + @per_page), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Error Groups", admin_error_groups_path, class: "tui-button green-168" %>
+        <%= link_to "← Admin Dashboard", admin_root_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -78,7 +78,6 @@
       <%= link_to "Streams", admin_hackr_streams_path, class: "green-255-text", style: "text-decoration: none;" %>
       <%= link_to "PulseWire", admin_pulse_wire_index_path, class: "purple-168-text", style: "text-decoration: none;" %>
       <%= link_to "Uplink", admin_uplink_index_path, class: "purple-168-text", style: "text-decoration: none;" %>
-      <%= link_to "Overlays", admin_overlays_path, class: "yellow-168-text", style: "text-decoration: none;" %>
       <div class="admin-nav-dropdown">
         <span class="admin-nav-dropdown-trigger green-168-text">Grid</span>
         <div class="admin-nav-dropdown-menu">
@@ -114,7 +113,15 @@
       <% else %>
         <%= link_to "Hackrs", admin_grid_hackrs_path, class: "green-168-text", style: "text-decoration: none;" %>
       <% end %>
-      <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text", style: "text-decoration: none;" %>
+      <div class="admin-nav-dropdown">
+        <span class="admin-nav-dropdown-trigger cyan-168-text">Meta</span>
+        <div class="admin-nav-dropdown-menu">
+          <%= link_to "Errors", admin_error_groups_path, class: "red-168-text" %>
+          <%= link_to "Analytics", admin_analytics_dashboard_path, class: "cyan-168-text" %>
+          <%= link_to "Overlays", admin_overlays_path, class: "yellow-168-text" %>
+          <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text" %>
+        </div>
+      </div>
       <span style="color: #333;">|</span>
       <%= link_to "← Exit", root_path, class: "red-168-text", style: "text-decoration: none;" %>
     </nav>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module HackrRails
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.autoload_paths << Rails.root.join("app/observers")
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,10 @@ development:
     <<: *default
     database: storage/development_cable.sqlite3
     migrations_paths: db/cable_migrate
+  telemetry:
+    <<: *default
+    database: storage/development_telemetry.sqlite3
+    migrations_paths: db/telemetry_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -29,6 +33,10 @@ test:
     <<: *default
     database: storage/test_cable.sqlite3
     migrations_paths: db/cable_migrate
+  telemetry:
+    <<: *default
+    database: storage/test_telemetry.sqlite3
+    migrations_paths: db/telemetry_migrate
 
 # Staging environment configuration
 staging:
@@ -47,6 +55,10 @@ staging:
     <<: *default
     database: storage/staging_cable.sqlite3
     migrations_paths: db/cable_migrate
+  telemetry:
+    <<: *default
+    database: storage/staging_telemetry.sqlite3
+    migrations_paths: db/telemetry_migrate
 
 
 # Store production database in the storage/ directory, which by default
@@ -67,3 +79,7 @@ production:
     <<: *default
     database: storage/production_cable.sqlite3
     migrations_paths: db/cable_migrate
+  telemetry:
+    <<: *default
+    database: storage/production_telemetry.sqlite3
+    migrations_paths: db/telemetry_migrate

--- a/config/initializers/error_tracker.rb
+++ b/config/initializers/error_tracker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/middleware/error_tracker_middleware"
+
+# Mount error tracking middleware early in the stack so it catches
+# unhandled exceptions from all downstream middleware and the app.
+Rails.application.config.middleware.insert_before(
+  ActionDispatch::ShowExceptions,
+  ErrorTrackerMiddleware
+)

--- a/config/initializers/error_tracker.rb
+++ b/config/initializers/error_tracker.rb
@@ -2,9 +2,9 @@
 
 require_relative "../../lib/middleware/error_tracker_middleware"
 
-# Mount error tracking middleware early in the stack so it catches
-# unhandled exceptions from all downstream middleware and the app.
-Rails.application.config.middleware.insert_before(
+# Mount error tracking middleware inside ShowExceptions so it observes
+# app exceptions before ShowExceptions rescues them for error rendering.
+Rails.application.config.middleware.insert_after(
   ActionDispatch::ShowExceptions,
   ErrorTrackerMiddleware
 )

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.lograge.enabled = !Rails.env.development?
+  config.lograge.keep_original_rails_log = false
+  config.lograge.formatter = Lograge::Formatters::Json.new
+
+  # Silence health checks (already silenced in production.rb, belt-and-suspenders)
+  config.lograge.ignore_actions = ["Rails::HealthController#show"]
+
+  config.lograge.custom_options = lambda do |event|
+    # Use Rails' built-in parameter filter to strip passwords, tokens, etc.
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    raw_params = event.payload[:params]&.except("controller", "action", "format")
+    filtered = raw_params.present? ? filter.filter(raw_params) : nil
+
+    {
+      request_id: event.payload[:headers]&.fetch("action_dispatch.request_id", nil),
+      params: filtered,
+      hackr_id: event.payload[:hackr_id],
+      hackr_alias: event.payload[:hackr_alias],
+      slow: event.duration > ENV.fetch("SLOW_REQUEST_MS", "1000").to_f,
+      exception: event.payload[:exception_object]&.then { |e| "#{e.class}: #{e.message}" }
+    }.compact
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,6 +116,13 @@ class Rack::Attack
     end
   end
 
+  ### Throttle error reports ###
+
+  # 10 error reports per IP per minute (frontend JS errors)
+  throttle("error_report/ip", limit: 10, period: 1.minute) do |req|
+    req.ip if req.path == "/api/error_report" && req.post?
+  end
+
   ### Throttle API requests ###
 
   # General API throttle - 300 requests per minute per IP

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -29,3 +29,11 @@ production:
   shop_rotation:
     class: ShopRotationJob
     schedule: every Monday at midnight
+
+  error_tracker_retention:
+    class: ErrorTracker::RetentionJob
+    schedule: at 3am every day
+
+  telemetry_prune:
+    class: TelemetryPruneJob
+    schedule: at 4am every day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,15 @@ Rails.application.routes.draw do
       get "moderation_log", to: "moderation#moderation_log", as: :moderation_log
     end
 
+    # Error reporting (frontend JS errors)
+    post "error_report", to: "error_reports#create"
+
+    # Performance metrics (frontend Web Vitals + component timing)
+    post "perf/metrics", to: "perf#create"
+
+    # Analytics events (frontend behavior tracking)
+    post "analytics/events", to: "analytics#create_batch"
+
     # Admin API routes (bearer token auth)
     namespace :admin do
       # Meta
@@ -279,6 +288,18 @@ Rails.application.routes.draw do
   # Edit YAML files in data/ directory and run: rails data:load
   namespace :admin, path: "root" do
     root "dashboard#index"
+
+    # Analytics dashboard
+    get "analytics", to: "analytics_dashboard#index", as: :analytics_dashboard
+
+    # Error tracking
+    resources :error_groups, only: %i[index show] do
+      member do
+        post :resolve
+        post :ignore
+        post :reopen
+      end
+    end
 
     # Catalog resources (full CRUD)
     resources :artists do

--- a/db/migrate/20260517200000_create_error_tracking.rb
+++ b/db/migrate/20260517200000_create_error_tracking.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CreateErrorTracking < ActiveRecord::Migration[8.1]
+  def change
+    create_table :error_groups do |t|
+      t.string :fingerprint, null: false
+      t.string :title, null: false
+      t.string :component, null: false # "backend" | "frontend"
+      t.string :severity, null: false, default: "error" # "error" | "warning" | "info"
+      t.string :status, null: false, default: "open" # "open" | "resolved" | "ignored"
+      t.datetime :ignore_until
+      t.integer :occurrence_count, null: false, default: 0
+      t.datetime :first_seen_at
+      t.datetime :last_seen_at
+      t.datetime :resolved_at
+      t.integer :resolved_by_hackr_id
+      t.timestamps
+    end
+
+    add_index :error_groups, :fingerprint, unique: true
+    add_index :error_groups, [:status, :last_seen_at]
+    add_index :error_groups, :component
+    add_index :error_groups, :severity
+
+    create_table :error_occurrences do |t|
+      t.references :error_group, null: false, foreign_key: true
+      t.datetime :occurred_at, null: false
+      t.string :component, null: false
+      t.string :exception_class
+      t.string :message, null: false
+      t.text :backtrace # JSON array
+      t.string :request_url
+      t.string :request_method
+      t.text :request_params # JSON, sanitized
+      t.string :ip_address
+      t.string :user_agent
+      t.integer :hackr_id
+      t.string :hackr_alias
+      t.string :rails_env
+      t.text :metadata # JSON, arbitrary context
+      t.datetime :created_at, null: false
+    end
+
+    add_index :error_occurrences, [:error_group_id, :occurred_at], order: {occurred_at: :desc}
+    add_index :error_occurrences, :occurred_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_204418) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -142,6 +142,48 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_204418) do
     t.index ["is_seed"], name: "index_echoes_on_is_seed"
     t.index ["pulse_id", "grid_hackr_id"], name: "index_echoes_on_pulse_id_and_grid_hackr_id", unique: true
     t.index ["pulse_id"], name: "index_echoes_on_pulse_id"
+  end
+
+  create_table "error_groups", force: :cascade do |t|
+    t.string "component", null: false
+    t.datetime "created_at", null: false
+    t.string "fingerprint", null: false
+    t.datetime "first_seen_at"
+    t.datetime "ignore_until"
+    t.datetime "last_seen_at"
+    t.integer "occurrence_count", default: 0, null: false
+    t.datetime "resolved_at"
+    t.integer "resolved_by_hackr_id"
+    t.string "severity", default: "error", null: false
+    t.string "status", default: "open", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["component"], name: "index_error_groups_on_component"
+    t.index ["fingerprint"], name: "index_error_groups_on_fingerprint", unique: true
+    t.index ["severity"], name: "index_error_groups_on_severity"
+    t.index ["status", "last_seen_at"], name: "index_error_groups_on_status_and_last_seen_at"
+  end
+
+  create_table "error_occurrences", force: :cascade do |t|
+    t.text "backtrace"
+    t.string "component", null: false
+    t.datetime "created_at", null: false
+    t.integer "error_group_id", null: false
+    t.string "exception_class"
+    t.string "hackr_alias"
+    t.integer "hackr_id"
+    t.string "ip_address"
+    t.string "message", null: false
+    t.text "metadata"
+    t.datetime "occurred_at", null: false
+    t.string "rails_env"
+    t.string "request_method"
+    t.text "request_params"
+    t.string "request_url"
+    t.string "user_agent"
+    t.index ["error_group_id", "occurred_at"], name: "index_error_occurrences_on_error_group_id_and_occurred_at", order: { occurred_at: :desc }
+    t.index ["error_group_id"], name: "index_error_occurrences_on_error_group_id"
+    t.index ["occurred_at"], name: "index_error_occurrences_on_occurred_at"
   end
 
   create_table "feature_grants", force: :cascade do |t|
@@ -1371,6 +1413,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_204418) do
   add_foreign_key "codex_entry_reads", "grid_hackrs"
   add_foreign_key "echoes", "grid_hackrs"
   add_foreign_key "echoes", "pulses"
+  add_foreign_key "error_occurrences", "error_groups"
   add_foreign_key "feature_grants", "grid_hackrs"
   add_foreign_key "grid_breach_encounters", "grid_breach_templates", on_delete: :restrict
   add_foreign_key "grid_breach_encounters", "grid_rooms", on_delete: :cascade

--- a/db/telemetry_migrate/20260517200001_create_telemetry_tables.rb
+++ b/db/telemetry_migrate/20260517200001_create_telemetry_tables.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CreateTelemetryTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :performance_metrics do |t|
+      t.string :metric_name, null: false # LCP, INP, CLS, FCP, TTFB, zone_map_render, panel_open, page_nav
+      t.string :metric_type, null: false # web_vital, component, navigation
+      t.float :value, null: false
+      t.string :unit, null: false # ms, score
+      t.string :page_path, null: false
+      t.string :session_id, limit: 64
+      t.integer :hackr_id
+      t.string :connection_type, limit: 32
+      t.string :device_class, limit: 16
+      t.timestamps
+    end
+
+    add_index :performance_metrics, :metric_name
+    add_index :performance_metrics, :created_at
+
+    create_table :analytics_events do |t|
+      t.string :event_type, null: false # page_view, feature_click, button_click, panel_open, panel_close, command_entered, session_start, session_end
+      t.string :event_name, null: false
+      t.integer :hackr_id
+      t.string :session_id, limit: 36, null: false
+      t.text :properties # JSON
+      t.datetime :created_at, null: false
+    end
+
+    add_index :analytics_events, :created_at
+    add_index :analytics_events, :event_type
+  end
+end

--- a/db/telemetry_migrate/20260517200002_add_session_id_index_to_analytics_events.rb
+++ b/db/telemetry_migrate/20260517200002_add_session_id_index_to_analytics_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSessionIdIndexToAnalyticsEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_index :analytics_events, :session_id
+  end
+end

--- a/db/telemetry_schema.rb
+++ b/db/telemetry_schema.rb
@@ -1,0 +1,41 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_05_17_200002) do
+  create_table "analytics_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "event_name", null: false
+    t.string "event_type", null: false
+    t.integer "hackr_id"
+    t.text "properties"
+    t.string "session_id", limit: 36, null: false
+    t.index ["created_at"], name: "index_analytics_events_on_created_at"
+    t.index ["event_type"], name: "index_analytics_events_on_event_type"
+    t.index ["session_id"], name: "index_analytics_events_on_session_id"
+  end
+
+  create_table "performance_metrics", force: :cascade do |t|
+    t.string "connection_type", limit: 32
+    t.datetime "created_at", null: false
+    t.string "device_class", limit: 16
+    t.integer "hackr_id"
+    t.string "metric_name", null: false
+    t.string "metric_type", null: false
+    t.string "page_path", null: false
+    t.string "session_id", limit: 64
+    t.string "unit", null: false
+    t.datetime "updated_at", null: false
+    t.float "value", null: false
+    t.index ["created_at"], name: "index_performance_metrics_on_created_at"
+    t.index ["metric_name"], name: "index_performance_metrics_on_metric_name"
+  end
+end

--- a/lib/middleware/error_tracker_middleware.rb
+++ b/lib/middleware/error_tracker_middleware.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Rack middleware that captures unhandled exceptions for error tracking.
+# Re-raises after tracking so Rails default error handling still fires.
+class ErrorTrackerMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue Exception => exception # rubocop:disable Lint/RescueException
+    # Skip non-application exceptions (signals, system exits)
+    raise if exception.is_a?(SystemExit) || exception.is_a?(SignalException)
+
+    track_exception(exception, env)
+    raise
+  end
+
+  private
+
+  def track_exception(exception, env)
+    context = ErrorTracker::RequestSanitizer.from_env(env)
+
+    # Read hackr identity from session — no DB query during exception handling
+    # to avoid cascade failures when the DB itself is the problem.
+    hackr_id = env["rack.session"]&.fetch(:grid_hackr_id, nil)
+    context[:hackr_id] = hackr_id if hackr_id
+
+    ErrorTracker.track(exception, context: context)
+  rescue => e
+    Rails.logger.error "[ErrorTrackerMiddleware] Failed to track: #{e.message}"
+  end
+end

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-router-dom": "^7.9.6",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "web-vitals": "^5.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      web-vitals:
+        specifier: ^5.2.0
+        version: 5.2.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -2819,6 +2822,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
@@ -6019,6 +6025,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@8.0.0: {}
 

--- a/spec/factories/grid_room_visits.rb
+++ b/spec/factories/grid_room_visits.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_room_visits
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  first_visited_at :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  grid_hackr_id    :integer          not null
+#  grid_room_id     :integer          not null
+#
+# Indexes
+#
+#  index_grid_room_visits_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_room_visits_on_grid_room_id   (grid_room_id)
+#  index_grid_room_visits_unique            (grid_hackr_id,grid_room_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_room_id   (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
 FactoryBot.define do
   factory :grid_room_visit do
     association :grid_hackr

--- a/spec/lib/terminal/handlers/uplink_handler_spec.rb
+++ b/spec/lib/terminal/handlers/uplink_handler_spec.rb
@@ -3,6 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Terminal::Handlers::UplinkHandler do
+  # ActionCable's test adapter delivers callbacks asynchronously via
+  # Concurrent.global_io_executor. A fixed sleep is unreliable — poll instead.
+  def wait_for(collection, expected_size:, timeout: 2)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    while collection.size < expected_size && Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+      sleep 0.02
+    end
+  end
+
   let(:hackr) { create(:grid_hackr) }
   let(:other_hackr) { create(:grid_hackr) }
   let!(:channel) { create(:chat_channel, name: "Ambient", slug: "ambient", is_active: true) }
@@ -266,7 +275,7 @@ RSpec.describe Terminal::Handlers::UplinkHandler do
         }
       })
 
-      sleep 0.1
+      wait_for(received_events, expected_size: 1)
 
       expect(received_events.size).to eq(1)
       expect(received_events.first[:content]).to eq("Live from the network!")
@@ -277,6 +286,7 @@ RSpec.describe Terminal::Handlers::UplinkHandler do
 
       session.realtime.on_uplink { |event| received_events << event }
       session.realtime.subscribe_uplink(channel.stream_name)
+      sleep 0.05 # Allow event loop to settle after prior test's unsubscribe
 
       ActionCable.server.broadcast(channel.stream_name, {
         type: "new_packet",
@@ -289,7 +299,7 @@ RSpec.describe Terminal::Handlers::UplinkHandler do
         }
       })
 
-      sleep 0.1
+      wait_for(received_events, expected_size: 1)
 
       expect(received_events.size).to eq(1)
       expect(received_events.first[:content]).to eq("From the web client")
@@ -357,7 +367,7 @@ RSpec.describe Terminal::Handlers::UplinkHandler do
         }
       })
 
-      sleep 0.1
+      wait_for(received_events, expected_size: 1)
 
       expect(received_events.size).to eq(1)
       expect(received_events.first[:content]).to eq("From another user after suppression ends")

--- a/spec/models/grid_room_visit_spec.rb
+++ b/spec/models/grid_room_visit_spec.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: grid_room_visits
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  first_visited_at :datetime         not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  grid_hackr_id    :integer          not null
+#  grid_room_id     :integer          not null
+#
+# Indexes
+#
+#  index_grid_room_visits_on_grid_hackr_id  (grid_hackr_id)
+#  index_grid_room_visits_on_grid_room_id   (grid_room_id)
+#  index_grid_room_visits_unique            (grid_hackr_id,grid_room_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id) ON DELETE => cascade
+#  grid_room_id   (grid_room_id => grid_rooms.id) ON DELETE => cascade
+#
 require "rails_helper"
 
 RSpec.describe GridRoomVisit, type: :model do


### PR DESCRIPTION
Four-pillar self-hosted observability for hackr.tv. Fully first-party.

ERROR TRACKING (internal BugSnag-like):
- error_groups + error_occurrences tables in primary DB
- ErrorTracker.track(exception, context: {}) public API — never raises
- ErrorTracker::Persister writes synchronously via insert_all (~1ms per error)
- ErrorTracker::Fingerprinter groups by SHA256 of class + normalized backtrace (backend) or message + source + line (frontend)
- ErrorTrackerMiddleware (Rack) catches unhandled exceptions, re-raises after tracking. No DB queries during exception handling to avoid cascade failures.
- errorReporter.ts captures window.onerror, unhandledrejection, and ErrorBoundary.componentDidCatch. Client-side dedup (max 5 identical/session). POST /api/error_report, rate-limited 10/min/IP via Rack::Attack.
- Admin UI at /root/error_groups: filterable index (status, component, severity, search), striped rows, inline action buttons. Group detail with occurrence list
  + backtrace + metadata + request params. Resolve/Ignore (1h/24h/7d/30d/forever) /Reopen lifecycle. Auto-reopens resolved groups on recurrence. Flash messages on actions. 90-day occurrence retention, groups kept forever (lifetime counts).

STRUCTURED LOGGING:
- lograge gem with JSON formatter — single-line per request, replaces verbose multi-line Rails logs. StructuredLogging concern injects hackr_id/alias via append_info_to_payload. Params filtered through ActiveSupport::ParameterFilter (strips passwords, tokens, secrets). Slow request flag (>1s, configurable via SLOW_REQUEST_MS env var).

PERFORMANCE MONITORING:
- web-vitals npm package + perfCollector.ts. Collects LCP/INP/CLS/FCP/TTFB. measureComponent() export for custom component timing (ZoneMap renders, panel transitions — call sites ready, not yet wired). Batched via sendBeacon every 30s or on page unload. Init guard prevents HMR double-registration.
- performance_metrics table in separate telemetry SQLite DB. insert_all batch writes via POST /api/perf/metrics. 30-day retention.

ANALYTICS DASHBOARD:
- /root/analytics admin page with CSS-only bar charts (TUI aesthetic, zero JS libs). Analytics::GridMetricsService queries existing tables (room visits, track plays, breaches, shops, missions, terminal sessions) with 10-min cache TTL via Solid Cache. Sections: DAU/WAU/MAU, registrations + activity time-series (raw SQLite strftime, no groupdate gem), top rooms/tracks, BREACH success rate, shop volume, mission completion rate, 53-step tutorial funnel with step-over-step drop-off analysis (json_extract), session metrics.
- Frontend event collection: analyticsCollector.ts with trackEvent() API, batched to POST /api/analytics/events. analytics_events table in telemetry DB. No reporting UI yet — collection + admin count display. Init guard prevents HMR double-registration. 90-day event retention.

TELEMETRY DATABASE:
- 5th SQLite DB (telemetry) isolates high-frequency perf + analytics writes from primary. TelemetryRecord abstract base class with connects_to. Configured in database.yml for all environments. Migrations in db/telemetry_migrate/. TelemetryPruneJob (daily 4am) with MIN_RETENTION=7 floor guard to prevent accidental full wipe from empty ENV vars.

ADMIN NAV:
- New "Meta" dropdown groups Errors, Analytics, Overlays, and Redirects.

CONFIG:
- Set time_zone to Central Time (US & Canada).