### PR TITLE
Wire frontend instrumentation hooks into tactical UI components

### DIFF
--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, lazy, Suspense } from 'react'
 import { Routes, Route, useLocation } from 'react-router-dom'
+import { trackEvent } from '~/utils/analyticsCollector'
 import { HomePage } from '~/components/pages/HomePage'
 import { LoadingPage } from '~/components/shared/LoadingSpinner'
 
@@ -64,9 +65,10 @@ import { AchievementToastContainer } from '~/components/shared/AchievementToast'
 export const AppLayout: React.FC = () => {
   const location = useLocation()
 
-  // Scroll to top on route change
+  // Scroll to top on route change + track page view (including initial load)
   useEffect(() => {
     window.scrollTo(0, 0)
+    trackEvent('page_view', location.pathname)
   }, [location.pathname])
 
   return (

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -88,18 +88,19 @@ const TacticalInner: React.FC = () => {
   }, [confirmTarget, sendCommand])
 
   // Panel open/close with analytics + perf tracking
-  // deps empty: performance.mark, trackEvent, measureComponent are all module-level
+  // deps empty: performance.mark, trackEvent, measureComponent are all module-level.
+  // All tactical panels use a 300ms CSS transform transition, so measure after
+  // transition completes (316ms = mount frame + 300ms slide) rather than double-rAF
+  // which would only capture ~32ms before the animation starts.
   const openPanel = useCallback((panel: string, setter: (v: boolean) => void) => {
     const markId = Math.random().toString(36).slice(2, 8)
     performance.mark(`panel_open_start_${markId}`)
     setter(true)
     trackEvent('panel_open', panel)
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        performance.mark(`panel_open_end_${markId}`)
-        measureComponent('panel_open', `panel_open_start_${markId}`, `panel_open_end_${markId}`)
-      })
-    })
+    setTimeout(() => {
+      performance.mark(`panel_open_end_${markId}`)
+      measureComponent('panel_open', `panel_open_start_${markId}`, `panel_open_end_${markId}`)
+    }, 350)
   }, [])
 
   const closePanel = useCallback((panel: string, setter: (v: boolean) => void) => {

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { trackEvent } from '~/utils/analyticsCollector'
+import { measureComponent } from '~/utils/perfCollector'
 import { useGridAuth } from '~/hooks/useGridAuth'
 import { useActionCable, GridEvent } from '~/hooks/useActionCable'
 import { TacticalProvider, useTactical } from '~/components/tactical/TacticalContext'
@@ -79,10 +81,31 @@ const TacticalInner: React.FC = () => {
 
   const handleBreachConfirm = useCallback(() => {
     if (confirmTarget) {
+      trackEvent('feature_click', 'breach_initiate', { target: confirmTarget.name, tier: confirmTarget.tier })
       sendCommand(`breach ${confirmTarget.name}`)
       setConfirmTarget(null)
     }
   }, [confirmTarget, sendCommand])
+
+  // Panel open/close with analytics + perf tracking
+  // deps empty: performance.mark, trackEvent, measureComponent are all module-level
+  const openPanel = useCallback((panel: string, setter: (v: boolean) => void) => {
+    const markId = Math.random().toString(36).slice(2, 8)
+    performance.mark(`panel_open_start_${markId}`)
+    setter(true)
+    trackEvent('panel_open', panel)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        performance.mark(`panel_open_end_${markId}`)
+        measureComponent('panel_open', `panel_open_start_${markId}`, `panel_open_end_${markId}`)
+      })
+    })
+  }, [])
+
+  const closePanel = useCallback((panel: string, setter: (v: boolean) => void) => {
+    setter(false)
+    trackEvent('panel_close', panel)
+  }, [])
 
   // Tab anywhere → focus command input
   useEffect(() => {
@@ -206,22 +229,22 @@ const TacticalInner: React.FC = () => {
           onCommand={sendCommand}
         />
         {hasTransit && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <TransitHandle onClick={() => setTransitOpen(true)} />
+          <TransitHandle onClick={() => openPanel('transit', setTransitOpen)} />
         )}
         <TransitPanel
           visible={transitOpen && !inBreach}
           refreshToken={refreshToken}
           onCommand={sendCommand}
-          onClose={() => setTransitOpen(false)}
+          onClose={() => closePanel('transit', setTransitOpen)}
         />
         {hasVendor && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <VendorHandle onClick={() => setVendorOpen(true)} />
+          <VendorHandle onClick={() => openPanel('vendor', setVendorOpen)} />
         )}
         <VendorPanel
           visible={vendorOpen && !inBreach}
           refreshToken={refreshToken}
           onCommand={sendCommand}
-          onClose={() => setVendorOpen(false)}
+          onClose={() => closePanel('vendor', setVendorOpen)}
         />
         {hasNpc && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen &&
           npcMobs.map((mob, i) => {
@@ -232,7 +255,7 @@ const TacticalInner: React.FC = () => {
                 key={mob.id}
                 npc={mob}
                 offsetX={offsetX}
-                onClick={() => { setSelectedNpcId(mob.id); setNpcOpen(true) }}
+                onClick={() => { setSelectedNpcId(mob.id); openPanel('npc', setNpcOpen) }}
               />
             )
           })
@@ -241,17 +264,17 @@ const TacticalInner: React.FC = () => {
           visible={npcOpen && !inBreach}
           refreshToken={refreshToken}
           onCommand={sendCommand}
-          onClose={() => setNpcOpen(false)}
+          onClose={() => closePanel('npc', setNpcOpen)}
           selectedMobId={selectedNpcId}
         />
         {hasRestPod && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <RestPodHandle onClick={() => setRestPodOpen(true)} />
+          <RestPodHandle onClick={() => openPanel('rest_pod', setRestPodOpen)} />
         )}
         <RestPodPanel
           visible={restPodOpen && !inBreach}
           refreshToken={refreshToken}
           onCommand={sendCommand}
-          onClose={() => setRestPodOpen(false)}
+          onClose={() => closePanel('rest_pod', setRestPodOpen)}
         />
       </div>
 

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react'
 import { apiJson } from '~/utils/apiClient'
+import { trackEvent } from '~/utils/analyticsCollector'
 import { CommandInputHandle } from '~/components/grid/CommandInput'
 import { NpcMobStub } from '~/types/zoneMap'
 
@@ -81,12 +82,14 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const executingRef = useRef(false)
 
   const sendCommand = useCallback(async (command: string) => {
+    // clear/cls are UI-only (no server round-trip, no gameplay) — intentionally untracked
     if (['clear', 'cls', 'cl'].includes(command.toLowerCase())) {
       setOutput([])
       return
     }
 
     if (executingRef.current) return
+    trackEvent('command_entered', command.split(' ')[0].toLowerCase())
 
     const echoLines = [
       '<div style="height: 1px; background: #444; margin-top: 16px; margin-bottom: 12px; overflow: hidden;"></div>',

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { apiJson } from '~/utils/apiClient'
+import { measureComponent } from '~/utils/perfCollector'
 import { ZoneMapData, ZoneMapRoom, ZoneMapGhostRoom, BreachEncounter, DeckStatus, NpcMobStub } from '~/types/zoneMap'
 import { iso, isoPts, ISO_WALL_H, ISO_TILE_W, ISO_TILE_H, DIRECTION_VECTORS } from './isoGeometry'
 import { useZonePresence } from './useZonePresence'
@@ -42,6 +43,8 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
   useEffect(() => {
     apiJson<ZoneMapData>('/api/grid/zone_map')
       .then(data => {
+        const markId = Math.random().toString(36).slice(2, 8)
+        performance.mark(`zone_map_render_start_${markId}`)
         setMapData(data)
         setPanOffset([0, 0])
         onBreachEncountersChange?.(data.breach_encounters || [], data.deck_status || { equipped: false, fried: false })
@@ -49,6 +52,13 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
         onTransitPresenceChange?.(data.has_transit ?? false)
         onNpcPresenceChange?.(data.has_npc ?? false, data.npc_mobs ?? [])
         onRestPodPresenceChange?.(data.has_rest_pod ?? false)
+        // Double-rAF: measure after browser has actually painted the new frame
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            performance.mark(`zone_map_render_end_${markId}`)
+            measureComponent('zone_map_render', `zone_map_render_start_${markId}`, `zone_map_render_end_${markId}`)
+          })
+        })
       })
       .catch(err => console.error('Zone map fetch failed:', err))
   // eslint-disable-next-line react-hooks/exhaustive-deps -- callback ref change should not re-trigger fetch; refreshToken controls cadence


### PR DESCRIPTION
Connect perfCollector.measureComponent() and analyticsCollector.trackEvent() to their call sites. All collector infrastructure was built in the prior commit — this wires the actual event sources.

PERFORMANCE TIMING:
- ZoneMap.tsx: measure fetch-to-paint render time via double-rAF pattern. Unique mark IDs per invocation prevent collisions under rapid refreshes.
- GridTacticalPage.tsx: measure panel slide-in transition time (transit, vendor, NPC, rest pod). Same unique mark ID pattern.

ANALYTICS EVENTS:
- panel_open/panel_close: transit, vendor, NPC, rest pod panels
- command_entered: every gameplay command (first word as event name). clear/cls intentionally untracked (UI-only, no server round-trip).
- page_view: SPA route changes including initial landing page
- feature_click/breach_initiate: breach target confirmation with name + tier