### PR TITLE
Scheduled Streams with countdown banner, live banner, schedule page

### DIFF
--- a/app/channels/stream_status_channel.rb
+++ b/app/channels/stream_status_channel.rb
@@ -14,21 +14,14 @@ class StreamStatusChannel < ApplicationCable::Channel
   private
 
   def transmit_current_status
-    current_stream = HackrStream.current_live
+    current_stream = HackrStream.includes(:artist).current_live
+    next_stream = HackrStream.includes(:artist).next_scheduled
 
     transmit({
       type: "stream_status",
       is_live: current_stream.present?,
-      stream: current_stream ? stream_json(current_stream) : nil
+      stream: current_stream&.stream_json,
+      next_scheduled: next_stream&.scheduled_json
     })
-  end
-
-  def stream_json(stream)
-    {
-      id: stream.id,
-      title: stream.title,
-      artist: stream.artist&.name,
-      started_at: stream.started_at&.iso8601
-    }
   end
 end

--- a/app/controllers/admin/hackr_streams_controller.rb
+++ b/app/controllers/admin/hackr_streams_controller.rb
@@ -30,8 +30,10 @@ class Admin::HackrStreamsController < Admin::ApplicationController
 
   def update
     update_params = hackr_stream_params
-    # Auto-clear cancellation when rescheduling
-    if update_params[:scheduled_at].present? && @hackr_stream.cancelled_at.present?
+    # Auto-clear cancellation only when scheduled_at actually changes (not just resubmitted)
+    if @hackr_stream.cancelled_at.present? &&
+        update_params[:scheduled_at].present? &&
+        update_params[:scheduled_at].to_s != @hackr_stream.scheduled_at&.to_fs(:db)
       update_params[:cancelled_at] = nil
     end
 

--- a/app/controllers/admin/hackr_streams_controller.rb
+++ b/app/controllers/admin/hackr_streams_controller.rb
@@ -1,5 +1,5 @@
 class Admin::HackrStreamsController < Admin::ApplicationController
-  before_action :set_stream, only: [:edit, :update, :destroy, :go_live, :end_stream]
+  before_action :set_stream, only: [:edit, :update, :destroy, :go_live, :end_stream, :cancel]
 
   def index
     @hackr_streams = HackrStream.includes(:artist).recent
@@ -29,7 +29,13 @@ class Admin::HackrStreamsController < Admin::ApplicationController
   end
 
   def update
-    if @hackr_stream.update(hackr_stream_params)
+    update_params = hackr_stream_params
+    # Auto-clear cancellation when rescheduling
+    if update_params[:scheduled_at].present? && @hackr_stream.cancelled_at.present?
+      update_params[:cancelled_at] = nil
+    end
+
+    if @hackr_stream.update(update_params)
       set_flash_success("Stream updated successfully!")
       redirect_to admin_hackr_streams_path
     else
@@ -66,6 +72,15 @@ class Admin::HackrStreamsController < Admin::ApplicationController
     redirect_to admin_hackr_streams_path
   end
 
+  def cancel
+    @hackr_stream.cancel!
+    set_flash_success("Scheduled stream cancelled.")
+  rescue ActiveRecord::RecordInvalid => e
+    set_flash_error("Failed to cancel stream: #{e.record.errors.full_messages.join(", ")}")
+  ensure
+    redirect_to admin_hackr_streams_path
+  end
+
   private
 
   def set_stream
@@ -73,6 +88,6 @@ class Admin::HackrStreamsController < Admin::ApplicationController
   end
 
   def hackr_stream_params
-    params.require(:hackr_stream).permit(:artist_id, :live_url, :vod_url, :title, :is_live, :started_at, :ended_at)
+    params.require(:hackr_stream).permit(:artist_id, :live_url, :vod_url, :title, :is_live, :started_at, :ended_at, :scheduled_at, :cancelled_at)
   end
 end

--- a/app/controllers/api/admin/streams_controller.rb
+++ b/app/controllers/api/admin/streams_controller.rb
@@ -39,7 +39,10 @@ module Api
 
         # Use existing scheduled stream or create new
         stream = if params[:stream_id].present?
-          s = artist.hackr_streams.find(params[:stream_id])
+          s = artist.hackr_streams.find_by(id: params[:stream_id])
+          unless s
+            return render json: {success: false, error: "Stream not found"}, status: :not_found
+          end
           if s.ended_at.present?
             return render json: {success: false, error: "Stream already ended"}, status: :unprocessable_entity
           end

--- a/app/controllers/api/admin/streams_controller.rb
+++ b/app/controllers/api/admin/streams_controller.rb
@@ -27,6 +27,7 @@ module Api
       end
 
       # POST /api/admin/streams/go_live
+      # Accepts optional stream_id to go live from a scheduled stream
       def go_live
         artist = Artist.find_by(slug: params[:artist_slug])
         unless artist
@@ -36,16 +37,30 @@ module Api
         url = params[:url]
         title = params[:title]
 
-        unless url.present?
-          return render json: {success: false, error: "URL is required"}, status: :unprocessable_entity
+        # Use existing scheduled stream or create new
+        stream = if params[:stream_id].present?
+          s = artist.hackr_streams.find(params[:stream_id])
+          if s.ended_at.present?
+            return render json: {success: false, error: "Stream already ended"}, status: :unprocessable_entity
+          end
+          if s.cancelled_at.present?
+            return render json: {success: false, error: "Stream was cancelled"}, status: :unprocessable_entity
+          end
+          s
+        else
+          unless url.present?
+            return render json: {success: false, error: "URL is required"}, status: :unprocessable_entity
+          end
+          nil
         end
 
-        # End all currently live streams
-        HackrStream.live.find_each(&:end_stream!)
+        HackrStream.transaction do
+          # End all currently live streams
+          HackrStream.live.find_each(&:end_stream!)
 
