### PR TITLE
Data Audit System (RED FLAGS)

### DIFF
--- a/app/controllers/admin/data_audit_flags_controller.rb
+++ b/app/controllers/admin/data_audit_flags_controller.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+class Admin::DataAuditFlagsController < Admin::ApplicationController
+  PER_PAGE = 50
+
+  before_action :set_flag, only: %i[acknowledge reopen]
+
+  # GET /root/data_audit_flags
+  def index
+    @flags = DataAuditFlag.newest_first
+
+    # Filters
+    if params[:status].present? && DataAuditFlag::STATUSES.include?(params[:status])
+      @flags = @flags.where(status: params[:status])
+    end
+    @flags = @flags.for_severity(params[:severity])
+    @flags = @flags.for_domain(params[:domain])
+    @flags = @flags.for_check(params[:check_name])
+
+    if params[:search].present?
+      escaped = ActiveRecord::Base.sanitize_sql_like(params[:search])
+      @flags = @flags.where("title LIKE ?", "%#{escaped}%")
+    end
+
+    # Summary counts (before pagination)
+    @by_severity = DataAuditFlag.effective_open.group(:severity).count
+    @by_domain = DataAuditFlag.effective_open.group(:domain).count
+    @check_names = DataAuditFlag.distinct.pluck(:check_name).sort
+
+    # Pagination
+    @per_page = PER_PAGE
+    @offset = [params[:offset].to_i, 0].max
+    @total_count = @flags.count
+    @flags = @flags.offset(@offset).limit(@per_page)
+
+    # Batch-preload slugs for models that use slug-based to_param (avoids N+1)
+    @subject_slugs = preload_subject_slugs(@flags)
+
+    @last_scan_at = DataAudit::FlagCache.last_scan_at
+  end
+
+  # POST /root/data_audit_flags/:id/acknowledge
+  def acknowledge
+    duration = params[:duration].to_s
+    until_time = case duration
+    when "24h" then 24.hours.from_now
+    when "7d" then 7.days.from_now
+    when "30d" then 30.days.from_now
+    when "forever" then nil
+    else 24.hours.from_now
+    end
+
+    @flag.acknowledge!(until_time)
+    DataAudit::FlagCache.invalidate!
+    label = until_time ? "until #{until_time.strftime("%Y-%m-%d %H:%M")}" : "permanently"
+    set_flash_success "Flag acknowledged #{label}."
+    redirect_to admin_data_audit_flags_path
+  end
+
+  # POST /root/data_audit_flags/:id/reopen
+  def reopen
+    @flag.reopen!
+    DataAudit::FlagCache.invalidate!
+    set_flash_success "Flag reopened."
+    redirect_to admin_data_audit_flags_path
+  end
+
+  # POST /root/data_audit_flags/scan
+  def scan
+    DataAudit::ScanJob.perform_later
+    set_flash_success "Audit scan enqueued. Results will appear shortly."
+    redirect_to admin_data_audit_flags_path
+  end
+
+  private
+
+  def set_flag
+    @flag = DataAuditFlag.find(params[:id])
+  end
+
+  # Build an admin edit path for the flagged subject record.
+  # Some models override to_param to return slug instead of ID,
+  # so we batch-preload slugs to avoid N+1 queries.
+  SUBJECT_ROUTE_MAP = {
+    "GridRoom" => :edit_admin_grid_room_path,
+    "GridZone" => :edit_admin_grid_zone_path,
+    "GridRegion" => :edit_admin_grid_region_path,
+    "GridMission" => :edit_admin_grid_mission_path,
+    "GridMob" => :edit_admin_grid_mob_path,
+    "GridSchematic" => :edit_admin_grid_schematic_path,
+    "GridBreachTemplate" => :edit_admin_grid_breach_template_path,
+    "GridBreachEncounter" => :edit_admin_grid_breach_encounter_path,
+    "Release" => :edit_admin_release_path,
+    "Track" => :edit_admin_track_path
+  }.freeze
+
+  # Models that use slug-based to_param — need slug lookup instead of raw ID.
+  SLUG_PARAM_TYPES = %w[GridMission GridSchematic GridBreachTemplate Release Track].to_set.freeze
+
+  helper_method :admin_subject_path
+
+  def admin_subject_path(subject_type, subject_id)
+    route = SUBJECT_ROUTE_MAP[subject_type]
+    return nil unless route
+
+    param = if SLUG_PARAM_TYPES.include?(subject_type)
+      @subject_slugs&.dig(subject_type, subject_id)
+    else
+      subject_id
+    end
+
+    param ? send(route, param) : nil
+  rescue ActionController::UrlGenerationError
+    nil
+  end
+
+  # Batch-load slugs for all slug-based subject types on the current page.
+  # One query per type that appears, instead of one per flag row.
+  def preload_subject_slugs(flags)
+    slugs = {}
+    flags.select { |f| SLUG_PARAM_TYPES.include?(f.subject_type) }
+      .group_by(&:subject_type)
+      .each do |type, type_flags|
+        ids = type_flags.map(&:subject_id).compact
+        next if ids.empty?
+        klass = type.constantize
+        slugs[type] = klass.where(id: ids).pluck(:id, :slug).to_h
+      rescue NameError
+        # Model class not found — skip
+      end
+    slugs
+  end
+end

--- a/app/controllers/admin/grid_missions_controller.rb
+++ b/app/controllers/admin/grid_missions_controller.rb
@@ -52,7 +52,20 @@ class Admin::GridMissionsController < Admin::ApplicationController
 
   def destroy
     name = @mission.name
-    @mission.destroy!
+    active_count = @mission.grid_hackr_missions.active.count
+
+    if active_count > 0
+      set_flash_error("Cannot delete '#{name}' — #{active_count} hackr(s) currently have this mission active. They must abandon it first.")
+      redirect_to edit_admin_grid_mission_path(@mission)
+      return
+    end
+
+    # Destroy hackr mission records first (cascades their objectives),
+    # then the mission itself destroys its definition objectives/rewards.
+    ActiveRecord::Base.transaction do
+      @mission.grid_hackr_missions.destroy_all
+      @mission.destroy!
+    end
     set_flash_success("Mission '#{name}' deleted.")
     redirect_to admin_grid_missions_path
   end