-        # Create a new stream (cannot_restart_stream validation prevents reuse)
-        stream = HackrStream.create!(artist: artist)
-        stream.go_live!(url, title)
+          stream ||= HackrStream.create!(artist: artist)
+          stream.go_live!(url || stream.live_url, title || stream.title)
+        end
 
         render json: {
           success: true,

--- a/app/controllers/api/hackr_streams_controller.rb
+++ b/app/controllers/api/hackr_streams_controller.rb
@@ -1,12 +1,13 @@
 class Api::HackrStreamsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-  # GET /api/hackr_stream - Get current live stream (if any)
+  # GET /api/hackr_stream - Get current live stream + next scheduled
   def show
     @stream = HackrStream.includes(:artist).current_live
+    @next_scheduled = HackrStream.includes(:artist).next_scheduled
 
-    if @stream
-      render json: {
+    response = if @stream
+      {
         is_live: true,
         artist: {
           id: @stream.artist.id,
@@ -19,10 +20,23 @@ class Api::HackrStreamsController < ApplicationController
         started_at: @stream.started_at
       }
     else
-      render json: {
-        is_live: false
-      }
+      {is_live: false}
     end
+
+    response[:next_scheduled] = @next_scheduled&.scheduled_json
+
+    render json: response
+  end
+
+  # GET /api/streams/schedule - Public schedule page data
+  def schedule
+    upcoming = HackrStream.includes(:artist).upcoming.limit(20)
+    past = HackrStream.includes(:artist).past_broadcasts.limit(20)
+
+    render json: {
+      upcoming: upcoming.map { |s| schedule_stream_json(s) },
+      past: past.map { |s| schedule_stream_json(s) }
+    }
   end
 
   # GET /api/artists/:artist_slug/vods - Get all VODs for an artist
@@ -90,5 +104,22 @@ class Api::HackrStreamsController < ApplicationController
 
   def record_not_found
     render json: {error: "Not found"}, status: :not_found
+  end
+
+  def schedule_stream_json(stream)
+    {
+      id: stream.id,
+      title: stream.title,
+      artist: {
+        id: stream.artist.id,
+        name: stream.artist.name,
+        slug: stream.artist.slug
+      },
+      scheduled_at: stream.scheduled_at&.iso8601,
+      started_at: stream.started_at&.iso8601,
+      ended_at: stream.ended_at&.iso8601,
+      vod_url: stream.vod_url,
+      display_state: stream.display_state.to_s
+    }
   end
 end

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -55,6 +55,7 @@ const UplinkPage = lazy(() => import('~/components/pages/uplink/UplinkPage').the
 const UplinkPopoutPage = lazy(() => import('~/components/pages/uplink/UplinkPopoutPage').then(m => ({ default: m.UplinkPopoutPage })))
 const CodeIndexPage = lazy(() => import('~/components/pages/code/CodeIndexPage').then(m => ({ default: m.CodeIndexPage })))
 const CodeRepoPage = lazy(() => import('~/components/pages/code/CodeRepoPage'))
+const StreamSchedulePage = lazy(() => import('~/components/pages/streams/StreamSchedulePage').then(m => ({ default: m.StreamSchedulePage })))
 const NotFoundPage = lazy(() => import('~/components/errors/NotFoundPage').then(m => ({ default: m.NotFoundPage })))
 
 // Auth components
@@ -104,6 +105,8 @@ export const AppLayout: React.FC = () => {
           <Route path="/sector/x" element={<SectorXPage />} />
           {/* Wavelength Zero has a custom landing page */}
           <Route path="/wavelength-zero" element={<WavelengthZeroPage />} />
+          {/* Stream schedule — public */}
+          <Route path="/schedule" element={<StreamSchedulePage />} />
           {/* Dynamic artist routes — catches any artist slug */}
           <Route path="/:artistSlug" element={<BandProfilePage />} />
           <Route path="/:artistSlug/releases" element={<ReleaseListPage />} />

--- a/app/javascript/components/layouts/DefaultLayout.tsx
+++ b/app/javascript/components/layouts/DefaultLayout.tsx
@@ -2,25 +2,33 @@ import React, { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { HeaderMenu } from '~/components/navigation/HeaderMenu'
 import { FooterMenu } from '~/components/navigation/FooterMenu'
-import { PrereleaseBanner } from '~/components/prerelease/PrereleaseBanner'
+import { LiveNowBanner } from '~/components/stream/LiveNowBanner'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { useMobileMenu } from '~/contexts/MobileMenuContext'
+import { useStreamStatus } from '~/hooks/useStreamStatus'
 
 interface DefaultLayoutProps {
   children: ReactNode
   showAsciiArt?: boolean
+  topBanner?: ReactNode
+  hideLiveBanner?: boolean
 }
 
-export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children, showAsciiArt = true }) => {
+export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children, showAsciiArt = true, topBanner, hideLiveBanner }) => {
   const { isMobile } = useMobileDetect()
   const { setMobileMenuOpen } = useMobileMenu()
+  const { isLive, streamInfo } = useStreamStatus()
 
   return (
     <div className="black-168">
       <HeaderMenu />
-      <PrereleaseBanner />
+      {isLive && streamInfo && !hideLiveBanner && (
+        <LiveNowBanner stream={streamInfo} />
+      )}
 
       {!isMobile && <br />}
+
+      {topBanner}
 
       {/* ASCII Art Header - hidden on mobile */}
       {showAsciiArt && !isMobile && (

--- a/app/javascript/components/layouts/FmLayout.tsx
+++ b/app/javascript/components/layouts/FmLayout.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode } from 'react'
 import { HeaderMenu } from '~/components/navigation/HeaderMenu'
 import { FooterMenu } from '~/components/navigation/FooterMenu'
-import { PrereleaseBanner } from '~/components/prerelease/PrereleaseBanner'
+import { LiveNowBanner } from '~/components/stream/LiveNowBanner'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { useMobileMenu } from '~/contexts/MobileMenuContext'
+import { useStreamStatus } from '~/hooks/useStreamStatus'
 
 interface FmLayoutProps {
   children: ReactNode
@@ -12,11 +13,14 @@ interface FmLayoutProps {
 export const FmLayout: React.FC<FmLayoutProps> = ({ children }) => {
   const { isMobile } = useMobileDetect()
   const { setMobileMenuOpen } = useMobileMenu()
+  const { isLive, streamInfo } = useStreamStatus()
 
   return (
     <div className="black-168">
       <HeaderMenu />
-      <PrereleaseBanner />
+      {isLive && streamInfo && (
+        <LiveNowBanner stream={streamInfo} />
+      )}
 
       {!isMobile && <br />}
 

--- a/app/javascript/components/layouts/GridLayout.tsx
+++ b/app/javascript/components/layouts/GridLayout.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { HeaderMenu } from '~/components/navigation/HeaderMenu'
 import { FooterMenu } from '~/components/navigation/FooterMenu'
-import { PrereleaseBanner } from '~/components/prerelease/PrereleaseBanner'
+import { LiveNowBanner } from '~/components/stream/LiveNowBanner'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { useMobileMenu } from '~/contexts/MobileMenuContext'
+import { useStreamStatus } from '~/hooks/useStreamStatus'
 
 interface GridLayoutProps {
   children: React.ReactNode
@@ -12,11 +13,14 @@ interface GridLayoutProps {
 export const GridLayout: React.FC<GridLayoutProps> = ({ children }) => {
   const { isMobile } = useMobileDetect()
   const { setMobileMenuOpen } = useMobileMenu()
+  const { isLive, streamInfo } = useStreamStatus()
 
   return (
     <>
       <HeaderMenu />
-      <PrereleaseBanner />
+      {isLive && streamInfo && (
+        <LiveNowBanner stream={streamInfo} />
+      )}
       {!isMobile && <br />}
       <FooterMenu />
       <div className={isMobile ? 'mb-20 pb-50' : 'ml-10 mb-20 pb-50'} style={isMobile ? { padding: '0 5px' } : undefined}>

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -167,6 +167,9 @@ export const HeaderMenu: React.FC = () => {
                 <Link to="/" className={`mobile-menu-item${isActive('/') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">0</span> / hackr.tv
                 </Link>
+                <Link to="/schedule" className={`mobile-menu-item${isActive('/schedule') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                  <span className="purple-168-text">/</span> schedule
+                </Link>
                 <button
                   className="mobile-menu-item"
                   onClick={() => {
@@ -423,6 +426,11 @@ export const HeaderMenu: React.FC = () => {
                 <li>
                   <Link to="/" onClick={closeDropdown}>
                     <span className="purple-168-text">/</span>root
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/schedule" onClick={closeDropdown}>
+                    <span className="purple-168-text">/</span>schedule
                   </Link>
                 </li>
                 <li>

--- a/app/javascript/components/pages/HomePage.tsx
+++ b/app/javascript/components/pages/HomePage.tsx
@@ -3,7 +3,10 @@ import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import { TerminalAnimation } from '~/components/terminal/TerminalAnimation'
 import { LiveStreamEmbed } from '~/components/LiveStreamEmbed'
 import { UplinkPanel } from '~/components/uplink/UplinkPanel'
+import { ScheduledStreamBanner } from '~/components/stream/ScheduledStreamBanner'
+import { StartingSoonHero } from '~/components/stream/StartingSoonHero'
 import { apiJson } from '~/utils/apiClient'
+import type { ScheduledStreamInfo } from '~/types/uplink'
 
 interface StreamData {
   is_live: boolean
@@ -16,6 +19,7 @@ interface StreamData {
   live_url?: string
   vod_url?: string
   started_at?: string
+  next_scheduled?: ScheduledStreamInfo | null
 }
 
 const HEARTBEAT_KEY = 'uplink_popout_heartbeat'
@@ -102,8 +106,15 @@ export const HomePage: React.FC = () => {
     )
   }
 
+  const isStartingSoon = !streamData?.is_live &&
+    streamData?.next_scheduled?.display_state === 'starting_soon'
+
+  const scheduledBanner = !streamData?.is_live && streamData?.next_scheduled
+    ? <ScheduledStreamBanner stream={streamData.next_scheduled} />
+    : undefined
+
   return (
-    <DefaultLayout>
+    <DefaultLayout topBanner={scheduledBanner} hideLiveBanner>
       {streamData?.is_live && streamData.live_url ? (
         <LiveStreamEmbed
           url={streamData.live_url}
@@ -122,6 +133,8 @@ export const HomePage: React.FC = () => {
             )
           }
         />
+      ) : isStartingSoon && streamData?.next_scheduled ? (
+        <StartingSoonHero stream={streamData.next_scheduled} />
       ) : (
         <TerminalAnimation />
       )}

--- a/app/javascript/components/pages/grid/GridLoginPage.tsx
+++ b/app/javascript/components/pages/grid/GridLoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { GridLayout } from '~/components/layouts/GridLayout'
+import { PrereleaseBanner } from '~/components/prerelease/PrereleaseBanner'
 import { useGridAuth } from '~/hooks/useGridAuth'
 import { useGridAuthContext } from '~/contexts/GridAuthContext'
 
@@ -51,6 +52,7 @@ export const GridLoginPage: React.FC = () => {
 
   return (
     <GridLayout>
+      <PrereleaseBanner />
       <div className="tui-window cyan-168 white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block' }}>
         <fieldset className="cyan-168-border">
           <legend className="center">THE PULSE GRID :: ACCESS</legend>

--- a/app/javascript/components/pages/streams/StreamSchedulePage.tsx
+++ b/app/javascript/components/pages/streams/StreamSchedulePage.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { apiJson } from '~/utils/apiClient'
+import { formatFutureDate } from '~/utils/dateUtils'
+
+interface ScheduleArtist {
+  id: number
+  name: string
+  slug: string
+}
+
+interface ScheduleStream {
+  id: number
+  title: string | null
+  artist: ScheduleArtist
+  scheduled_at: string | null
+  started_at: string | null
+  ended_at: string | null
+  vod_url: string | null
+  display_state: string
+}
+
+interface ScheduleResponse {
+  upcoming: ScheduleStream[]
+  past: ScheduleStream[]
+}
+
+const STATE_BADGES: Record<string, { label: string; color: string }> = {
+  upcoming: { label: 'UPCOMING', color: '#06b6d4' },
+  starting_soon: { label: 'STARTING SOON', color: '#f59e0b' },
+  live: { label: 'LIVE', color: '#00ff00' },
+  ended: { label: 'ENDED', color: '#666' },
+  cancelled: { label: 'CANCELLED', color: '#ff4444' },
+  expired: { label: 'EXPIRED', color: '#888' },
+  unscheduled: { label: 'ON-DEMAND', color: '#888' }
+}
+
+const formatDate = (iso: string | null): string => {
+  if (!iso) return '—'
+  return formatFutureDate(iso, true)
+}
+
+const formatDuration = (start: string | null, end: string | null): string => {
+  if (!start || !end) return '—'
+  const diffMs = new Date(end).getTime() - new Date(start).getTime()
+  const minutes = Math.floor(diffMs / 60000)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainingMins = minutes % 60
+  return `${hours}h ${remainingMins}m`
+}
+
+export const StreamSchedulePage: React.FC = () => {
+  const [data, setData] = useState<ScheduleResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchSchedule = async () => {
+      try {
+        const result = await apiJson<ScheduleResponse>('/api/streams/schedule')
+        setData(result)
+      } catch (error) {
+        console.error('Failed to fetch stream schedule:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchSchedule()
+  }, [])
+
+  if (loading) {
+    return (
+      <DefaultLayout>
+        <div style={{ textAlign: 'center', padding: '60px 0', color: '#888' }}>
+          Loading schedule...
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  return (
+    <DefaultLayout>
+      <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '0 20px' }}>
+        <h1 style={{
+          color: '#06b6d4',
+          fontSize: '1.4em',
+          fontWeight: 'bold',
+          marginBottom: '8px',
+          letterSpacing: '0.1em'
+        }}>
+          STREAM SCHEDULE
+        </h1>
+        <p style={{ color: '#666', marginBottom: '30px', fontSize: '0.9em' }}>
+          Upcoming livestreams and past broadcasts
+        </p>
+
+        {/* Upcoming Streams */}
+        <h2 style={{
+          color: '#06b6d4',
+          fontSize: '1.1em',
+          borderBottom: '1px solid #06b6d4',
+          paddingBottom: '6px',
+          marginBottom: '16px'
+        }}>
+          [:: UPCOMING ::]
+        </h2>
+
+        {data && data.upcoming.length > 0 ? (
+          <div style={{ marginBottom: '40px' }}>
+            {data.upcoming.map(stream => {
+              const badge = STATE_BADGES[stream.display_state] || STATE_BADGES.upcoming
+              return (
+                <div key={stream.id} style={{
+                  background: '#0a0a0a',
+                  border: '1px solid #1a1a1a',
+                  borderLeft: `3px solid ${badge.color}`,
+                  padding: '14px 18px',
+                  marginBottom: '8px'
+                }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
+                    <div>
+                      <span style={{ color: badge.color, fontWeight: 'bold', fontSize: '0.8em', marginRight: '10px' }}>
+                        [{badge.label}]
+                      </span>
+                      <span style={{ color: '#e0f2fe', fontWeight: 'bold' }}>
+                        {stream.title || 'Untitled Stream'}
+                      </span>
+                      <span style={{ color: '#888', margin: '0 8px' }}>—</span>
+                      <span style={{ color: '#aaa' }}>{stream.artist.name}</span>
+                    </div>
+                    <div style={{ color: '#67e8f9', fontSize: '0.9em' }}>
+                      {formatDate(stream.scheduled_at)}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <p style={{ color: '#444', padding: '20px 0', marginBottom: '40px' }}>
+            No upcoming streams scheduled.
+          </p>
+        )}
+
+        {/* Past Broadcasts */}
+        <h2 style={{
+          color: '#888',
+          fontSize: '1.1em',
+          borderBottom: '1px solid #333',
+          paddingBottom: '6px',
+          marginBottom: '16px'
+        }}>
+          [:: PAST BROADCASTS ::]
+        </h2>
+
+        {data && data.past.length > 0 ? (
+          <div style={{ marginBottom: '40px' }}>
+            {data.past.map(stream => (
+              <div key={stream.id} style={{
+                background: '#0a0a0a',
+                border: '1px solid #1a1a1a',
+                borderLeft: '3px solid #333',
+                padding: '14px 18px',
+                marginBottom: '8px'
+              }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '8px' }}>
+                  <div>
+                    <span style={{ color: '#aaa', fontWeight: 'bold' }}>
+                      {stream.title || 'Untitled Stream'}
+                    </span>
+                    <span style={{ color: '#666', margin: '0 8px' }}>—</span>
+                    <span style={{ color: '#777' }}>{stream.artist.name}</span>
+                  </div>
+                  <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+                    <span style={{ color: '#666', fontSize: '0.85em' }}>
+                      {formatDate(stream.started_at)}
+                    </span>
+                    {stream.started_at && stream.ended_at && (
+                      <span style={{ color: '#555', fontSize: '0.85em' }}>
+                        ({formatDuration(stream.started_at, stream.ended_at)})
+                      </span>
+                    )}
+                    {stream.vod_url && (
+                      <Link
+                        to={`/${stream.artist.slug}/vidz/${stream.id}`}
+                        style={{ color: '#7c3aed', fontSize: '0.85em', textDecoration: 'none' }}
+                      >
+                        [VOD]
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p style={{ color: '#444', padding: '20px 0' }}>
+            No past broadcasts yet.
+          </p>
+        )}
+      </div>
+    </DefaultLayout>
+  )
+}

--- a/app/javascript/components/stream/LiveNowBanner.tsx
+++ b/app/javascript/components/stream/LiveNowBanner.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { StreamInfo } from '~/types/uplink'
+
+const MENU_HEIGHT = 26 // matches .tui-nav height in tuicss
+const BANNER_HEIGHT = 70
+
+interface LiveNowBannerProps {
+  stream: StreamInfo
+  topOffset?: number
+}
+
+export const LiveNowBanner: React.FC<LiveNowBannerProps> = ({
+  stream,
+  topOffset = 0
+}) => {
+  return (
+    <>
+      <div style={{
+        background: 'linear-gradient(90deg, #001a00 0%, #003300 50%, #001a00 100%)',
+        borderTop: '1px solid #00ff00',
+        borderBottom: '1px solid #00ff00',
+        padding: '20px 16px',
+        textAlign: 'center',
+        fontFamily: 'Terminus, \'Courier New\', monospace',
+        fontSize: '18px',
+        position: 'fixed',
+        top: MENU_HEIGHT + topOffset,
+        left: 0,
+        right: 0,
+        zIndex: 8,
+        overflow: 'hidden',
+        contain: 'paint'
+      }}>
+        <div style={{
+          position: 'absolute',
+          top: 0,
+          left: '-100%',
+          width: '100%',
+          height: '100%',
+          background: 'linear-gradient(90deg, transparent, rgba(0, 255, 0, 0.15), transparent)',
+          animation: 'live-pulse 3s linear infinite'
+        }} />
+        <span style={{ position: 'relative', zIndex: 1 }}>
+          <span style={{ color: '#00ff00', fontWeight: 'bold', textShadow: '0 0 10px #00ff00' }}>
+            [ LIVE NOW ]
+          </span>
+          <span style={{ color: '#e0ffe0' }}>
+            {' '}{stream.title}{stream.artist ? ` — ${stream.artist}` : ''}
+          </span>
+          <Link to="/" style={{
+            color: '#00cc00',
+            marginLeft: '16px',
+            fontSize: '14px',
+            textDecoration: 'none',
+            fontWeight: 'bold'
+          }}>
+            WATCH LIVE →
+          </Link>
+        </span>
+      </div>
+
+      {/* Spacer */}
+      <div style={{ height: BANNER_HEIGHT }} />
+
+      <style>{`
+        @keyframes live-pulse {
+          0% { left: -100%; }
+          100% { left: 100%; }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/app/javascript/components/stream/ScheduledStreamBanner.tsx
+++ b/app/javascript/components/stream/ScheduledStreamBanner.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { ScheduledStreamInfo } from '~/types/uplink'
+import { useCountdown } from '~/hooks/useCountdown'
+import { formatFutureDate } from '~/utils/dateUtils'
+
+interface ScheduledStreamBannerProps {
+  stream: ScheduledStreamInfo
+}
+
+export const ScheduledStreamBanner: React.FC<ScheduledStreamBannerProps> = ({
+  stream
+}) => {
+  const countdown = useCountdown(stream.scheduled_at)
+
+  // Expired — countdown returned empty
+  if (!countdown) return null
+
+  const isStartingSoon = countdown === 'STARTING SOON!'
+
+  const formattedDate = formatFutureDate(stream.scheduled_at, true)
+
+  return (
+    <>
+      <div style={{
+        background: isStartingSoon
+          ? 'linear-gradient(90deg, #0a1a2e 0%, #0d2847 50%, #0a1a2e 100%)'
+          : 'linear-gradient(90deg, #0a1a2e 0%, #0d2340 50%, #0a1a2e 100%)',
+        borderTop: '1px solid #06b6d4',
+        borderBottom: '1px solid #06b6d4',
+        padding: '20px 16px',
+        textAlign: 'center',
+        fontFamily: 'Terminus, \'Courier New\', monospace',
+        fontSize: '18px',
+        position: 'relative',
+        overflow: 'hidden',
+        contain: 'paint'
+      }}>
+        {isStartingSoon && (
+          <div style={{
+            position: 'absolute',
+            top: 0,
+            left: '-100%',
+            width: '100%',
+            height: '100%',
+            background: 'linear-gradient(90deg, transparent, rgba(6, 182, 212, 0.15), transparent)',
+            animation: 'scheduled-pulse 2s linear infinite'
+          }} />
+        )}
+        <span style={{ position: 'relative', zIndex: 1 }}>
+          {isStartingSoon ? (
+            <>
+              <span style={{ color: '#f59e0b', fontWeight: 'bold' }}>[ STARTING SOON ]</span>
+              <span style={{ color: '#e0f2fe' }}>
+                {' '}{stream.title}{stream.artist ? ` — ${stream.artist}` : ''}
+              </span>
+            </>
+          ) : (
+            <>
+              <span style={{ color: '#06b6d4', fontWeight: 'bold' }}>NEXT STREAM:</span>
+              <span style={{ color: '#e0f2fe' }}>
+                {' '}{stream.title}
+                {stream.artist ? ` — ${stream.artist} will be LIVE at ${formattedDate}` : ''}
+              </span>
+              <span style={{ color: '#67e8f9', marginLeft: '8px' }}>
+                ({countdown})
+              </span>
+            </>
+          )}
+          <Link to="/schedule" style={{
+            color: '#0891b2',
+            marginLeft: '16px',
+            fontSize: '13px',
+            textDecoration: 'none'
+          }}>
+            [ SCHEDULE ]
+          </Link>
+        </span>
+      </div>
+
+      <style>{`
+        @keyframes scheduled-pulse {
+          0% { left: -100%; }
+          100% { left: 100%; }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/app/javascript/components/stream/StartingSoonHero.tsx
+++ b/app/javascript/components/stream/StartingSoonHero.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import type { ScheduledStreamInfo } from '~/types/uplink'
+
+interface StartingSoonHeroProps {
+  stream: ScheduledStreamInfo
+}
+
+export const StartingSoonHero: React.FC<StartingSoonHeroProps> = ({ stream }) => {
+  return (
+    <div style={{
+      width: '100%',
+      maxWidth: '1400px',
+      margin: '0 auto',
+      padding: '4px 20px 20px'
+    }}>
+      <div style={{
+        background: 'linear-gradient(90deg, #0a1a2e 0%, #0d2847 50%, #0a1a2e 100%)',
+        border: '2px solid #06b6d4',
+        padding: '60px 20px',
+        textAlign: 'center',
+        position: 'relative',
+        overflow: 'hidden',
+        contain: 'paint'
+      }}>
+        <div style={{
+          position: 'absolute',
+          top: 0,
+          left: '-100%',
+          width: '100%',
+          height: '100%',
+          background: 'linear-gradient(90deg, transparent, rgba(6, 182, 212, 0.1), transparent)',
+          animation: 'starting-soon-pulse 3s linear infinite'
+        }} />
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          <p style={{
+            color: '#06b6d4',
+            fontSize: '2em',
+            fontWeight: 'bold',
+            letterSpacing: '0.15em',
+            margin: '0 0 16px 0',
+            textShadow: '0 0 20px rgba(6, 182, 212, 0.5)'
+          }}>
+            STREAM STARTING SOON
+          </p>
+          <p style={{ color: '#e0f2fe', fontSize: '1.3em', margin: '0 0 8px 0' }}>
+            {stream.title}
+          </p>
+          {stream.artist && (
+            <p style={{ color: '#888', fontSize: '1em', margin: 0 }}>
+              {stream.artist}
+            </p>
+          )}
+        </div>
+      </div>
+      <style>{`
+        @keyframes starting-soon-pulse {
+          0% { left: -100%; }
+          100% { left: 100%; }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/app/javascript/hooks/useCountdown.ts
+++ b/app/javascript/hooks/useCountdown.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback } from 'react'
+
+const EXPIRY_SEC = 3600
+
+/**
+ * Returns a countdown string for a target ISO timestamp.
+ * - "> 1hr": "in 2h 14m"
+ * - "< 1hr": "in 47m 12s"
+ * - "<= 0 && < 1hr past": "STARTING SOON!"
+ * - "> 1hr past or null": "" (expired)
+ */
+export const useCountdown = (targetIso: string | null): string => {
+  const computeDisplay = useCallback(() => {
+    if (!targetIso) return ''
+    const diffSec = Math.floor((new Date(targetIso).getTime() - Date.now()) / 1000)
+
+    if (diffSec <= -EXPIRY_SEC) return ''
+    if (diffSec <= 0) return 'STARTING SOON!'
+
+    const hours = Math.floor(diffSec / 3600)
+    const minutes = Math.floor((diffSec % 3600) / 60)
+    const seconds = diffSec % 60
+
+    return hours > 0
+      ? `in ${hours}h ${minutes}m`
+      : `in ${minutes}m ${seconds}s`
+  }, [targetIso])
+
+  const [display, setDisplay] = useState(computeDisplay)
+
+  useEffect(() => {
+    setDisplay(computeDisplay())
+
+    if (!targetIso) return
+
+    const id = window.setInterval(() => {
+      const value = computeDisplay()
+      setDisplay(value)
+      // Stop when expired
+      if (value === '') window.clearInterval(id)
+    }, 1000)
+
+    return () => window.clearInterval(id)
+  }, [targetIso, computeDisplay])
+
+  return display
+}

--- a/app/javascript/hooks/useStreamStatus.ts
+++ b/app/javascript/hooks/useStreamStatus.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import { createConsumer, Cable, Channel } from '@rails/actioncable'
-import type { StreamStatusMessage, StreamInfo } from '../types/uplink'
+import type { StreamStatusMessage, StreamInfo, ScheduledStreamInfo } from '../types/uplink'
 
 interface UseStreamStatusOptions {
   enabled?: boolean
@@ -14,6 +14,7 @@ export const useStreamStatus = ({ enabled = true }: UseStreamStatusOptions = {})
   const connectRef = useRef<() => void>(() => {})
   const [isLive, setIsLive] = useState(false)
   const [streamInfo, setStreamInfo] = useState<StreamInfo | null>(null)
+  const [nextScheduled, setNextScheduled] = useState<ScheduledStreamInfo | null>(null)
   const [isConnected, setIsConnected] = useState(false)
 
   const clearReconnectTimeout = useCallback(() => {
@@ -44,10 +45,15 @@ export const useStreamStatus = ({ enabled = true }: UseStreamStatusOptions = {})
     case 'stream_live':
       setIsLive(message.is_live)
       setStreamInfo(message.stream)
+      setNextScheduled(message.next_scheduled ?? null)
       break
     case 'stream_ended':
       setIsLive(false)
       setStreamInfo(null)
+      setNextScheduled(message.next_scheduled ?? null)
+      break
+    case 'scheduled_stream_updated':
+      setNextScheduled(message.next_scheduled ?? null)
       break
     }
   }, [])
@@ -128,6 +134,7 @@ export const useStreamStatus = ({ enabled = true }: UseStreamStatusOptions = {})
   return {
     isLive,
     streamInfo,
+    nextScheduled,
     isConnected
   }
 }

--- a/app/javascript/types/uplink.ts
+++ b/app/javascript/types/uplink.ts
@@ -39,9 +39,10 @@ export interface UplinkMessage {
 }
 
 export interface StreamStatusMessage {
-  type: 'stream_status' | 'stream_live' | 'stream_ended'
+  type: 'stream_status' | 'stream_live' | 'stream_ended' | 'scheduled_stream_updated'
   is_live: boolean
   stream: StreamInfo | null
+  next_scheduled: ScheduledStreamInfo | null
 }
 
 export interface StreamInfo {
@@ -49,6 +50,15 @@ export interface StreamInfo {
   title: string | null
   artist: string | null
   started_at: string | null
+}
+
+export interface ScheduledStreamInfo {
+  id: number
+  title: string | null
+  artist: string | null
+  artist_slug: string | null
+  scheduled_at: string
+  display_state: 'upcoming' | 'starting_soon' | 'expired' | 'cancelled' | 'live' | 'ended' | 'unscheduled'
 }
 
 export interface ChannelsResponse {

--- a/app/javascript/utils/dateUtils.ts
+++ b/app/javascript/utils/dateUtils.ts
@@ -9,7 +9,7 @@ export const formatFutureDate = (dateStr: string, includeTime: boolean = false):
   }
 
   if (includeTime) {
-    return date.toLocaleDateString('en-US', options) + ` at ${date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}`
+    return date.toLocaleDateString('en-US', options) + ` at ${date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}`
   }
 
   return date.toLocaleDateString('en-US', options)

--- a/app/models/hackr_stream.rb
+++ b/app/models/hackr_stream.rb
@@ -3,27 +3,32 @@
 # Table name: hackr_streams
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  ended_at   :datetime
-#  is_live    :boolean          default(FALSE), not null
-#  live_url   :string
-#  started_at :datetime
-#  title      :string
-#  track_slug :string
-#  vod_url    :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  artist_id  :integer          not null
+#  id           :integer          not null, primary key
+#  cancelled_at :datetime
+#  ended_at     :datetime
+#  is_live      :boolean          default(FALSE), not null
+#  live_url     :string
+#  scheduled_at :datetime
+#  started_at   :datetime
+#  title        :string
+#  track_slug   :string
+#  vod_url      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  artist_id    :integer          not null
 #
 # Indexes
 #
-#  index_hackr_streams_on_artist_id  (artist_id)
+#  index_hackr_streams_on_artist_id     (artist_id)
+#  index_hackr_streams_on_scheduled_at  (scheduled_at)
 #
 # Foreign Keys
 #
 #  artist_id  (artist_id => artists.id)
 #
 class HackrStream < ApplicationRecord
+  EXPIRY_WINDOW = 1.hour
+
   belongs_to :artist
   belongs_to :track, primary_key: :slug, foreign_key: :track_slug, optional: true
   has_many :hackr_vod_watches, dependent: :destroy
@@ -34,22 +39,37 @@ class HackrStream < ApplicationRecord
   validate :cannot_restart_stream, on: :update
 
   before_validation :convert_youtube_urls
-  after_update_commit :broadcast_stream_status, if: :saved_change_to_is_live?
+  after_update_commit :broadcast_stream_status, if: -> {
+    saved_change_to_is_live? || saved_change_to_scheduled_at? || saved_change_to_cancelled_at?
+  }
 
   scope :live, -> { where(is_live: true) }
   scope :recent, -> { order(created_at: :desc) }
+  scope :upcoming, -> {
+    where(is_live: false, cancelled_at: nil, ended_at: nil)
+      .where.not(scheduled_at: nil)
+      .where("scheduled_at > ?", EXPIRY_WINDOW.ago)
+      .order(scheduled_at: :asc)
+  }
+  scope :past_broadcasts, -> {
+    where.not(started_at: nil)
+      .where(is_live: false)
+      .order(started_at: :desc)
+  }
 
-  # Get the current live stream (if any)
   def self.current_live
     live.first
   end
 
-  # Toggle stream live status
+  def self.next_scheduled
+    upcoming.first
+  end
+
   def go_live!(stream_url, stream_title = nil)
     update!(
       is_live: true,
       live_url: stream_url,
-      title: stream_title,
+      title: stream_title || title,
       started_at: Time.current
     )
   end
@@ -59,6 +79,54 @@ class HackrStream < ApplicationRecord
       is_live: false,
       ended_at: Time.current
     )
+  end
+
+  def cancel!
+    if is_live?
+      errors.add(:base, "Cannot cancel a live stream")
+      raise ActiveRecord::RecordInvalid, self
+    end
+    update!(cancelled_at: Time.current)
+  end
+
+  def display_state
+    return :live if is_live?
+    return :cancelled if cancelled_at.present?
+    return :ended if ended_at.present?
+    return :expired if expired?
+    return :starting_soon if starting_soon?
+    return :upcoming if scheduled_at.present?
+    :unscheduled
+  end
+
+  def starting_soon?
+    scheduled_at.present? && scheduled_at <= Time.current &&
+      scheduled_at > EXPIRY_WINDOW.ago && !is_live? && ended_at.nil? && cancelled_at.nil?
+  end
+
+  def expired?
+    scheduled_at.present? && scheduled_at <= EXPIRY_WINDOW.ago &&
+      !is_live? && ended_at.nil? && cancelled_at.nil?
+  end
+
+  def stream_json
+    {
+      id: id,
+      title: title,
+      artist: artist&.name,
+      started_at: started_at&.iso8601
+    }
+  end
+
+  def scheduled_json
+    {
+      id: id,
+      title: title,
+      artist: artist&.name,
+      artist_slug: artist&.slug,
+      scheduled_at: scheduled_at&.iso8601,
+      display_state: display_state.to_s
+    }
   end
 
   private
@@ -105,19 +173,18 @@ class HackrStream < ApplicationRecord
   end
 
   def broadcast_stream_status
+    next_stream = HackrStream.includes(:artist).next_scheduled
     ActionCable.server.broadcast("stream_status", {
-      type: is_live? ? "stream_live" : "stream_ended",
+      type: broadcast_type,
       is_live: is_live?,
-      stream: is_live? ? stream_json : nil
+      stream: is_live? ? stream_json : nil,
+      next_scheduled: next_stream&.scheduled_json
     })
   end
 
-  def stream_json
-    {
-      id: id,
-      title: title,
-      artist: artist&.name,
-      started_at: started_at&.iso8601
-    }
+  def broadcast_type
+    return "stream_live" if saved_change_to_is_live? && is_live?
+    return "stream_ended" if saved_change_to_is_live? && !is_live?
+    "scheduled_stream_updated"
   end
 end

--- a/app/views/admin/hackr_streams/_form.html.erb
+++ b/app/views/admin/hackr_streams/_form.html.erb
@@ -49,13 +49,32 @@
     <% end %>
   </div>
 
+  <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: SCHEDULING ::]</h3>
+
+  <div style="margin-bottom: 20px;">
+    <%= f.label :scheduled_at, "SCHEDULED FOR", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
+    <%= f.datetime_local_field :scheduled_at, class: "tui-input", style: "width: 100%; max-width: 400px;" %>
+    <small style="color: #888;">When this stream is planned to go live. Leave blank for on-demand streams.</small>
+    <% if hackr_stream.errors[:scheduled_at].any? %>
+      <br><small class="red-255-text"><%= hackr_stream.errors[:scheduled_at].join(", ") %></small>
+    <% end %>
+  </div>
+
+  <% if hackr_stream.persisted? && hackr_stream.cancelled_at.present? %>
+    <div style="margin-bottom: 20px; padding: 10px; background: #1a0000; border: 1px solid #ff4444;">
+      <span class="red-255-text" style="font-weight: bold;">CANCELLED</span>
+      <span style="color: #888;"> at <%= hackr_stream.cancelled_at.strftime("%Y-%m-%d %H:%M") %></span>
+      <small style="color: #888; display: block; margin-top: 4px;">To reschedule, set a new scheduled date and save. The cancellation will be cleared automatically.</small>
+    </div>
+  <% end %>
+
   <h3 class="cyan-255-text" style="margin: 30px 0 15px 0;">[:: STREAM TIMING ::]</h3>
 
   <div style="display: flex; gap: 20px; flex-wrap: wrap;">
     <div style="flex: 1; min-width: 200px;">
       <%= f.label :started_at, "STARTED AT", class: "white-text", style: "display: block; margin-bottom: 8px; font-weight: bold;" %>
       <%= f.datetime_local_field :started_at, class: "tui-input", style: "width: 100%;" %>
-      <small style="color: #888;">When the stream started (or will start)</small>
+      <small style="color: #888;">When the stream started (set automatically on Go Live)</small>
       <% if hackr_stream.errors[:started_at].any? %>
         <br><small class="red-255-text"><%= hackr_stream.errors[:started_at].join(", ") %></small>
       <% end %>

--- a/app/views/admin/hackr_streams/index.html.erb
+++ b/app/views/admin/hackr_streams/index.html.erb
@@ -52,8 +52,8 @@
               <tr>
                 <th style="text-align: left;">Artist</th>
                 <th style="text-align: left;">Title</th>
+                <th style="text-align: left;">Scheduled</th>
                 <th style="text-align: left;">Live URL</th>
-                <th style="text-align: left;">VOD URL</th>
                 <th style="text-align: center;">Status</th>
                 <th style="text-align: center;">Actions</th>
               </tr>
@@ -80,6 +80,15 @@
                     <% end %>
                   </td>
                   <td>
+                    <% if stream.scheduled_at.present? %>
+                      <small style="color: #00d9ff;">
+                        <%= stream.scheduled_at.strftime("%Y-%m-%d %H:%M") %>
+                      </small>
+                    <% else %>
+                      <span style="color: #666;">—</span>
+                    <% end %>
+                  </td>
+                  <td>
                     <% if stream.live_url.present? %>
                       <small style="color: #888; font-family: monospace; word-break: break-all;">
                         <%= truncate(stream.live_url, length: 40) %>
@@ -88,18 +97,20 @@
                       <span style="color: #666;">—</span>
                     <% end %>
                   </td>
-                  <td>
-                    <% if stream.vod_url.present? %>
-                      <small style="color: #888; font-family: monospace; word-break: break-all;">
-                        <%= truncate(stream.vod_url, length: 40) %>
-                      </small>
-                    <% else %>
-                      <span style="color: #666;">—</span>
-                    <% end %>
-                  </td>
                   <td style="text-align: center;">
-                    <% if stream.is_live %>
+                    <% case stream.display_state %>
+                    <% when :live %>
                       <span class="green-255-text" style="font-weight: bold;">⚡ LIVE</span>
+                    <% when :upcoming %>
+                      <span style="color: #00d9ff; font-weight: bold;">📅 SCHEDULED</span>
+                    <% when :starting_soon %>
+                      <span style="color: #f59e0b; font-weight: bold;">⏳ STARTING SOON</span>
+                    <% when :cancelled %>
+                      <span style="color: #ff4444;">✗ CANCELLED</span>
+                    <% when :expired %>
+                      <span style="color: #888;">⏰ EXPIRED</span>
+                    <% when :ended %>
+                      <span style="color: #666;">✓ Ended</span>
                     <% else %>
                       <span style="color: #666;">⚫ Offline</span>
                     <% end %>
@@ -112,11 +123,16 @@
                             style: "padding: 2px 10px; font-size: 0.9em;",
                             form: { style: "display: contents;" },
                             data: { confirm: "End this livestream?" } %>
-                      <% elsif stream.started_at.present? %>
+                      <% elsif stream.ended_at.present? %>
                         <span class="tui-button grey-168"
                               style="padding: 2px 10px; font-size: 0.9em; opacity: 0.5; cursor: not-allowed;"
                               title="Stream already finished. Create a new stream to go live again.">
                           ✓ Finished
+                        </span>
+                      <% elsif stream.cancelled_at.present? %>
+                        <span class="tui-button grey-168"
+                              style="padding: 2px 10px; font-size: 0.9em; opacity: 0.5; cursor: not-allowed;">
+                          ✗ Cancelled
                         </span>
                       <% elsif stream.live_url.present? %>
                         <%= button_to "▶ Go Live", go_live_admin_hackr_stream_path(stream),
@@ -130,6 +146,13 @@
                               title="Set stream URL first">
                           ▶ Go Live
                         </span>
+                      <% end %>
+                      <% if stream.scheduled_at.present? && stream.cancelled_at.nil? && !stream.is_live? && stream.ended_at.nil? %>
+                        <%= button_to "✗ Cancel", cancel_admin_hackr_stream_path(stream),
+                            class: "tui-button orange-168",
+                            style: "padding: 2px 10px; font-size: 0.9em;",
+                            form: { style: "display: contents;" },
+                            data: { confirm: "Cancel scheduled stream?" } %>
                       <% end %>
                       <%= link_to "✎ Edit", edit_admin_hackr_stream_path(stream),
                           class: "tui-button cyan-168",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,9 @@ Rails.application.routes.draw do
   get "deck", to: "pages#spa_root", as: :deck_page
   get "transit", to: "pages#spa_root", as: :transit_page
 
+  # Stream schedule (SPA)
+  get "schedule", to: "pages#spa_root", as: :streams_schedule
+
   # Codex (wiki) routes - SPA
   scope "codex" do
     get "/", to: "pages#spa_root", as: :codex
@@ -161,6 +164,7 @@ Rails.application.routes.draw do
     get "radio_stations/:id/playlists", to: "radio#station_playlists"
     post "radio_stations/:id/tune_in", to: "radio#tune_in"
     get "hackr_stream", to: "hackr_streams#show"
+    get "streams/schedule", to: "hackr_streams#schedule"
     get "artists/:artist_slug/vods", to: "hackr_streams#index"
     get "artists/:artist_slug/vods/:id", to: "hackr_streams#vod_show"
     post "artists/:artist_slug/vods/:id/watch", to: "hackr_streams#watch"
@@ -604,6 +608,7 @@ Rails.application.routes.draw do
       member do
         post :go_live
         post :end_stream
+        post :cancel
       end
     end
 

--- a/db/migrate/20260519172056_add_schedule_to_hackr_streams.rb
+++ b/db/migrate/20260519172056_add_schedule_to_hackr_streams.rb
@@ -1,0 +1,6 @@
+class AddScheduleToHackrStreams < ActiveRecord::Migration[8.1]
+  def change
+    add_column :hackr_streams, :scheduled_at, :datetime
+    add_column :hackr_streams, :cancelled_at, :datetime
+  end
+end

--- a/db/migrate/20260519194536_add_index_to_hackr_streams_scheduled_at.rb
+++ b/db/migrate/20260519194536_add_index_to_hackr_streams_scheduled_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToHackrStreamsScheduledAt < ActiveRecord::Migration[8.1]
+  def change
+    add_index :hackr_streams, :scheduled_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_194536) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -1021,16 +1021,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_18_200000) do
 
   create_table "hackr_streams", force: :cascade do |t|
     t.integer "artist_id", null: false
+    t.datetime "cancelled_at"
     t.datetime "created_at", null: false
     t.datetime "ended_at"
     t.boolean "is_live", default: false, null: false
     t.string "live_url"
+    t.datetime "scheduled_at"
     t.datetime "started_at"
     t.string "title"
     t.string "track_slug"
     t.datetime "updated_at", null: false
     t.string "vod_url"
     t.index ["artist_id"], name: "index_hackr_streams_on_artist_id"
+    t.index ["scheduled_at"], name: "index_hackr_streams_on_scheduled_at"
   end
 
   create_table "hackr_vod_watches", force: :cascade do |t|

--- a/spec/factories/hackr_streams.rb
+++ b/spec/factories/hackr_streams.rb
@@ -3,21 +3,24 @@
 # Table name: hackr_streams
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  ended_at   :datetime
-#  is_live    :boolean          default(FALSE), not null
-#  live_url   :string
-#  started_at :datetime
-#  title      :string
-#  track_slug :string
-#  vod_url    :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  artist_id  :integer          not null
+#  id           :integer          not null, primary key
+#  cancelled_at :datetime
+#  ended_at     :datetime
+#  is_live      :boolean          default(FALSE), not null
+#  live_url     :string
+#  scheduled_at :datetime
+#  started_at   :datetime
+#  title        :string
+#  track_slug   :string
+#  vod_url      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  artist_id    :integer          not null
 #
 # Indexes
 #
-#  index_hackr_streams_on_artist_id  (artist_id)
+#  index_hackr_streams_on_artist_id     (artist_id)
+#  index_hackr_streams_on_scheduled_at  (scheduled_at)
 #
 # Foreign Keys
 #
@@ -51,6 +54,41 @@ FactoryBot.define do
       vod_url { "https://www.youtube.com/embed/vod123" }
       started_at { 1.day.ago }
       ended_at { 1.day.ago + 2.hours }
+    end
+
+    trait :scheduled do
+      scheduled_at { 2.hours.from_now }
+      started_at { nil }
+      ended_at { nil }
+      is_live { false }
+      live_url { "https://www.youtube.com/embed/scheduled123" }
+      title { "Scheduled Stream" }
+    end
+
+    trait :starting_soon do
+      scheduled_at { 10.minutes.ago }
+      started_at { nil }
+      ended_at { nil }
+      is_live { false }
+      live_url { "https://www.youtube.com/embed/soon123" }
+      title { "Starting Soon Stream" }
+    end
+
+    trait :expired_schedule do
+      scheduled_at { 2.hours.ago }
+      started_at { nil }
+      ended_at { nil }
+      is_live { false }
+      title { "Expired Stream" }
+    end
+
+    trait :cancelled do
+      scheduled_at { 2.hours.from_now }
+      cancelled_at { 1.hour.ago }
+      started_at { nil }
+      ended_at { nil }
+      is_live { false }
+      title { "Cancelled Stream" }
     end
   end
 end

--- a/spec/models/hackr_stream_spec.rb
+++ b/spec/models/hackr_stream_spec.rb
@@ -3,21 +3,24 @@
 # Table name: hackr_streams
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  ended_at   :datetime
-#  is_live    :boolean          default(FALSE), not null
-#  live_url   :string
-#  started_at :datetime
-#  title      :string
-#  track_slug :string
-#  vod_url    :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  artist_id  :integer          not null
+#  id           :integer          not null, primary key
+#  cancelled_at :datetime
+#  ended_at     :datetime
+#  is_live      :boolean          default(FALSE), not null
+#  live_url     :string
+#  scheduled_at :datetime
+#  started_at   :datetime
+#  title        :string
+#  track_slug   :string
+#  vod_url      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  artist_id    :integer          not null
 #
 # Indexes
 #
-#  index_hackr_streams_on_artist_id  (artist_id)
+#  index_hackr_streams_on_artist_id     (artist_id)
+#  index_hackr_streams_on_scheduled_at  (scheduled_at)
 #
 # Foreign Keys
 #
@@ -26,5 +29,283 @@
 require "rails_helper"
 
 RSpec.describe HackrStream, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe ".upcoming" do
+    it "returns scheduled, non-cancelled, non-ended, non-live streams ordered by scheduled_at" do
+      artist = create(:artist)
+      later = create(:hackr_stream, :scheduled, artist: artist, scheduled_at: 3.hours.from_now)
+      sooner = create(:hackr_stream, :scheduled, artist: artist, scheduled_at: 1.hour.from_now)
+
+      expect(described_class.upcoming).to eq([sooner, later])
+    end
+
+    it "excludes cancelled streams" do
+      create(:hackr_stream, :cancelled)
+      expect(described_class.upcoming).to be_empty
+    end
+
+    it "excludes live streams" do
+      create(:hackr_stream, :live, scheduled_at: 1.hour.from_now)
+      expect(described_class.upcoming).to be_empty
+    end
+
+    it "excludes ended streams" do
+      create(:hackr_stream, :scheduled, ended_at: 1.hour.ago)
+      expect(described_class.upcoming).to be_empty
+    end
+
+    it "excludes expired streams (>1hr past scheduled_at)" do
+      create(:hackr_stream, :expired_schedule)
+      expect(described_class.upcoming).to be_empty
+    end
+
+    it "includes starting-soon streams (past scheduled_at within 1hr)" do
+      stream = create(:hackr_stream, :starting_soon)
+      expect(described_class.upcoming).to eq([stream])
+    end
+
+    it "excludes streams with no scheduled_at" do
+      create(:hackr_stream)
+      expect(described_class.upcoming).to be_empty
+    end
+  end
+
+  describe ".past_broadcasts" do
+    it "returns streams with started_at that are not live, ordered by started_at desc" do
+      artist = create(:artist)
+      older = create(:hackr_stream, artist: artist, started_at: 2.days.ago, ended_at: 2.days.ago + 1.hour)
+      newer = create(:hackr_stream, artist: artist, started_at: 1.day.ago, ended_at: 1.day.ago + 1.hour)
+
+      expect(described_class.past_broadcasts).to eq([newer, older])
+    end
+
+    it "excludes live streams" do
+      create(:hackr_stream, :live)
+      expect(described_class.past_broadcasts).to be_empty
+    end
+
+    it "excludes streams with no started_at" do
+      create(:hackr_stream, :scheduled)
+      expect(described_class.past_broadcasts).to be_empty
+    end
+  end
+
+  describe ".next_scheduled" do
+    it "returns the soonest upcoming stream" do
+      artist = create(:artist)
+      create(:hackr_stream, :scheduled, artist: artist, scheduled_at: 3.hours.from_now)
+      sooner = create(:hackr_stream, :scheduled, artist: artist, scheduled_at: 1.hour.from_now)
+
+      expect(described_class.next_scheduled).to eq(sooner)
+    end
+
+    it "returns nil when no upcoming streams" do
+      expect(described_class.next_scheduled).to be_nil
+    end
+
+    it "skips cancelled streams and returns next non-cancelled" do
+      artist = create(:artist)
+      create(:hackr_stream, :cancelled, artist: artist, scheduled_at: 1.hour.from_now)
+      next_stream = create(:hackr_stream, :scheduled, artist: artist, scheduled_at: 2.hours.from_now)
+
+      expect(described_class.next_scheduled).to eq(next_stream)
+    end
+  end
+
+  describe "#display_state" do
+    it "returns :live when stream is live" do
+      stream = build(:hackr_stream, :live)
+      expect(stream.display_state).to eq(:live)
+    end
+
+    it "returns :cancelled when cancelled_at is set" do
+      stream = build(:hackr_stream, :cancelled)
+      expect(stream.display_state).to eq(:cancelled)
+    end
+
+    it "returns :ended when ended_at is set" do
+      stream = build(:hackr_stream, ended_at: 1.hour.ago)
+      expect(stream.display_state).to eq(:ended)
+    end
+
+    it "returns :expired when scheduled_at is >1hr past and never went live" do
+      stream = build(:hackr_stream, :expired_schedule)
+      expect(stream.display_state).to eq(:expired)
+    end
+
+    it "returns :starting_soon when scheduled_at is past but within 1hr" do
+      stream = build(:hackr_stream, :starting_soon)
+      expect(stream.display_state).to eq(:starting_soon)
+    end
+
+    it "returns :upcoming when scheduled_at is in future" do
+      stream = build(:hackr_stream, :scheduled)
+      expect(stream.display_state).to eq(:upcoming)
+    end
+
+    it "returns :unscheduled when no scheduled_at" do
+      stream = build(:hackr_stream, started_at: nil)
+      expect(stream.display_state).to eq(:unscheduled)
+    end
+
+    it "prioritizes :live over :cancelled" do
+      stream = build(:hackr_stream, :live, cancelled_at: 1.hour.ago)
+      expect(stream.display_state).to eq(:live)
+    end
+
+    it "prioritizes :cancelled over :expired" do
+      stream = build(:hackr_stream, scheduled_at: 2.hours.ago, cancelled_at: 1.hour.ago, started_at: nil, ended_at: nil)
+      expect(stream.display_state).to eq(:cancelled)
+    end
+  end
+
+  describe "#starting_soon?" do
+    it "returns true when scheduled_at is past but within expiry window" do
+      stream = build(:hackr_stream, :starting_soon)
+      expect(stream.starting_soon?).to be true
+    end
+
+    it "returns false when scheduled_at is in the future" do
+      stream = build(:hackr_stream, :scheduled)
+      expect(stream.starting_soon?).to be false
+    end
+
+    it "returns false when expired (>1hr past)" do
+      stream = build(:hackr_stream, :expired_schedule)
+      expect(stream.starting_soon?).to be false
+    end
+
+    it "returns false when live" do
+      stream = build(:hackr_stream, :live, scheduled_at: 10.minutes.ago)
+      expect(stream.starting_soon?).to be false
+    end
+
+    it "returns false when cancelled" do
+      stream = build(:hackr_stream, :starting_soon, cancelled_at: 5.minutes.ago)
+      expect(stream.starting_soon?).to be false
+    end
+  end
+
+  describe "#expired?" do
+    it "returns true when scheduled_at is >1hr past and never went live" do
+      stream = build(:hackr_stream, :expired_schedule)
+      expect(stream.expired?).to be true
+    end
+
+    it "returns false when within expiry window" do
+      stream = build(:hackr_stream, :starting_soon)
+      expect(stream.expired?).to be false
+    end
+
+    it "returns false when ended (went live then ended)" do
+      stream = build(:hackr_stream, scheduled_at: 2.hours.ago, started_at: 2.hours.ago, ended_at: 1.hour.ago)
+      expect(stream.expired?).to be false
+    end
+
+    it "returns false when cancelled" do
+      stream = build(:hackr_stream, scheduled_at: 2.hours.ago, cancelled_at: 1.hour.ago, started_at: nil, ended_at: nil)
+      expect(stream.expired?).to be false
+    end
+  end
+
+  describe "#cancel!" do
+    it "sets cancelled_at" do
+      stream = create(:hackr_stream, :scheduled)
+      stream.cancel!
+      expect(stream.reload.cancelled_at).to be_present
+    end
+
+    it "raises error when stream is live" do
+      stream = create(:hackr_stream, :live)
+      expect { stream.cancel! }.to raise_error(ActiveRecord::RecordInvalid, /Cannot cancel a live stream/)
+    end
+
+    it "does not modify is_live" do
+      stream = create(:hackr_stream, :scheduled)
+      stream.cancel!
+      expect(stream.reload.is_live).to be false
+    end
+  end
+
+  describe "#go_live!" do
+    it "sets is_live, live_url, started_at" do
+      stream = create(:hackr_stream, :scheduled)
+      stream.go_live!("https://www.youtube.com/embed/abc123", "Live Title")
+      stream.reload
+      expect(stream.is_live).to be true
+      expect(stream.live_url).to eq("https://www.youtube.com/embed/abc123")
+      expect(stream.title).to eq("Live Title")
+      expect(stream.started_at).to be_present
+    end
+
+    it "preserves existing title when no title given" do
+      stream = create(:hackr_stream, :scheduled, title: "Original Title")
+      stream.go_live!("https://www.youtube.com/embed/abc123")
+      expect(stream.reload.title).to eq("Original Title")
+    end
+
+    it "works on a scheduled stream that has never been live" do
+      stream = create(:hackr_stream, :scheduled)
+      expect { stream.go_live!(stream.live_url, stream.title) }.not_to raise_error
+      expect(stream.reload.is_live).to be true
+    end
+
+    it "rejects going live on an ended stream" do
+      stream = create(:hackr_stream, started_at: 2.hours.ago, ended_at: 1.hour.ago)
+      expect {
+        stream.go_live!("https://www.youtube.com/embed/abc123")
+      }.to raise_error(ActiveRecord::RecordInvalid, /Cannot restart/)
+    end
+  end
+
+  describe "#stream_json" do
+    it "returns hash with id, title, artist name, started_at" do
+      stream = create(:hackr_stream, :live)
+      json = stream.stream_json
+      expect(json[:id]).to eq(stream.id)
+      expect(json[:title]).to eq(stream.title)
+      expect(json[:artist]).to eq(stream.artist.name)
+      expect(json[:started_at]).to eq(stream.started_at.iso8601)
+    end
+  end
+
+  describe "#scheduled_json" do
+    it "returns hash with id, title, artist name, artist_slug, scheduled_at, display_state" do
+      stream = create(:hackr_stream, :scheduled)
+      json = stream.scheduled_json
+      expect(json[:id]).to eq(stream.id)
+      expect(json[:title]).to eq(stream.title)
+      expect(json[:artist]).to eq(stream.artist.name)
+      expect(json[:artist_slug]).to eq(stream.artist.slug)
+      expect(json[:scheduled_at]).to eq(stream.scheduled_at.iso8601)
+      expect(json[:display_state]).to eq("upcoming")
+    end
+
+    it "reflects starting_soon display_state" do
+      stream = build(:hackr_stream, :starting_soon)
+      expect(stream.scheduled_json[:display_state]).to eq("starting_soon")
+    end
+  end
+
+  describe "broadcast on schedule changes" do
+    it "broadcasts when scheduled_at changes" do
+      stream = create(:hackr_stream, :scheduled)
+      expect {
+        stream.update!(scheduled_at: 5.hours.from_now)
+      }.to have_broadcasted_to("stream_status")
+    end
+
+    it "broadcasts when cancelled_at changes" do
+      stream = create(:hackr_stream, :scheduled)
+      expect {
+        stream.cancel!
+      }.to have_broadcasted_to("stream_status")
+    end
+
+    it "does not broadcast when unrelated fields change" do
+      stream = create(:hackr_stream, :scheduled)
+      expect {
+        stream.update!(title: "New Title")
+      }.not_to have_broadcasted_to("stream_status")
+    end
+  end
 end


### PR DESCRIPTION
Stream scheduling system for hackr.tv. Admins schedule future streams with scheduled_at datetime; the home page displays a countdown banner, and all pages show a "LIVE NOW" banner when a stream goes live.

Schema: scheduled_at and cancelled_at datetime columns on hackr_streams with index on scheduled_at. No new tables.

Model: HackrStream gains upcoming/past_broadcasts scopes, .next_scheduled class method, #display_state (7 states:
live/cancelled/ended/expired/starting_soon/upcoming/unscheduled), \#starting_soon?, #expired?, #cancel! (with live-stream guard), \ #stream_json/#scheduled_json public serializers. 1-hour expiry window - streams past scheduled_at by >1hr auto-expire at read time (no background job). after_update_commit broadcast extended to fire on scheduled_at/cancelled_at changes.

ActionCable: StreamStatusChannel includes next_scheduled in all messages. New scheduled_stream_updated broadcast type.

API:
* GET /api/hackr_stream extended with next_scheduled.
* New GET /api/streams/schedule for public schedule page.
* POST /api/admin/streams/go_live accepts optional stream_id to go live from a scheduled stream (transaction-wrapped, guards cancelled/ended).

Admin: scheduled_at datetime field on stream form. Status badges in index (SCHEDULED/STARTING SOON/CANCELLED/EXPIRED). Cancel button for scheduled streams. Auto-clears cancelled_at on reschedule.

Frontend — Banners: ScheduledStreamBanner (cyan, home page only, above ASCII art via topBanner slot) with countdown: "NEXT STREAM: [title] — [artist] will be LIVE at [date] ([countdown])". LiveNowBanner (green, all pages except home, fixed-position) with "[ LIVE NOW ] ... WATCH LIVE →". Both 70px tall, 18px font, contain: paint to prevent animation scrollbar.

Frontend — Starting Soon: When scheduled_at passes, home page replaces terminal animation with StartingSoonHero — static cyan panel with "STREAM STARTING SOON", title, and artist.

Frontend — Schedule Page: /schedule with upcoming + past broadcasts, century-shifted dates (12hr clock), internal VOD links. Nav link in hackr.tv dropdown (desktop + mobile).

Frontend — Hook: useStreamStatus extended with nextScheduled. New useCountdown hook (1s tick, auto-expires). PrereleaseBanner moved from all layouts to GridLoginPage only.