--- a/app/javascript/utils/analyticsCollector.ts
+++ b/app/javascript/utils/analyticsCollector.ts
@@ -29,7 +29,7 @@ let initialized = false
 function getOrCreateSessionId (): string {
   let id = sessionStorage.getItem(SESSION_KEY)
   if (!id) {
-    id = crypto.randomUUID()
+    id = crypto.randomUUID?.() ?? Math.random().toString(36).slice(2) + Date.now().toString(36)
     sessionStorage.setItem(SESSION_KEY, id)
   }
   return id

--- a/app/jobs/data_audit/scan_job.rb
+++ b/app/jobs/data_audit/scan_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DataAudit
+  class ScanJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      DataAudit::Runner.run!
+    rescue => e
+      Rails.logger.error("[DataAudit::ScanJob] Failed: #{e.message}")
+      raise
+    end
+  end
+end

--- a/app/models/data_audit_flag.rb
+++ b/app/models/data_audit_flag.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: data_audit_flags
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  check_name       :string           not null
+#  domain           :string           not null
+#  fingerprint      :string           not null
+#  first_flagged_at :datetime         not null
+#  last_seen_at     :datetime         not null
+#  severity         :string           default("warning"), not null
+#  snooze_until     :datetime
+#  status           :string           default("open"), not null
+#  subject_type     :string
+#  title            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  subject_id       :integer
+#
+# Indexes
+#
+#  index_data_audit_flags_on_check_name                   (check_name)
+#  index_data_audit_flags_on_domain                       (domain)
+#  index_data_audit_flags_on_fingerprint                  (fingerprint) UNIQUE
+#  index_data_audit_flags_on_status_and_severity          (status,severity)
+#  index_data_audit_flags_on_subject_type_and_subject_id  (subject_type,subject_id)
+#
+class DataAuditFlag < ApplicationRecord
+  STATUSES = %w[open acknowledged].freeze
+  SEVERITIES = %w[critical warning info].freeze
+  DOMAINS = %w[grid music].freeze
+
+  validates :fingerprint, presence: true, uniqueness: true
+  validates :title, presence: true
+  validates :check_name, presence: true
+  validates :severity, inclusion: {in: SEVERITIES}
+  validates :domain, inclusion: {in: DOMAINS}
+  validates :status, inclusion: {in: STATUSES}
+
+  scope :open_status, -> { where(status: "open") }
+  scope :acknowledged, -> { where(status: "acknowledged") }
+  scope :for_severity, ->(s) { where(severity: s) if s.present? }
+  scope :for_domain, ->(d) { where(domain: d) if d.present? }
+  scope :for_check, ->(c) { where(check_name: c) if c.present? }
+  scope :newest_first, -> { order(last_seen_at: :desc) }
+
+  # Flags that should be visible as "open" — either actually open,
+  # or acknowledged with an expired snooze.
+  scope :effective_open, -> {
+    where(status: "open")
+      .or(where(status: "acknowledged").where("snooze_until IS NOT NULL AND snooze_until < ?", Time.current))
+  }
+
+  def effective_status
+    if status == "acknowledged" && snooze_until.present? && snooze_until < Time.current
+      "open"
+    else
+      status
+    end
+  end
+
+  def snooze_expired?
+    status == "acknowledged" && snooze_until.present? && snooze_until < Time.current
+  end
+
+  def acknowledge!(until_time = nil)
+    update!(status: "acknowledged", snooze_until: until_time)
+  end
+
+  def reopen!
+    update!(status: "open", snooze_until: nil)
+  end
+end

--- a/app/services/data_audit/check.rb
+++ b/app/services/data_audit/check.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DataAudit
+  # Base class for all data audit checks. Subclasses must:
+  #   1. Define SEVERITY ("critical", "warning", or "info")
+  #   2. Define DOMAIN ("grid" or "music")
+  #   3. Implement #violations returning an array of violation hashes
+  #
+  # Each violation hash must contain:
+  #   { title:, subject_type:, subject_id: }
+  #
+  # Use build_violation to get the correct shape with fingerprint included.
+  class Check
+    def violations
+      raise NotImplementedError, "#{self.class}#violations must be implemented"
+    end
+
+    def check_name
+      self.class.name.demodulize.underscore
+    end
+
+    def severity
+      self.class::SEVERITY
+    end
+
+    def domain
+      self.class::DOMAIN
+    end
+
+    def self.fingerprint_for(subject_type, subject_id, detail_key: "")
+      Digest::SHA256.hexdigest(
+        [name, subject_type.to_s, subject_id.to_s, detail_key.to_s].join(":")
+      )
+    end
+
+    private
+
+    def build_violation(title:, subject_type:, subject_id:, detail_key: "")
+      {
+        fingerprint: self.class.fingerprint_for(subject_type, subject_id, detail_key: detail_key),
+        check_name: check_name,
+        title: title,
+        severity: severity,
+        domain: domain,
+        subject_type: subject_type,
+        subject_id: subject_id
+      }
+    end
+  end
+end

--- a/app/services/data_audit/checks/breach_encounter_orphaned.rb
+++ b/app/services/data_audit/checks/breach_encounter_orphaned.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class BreachEncounterOrphaned < DataAudit::Check
+      SEVERITY = "critical"
+      DOMAIN = "grid"
+
+      def violations
+        # Encounters stuck in "active" state with no corresponding active breach.
+        # This makes the encounter invisible to players (filtered out of available list).
+        active_encounter_ids = GridBreachEncounter.where(state: "active").pluck(:id)
+        return [] if active_encounter_ids.empty?
+
+        encounters_with_active_breach = GridHackrBreach
+          .where(state: "active")
+          .where(grid_breach_encounter_id: active_encounter_ids)
+          .pluck(:grid_breach_encounter_id)
+          .to_set
+
+        orphaned = active_encounter_ids.reject { |id| encounters_with_active_breach.include?(id) }
+        return [] if orphaned.empty?
+
+        GridBreachEncounter
+          .where(id: orphaned)
+          .joins(:grid_breach_template)
+          .pluck("grid_breach_encounters.id", "grid_breach_templates.name")
+          .map do |id, template_name|
+            build_violation(
+              title: "Breach encounter ##{id} ('#{template_name}') stuck in active state — no matching active breach",
+              subject_type: "GridBreachEncounter",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/breach_template_no_protocols.rb
+++ b/app/services/data_audit/checks/breach_template_no_protocols.rb
@@ -9,7 +9,7 @@ module DataAudit
       def violations
         GridBreachTemplate
           .where(published: true)
-          .where("protocol_composition IS NULL OR protocol_composition = '[]' OR protocol_composition = 'null'")
+          .where("protocol_composition IS NULL OR protocol_composition = '[]' OR protocol_composition = '{}' OR protocol_composition = 'null'")
           .pluck(:id, :name)
           .map do |id, name|
             build_violation(

--- a/app/services/data_audit/checks/breach_template_no_protocols.rb
+++ b/app/services/data_audit/checks/breach_template_no_protocols.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class BreachTemplateNoProtocols < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        GridBreachTemplate
+          .where(published: true)
+          .where("protocol_composition IS NULL OR protocol_composition = '[]' OR protocol_composition = 'null'")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Published breach template '#{name}' has empty protocol composition",
+              subject_type: "GridBreachTemplate",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/mission_blocked_prereq.rb
+++ b/app/services/data_audit/checks/mission_blocked_prereq.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class MissionBlockedPrereq < DataAudit::Check
+      SEVERITY = "critical"
+      DOMAIN = "grid"
+
+      def violations
+        # Published missions whose prereq exists but is unpublished —
+        # players can never complete the prereq, so the chain is permanently blocked.
+        GridMission
+          .where(published: true)
+          .where.not(prereq_mission_id: nil)
+          .joins("INNER JOIN grid_missions prereqs ON prereqs.id = grid_missions.prereq_mission_id")
+          .where("prereqs.published = ?", false)
+          .pluck("grid_missions.id", "grid_missions.name", "prereqs.name")
+          .map do |id, name, prereq_name|
+            build_violation(
+              title: "Published mission '#{name}' requires unpublished prereq '#{prereq_name}'",
+              subject_type: "GridMission",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/mission_no_giver.rb
+++ b/app/services/data_audit/checks/mission_no_giver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class MissionNoGiver < DataAudit::Check
+      SEVERITY = "critical"
+      DOMAIN = "grid"
+
+      def violations
+        GridMission
+          .where(published: true, giver_mob_id: nil)
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Published mission '#{name}' has no giver mob",
+              subject_type: "GridMission",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/mission_no_objectives.rb
+++ b/app/services/data_audit/checks/mission_no_objectives.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class MissionNoObjectives < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        GridMission
+          .where(published: true)
+          .left_joins(:grid_mission_objectives)
+          .group("grid_missions.id")
+          .having("COUNT(grid_mission_objectives.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Published mission '#{name}' has no objectives",
+              subject_type: "GridMission",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/quest_giver_no_missions.rb
+++ b/app/services/data_audit/checks/quest_giver_no_missions.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class QuestGiverNoMissions < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        quest_giver_ids = GridMob.where(mob_type: "quest_giver").pluck(:id)
+        return [] if quest_giver_ids.empty?
+
+        givers_with_missions = GridMission
+          .where(published: true)
+          .where(giver_mob_id: quest_giver_ids)
+          .distinct
+          .pluck(:giver_mob_id)
+          .to_set
+
+        orphaned_ids = quest_giver_ids.reject { |id| givers_with_missions.include?(id) }
+        return [] if orphaned_ids.empty?
+
+        GridMob
+          .where(id: orphaned_ids)
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Quest giver mob '#{name}' has no published missions",
+              subject_type: "GridMob",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/region_missing_hospital.rb
+++ b/app/services/data_audit/checks/region_missing_hospital.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class RegionMissingHospital < DataAudit::Check
+      SEVERITY = "critical"
+      DOMAIN = "grid"
+
+      def violations
+        GridRegion
+          .where(hospital_room_id: nil)
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Region '#{name}' has no hospital room (RestorePoint™)",
+              subject_type: "GridRegion",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/release_no_cover.rb
+++ b/app/services/data_audit/checks/release_no_cover.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class ReleaseNoCover < DataAudit::Check
+      SEVERITY = "info"
+      DOMAIN = "music"
+
+      def violations
+        Release
+          .where(coming_soon: false)
+          .left_joins(:cover_image_attachment)
+          .where(active_storage_attachments: {id: nil})
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Release '#{name}' has no cover image",
+              subject_type: "Release",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/release_no_tracks.rb
+++ b/app/services/data_audit/checks/release_no_tracks.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class ReleaseNoTracks < DataAudit::Check
+      SEVERITY = "info"
+      DOMAIN = "music"
+
+      def violations
+        Release
+          .where(coming_soon: false)
+          .left_joins(:tracks)
+          .group("releases.id")
+          .having("COUNT(tracks.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Release '#{name}' has no tracks",
+              subject_type: "Release",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/room_no_description.rb
+++ b/app/services/data_audit/checks/room_no_description.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class RoomNoDescription < DataAudit::Check
+      SEVERITY = "info"
+      DOMAIN = "grid"
+
+      # Den rooms have user-controlled descriptions, skip them.
+      EXEMPT_TYPES = %w[den].freeze
+
+      def violations
+        GridRoom
+          .where.not(room_type: EXEMPT_TYPES)
+          .where(description: [nil, ""])
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Room '#{name}' has no description",
+              subject_type: "GridRoom",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/room_no_exits.rb
+++ b/app/services/data_audit/checks/room_no_exits.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class RoomNoExits < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      # Room types that are intentionally isolated (no outbound exits expected)
+      EXEMPT_TYPES = %w[den].freeze
+
+      def violations
+        GridRoom
+          .where.not(room_type: EXEMPT_TYPES)
+          .left_joins(:exits_from)
+          .group("grid_rooms.id")
+          .having("COUNT(grid_exits.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Room '#{name}' has no exits",
+              subject_type: "GridRoom",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/schematic_no_ingredients.rb
+++ b/app/services/data_audit/checks/schematic_no_ingredients.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class SchematicNoIngredients < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        GridSchematic
+          .where(published: true)
+          .left_joins(:ingredients)
+          .group("grid_schematics.id")
+          .having("COUNT(grid_schematic_ingredients.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Published schematic '#{name}' has no ingredients",
+              subject_type: "GridSchematic",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/track_no_audio.rb
+++ b/app/services/data_audit/checks/track_no_audio.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class TrackNoAudio < DataAudit::Check
+      SEVERITY = "info"
+      DOMAIN = "music"
+
+      def violations
+        Track
+          .joins(:release)
+          .where(releases: {coming_soon: false})
+          .left_joins(:audio_file_attachment)
+          .where(active_storage_attachments: {id: nil})
+          .pluck("tracks.id", "tracks.title")
+          .map do |id, title|
+            build_violation(
+              title: "Track '#{title}' has no audio file attached",
+              subject_type: "Track",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/vendor_no_listings.rb
+++ b/app/services/data_audit/checks/vendor_no_listings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class VendorNoListings < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        GridMob
+          .where(mob_type: "vendor")
+          .left_joins(:grid_shop_listings)
+          .group("grid_mobs.id")
+          .having("COUNT(grid_shop_listings.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Vendor mob '#{name}' has no shop listings",
+              subject_type: "GridMob",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/checks/zone_no_rooms.rb
+++ b/app/services/data_audit/checks/zone_no_rooms.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Checks
+    class ZoneNoRooms < DataAudit::Check
+      SEVERITY = "warning"
+      DOMAIN = "grid"
+
+      def violations
+        GridZone
+          .left_joins(:grid_rooms)
+          .group("grid_zones.id")
+          .having("COUNT(grid_rooms.id) = 0")
+          .pluck(:id, :name)
+          .map do |id, name|
+            build_violation(
+              title: "Zone '#{name}' has no rooms",
+              subject_type: "GridZone",
+              subject_id: id
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/services/data_audit/flag_cache.rb
+++ b/app/services/data_audit/flag_cache.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module FlagCache
+    OPEN_COUNT_KEY = "data_audit/open_count"
+    LAST_SCAN_KEY = "data_audit/last_scan_at"
+    TTL = 5.minutes
+
+    module_function
+
+    def open_count
+      Rails.cache.fetch(OPEN_COUNT_KEY, expires_in: TTL) do
+        DataAuditFlag.effective_open.count
+      end
+    end
+
+    def last_scan_at
+      Rails.cache.read(LAST_SCAN_KEY)
+    end
+
+    def record_scan!
+      Rails.cache.write(LAST_SCAN_KEY, Time.current)
+    end
+
+    def invalidate!
+      Rails.cache.delete(OPEN_COUNT_KEY)
+    end
+  end
+end

--- a/app/services/data_audit/registry.rb
+++ b/app/services/data_audit/registry.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DataAudit
+  module Registry
+    CHECKS = [
+      # Grid — Critical
+      DataAudit::Checks::MissionNoGiver,
+      DataAudit::Checks::MissionBlockedPrereq,
+      DataAudit::Checks::BreachEncounterOrphaned,
+      DataAudit::Checks::RegionMissingHospital,
+
+      # Grid — Warning
+      DataAudit::Checks::RoomNoExits,
+      DataAudit::Checks::MissionNoObjectives,
+      DataAudit::Checks::SchematicNoIngredients,
+      DataAudit::Checks::BreachTemplateNoProtocols,
+      DataAudit::Checks::VendorNoListings,
+      DataAudit::Checks::QuestGiverNoMissions,
+      DataAudit::Checks::ZoneNoRooms,
+
+      # Music — Info
+      DataAudit::Checks::ReleaseNoCover,
+      DataAudit::Checks::ReleaseNoTracks,
+      DataAudit::Checks::TrackNoAudio,
+
+      # Grid — Info
+      DataAudit::Checks::RoomNoDescription
+    ].freeze
+  end
+end

--- a/app/services/data_audit/runner.rb
+++ b/app/services/data_audit/runner.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module DataAudit
+  # Runs all registered checks, reconciles results against existing flags.
+  # New violations are created, resolved violations are deleted,
+  # expired snoozes are reopened.
+  module Runner
+    module_function
+
+    def run!
+      now = Time.current
+      current_violations, failed_checks = gather_violations
+      reconcile(current_violations, failed_checks, now)
+      FlagCache.record_scan!
+      FlagCache.invalidate!
+    end
+
+    def gather_violations
+      violations = {}
+      failed_checks = Set.new
+
+      Registry::CHECKS.each do |check_class|
+        check = check_class.new
+        begin
+          check.violations.each do |v|
+            violations[v[:fingerprint]] = v
+          end
+        rescue => e
+          failed_checks << check.check_name
+          Rails.logger.error("[DataAudit] Check #{check_class} failed: #{e.message}")
+        end
+      end
+
+      [violations, failed_checks]
+    end
+
+    def reconcile(current_violations, failed_checks, now)
+      existing_flags = DataAuditFlag.all.index_by(&:fingerprint)
+      current_fps = current_violations.keys.to_set
+
+      to_insert = []
+      to_touch_ids = []
+      to_reopen_ids = []
+
+      current_violations.each do |fp, violation|
+        flag = existing_flags[fp]
+
+        if flag.nil?
+          # New violation — create flag
+          to_insert << violation.merge(
+            first_flagged_at: now,
+            last_seen_at: now,
+            status: "open",
+            created_at: now,
+            updated_at: now
+          )
+        elsif flag.status == "open"
+          # Still open, still present — touch last_seen_at
+          to_touch_ids << flag.id
+        elsif flag.snooze_expired?
+          # Snooze expired and violation still present — reopen
+          to_reopen_ids << flag.id
+        else
+          # Acknowledged with active snooze — touch last_seen_at but leave status
+          to_touch_ids << flag.id
+        end
+      end
+
+      # Flags whose violations have been resolved — delete them.
+      # Skip flags from checks that failed (we can't confirm they're resolved).
+      to_delete_ids = existing_flags.values
+        .reject { |f| current_fps.include?(f.fingerprint) }
+        .reject { |f| failed_checks.include?(f.check_name) }
+        .map(&:id)
+
+      # Apply all changes
+      DataAuditFlag.upsert_all(to_insert, unique_by: :fingerprint) if to_insert.any?
+
+      if to_touch_ids.any?
+        DataAuditFlag.where(id: to_touch_ids).update_all(last_seen_at: now, updated_at: now)
+      end
+
+      if to_reopen_ids.any?
+        DataAuditFlag.where(id: to_reopen_ids).update_all(
+          status: "open", snooze_until: nil, last_seen_at: now, updated_at: now
+        )
+      end
+
+      DataAuditFlag.where(id: to_delete_ids).delete_all if to_delete_ids.any?
+    end
+  end
+end

--- a/app/views/admin/data_audit_flags/index.html.erb
+++ b/app/views/admin/data_audit_flags/index.html.erb
@@ -1,0 +1,185 @@
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/data_audit :: RED FLAGS</legend>
+
+    <div style="padding: 20px;">
+      <% if flash[:success] %>
+        <div style="background: #002200; border: 2px solid #00ff00; padding: 10px 15px; margin-bottom: 15px;">
+          <span class="green-255-text"><%= flash[:success] %></span>
+        </div>
+      <% end %>
+      <% if flash[:error] %>
+        <div style="background: #220000; border: 2px solid #ff0000; padding: 10px 15px; margin-bottom: 15px;">
+          <span class="red-255-text"><%= flash[:error] %></span>
+        </div>
+      <% end %>
+
+      <%# Summary cards %>
+      <div style="display: flex; gap: 15px; margin-bottom: 20px; flex-wrap: wrap;">
+        <% %w[critical warning info].each do |sev| %>
+          <% count = @by_severity[sev] || 0 %>
+          <% color = case sev
+            when "critical" then "#ff4444"
+            when "warning" then "#ff6600"
+            when "info" then "#fbbf24"
+          end %>
+          <div style="border: 1px solid <%= color %>; padding: 10px 18px; background: #0a0a0a; min-width: 120px; text-align: center;">
+            <div style="color: <%= color %>; font-size: 1.4em; font-weight: bold;"><%= count %></div>
+            <div style="color: #888; font-size: 0.8em; text-transform: uppercase;"><%= sev %></div>
+          </div>
+        <% end %>
+        <% %w[grid music].each do |dom| %>
+          <% count = @by_domain[dom] || 0 %>
+          <% color = dom == "grid" ? "#34d399" : "#a78bfa" %>
+          <div style="border: 1px solid <%= color %>; padding: 10px 18px; background: #0a0a0a; min-width: 120px; text-align: center;">
+            <div style="color: <%= color %>; font-size: 1.4em; font-weight: bold;"><%= count %></div>
+            <div style="color: #888; font-size: 0.8em; text-transform: uppercase;"><%= dom %></div>
+          </div>
+        <% end %>
+      </div>
+
+      <%# Scan info + refresh %>
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+        <span style="color: #666; font-size: 0.85em;">
+          Last scan: <%= @last_scan_at ? @last_scan_at.strftime("%Y-%m-%d %H:%M:%S") : "Never" %>
+        </span>
+        <%= button_to "⟳ Refresh Scan", scan_admin_data_audit_flags_path, method: :post, class: "tui-button cyan-168", style: "padding: 4px 12px; font-size: 0.85em;", form: {style: "display: inline;"} %>
+      </div>
+
+      <%# Filter form %>
+      <div style="margin-bottom: 20px; padding: 15px; border: 1px solid #333; background: #0a0a0a;">
+        <%= form_tag admin_data_audit_flags_path, method: :get, style: "display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;" do %>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Status</label>
+            <%= select_tag :status, options_for_select([["All", ""]] + DataAuditFlag::STATUSES.map { |s| [s.upcase, s] }, params[:status]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Severity</label>
+            <%= select_tag :severity, options_for_select([["All", ""]] + DataAuditFlag::SEVERITIES.map { |s| [s.upcase, s] }, params[:severity]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Domain</label>
+            <%= select_tag :domain, options_for_select([["All", ""]] + DataAuditFlag::DOMAINS.map { |d| [d.upcase, d] }, params[:domain]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Check</label>
+            <%= select_tag :check_name, options_for_select([["All", ""]] + @check_names.map { |c| [c.humanize, c] }, params[:check_name]), style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;" %>
+          </div>
+          <div>
+            <label style="color: #888; font-size: 0.8em; display: block; margin-bottom: 4px;">Search</label>
+            <%= text_field_tag :search, params[:search], style: "background: #111; color: #d0d0d0; border: 1px solid #444; padding: 6px 10px; font-family: monospace;", placeholder: "flag title..." %>
+          </div>
+          <div>
+            <button type="submit" class="tui-button cyan-168" style="padding: 6px 14px;">Filter</button>
+          </div>
+          <% if params.values_at(:status, :severity, :domain, :check_name, :search).any?(&:present?) %>
+            <div>
+              <%= link_to "Clear", admin_data_audit_flags_path, class: "tui-button", style: "padding: 6px 14px;" %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <h3 style="color: #ff6600; margin-bottom: 15px;">[:: RED FLAGS (<%= @total_count %> total<%= ", showing #{@offset + 1}–#{[@offset + @per_page, @total_count].min}" if @total_count > 0 %>) ::]</h3>
+
+      <% if @flags.any? %>
+        <style>.audit-flags-table tbody tr td, .audit-flags-table thead tr th { padding: 8px 10px; }</style>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
+          <table class="tui-table audit-flags-table" style="width: 100%;">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Status</th>
+                <th style="text-align: center;">Severity</th>
+                <th style="text-align: left;">Title</th>
+                <th style="text-align: center;">Domain</th>
+                <th style="text-align: center;">Subject</th>
+                <th style="text-align: center;">First Flagged</th>
+                <th style="text-align: center;">Last Seen</th>
+                <th style="text-align: center;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @flags.each_with_index do |flag, i| %>
+                <% eff_status = flag.effective_status %>
+                <tr style="<%= " background: #112;" if i.odd? %>">
+                  <td style="text-align: center;">
+                    <% status_color = eff_status == "open" ? "#ff6600" : "#888" %>
+                    <span style="color: <%= status_color %>; font-weight: bold;"><%= eff_status.upcase %></span>
+                    <% if flag.status == "acknowledged" && flag.snooze_until %>
+                      <br><span style="color: #555; font-size: 0.75em;">until <%= flag.snooze_until.strftime("%m/%d %H:%M") %></span>
+                    <% elsif flag.status == "acknowledged" && flag.snooze_until.nil? %>
+                      <br><span style="color: #555; font-size: 0.75em;">forever</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center;">
+                    <% sev_color = case flag.severity
+                      when "critical" then "#ff4444"
+                      when "warning" then "#ff6600"
+                      when "info" then "#fbbf24"
+                    end %>
+                    <span style="color: <%= sev_color %>; font-weight: bold; font-size: 0.85em;"><%= flag.severity.upcase %></span>
+                  </td>
+                  <td style="max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="<%= flag.title %>">
+                    <span style="color: #d0d0d0;"><%= flag.title %></span>
+                  </td>
+                  <td style="text-align: center;">
+                    <% dom_color = flag.domain == "grid" ? "#34d399" : "#a78bfa" %>
+                    <span style="color: <%= dom_color %>; font-size: 0.85em;"><%= flag.domain.upcase %></span>
+                  </td>
+                  <td style="text-align: center;">
+                    <% if flag.subject_type.present? && flag.subject_id.present? %>
+                      <% admin_path = admin_subject_path(flag.subject_type, flag.subject_id) %>
+                      <% if admin_path %>
+                        <%= link_to "Edit →", admin_path, style: "color: #00ffff; text-decoration: none; font-size: 0.85em;" %>
+                      <% else %>
+                        <span style="color: #555; font-size: 0.85em;"><%= flag.subject_type.demodulize %>#<%= flag.subject_id %></span>
+                      <% end %>
+                    <% else %>
+                      <span style="color: #333;">—</span>
+                    <% end %>
+                  </td>
+                  <td style="text-align: center; color: #666; white-space: nowrap; font-size: 0.85em;">
+                    <%= flag.first_flagged_at&.strftime("%Y-%m-%d %H:%M") || "—" %>
+                  </td>
+                  <td style="text-align: center; color: #666; white-space: nowrap; font-size: 0.85em;">
+                    <%= flag.last_seen_at&.strftime("%Y-%m-%d %H:%M") || "—" %>
+                  </td>
+                  <td style="text-align: center; white-space: nowrap;">
+                    <% if eff_status == "open" %>
+                      <%= button_to "Ack 24h", acknowledge_admin_data_audit_flag_path(flag, duration: "24h"), method: :post, class: "tui-button", style: "padding: 2px 6px; font-size: 0.75em;", form: {style: "display: inline;"} %>
+                      <%= button_to "Ack 7d", acknowledge_admin_data_audit_flag_path(flag, duration: "7d"), method: :post, class: "tui-button", style: "padding: 2px 6px; font-size: 0.75em;", form: {style: "display: inline;"} %>
+                      <%= button_to "Ack ∞", acknowledge_admin_data_audit_flag_path(flag, duration: "forever"), method: :post, class: "tui-button", style: "padding: 2px 6px; font-size: 0.75em;", form: {style: "display: inline;"} %>
+                    <% else %>
+                      <%= button_to "Reopen", reopen_admin_data_audit_flag_path(flag), method: :post, class: "tui-button red-168", style: "padding: 2px 6px; font-size: 0.75em;", form: {style: "display: inline;"} %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <%# Pagination %>
+        <div style="display: flex; gap: 15px; align-items: center; margin-top: 15px;">
+          <% if @offset > 0 %>
+            <%= link_to "← Prev", admin_data_audit_flags_path(request.query_parameters.merge("offset" => [@offset - @per_page, 0].max)), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+          <span style="color: #888;">
+            Page <%= (@offset / @per_page) + 1 %> of <%= [(@total_count.to_f / @per_page).ceil, 1].max %>
+          </span>
+          <% if @offset + @per_page < @total_count %>
+            <%= link_to "Next →", admin_data_audit_flags_path(request.query_parameters.merge("offset" => @offset + @per_page)), class: "tui-button green-168", style: "padding: 6px 14px;" %>
+          <% end %>
+        </div>
+      <% else %>
+        <div style="padding: 40px; text-align: center; background: #1a1a1a; border: 1px solid #333;">
+          <p style="color: #666;">No red flags found. All clear.</p>
+        </div>
+      <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
+        <%= link_to "← Admin Dashboard", admin_root_path, class: "tui-button green-168" %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/grid_missions/edit.html.erb
+++ b/app/views/admin/grid_missions/edit.html.erb
@@ -5,6 +5,11 @@
       <%= form_with model: @mission, url: admin_grid_mission_path(@mission), local: true do |f| %>
         <%= render "form", f: f %>
       <% end %>
+
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333; display: flex; justify-content: space-between; align-items: center;">
+        <%= link_to "← Back to Missions", admin_grid_missions_path, class: "tui-button green-168", style: "padding: 6px 14px;" %>
+        <%= button_to "Delete Mission", admin_grid_mission_path(@mission), method: :delete, class: "tui-button red-168", style: "padding: 6px 14px;", data: { confirm: "Delete mission '#{@mission.name}'? This will also delete all objectives, rewards, and player progress." } %>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/app/views/admin/shared/_data_audit_banner.html.erb
+++ b/app/views/admin/shared/_data_audit_banner.html.erb
@@ -1,0 +1,8 @@
+<% count = DataAudit::FlagCache.open_count %>
+<% if count > 0 %>
+  <div style="background: #1a0a00; border-bottom: 2px solid #ff6600; padding: 8px 20px; text-align: center;">
+    <span style="color: #ff6600; font-weight: bold;">⚑ RED FLAGS: <%= count %> open</span>
+    <span style="color: #666; margin: 0 8px;">|</span>
+    <%= link_to "View All →", admin_data_audit_flags_path, style: "color: #ff9944; text-decoration: none;" %>
+  </div>
+<% end %>

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -117,6 +117,7 @@
         <span class="admin-nav-dropdown-trigger cyan-168-text">Meta</span>
         <div class="admin-nav-dropdown-menu">
           <%= link_to "Errors", admin_error_groups_path, class: "red-168-text" %>
+          <%= link_to "Red Flags", admin_data_audit_flags_path, style: "color: #ff6600;" %>
           <%= link_to "Analytics", admin_analytics_dashboard_path, class: "cyan-168-text" %>
           <%= link_to "Overlays", admin_overlays_path, class: "yellow-168-text" %>
           <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -29,6 +29,7 @@
 
   <body class="black-168" style="background: #0a0a0a;">
     <%= render "admin/shared/nav" %>
+    <%= render "admin/shared/data_audit_banner" %>
     <%= yield %>
     <%= render "admin/shared/sortable_tables" %>
   </body>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -37,3 +37,7 @@ production:
   telemetry_prune:
     class: TelemetryPruneJob
     schedule: at 4am every day
+
+  data_audit_scan:
+    class: DataAudit::ScanJob
+    schedule: every 6 hours

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,6 +301,17 @@ Rails.application.routes.draw do
       end
     end
 
+    # Data audit
+    resources :data_audit_flags, only: [:index] do
+      collection do
+        post :scan
+      end
+      member do
+        post :acknowledge
+        post :reopen
+      end
+    end
+
     # Catalog resources (full CRUD)
     resources :artists do
       member do

--- a/db/migrate/20260518200000_create_data_audit_flags.rb
+++ b/db/migrate/20260518200000_create_data_audit_flags.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateDataAuditFlags < ActiveRecord::Migration[8.0]
+  def change
+    create_table :data_audit_flags do |t|
+      t.string :fingerprint, null: false
+      t.string :check_name, null: false
+      t.string :title, null: false
+      t.string :severity, null: false, default: "warning"
+      t.string :domain, null: false
+      t.string :subject_type
+      t.integer :subject_id
+      t.string :status, null: false, default: "open"
+      t.datetime :snooze_until
+      t.datetime :first_flagged_at, null: false
+      t.datetime :last_seen_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :data_audit_flags, :fingerprint, unique: true
+    add_index :data_audit_flags, [:status, :severity]
+    add_index :data_audit_flags, :check_name
+    add_index :data_audit_flags, :domain
+    add_index :data_audit_flags, [:subject_type, :subject_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_18_200000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -128,6 +128,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
     t.index ["codex_entry_id"], name: "index_codex_entry_reads_on_codex_entry_id"
     t.index ["grid_hackr_id", "codex_entry_id"], name: "index_codex_entry_reads_unique", unique: true
     t.index ["grid_hackr_id"], name: "index_codex_entry_reads_on_grid_hackr_id"
+  end
+
+  create_table "data_audit_flags", force: :cascade do |t|
+    t.string "check_name", null: false
+    t.datetime "created_at", null: false
+    t.string "domain", null: false
+    t.string "fingerprint", null: false
+    t.datetime "first_flagged_at", null: false
+    t.datetime "last_seen_at", null: false
+    t.string "severity", default: "warning", null: false
+    t.datetime "snooze_until"
+    t.string "status", default: "open", null: false
+    t.integer "subject_id"
+    t.string "subject_type"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["check_name"], name: "index_data_audit_flags_on_check_name"
+    t.index ["domain"], name: "index_data_audit_flags_on_domain"
+    t.index ["fingerprint"], name: "index_data_audit_flags_on_fingerprint", unique: true
+    t.index ["status", "severity"], name: "index_data_audit_flags_on_status_and_severity"
+    t.index ["subject_type", "subject_id"], name: "index_data_audit_flags_on_subject_type_and_subject_id"
   end
 
   create_table "echoes", force: :cascade do |t|

--- a/spec/models/data_audit_flag_spec.rb
+++ b/spec/models/data_audit_flag_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: data_audit_flags
+# Database name: primary
+#
+#  id               :integer          not null, primary key
+#  check_name       :string           not null
+#  domain           :string           not null
+#  fingerprint      :string           not null
+#  first_flagged_at :datetime         not null
+#  last_seen_at     :datetime         not null
+#  severity         :string           default("warning"), not null
+#  snooze_until     :datetime
+#  status           :string           default("open"), not null
+#  subject_type     :string
+#  title            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  subject_id       :integer
+#
+# Indexes
+#
+#  index_data_audit_flags_on_check_name                   (check_name)
+#  index_data_audit_flags_on_domain                       (domain)
+#  index_data_audit_flags_on_fingerprint                  (fingerprint) UNIQUE
+#  index_data_audit_flags_on_status_and_severity          (status,severity)
+#  index_data_audit_flags_on_subject_type_and_subject_id  (subject_type,subject_id)
+#
+require "rails_helper"
+
+RSpec.describe DataAuditFlag do
+  def create_flag(attrs = {})
+    DataAuditFlag.create!({
+      fingerprint: SecureRandom.hex(32),
+      check_name: "test_check",
+      title: "Test flag",
+      severity: "warning",
+      domain: "grid",
+      status: "open",
+      first_flagged_at: Time.current,
+      last_seen_at: Time.current
+    }.merge(attrs))
+  end
+
+  describe "validations" do
+    it "requires fingerprint, title, check_name" do
+      flag = DataAuditFlag.new
+      flag.valid?
+      expect(flag.errors[:fingerprint]).to be_present
+      expect(flag.errors[:title]).to be_present
+      expect(flag.errors[:check_name]).to be_present
+    end
+
+    it "enforces fingerprint uniqueness" do
+      create_flag(fingerprint: "dup")
+      dup = DataAuditFlag.new(fingerprint: "dup", check_name: "x", title: "x",
+        severity: "warning", domain: "grid", first_flagged_at: Time.current, last_seen_at: Time.current)
+      expect(dup).not_to be_valid
+      expect(dup.errors[:fingerprint]).to include("has already been taken")
+    end
+
+    it "validates severity inclusion" do
+      flag = DataAuditFlag.new(severity: "bogus")
+      flag.valid?
+      expect(flag.errors[:severity]).to be_present
+    end
+
+    it "validates domain inclusion" do
+      flag = DataAuditFlag.new(domain: "bogus")
+      flag.valid?
+      expect(flag.errors[:domain]).to be_present
+    end
+
+    it "validates status inclusion" do
+      flag = DataAuditFlag.new(status: "bogus")
+      flag.valid?
+      expect(flag.errors[:status]).to be_present
+    end
+  end
+
+  describe "#effective_status" do
+    it "returns open for open flags" do
+      flag = create_flag(status: "open")
+      expect(flag.effective_status).to eq("open")
+    end
+
+    it "returns acknowledged for actively snoozed flags" do
+      flag = create_flag(status: "acknowledged", snooze_until: 1.hour.from_now)
+      expect(flag.effective_status).to eq("acknowledged")
+    end
+
+    it "returns open for expired snooze" do
+      flag = create_flag(status: "acknowledged", snooze_until: 1.hour.ago)
+      expect(flag.effective_status).to eq("open")
+    end
+
+    it "returns acknowledged for forever-snoozed flags (nil snooze_until)" do
+      flag = create_flag(status: "acknowledged", snooze_until: nil)
+      expect(flag.effective_status).to eq("acknowledged")
+    end
+  end
+
+  describe "#snooze_expired?" do
+    it "false for open flags" do
+      expect(create_flag(status: "open").snooze_expired?).to be false
+    end
+
+    it "false for actively snoozed" do
+      expect(create_flag(status: "acknowledged", snooze_until: 1.day.from_now).snooze_expired?).to be false
+    end
+
+    it "true for expired snooze" do
+      expect(create_flag(status: "acknowledged", snooze_until: 1.hour.ago).snooze_expired?).to be true
+    end
+
+    it "false for forever snooze" do
+      expect(create_flag(status: "acknowledged", snooze_until: nil).snooze_expired?).to be false
+    end
+  end
+
+  describe "#acknowledge!" do
+    it "sets status and snooze_until" do
+      flag = create_flag
+      until_time = 7.days.from_now
+      flag.acknowledge!(until_time)
+      flag.reload
+      expect(flag.status).to eq("acknowledged")
+      expect(flag.snooze_until).to be_within(1.second).of(until_time)
+    end
+
+    it "supports forever snooze with nil" do
+      flag = create_flag
+      flag.acknowledge!(nil)
+      flag.reload
+      expect(flag.status).to eq("acknowledged")
+      expect(flag.snooze_until).to be_nil
+    end
+  end
+
+  describe "#reopen!" do
+    it "resets status and clears snooze" do
+      flag = create_flag(status: "acknowledged", snooze_until: 1.day.from_now)
+      flag.reopen!
+      flag.reload
+      expect(flag.status).to eq("open")
+      expect(flag.snooze_until).to be_nil
+    end
+  end
+
+  describe ".effective_open scope" do
+    it "includes open flags" do
+      flag = create_flag(status: "open")
+      expect(DataAuditFlag.effective_open).to include(flag)
+    end
+
+    it "includes expired snoozes" do
+      flag = create_flag(status: "acknowledged", snooze_until: 1.hour.ago)
+      expect(DataAuditFlag.effective_open).to include(flag)
+    end
+
+    it "excludes actively snoozed flags" do
+      flag = create_flag(status: "acknowledged", snooze_until: 1.day.from_now)
+      expect(DataAuditFlag.effective_open).not_to include(flag)
+    end
+
+    it "excludes forever-snoozed flags" do
+      flag = create_flag(status: "acknowledged", snooze_until: nil)
+      expect(DataAuditFlag.effective_open).not_to include(flag)
+    end
+  end
+end

--- a/spec/services/data_audit/checks_spec.rb
+++ b/spec/services/data_audit/checks_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DataAudit::Checks" do
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+
+  describe DataAudit::Checks::RoomNoExits do
+    it "flags rooms with no exits" do
+      room = create(:grid_room, grid_zone: zone, description: "A room")
+      # No exits created
+      violations = described_class.new.violations
+      fps = violations.map { |v| v[:subject_id] }
+      expect(fps).to include(room.id)
+    end
+
+    it "does not flag rooms with exits" do
+      room = create(:grid_room, grid_zone: zone)
+      target = create(:grid_room, grid_zone: zone)
+      create(:grid_exit, from_room: room, to_room: target, direction: "north")
+
+      violations = described_class.new.violations
+      fps = violations.map { |v| v[:subject_id] }
+      expect(fps).not_to include(room.id)
+    end
+
+    it "does not flag den rooms" do
+      create(:grid_room, :den, grid_zone: zone)
+      violations = described_class.new.violations
+      den_violations = violations.select { |v| v[:title].include?("Den") }
+      expect(den_violations).to be_empty
+    end
+  end
+
+  describe DataAudit::Checks::MissionNoGiver do
+    it "flags published missions with no giver" do
+      # Model validates giver presence on published missions, so simulate
+      # the nullified-FK case (mob deleted after publish) via direct update
+      mission = create(:grid_mission, published: true)
+      mission.update_column(:giver_mob_id, nil)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).to include(mission.id)
+    end
+
+    it "does not flag published missions with a giver" do
+      mission = create(:grid_mission, published: true)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(mission.id)
+    end
+
+    it "does not flag unpublished missions" do
+      mission = create(:grid_mission, :unpublished, giver_mob: nil)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(mission.id)
+    end
+  end
+
+  describe DataAudit::Checks::MissionBlockedPrereq do
+    it "flags published missions whose prereq is unpublished" do
+      prereq = create(:grid_mission, :unpublished)
+      mission = create(:grid_mission, published: true, prereq_mission: prereq)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).to include(mission.id)
+    end
+
+    it "does not flag missions with published prereqs" do
+      prereq = create(:grid_mission, published: true)
+      mission = create(:grid_mission, published: true, prereq_mission: prereq)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(mission.id)
+    end
+  end
+
+  describe DataAudit::Checks::VendorNoListings do
+    it "flags vendor mobs with no listings" do
+      vendor = create(:grid_mob, :vendor)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).to include(vendor.id)
+    end
+
+    it "does not flag vendors with listings" do
+      vendor = create(:grid_mob, :vendor)
+      item_def = create(:grid_item_definition)
+      create(:grid_shop_listing, grid_mob: vendor, grid_item_definition: item_def)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(vendor.id)
+    end
+  end
+
+  describe DataAudit::Checks::ZoneNoRooms do
+    it "flags zones with no rooms" do
+      empty_zone = create(:grid_zone, grid_region: region)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).to include(empty_zone.id)
+    end
+
+    it "does not flag zones with rooms" do
+      zone_with_rooms = create(:grid_zone, grid_region: region)
+      create(:grid_room, grid_zone: zone_with_rooms)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(zone_with_rooms.id)
+    end
+  end
+
+  describe DataAudit::Checks::RegionMissingHospital do
+    it "flags regions with no hospital room" do
+      region # force create before check runs
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).to include(region.id)
+    end
+
+    it "does not flag regions with hospital room set" do
+      room = create(:grid_room, grid_zone: zone)
+      region.update!(hospital_room_id: room.id)
+      violations = described_class.new.violations
+      ids = violations.map { |v| v[:subject_id] }
+      expect(ids).not_to include(region.id)
+    end
+  end
+
+  describe "all checks" do
+    it "every registered check returns an array of hashes with required keys" do
+      DataAudit::Registry::CHECKS.each do |check_class|
+        check = check_class.new
+        violations = check.violations
+        expect(violations).to be_an(Array), "#{check_class} did not return Array"
+        violations.each do |v|
+          expect(v).to have_key(:fingerprint), "#{check_class} violation missing :fingerprint"
+          expect(v).to have_key(:check_name), "#{check_class} violation missing :check_name"
+          expect(v).to have_key(:title), "#{check_class} violation missing :title"
+          expect(v).to have_key(:severity), "#{check_class} violation missing :severity"
+          expect(v).to have_key(:domain), "#{check_class} violation missing :domain"
+          expect(v).to have_key(:subject_type), "#{check_class} violation missing :subject_type"
+          expect(v).to have_key(:subject_id), "#{check_class} violation missing :subject_id"
+        end
+      end
+    end
+
+    it "every check has a valid severity and domain" do
+      DataAudit::Registry::CHECKS.each do |check_class|
+        check = check_class.new
+        expect(DataAuditFlag::SEVERITIES).to include(check.severity), "#{check_class} has invalid severity: #{check.severity}"
+        expect(DataAuditFlag::DOMAINS).to include(check.domain), "#{check_class} has invalid domain: #{check.domain}"
+      end
+    end
+  end
+end

--- a/spec/services/data_audit/runner_spec.rb
+++ b/spec/services/data_audit/runner_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataAudit::Runner do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:region) { create(:grid_region) }
+  let(:zone) { create(:grid_zone, grid_region: region) }
+
+  # Create a room with no exits — guaranteed to trigger RoomNoExits check
+  let!(:room_without_exits) { create(:grid_room, :standard, grid_zone: zone, description: "sealed") }
+
+  def create_flag(attrs = {})
+    DataAuditFlag.create!({
+      fingerprint: SecureRandom.hex(32),
+      check_name: "test_check",
+      title: "Test flag",
+      severity: "warning",
+      domain: "grid",
+      status: "open",
+      first_flagged_at: Time.current,
+      last_seen_at: Time.current
+    }.merge(attrs))
+  end
+
+  describe ".run!" do
+    it "creates flags for violations found by checks" do
+      expect { DataAudit::Runner.run! }.to change(DataAuditFlag, :count).by_at_least(1)
+    end
+
+    it "is idempotent — second run does not duplicate flags" do
+      DataAudit::Runner.run!
+      count_after_first = DataAuditFlag.count
+      DataAudit::Runner.run!
+      expect(DataAuditFlag.count).to eq(count_after_first)
+    end
+
+    it "records scan timestamp" do
+      # Use memory store to ensure cache works in test
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      DataAudit::Runner.run!
+      expect(DataAudit::FlagCache.last_scan_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "invalidates the open count cache" do
+      cache = ActiveSupport::Cache::MemoryStore.new
+      allow(Rails).to receive(:cache).and_return(cache)
+      cache.write(DataAudit::FlagCache::OPEN_COUNT_KEY, 999)
+      DataAudit::Runner.run!
+      expect(cache.read(DataAudit::FlagCache::OPEN_COUNT_KEY)).to be_nil
+    end
+  end
+
+  describe "reconciliation" do
+    it "auto-clears flags when violations are resolved" do
+      DataAudit::Runner.run!
+      flag = DataAuditFlag.find_by(check_name: "room_no_exits", subject_id: room_without_exits.id)
+      expect(flag).to be_present
+
+      # Fix the violation: add an exit
+      target = create(:grid_room, grid_zone: zone)
+      create(:grid_exit, from_room: room_without_exits, to_room: target, direction: "north")
+
+      DataAudit::Runner.run!
+      expect(DataAuditFlag.find_by(fingerprint: flag.fingerprint)).to be_nil
+    end
+
+    it "reopens flags with expired snoozes when violation persists" do
+      DataAudit::Runner.run!
+      flag = DataAuditFlag.find_by(check_name: "room_no_exits", subject_id: room_without_exits.id)
+      flag.acknowledge!(1.second.ago) # Already expired
+
+      DataAudit::Runner.run!
+      flag.reload
+      expect(flag.status).to eq("open")
+      expect(flag.snooze_until).to be_nil
+    end
+
+    it "leaves actively snoozed flags alone" do
+      DataAudit::Runner.run!
+      flag = DataAuditFlag.find_by(check_name: "room_no_exits", subject_id: room_without_exits.id)
+      flag.acknowledge!(1.day.from_now)
+
+      DataAudit::Runner.run!
+      flag.reload
+      expect(flag.status).to eq("acknowledged")
+    end
+
+    it "touches last_seen_at on existing open flags" do
+      DataAudit::Runner.run!
+      flag = DataAuditFlag.find_by(check_name: "room_no_exits", subject_id: room_without_exits.id)
+      old_seen = flag.last_seen_at
+
+      travel_to 1.minute.from_now do
+        DataAudit::Runner.run!
+        flag.reload
+        expect(flag.last_seen_at).to be > old_seen
+      end
+    end
+  end
+end


### PR DESCRIPTION
  Per-violation integrity checker with error-tracker-inspired lifecycle.
  15 checks across Grid (critical/warning) and Music (info) domains scan
  for nonsensical, incomplete, or broken data — rooms without exits,
  published missions with no giver, tracks without audio, etc. Flags
  auto-clear when violations are fixed, auto-reopen when snoozes expire.

  - `data_audit_flags` table with SHA256 fingerprinting, open/acknowledged status, snooze durations (24h/7d/30d/forever)
  - `DataAudit::Runner` reconciliation engine with failed-check protection (never false-deletes flags from errored checks)
  - Layout-level orange banner on all admin pages when open flags exist
  - Dedicated filterable admin page at /root/data_audit_flags with severity/domain/check/status filters and per-flag edit links
  - `DataAudit::ScanJob` recurring every 6 hours + on-demand refresh
  - `FlagCache` via Solid Cache (5min TTL) for zero-query banner renders

  Also: mission delete button on edit page with active-mission guard and
  transaction-wrapped cascading destroy. crypto.randomUUID fallback for
  non-secure contexts (LAN dev over HTTP).