### PR TITLE
World Event Feed with simulated population activity

### DIFF
--- a/app/channels/world_event_feed_channel.rb
+++ b/app/channels/world_event_feed_channel.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class WorldEventFeedChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from WorldEventFeed::Publisher::STREAM_NAME
+
+    # Send recent events on subscribe so clients have initial state
+    transmit_recent_events
+  end
+
+  def unsubscribed
+    # No cleanup needed — global stream
+  end
+
+  private
+
+  def transmit_recent_events
+    events = WorldEvent.recent.limit(50).to_a.reverse
+    transmit({
+      type: "initial_events",
+      events: events.map { |e| WorldEventFeed::Publisher.serialize(e) }
+    })
+  end
+end

--- a/app/channels/world_event_feed_channel.rb
+++ b/app/channels/world_event_feed_channel.rb
@@ -2,6 +2,11 @@
 
 class WorldEventFeedChannel < ApplicationCable::Channel
   def subscribed
+    unless WorldEventSetting.visible? || current_hackr&.admin?
+      reject
+      return
+    end
+
     stream_from WorldEventFeed::Publisher::STREAM_NAME
 
     # Send recent events on subscribe so clients have initial state

--- a/app/controllers/admin/world_event_feed_controller.rb
+++ b/app/controllers/admin/world_event_feed_controller.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+class Admin::WorldEventFeedController < Admin::ApplicationController
+  # GET /root/world_event_feed
+  def index
+    @settings = WorldEventSetting.current
+    @recent_events = WorldEvent.recent.limit(50)
+    @simulants = WorldEventSimulant.includes(:grid_hackr).order("grid_hackrs.hackr_alias").to_a
+    @organic_rate = WorldEventFeed::Publisher.current_organic_rate
+    @total_events = WorldEvent.count
+    @simulated_count = WorldEvent.simulated.count
+    @organic_count = WorldEvent.organic.count
+  end
+
+  # PATCH /root/world_event_feed/settings
+  def update_settings
+    settings = WorldEventSetting.current
+    if settings.update(settings_params)
+      set_flash_success("Settings updated! Target: #{settings.target_events_per_minute}/min, Simulator: #{settings.simulator_enabled? ? "ON" : "OFF"}")
+    else
+      set_flash_error(settings.errors.full_messages.join(", "))
+    end
+    redirect_to admin_world_event_feed_index_path
+  end
+
+  # POST /root/world_event_feed/publish
+  def publish
+    hackr_alias = params[:hackr_alias].to_s.strip
+    event_type = params[:event_type].to_s.strip
+
+    unless WorldEvent::EVENT_TYPES.include?(event_type)
+      set_flash_error("Invalid event type: #{event_type}")
+      return redirect_to admin_world_event_feed_index_path
+    end
+
+    # Admin can only publish events for simulant accounts
+    simulant = WorldEventSimulant.joins(:grid_hackr).find_by(grid_hackrs: {hackr_alias: hackr_alias})
+    if hackr_alias.present? && simulant.nil?
+      set_flash_error("Events can only be published for simulant accounts.")
+      return redirect_to admin_world_event_feed_index_path
+    end
+
+    data = build_event_data(event_type)
+    alias_to_use = hackr_alias.presence || "SYSTEM"
+
+    WorldEventFeed::Publisher.publish(
+      event_type: event_type,
+      hackr_alias: alias_to_use,
+      data: data,
+      simulated: true
+    )
+
+    set_flash_success("Event published: #{event_type} for #{alias_to_use}")
+    redirect_to admin_world_event_feed_index_path
+  end
+
+  private
+
+  def settings_params
+    params.require(:world_event_setting).permit(:target_events_per_minute, :simulator_enabled, :visible)
+  end
+
+  def build_event_data(event_type)
+    case event_type
+    when "clearance_up"
+      {new_clearance: params[:new_clearance].to_i}
+    when "mission_accepted", "mission_completed"
+      {mission_name: params[:mission_name].to_s}
+    when "breach_completed"
+      {template_name: params[:template_name].to_s, tier: params[:tier].to_s}
+    when "rep_tier_changed"
+      {faction_name: params[:faction_name].to_s, new_tier: params[:new_tier].to_s, direction: params[:direction].to_s}
+    when "achievement_unlocked"
+      {achievement_name: params[:achievement_name].to_s}
+    when "wire_post"
+      {content: params[:content].to_s.truncate(80)}
+    when "manual"
+      {message: params[:message].to_s}
+    else
+      {}
+    end
+  end
+end

--- a/app/controllers/api/admin/world_events_controller.rb
+++ b/app/controllers/api/admin/world_events_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Api
+  module Admin
+    class WorldEventsController < BaseController
+      # POST /api/admin/world_events
+      #
+      # Publish an event to the World Event Feed. Used by Synthia and
+      # other external services for custom announcements.
+      #
+      # Params:
+      #   event_type: (required) One of WorldEvent::EVENT_TYPES
+      #   hackr_alias: (optional) Alias to attribute the event to. Defaults to admin hackr.
+      #   data: (optional) Hash of event-specific data
+      #   message: (optional) Shorthand for data.message when event_type is "manual"
+      def create
+        event_type = params[:event_type].to_s.strip
+
+        unless WorldEvent::EVENT_TYPES.include?(event_type)
+          return render json: {success: false, error: "Invalid event_type. Valid: #{WorldEvent::EVENT_TYPES.join(", ")}"}, status: :unprocessable_entity
+        end
+
+        hackr_alias = params[:hackr_alias].presence || @current_admin_hackr.hackr_alias
+        data = sanitize_event_data(params[:data]&.to_unsafe_h || {})
+
+        # Shorthand: if event_type is "manual" and message is provided at top level
+        if event_type == "manual" && params[:message].present? && data["message"].blank?
+          data["message"] = params[:message].to_s.truncate(256)
+        end
+
+        event = WorldEventFeed::Publisher.publish(
+          event_type: event_type,
+          hackr_alias: hackr_alias,
+          data: data,
+          simulated: false
+        )
+
+        if event
+          render json: {
+            success: true,
+            event: WorldEventFeed::Publisher.serialize(event)
+          }, status: :created
+        else
+          render json: {success: false, error: "Failed to publish event"}, status: :internal_server_error
+        end
+      end
+
+      private
+
+      # Cap string values in the data hash to prevent oversized payloads
+      def sanitize_event_data(hash)
+        hash.transform_values do |v|
+          v.is_a?(String) ? v.truncate(256) : v
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -754,6 +754,15 @@ class Api::GridController < ApplicationController
         }, status: :unprocessable_entity
       end
     end
+
+    # Publish after transaction commits so rollback doesn't leave phantom events
+    if @hackr&.persisted?
+      WorldEventFeed::Publisher.publish(
+        event_type: "hackr_registered",
+        hackr_alias: @hackr.hackr_alias,
+        data: {}
+      )
+    end
   end
 
   # DELETE /api/grid/disconnect - Disconnect from THE PULSE GRID

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -5,7 +5,8 @@ module Api
     def index
       render json: {
         prerelease_mode: APP_SETTINGS[:prerelease_mode],
-        prerelease_banner_text: APP_SETTINGS[:prerelease_banner_text]
+        prerelease_banner_text: APP_SETTINGS[:prerelease_banner_text],
+        world_feed_visible: WorldEventSetting.visible?
       }
     end
   end

--- a/app/controllers/api/world_events_controller.rb
+++ b/app/controllers/api/world_events_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  class WorldEventsController < ApplicationController
+    # GET /api/world_events
+    # Public endpoint for initial feed hydration.
+    def index
+      limit = (params[:limit] || 50).to_i.clamp(1, 100)
+      events = WorldEvent.recent.limit(limit).to_a.reverse
+
+      render json: {
+        events: events.map { |e| WorldEventFeed::Publisher.serialize(e) }
+      }
+    end
+  end
+end

--- a/app/controllers/api/world_events_controller.rb
+++ b/app/controllers/api/world_events_controller.rb
@@ -3,8 +3,12 @@
 module Api
   class WorldEventsController < ApplicationController
     # GET /api/world_events
-    # Public endpoint for initial feed hydration.
+    # Public endpoint for initial feed hydration. Returns empty when feed is hidden.
     def index
+      unless WorldEventSetting.visible?
+        return render json: {events: []}
+      end
+
       limit = (params[:limit] || 50).to_i.clamp(1, 100)
       events = WorldEvent.recent.limit(limit).to_a.reverse
 

--- a/app/controllers/overlays_controller.rb
+++ b/app/controllers/overlays_controller.rb
@@ -63,4 +63,8 @@ class OverlaysController < ApplicationController
       render layout: "overlay_fullscreen"
     end
   end
+
+  # GET /overlays/world-feed
+  def world_feed
+  end
 end

--- a/app/javascript/components/layouts/AppLayout.tsx
+++ b/app/javascript/components/layouts/AppLayout.tsx
@@ -56,6 +56,7 @@ const UplinkPopoutPage = lazy(() => import('~/components/pages/uplink/UplinkPopo
 const CodeIndexPage = lazy(() => import('~/components/pages/code/CodeIndexPage').then(m => ({ default: m.CodeIndexPage })))
 const CodeRepoPage = lazy(() => import('~/components/pages/code/CodeRepoPage'))
 const StreamSchedulePage = lazy(() => import('~/components/pages/streams/StreamSchedulePage').then(m => ({ default: m.StreamSchedulePage })))
+const WorldFeedPage = lazy(() => import('~/components/pages/feed/WorldFeedPage').then(m => ({ default: m.WorldFeedPage })))
 const NotFoundPage = lazy(() => import('~/components/errors/NotFoundPage').then(m => ({ default: m.NotFoundPage })))
 
 // Auth components
@@ -107,6 +108,7 @@ export const AppLayout: React.FC = () => {
           <Route path="/wavelength-zero" element={<WavelengthZeroPage />} />
           {/* Stream schedule — public */}
           <Route path="/schedule" element={<StreamSchedulePage />} />
+          <Route path="/feed" element={<WorldFeedPage />} />
           {/* Dynamic artist routes — catches any artist slug */}
           <Route path="/:artistSlug" element={<BandProfilePage />} />
           <Route path="/:artistSlug/releases" element={<ReleaseListPage />} />

--- a/app/javascript/components/navigation/HeaderMenu.tsx
+++ b/app/javascript/components/navigation/HeaderMenu.tsx
@@ -4,6 +4,7 @@ import { useGridAuth } from '~/hooks/useGridAuth'
 import { useMobileDetect } from '~/hooks/useMobileDetect'
 import { useMobileMenu } from '~/contexts/MobileMenuContext'
 import { useTerminal } from '~/contexts/TerminalContext'
+import { useAppSettings } from '~/contexts/AppSettingsContext'
 
 export const HeaderMenu: React.FC = () => {
   const { hackr, isLoggedIn, disconnect, hasFeature } = useGridAuth()
@@ -13,6 +14,7 @@ export const HeaderMenu: React.FC = () => {
   const { isMobile } = useMobileDetect()
   const { mobileMenuOpen, setMobileMenuOpen } = useMobileMenu()
   const { openTerminal } = useTerminal()
+  const { isWorldFeedVisible } = useAppSettings()
   const [openDropdown, setOpenDropdown] = useState<string | null>(null)
   const menuRef = useRef<HTMLElement>(null)
 
@@ -170,6 +172,11 @@ export const HeaderMenu: React.FC = () => {
                 <Link to="/schedule" className={`mobile-menu-item${isActive('/schedule') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
                   <span className="purple-168-text">/</span> schedule
                 </Link>
+                {isWorldFeedVisible && (
+                  <Link to="/feed" className={`mobile-menu-item${isActive('/feed') ? ' active' : ''}`} onClick={() => setMobileMenuOpen(false)}>
+                    <span className="purple-168-text">/</span> feed
+                  </Link>
+                )}
                 <button
                   className="mobile-menu-item"
                   onClick={() => {
@@ -433,6 +440,13 @@ export const HeaderMenu: React.FC = () => {
                     <span className="purple-168-text">/</span>schedule
                   </Link>
                 </li>
+                {isWorldFeedVisible && (
+                  <li>
+                    <Link to="/feed" onClick={closeDropdown}>
+                      <span className="purple-168-text">/</span>feed
+                    </Link>
+                  </li>
+                )}
                 <li>
                   <a href="#" onClick={(e) => { e.preventDefault(); closeDropdown(); openTerminal() }}>
                     <span className="purple-168-text">&gt;</span>terminal

--- a/app/javascript/components/pages/feed/WorldFeedPage.tsx
+++ b/app/javascript/components/pages/feed/WorldFeedPage.tsx
@@ -1,0 +1,360 @@
+import React, { useEffect, useState, useRef, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { DefaultLayout } from '~/components/layouts/DefaultLayout'
+import { getActionCableConsumer } from '~/lib/actionCableConsumer'
+import { useAppSettings } from '~/contexts/AppSettingsContext'
+
+interface WorldEventData {
+  new_clearance?: number
+  mission_name?: string
+  template_name?: string
+  tier?: string
+  faction_name?: string
+  new_tier?: string
+  direction?: string
+  achievement_name?: string
+  badge_icon?: string
+  content?: string
+  message?: string
+}
+
+interface WorldEvent {
+  id: number
+  event_type: string
+  hackr_alias: string
+  data: WorldEventData
+  message: string
+  created_at: string
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  clearance_up: '#fbbf24',
+  mission_accepted: '#22d3ee',
+  mission_completed: '#34d399',
+  breach_completed: '#f97316',
+  rep_tier_changed: '#a78bfa',
+  achievement_unlocked: '#fbbf24',
+  hackr_registered: '#22d3ee',
+  wire_post: '#9ca3af',
+  manual: '#d0d0d0'
+}
+
+const TYPING_SPEED_MS = 16
+const MAX_LINES = 50
+
+interface DisplayLine {
+  key: number
+  event: WorldEvent
+  text: string
+  typedLength: number
+  done: boolean
+}
+
+let lineKeyCounter = 0
+
+function formatEventText (event: WorldEvent): string {
+  const d = event.data || {}
+  const a = event.hackr_alias
+
+  switch (event.event_type) {
+  case 'clearance_up':
+    return `${a} reached CLEARANCE ${d.new_clearance}`
+  case 'mission_accepted':
+    return `${a} accepted mission: ${d.mission_name}`
+  case 'mission_completed':
+    return `${a} completed mission: ${d.mission_name}`
+  case 'breach_completed':
+    return `${a} completed ${d.tier || 'standard'}-tier BREACH: ${d.template_name}`
+  case 'rep_tier_changed': {
+    const verb = d.direction === 'down' ? 'dropped to' : 'reached'
+    return `${a} ${verb} ${d.new_tier} standing with ${d.faction_name}`
+  }
+  case 'achievement_unlocked': {
+    const icon = d.badge_icon ? `${d.badge_icon} ` : ''
+    return `${a} unlocked ${icon}${d.achievement_name}`
+  }
+  case 'hackr_registered':
+    return `${a} jacked into THE PULSE GRID for the first time`
+  case 'wire_post':
+    return `${a} posted to THE WIRE: "${d.content}"`
+  case 'manual':
+    return d.message || `${a}: system event`
+  default:
+    return event.message || `${a}: ${event.event_type}`
+  }
+}
+
+export const WorldFeedPage: React.FC = () => {
+  const { isWorldFeedVisible, isLoading } = useAppSettings()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!isLoading && !isWorldFeedVisible) {
+      navigate('/', { replace: true })
+    }
+  }, [isLoading, isWorldFeedVisible, navigate])
+
+  // Inject @keyframes blink for cursor animation
+  useEffect(() => {
+    const id = 'world-feed-blink-keyframes'
+    if (!document.getElementById(id)) {
+      const style = document.createElement('style')
+      style.id = id
+      style.textContent = '@keyframes blink { 50% { opacity: 0; } }'
+      document.head.appendChild(style)
+    }
+  }, [])
+
+  const [lines, setLines] = useState<DisplayLine[]>([])
+  const [connected, setConnected] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // All typing state lives in refs to avoid stale closures and re-render churn
+  const seenIdsRef = useRef<Set<number>>(new Set())
+  const queueRef = useRef<WorldEvent[]>([])
+  const typingRef = useRef(false)
+  const mountedRef = useRef(true)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const processQueue = useCallback(() => {
+    if (!mountedRef.current || typingRef.current || queueRef.current.length === 0) return
+    typingRef.current = true
+
+    const event = queueRef.current.shift()!
+    const text = formatEventText(event)
+    const key = ++lineKeyCounter
+
+    // Add line with 0 typed chars
+    setLines(prev => [...prev, { key, event, text, typedLength: 0, done: false }].slice(-MAX_LINES))
+
+    let charIdx = 0
+    timerRef.current = setInterval(() => {
+      if (!mountedRef.current) {
+        clearInterval(timerRef.current!)
+        return
+      }
+      charIdx++
+      if (charIdx >= text.length) {
+        // Done typing this line
+        clearInterval(timerRef.current!)
+        timerRef.current = null
+        setLines(prev => prev.map(l =>
+          l.key === key ? { ...l, typedLength: text.length, done: true } : l
+        ))
+        typingRef.current = false
+        timeoutRef.current = setTimeout(processQueue, 150 + Math.random() * 300)
+      } else {
+        // Advance cursor
+        setLines(prev => prev.map(l =>
+          l.key === key ? { ...l, typedLength: charIdx } : l
+        ))
+      }
+    }, TYPING_SPEED_MS)
+  }, [])
+
+  const addEvent = useCallback((event: WorldEvent) => {
+    // Dedup — skip events already seen or already in queue
+    if (seenIdsRef.current.has(event.id)) return
+    seenIdsRef.current.add(event.id)
+    // Cap seen set size to prevent unbounded growth
+    if (seenIdsRef.current.size > 200) {
+      const iter = seenIdsRef.current.values()
+      for (let i = 0; i < 100; i++) iter.next()
+      // Keep only the newer half — rebuild from iterator position
+      const keep = new Set<number>()
+      let next = iter.next()
+      while (!next.done) { keep.add(next.value); next = iter.next() }
+      seenIdsRef.current = keep
+    }
+
+    queueRef.current.push(event)
+    processQueue()
+  }, [processQueue])
+
+  // Stable refs for ActionCable callback
+  const addEventRef = useRef(addEvent)
+  useEffect(() => { addEventRef.current = addEvent }, [addEvent])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (timerRef.current) clearInterval(timerRef.current)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  // ActionCable subscription — runs once, dedup handles strict mode double-fire
+  useEffect(() => {
+    const cable = getActionCableConsumer()
+    const subscription = cable.subscriptions.create('WorldEventFeedChannel', {
+      connected () { setConnected(true) },
+      disconnected () { setConnected(false) },
+      received (data: { type: string; event?: WorldEvent; events?: WorldEvent[] }) {
+        if (data.type === 'initial_events' && data.events) {
+          const initialLines: DisplayLine[] = data.events.map(e => {
+            seenIdsRef.current.add(e.id)
+            const text = formatEventText(e)
+            return { key: ++lineKeyCounter, event: e, text, typedLength: text.length, done: true }
+          })
+          setLines(initialLines.slice(-MAX_LINES))
+        } else if (data.type === 'world_event' && data.event) {
+          addEventRef.current(data.event)
+        }
+      }
+    })
+
+    return () => { subscription.unsubscribe() }
+  }, [])
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [lines])
+
+  return (
+    <DefaultLayout showAsciiArt={false}>
+      <div style={styles.wrapper}>
+        <div style={styles.screen}>
+          <div style={styles.header}>
+            <span style={styles.headerTitle}>HACKR.TV // WORLD FEED</span>
+            <span style={{ ...styles.headerStatus, color: connected ? '#34d399' : '#ef4444' }}>
+              {connected ? '[ CONNECTED ]' : '[ DISCONNECTED ]'}
+            </span>
+          </div>
+
+          <div style={styles.scanlineOverlay} />
+
+          <div ref={containerRef} style={styles.feedContainer}>
+            {lines.map((line, idx) => {
+              const age = lines.length - 1 - idx
+              const opacity = age > 40 ? 0.2 : age > 30 ? 0.4 : age > 20 ? 0.6 : 1
+              const accentColor = EVENT_COLORS[line.event.event_type] || '#d0d0d0'
+
+              return (
+                <div key={line.key} style={{ ...styles.line, opacity }}>
+                  <span style={styles.linePrefix}>{'>'}</span>
+                  <span style={{ color: accentColor }}>
+                    {line.text.substring(0, line.typedLength)}
+                  </span>
+                  {!line.done && <span style={styles.cursor}>_</span>}
+                </div>
+              )
+            })}
+
+            {lines.length === 0 && (
+              <div style={styles.emptyState}>
+                <span style={{ color: '#666' }}>Awaiting signal...</span>
+                <span style={styles.cursor}>_</span>
+              </div>
+            )}
+          </div>
+
+          <div style={styles.footer}>
+            <span style={{ color: '#4b5563' }}>
+              {lines.filter(l => l.done).length} events loaded
+            </span>
+            <span style={{ color: '#4b5563' }}>
+              hackr.tv/feed
+            </span>
+          </div>
+        </div>
+      </div>
+    </DefaultLayout>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '20px',
+    minHeight: '80vh'
+  },
+  screen: {
+    width: '100%',
+    maxWidth: '1000px',
+    background: '#0a0a0a',
+    border: '2px solid #22d3ee',
+    borderRadius: '4px',
+    position: 'relative' as const,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column' as const
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 20px',
+    borderBottom: '1px solid #1a3a3a',
+    background: '#050505'
+  },
+  headerTitle: {
+    color: '#22d3ee',
+    fontFamily: 'monospace',
+    fontSize: '16px',
+    fontWeight: 'bold',
+    letterSpacing: '2px'
+  },
+  headerStatus: {
+    fontFamily: 'monospace',
+    fontSize: '12px'
+  },
+  scanlineOverlay: {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 255, 255, 0.015) 2px, rgba(0, 255, 255, 0.015) 4px)',
+    pointerEvents: 'none' as const,
+    zIndex: 1
+  },
+  feedContainer: {
+    flex: 1,
+    padding: '16px 20px',
+    overflowY: 'auto' as const,
+    minHeight: '500px',
+    maxHeight: '700px',
+    fontFamily: '"Courier New", monospace',
+    fontSize: '14px',
+    lineHeight: '1.6'
+  },
+  line: {
+    marginBottom: '2px',
+    whiteSpace: 'nowrap' as const,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    transition: 'opacity 0.5s ease-out'
+  },
+  linePrefix: {
+    color: '#22d3ee',
+    marginRight: '8px',
+    fontWeight: 'bold'
+  },
+  cursor: {
+    display: 'inline-block',
+    color: '#22d3ee',
+    animation: 'blink 0.6s step-end infinite'
+  },
+  emptyState: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '40px 0'
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '8px 20px',
+    borderTop: '1px solid #1a3a3a',
+    background: '#050505',
+    fontFamily: 'monospace',
+    fontSize: '11px'
+  }
+}

--- a/app/javascript/contexts/AppSettingsContext.tsx
+++ b/app/javascript/contexts/AppSettingsContext.tsx
@@ -4,17 +4,20 @@ import { apiJson } from '~/utils/apiClient'
 interface AppSettings {
   prerelease_mode: string | null
   prerelease_banner_text: string | null
+  world_feed_visible: boolean
 }
 
 interface AppSettingsContextType {
   settings: AppSettings
   isLoading: boolean
   isPrereleaseMode: boolean
+  isWorldFeedVisible: boolean
 }
 
 const defaultSettings: AppSettings = {
   prerelease_mode: null,
-  prerelease_banner_text: null
+  prerelease_banner_text: null,
+  world_feed_visible: false
 }
 
 const AppSettingsContext = createContext<AppSettingsContextType | null>(null)
@@ -56,9 +59,10 @@ export const AppSettingsProvider: React.FC<AppSettingsProviderProps> = ({ childr
   }, [])
 
   const isPrereleaseMode = Boolean(settings.prerelease_mode)
+  const isWorldFeedVisible = Boolean(settings.world_feed_visible)
 
   return (
-    <AppSettingsContext.Provider value={{ settings, isLoading, isPrereleaseMode }}>
+    <AppSettingsContext.Provider value={{ settings, isLoading, isPrereleaseMode, isWorldFeedVisible }}>
       {children}
     </AppSettingsContext.Provider>
   )

--- a/app/jobs/world_event_feed/retention_job.rb
+++ b/app/jobs/world_event_feed/retention_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WorldEventFeed
+  # Daily cleanup of world events older than 7 days.
+  class RetentionJob < ApplicationJob
+    queue_as :default
+
+    RETENTION_DAYS = 7
+
+    def perform
+      cutoff = RETENTION_DAYS.days.ago
+      deleted = WorldEvent.where("created_at < ?", cutoff).delete_all
+      Rails.logger.info("[WorldEventFeed::RetentionJob] purged #{deleted} events older than #{cutoff}")
+    end
+  end
+end

--- a/app/jobs/world_event_feed/simulator_job.rb
+++ b/app/jobs/world_event_feed/simulator_job.rb
@@ -25,7 +25,7 @@ module WorldEventFeed
       # Add variance: ±30%
       variance = (events_this_tick * 0.3).ceil
       events_this_tick = rand((events_this_tick - variance)..(events_this_tick + variance))
-      events_this_tick = events_this_tick.clamp(0, 20) # Safety cap per tick
+      events_this_tick = events_this_tick.clamp(0, 30) # Safety cap per tick (60/min max ÷ 2 ticks/min)
 
       return if events_this_tick <= 0
 

--- a/app/jobs/world_event_feed/simulator_job.rb
+++ b/app/jobs/world_event_feed/simulator_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module WorldEventFeed
+  # Recurring job that generates simulated world events at a dynamic rate.
+  # Runs every 30 seconds. Measures organic event rate and fills the gap
+  # to reach the configured target events per minute.
+  #
+  # If organic activity exceeds the target, emits zero simulated events.
+  class SimulatorJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      return unless WorldEventSetting.simulator_enabled? && WorldEventSetting.visible?
+
+      target = WorldEventSetting.target_rate
+      organic_rate = Publisher.current_organic_rate
+
+      # How many simulated events/min needed to reach target
+      deficit = target - organic_rate
+      return if deficit <= 0
+
+      # We run every 30s = 2 times per minute. Emit our share of the deficit
+      # per tick, with some randomness to avoid mechanical feel.
+      events_this_tick = (deficit / 2.0).ceil
+      # Add variance: ±30%
+      variance = (events_this_tick * 0.3).ceil
+      events_this_tick = rand((events_this_tick - variance)..(events_this_tick + variance))
+      events_this_tick = events_this_tick.clamp(0, 20) # Safety cap per tick
+
+      return if events_this_tick <= 0
+
+      simulator = Simulator.new
+      events_this_tick.times { simulator.generate_event! }
+    rescue => e
+      Rails.logger.error("[WorldEventFeed::SimulatorJob] failed: #{e.message}")
+    end
+  end
+end

--- a/app/models/pulse.rb
+++ b/app/models/pulse.rb
@@ -119,6 +119,15 @@ class Pulse < ApplicationRecord
         parent_pulse_id: parent_pulse_id
       }
     })
+
+    # Publish root pulses (not splices) to the world event feed
+    if parent_pulse_id.nil?
+      WorldEventFeed::Publisher.publish(
+        event_type: "wire_post",
+        hackr_alias: grid_hackr&.hackr_alias || "Unknown",
+        data: {content: content.truncate(80)}
+      )
+    end
   end
 
   def broadcast_deletion

--- a/app/models/world_event.rb
+++ b/app/models/world_event.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: world_events
+# Database name: primary
+#
+#  id          :integer          not null, primary key
+#  data        :json             not null
+#  event_type  :string           not null
+#  hackr_alias :string           not null
+#  simulated   :boolean          default(FALSE), not null
+#  created_at  :datetime         not null
+#
+# Indexes
+#
+#  index_world_events_on_created_at  (created_at)
+#  index_world_events_on_event_type  (event_type)
+#  index_world_events_on_simulated   (simulated)
+#
+class WorldEvent < ApplicationRecord
+  EVENT_TYPES = %w[
+    clearance_up
+    mission_accepted
+    mission_completed
+    breach_completed
+    rep_tier_changed
+    achievement_unlocked
+    hackr_registered
+    wire_post
+    manual
+  ].freeze
+
+  validates :event_type, presence: true, inclusion: {in: EVENT_TYPES}
+  validates :hackr_alias, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :organic, -> { where(simulated: false) }
+  scope :simulated, -> { where(simulated: true) }
+  scope :since, ->(time) { where("created_at >= ?", time) }
+
+  # Count organic events in the last N seconds for rate calculation
+  def self.organic_rate_per_minute(window_seconds: 60)
+    count = organic.since(window_seconds.seconds.ago).count
+    (count.to_f / window_seconds * 60).round(1)
+  end
+end

--- a/app/models/world_event_setting.rb
+++ b/app/models/world_event_setting.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: world_event_settings
+# Database name: primary
+#
+#  id                       :integer          not null, primary key
+#  simulator_enabled        :boolean          default(TRUE), not null
+#  target_events_per_minute :integer          default(30), not null
+#  visible                  :boolean          default(FALSE), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+class WorldEventSetting < ApplicationRecord
+  validates :target_events_per_minute, numericality: {greater_than: 0, less_than_or_equal_to: 120}
+
+  # Singleton pattern — one config row
+  def self.current
+    first_or_create!(target_events_per_minute: 12, simulator_enabled: true)
+  end
+
+  def self.target_rate
+    current.target_events_per_minute
+  end
+
+  def self.simulator_enabled?
+    current.simulator_enabled
+  end
+
+  def self.visible?
+    current.visible
+  end
+end

--- a/app/models/world_event_setting.rb
+++ b/app/models/world_event_setting.rb
@@ -13,7 +13,7 @@
 #  updated_at               :datetime         not null
 #
 class WorldEventSetting < ApplicationRecord
-  validates :target_events_per_minute, numericality: {greater_than: 0, less_than_or_equal_to: 120}
+  validates :target_events_per_minute, numericality: {greater_than: 0, less_than_or_equal_to: 60}
 
   # Singleton pattern — one config row
   def self.current

--- a/app/models/world_event_simulant.rb
+++ b/app/models/world_event_simulant.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: world_event_simulants
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  state         :json             not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#
+# Indexes
+#
+#  index_world_event_simulants_on_grid_hackr_id  (grid_hackr_id) UNIQUE
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#
+class WorldEventSimulant < ApplicationRecord
+  belongs_to :grid_hackr
+
+  validates :grid_hackr_id, uniqueness: true
+
+  delegate :hackr_alias, to: :grid_hackr
+
+  # Convenience accessors for state JSON keys
+  def clearance
+    state["clearance"] || 0
+  end
+
+  def breach_count
+    state["breach_count"] || 0
+  end
+
+  def completed_missions
+    state["completed_missions"] || []
+  end
+
+  def active_mission
+    state["active_mission"]
+  end
+
+  def faction_standings
+    state["faction_standings"] || {}
+  end
+
+  def achievements_earned
+    state["achievements_earned"] || []
+  end
+
+  def deck_name
+    state["deck_name"]
+  end
+
+  # Advance a single state key and persist
+  def advance_state!(key, value)
+    new_state = (state || {}).merge(key.to_s => value)
+    update_column(:state, new_state)
+    self.state = new_state
+  end
+end

--- a/app/services/grid/achievement_awarder.rb
+++ b/app/services/grid/achievement_awarder.rb
@@ -47,6 +47,7 @@ module Grid
       end
 
       broadcast_toast(xp_result, minted_cred)
+      publish_world_event(xp_result)
       build_notification(xp_result, minted_cred)
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
       # RecordInvalid: the uniqueness validator on GridHackrAchievement
@@ -81,6 +82,15 @@ module Grid
       )
     rescue => e
       Rails.logger.error("[AchievementAwarder] broadcast failed: #{e.message}")
+    end
+
+    def publish_world_event(xp_result)
+      WorldEventFeed::Publisher.publish(
+        event_type: "achievement_unlocked",
+        hackr_alias: @hackr.hackr_alias,
+        data: {achievement_name: @achievement.name, badge_icon: @achievement.badge_icon}
+      )
+      WorldEventFeed::Publisher.publish_level_up(hackr_alias: @hackr.hackr_alias, xp_result: xp_result)
     end
 
     def build_notification(xp_result, minted_cred)

--- a/app/services/grid/breach_service.rb
+++ b/app/services/grid/breach_service.rb
@@ -459,6 +459,13 @@ module Grid
         end
       end
 
+      WorldEventFeed::Publisher.publish(
+        event_type: "breach_completed",
+        hackr_alias: @hackr.hackr_alias,
+        data: {template_name: template.name, tier: template.tier}
+      )
+      WorldEventFeed::Publisher.publish_level_up(hackr_alias: @hackr.hackr_alias, xp_result: xp_result)
+
       display = Grid::BreachRenderer.new(hackr_breach).render_success(xp_awarded, cred_awarded, template.name, fragments_granted)
       ResolveResult.new(
         hackr_breach: hackr_breach,

--- a/app/services/grid/mission_reward_granter.rb
+++ b/app/services/grid/mission_reward_granter.rb
@@ -48,6 +48,7 @@ module Grid
       # sweep. These run outside the transaction so a broadcast failure
       # or achievement check error can't roll back the mission completion.
       broadcast_completion(outcome)
+      publish_world_events(outcome)
       outcome[:achievement_notifs] = fire_post_commit_achievement_checks
       outcome[:notification_html] = build_notification(outcome)
       outcome
@@ -164,6 +165,18 @@ module Grid
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.warn("[MissionRewardGranter] item grant failed: #{e.message}")
       nil
+    end
+
+    def publish_world_events(outcome)
+      WorldEventFeed::Publisher.publish(
+        event_type: "mission_completed",
+        hackr_alias: @hackr.hackr_alias,
+        data: {mission_name: @mission.name, arc_name: @mission.grid_mission_arc&.name}
+      )
+      WorldEventFeed::Publisher.publish_level_up(
+        hackr_alias: @hackr.hackr_alias,
+        xp_result: {leveled_up: outcome[:leveled_up], new_clearance: outcome[:new_clearance]}
+      )
     end
 
     def broadcast_completion(outcome)

--- a/app/services/grid/mission_service.rb
+++ b/app/services/grid/mission_service.rb
@@ -128,6 +128,11 @@ module Grid
       end
 
       invalidate_mission_ids_cache!
+      WorldEventFeed::Publisher.publish(
+        event_type: "mission_accepted",
+        hackr_alias: @hackr.hackr_alias,
+        data: {mission_name: mission.name, arc_name: mission.grid_mission_arc&.name}
+      )
       hackr_mission
     rescue ActiveRecord::RecordNotUnique => e
       # Only the partial index on active (hackr, mission) pairs is the

--- a/app/services/grid/reputation_service.rb
+++ b/app/services/grid/reputation_service.rb
@@ -95,6 +95,7 @@ module Grid
         raise
       end
 
+      publish_tier_change(result) if result && result[:tier_before][:key] != result[:tier_after][:key]
       result
     end
 
@@ -167,6 +168,21 @@ module Grid
     end
 
     private
+
+    def publish_tier_change(result)
+      direction = (result[:new_value] > result[:old_value]) ? "up" : "down"
+      faction_name = result[:subject].respond_to?(:name) ? result[:subject].name : result[:subject].to_s
+      WorldEventFeed::Publisher.publish(
+        event_type: "rep_tier_changed",
+        hackr_alias: @hackr.hackr_alias,
+        data: {
+          faction_name: faction_name,
+          new_tier: result[:tier_after][:label],
+          old_tier: result[:tier_before][:label],
+          direction: direction
+        }
+      )
+    end
 
     def resolve_subject(subject)
       case subject

--- a/app/services/world_event_feed/publisher.rb
+++ b/app/services/world_event_feed/publisher.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module WorldEventFeed
+  # Single entry point for all world event publishing. Writes to the DB,
+  # broadcasts over ActionCable, and tracks the organic event rate.
+  #
+  # Used by:
+  #   - Organic hooks in game services (achievements, missions, breaches, etc.)
+  #   - WorldEventFeed::Simulator (simulated population events)
+  #   - Admin panel manual publish
+  #   - External admin API (Synthia)
+  class Publisher
+    STREAM_NAME = "world_event_feed"
+
+    # Publish a world event. Never raises — logs and swallows errors so
+    # callers (game services) are never disrupted by feed failures.
+    def self.publish(event_type:, hackr_alias:, data: {}, simulated: false)
+      event = WorldEvent.create!(
+        event_type: event_type,
+        hackr_alias: hackr_alias,
+        data: data,
+        simulated: simulated
+      )
+
+      broadcast(event)
+      track_organic_rate unless simulated
+      event
+    rescue => e
+      Rails.logger.error("[WorldEventFeed] publish failed: #{e.message}")
+      nil
+    end
+
+    # Convenience: publish a clearance_up event if the hackr leveled up.
+    # Eliminates duplication across AchievementAwarder, MissionRewardGranter, BreachService.
+    def self.publish_level_up(hackr_alias:, xp_result:)
+      return unless xp_result&.dig(:leveled_up)
+      publish(
+        event_type: "clearance_up",
+        hackr_alias: hackr_alias,
+        data: {new_clearance: xp_result[:new_clearance]}
+      )
+    end
+
+    # Canonical event serialization. Used by ActionCable broadcast, channel
+    # hydration, and API responses. Single source of truth for the wire format.
+    def self.serialize(event)
+      {
+        id: event.id,
+        event_type: event.event_type,
+        hackr_alias: event.hackr_alias,
+        data: event.data,
+        message: render_message(event),
+        created_at: event.created_at.iso8601
+      }
+    end
+
+    # Render a human-readable message for an event.
+    def self.render_message(event)
+      alias_str = event.hackr_alias
+      d = event.data || {}
+
+      case event.event_type
+      when "clearance_up"
+        "#{alias_str} reached CLEARANCE #{d["new_clearance"]}"
+      when "mission_accepted"
+        "#{alias_str} accepted mission: #{d["mission_name"]}"
+      when "mission_completed"
+        "#{alias_str} completed mission: #{d["mission_name"]}"
+      when "breach_completed"
+        "#{alias_str} completed #{d["tier"] || "standard"}-tier BREACH: #{d["template_name"]}"
+      when "rep_tier_changed"
+        direction = (d["direction"] == "down") ? "dropped to" : "reached"
+        "#{alias_str} #{direction} #{d["new_tier"]} standing with #{d["faction_name"]}"
+      when "achievement_unlocked"
+        icon = d["badge_icon"].present? ? "#{d["badge_icon"]} " : ""
+        "#{alias_str} unlocked #{icon}#{d["achievement_name"]}"
+      when "hackr_registered"
+        "#{alias_str} jacked into THE PULSE GRID for the first time"
+      when "wire_post"
+        content = d["content"].to_s.truncate(80)
+        "#{alias_str} posted to THE WIRE: \"#{content}\""
+      when "manual"
+        d["message"].presence || "#{alias_str}: system event"
+      else
+        "#{alias_str}: #{event.event_type}"
+      end
+    end
+
+    def self.broadcast(event)
+      ActionCable.server.broadcast(STREAM_NAME, {
+        type: "world_event",
+        event: serialize(event)
+      })
+    rescue => e
+      Rails.logger.error("[WorldEventFeed] broadcast failed: #{e.message}")
+    end
+
+    # Increment the organic event counter in cache for rate tracking.
+    # Uses a per-minute bucket so the simulator can read a sliding window.
+    def self.track_organic_rate
+      bucket_key = "world_event_feed:organic:#{Time.current.strftime("%Y%m%d%H%M")}"
+      Rails.cache.increment(bucket_key, 1, expires_in: 5.minutes)
+    rescue => e
+      Rails.logger.error("[WorldEventFeed] rate tracking failed: #{e.message}")
+    end
+
+    # Read the organic events/minute rate from cache buckets.
+    # Looks at the current and previous minute buckets for a 2-minute window.
+    def self.current_organic_rate
+      now = Time.current
+      current_key = "world_event_feed:organic:#{now.strftime("%Y%m%d%H%M")}"
+      prev_key = "world_event_feed:organic:#{(now - 60).strftime("%Y%m%d%H%M")}"
+
+      current_count = Rails.cache.read(current_key).to_i
+      prev_count = Rails.cache.read(prev_key).to_i
+
+      # Weight: full previous minute + fraction of current minute elapsed
+      seconds_into_minute = now.sec
+      weighted = prev_count + (current_count.to_f * 60 / [seconds_into_minute, 1].max)
+      weighted.round(1)
+    rescue => e
+      Rails.logger.error("[WorldEventFeed] rate read failed: #{e.message}")
+      0
+    end
+  end
+end

--- a/app/services/world_event_feed/simulator.rb
+++ b/app/services/world_event_feed/simulator.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+module WorldEventFeed
+  # Generates consistent simulated events from population accounts.
+  # Each simulant tracks state so events are internally coherent —
+  # e.g. a hackr who "reaches CL15" won't later appear at CL10.
+  #
+  # Called by WorldEventFeed::SimulatorJob on a recurring schedule.
+  class Simulator
+    # Weighted event type distribution. Higher weight = more frequent.
+    EVENT_WEIGHTS = {
+      "breach_completed" => 30,
+      "clearance_up" => 15,
+      "mission_accepted" => 15,
+      "mission_completed" => 12,
+      "achievement_unlocked" => 10,
+      "rep_tier_changed" => 8,
+      "wire_post" => 7,
+      "hackr_registered" => 3
+    }.freeze
+
+    TOTAL_WEIGHT = EVENT_WEIGHTS.values.sum
+
+    # Pool of mission names for simulation (supplements real DB missions)
+    SIMULATED_MISSIONS = [
+      "Signal Recovery", "Data Salvage", "Shard Retrieval", "Dead Drop",
+      "Ghost Protocol", "Network Sweep", "Perimeter Check", "Cache Raid",
+      "Trace Cleanup", "Uplink Tap", "Firmware Extract", "Cipher Burn",
+      "Grid Walk", "Relay Ping", "Core Sample", "Dark Harvest",
+      "Proxy Chain", "Wire Tap", "Node Audit", "Pulse Intercept",
+      "Echo Trace", "Fracture Recon", "Drift Scan", "Breach Intel",
+      "Sector Sweep", "Clearance Run", "Depot Raid", "Rig Calibration"
+    ].freeze
+
+    # Pool of BREACH template names for simulation
+    SIMULATED_BREACHES = [
+      "Corrupted Terminal Node", "Data Siphon Relay", "Derelict Access Point",
+      "Signal Jammer Array", "GovCorp Firewall Node", "Checkpoint Auth Node",
+      "Sector 7 Maintenance Node", "Deep Net Archive", "Blacksite Terminal",
+      "RAINN Command Relay", "Cipher Lock Station", "PRISM Substation Core",
+      "Vault Core Epsilon", "GovCorp Authorization Node", "Access Terminal Echo",
+      "Corrupted Background Daemon", "Rogue Signal Burst", "Transit Checkpoint Ping"
+    ].freeze
+
+    BREACH_TIERS = %w[standard standard standard advanced advanced elite ambient].freeze
+
+    # Pool of WIRE post content for simulation
+    WIRE_POSTS = [
+      "anyone mapped the lower levels of The Hollows yet?",
+      "just found a Quantum Shard in the Underbelly. wild.",
+      "GovCorp patrols are thick in the Narrows today",
+      "new firmware dropped at the vendor in Gold Mile",
+      "PSA: don't skip the rest pod after elite BREACHes",
+      "looking for someone to trade Cipher Chips",
+      "the transit routes through The Canyon are sketchy",
+      "finally got my DECK repaired. that was expensive",
+      "has anyone seen the new schematics at Forge's shop?",
+      "hit ARCHITECT standing with Hackrcore today 💀",
+      "the ambient encounters in The Underbelly are no joke",
+      "first time in The Narrows. these exits are confusing",
+      "pro tip: salvage everything before you sell",
+      "running low on energy cells. where's the nearest vendor?",
+      "just completed my first elite BREACH. hands shaking",
+      "the Fracture Network rep grind is real",
+      "anyone else getting detected on slipstream routes lately?",
+      "found a rare drop from a standard BREACH. RNG blessed",
+      "mining rig output seems lower this week",
+      "GovCorp debt is brutal. avoid capture at all costs",
+      "the bootloader tutorial doesn't prepare you for real BREACHes",
+      "looking for a group to run The Canyon routes",
+      "my den is finally stacked. 3 fixtures, full storage",
+      "BLACKLISTED with GovCorp and proud of it",
+      "does anyone know the fastest route from Lakeshore to The Bend?",
+      "just saw someone at CL50+. how??",
+      "the puzzle gates on elite templates are impossible",
+      "sold my old DECK and upgraded. night and day difference",
+      "rest pods saved my run. was at 3 HP",
+      "first time fabricating. the ingredient grind is real"
+    ].freeze
+
+    # Achievement names for simulation
+    SIMULATED_ACHIEVEMENTS = [
+      "First Steps", "Grid Walker", "Grid Runner", "First Contact",
+      "Data Acquired", "Scrapper", "Breaker of Circuits", "Signal Acquired",
+      "Den Architect", "Pack Rat", "Rare Find", "Junk Dealer",
+      "Data Streamer", "Channel Found", "Screen Tap"
+    ].freeze
+
+    FACTION_NAMES = [
+      "The Fracture Network", "Hackrcore", "Blackout",
+      "Frontwave", "Offline", "GovCorp"
+    ].freeze
+
+    REP_TIERS = %w[UNKNOWN TRUSTED OPERATIVE SPECIALIST ARCHITECT].freeze
+
+    def initialize
+      @simulants = WorldEventSimulant.includes(:grid_hackr).to_a
+    end
+
+    # Generate a single simulated event from a random simulant.
+    # Returns the created WorldEvent, or nil on failure.
+    def generate_event!
+      return nil if @simulants.empty?
+
+      simulant = @simulants.sample
+      event_type = weighted_random_type
+
+      case event_type
+      when "clearance_up" then generate_clearance_up(simulant)
+      when "mission_accepted" then generate_mission_accepted(simulant)
+      when "mission_completed" then generate_mission_completed(simulant)
+      when "breach_completed" then generate_breach_completed(simulant)
+      when "rep_tier_changed" then generate_rep_tier_changed(simulant)
+      when "achievement_unlocked" then generate_achievement_unlocked(simulant)
+      when "hackr_registered" then generate_hackr_registered
+      when "wire_post" then generate_wire_post(simulant)
+      end
+    rescue => e
+      Rails.logger.error("[WorldEventFeed::Simulator] generate_event! failed: #{e.message}")
+      nil
+    end
+
+    private
+
+    def weighted_random_type
+      roll = rand(TOTAL_WEIGHT)
+      cumulative = 0
+      EVENT_WEIGHTS.each do |type, weight|
+        cumulative += weight
+        return type if roll < cumulative
+      end
+      EVENT_WEIGHTS.keys.last
+    end
+
+    def generate_clearance_up(simulant)
+      return generate_breach_completed(simulant) if simulant.clearance >= 99
+
+      new_cl = simulant.clearance + 1
+      simulant.advance_state!("clearance", new_cl)
+
+      Publisher.publish(
+        event_type: "clearance_up",
+        hackr_alias: simulant.hackr_alias,
+        data: {"new_clearance" => new_cl},
+        simulated: true
+      )
+    end
+
+    def generate_mission_accepted(simulant)
+      mission_name = pick_mission(simulant)
+      simulant.advance_state!("active_mission", mission_name)
+
+      Publisher.publish(
+        event_type: "mission_accepted",
+        hackr_alias: simulant.hackr_alias,
+        data: {"mission_name" => mission_name},
+        simulated: true
+      )
+    end
+
+    def generate_mission_completed(simulant)
+      # If no active mission, accept and complete one
+      mission_name = simulant.active_mission || pick_mission(simulant)
+      completed = simulant.completed_missions + [mission_name]
+      simulant.advance_state!("completed_missions", completed.last(20))
+      simulant.advance_state!("active_mission", nil)
+
+      Publisher.publish(
+        event_type: "mission_completed",
+        hackr_alias: simulant.hackr_alias,
+        data: {"mission_name" => mission_name},
+        simulated: true
+      )
+    end
+
+    def generate_breach_completed(simulant)
+      template_name = SIMULATED_BREACHES.sample
+      tier = BREACH_TIERS.sample
+      new_count = simulant.breach_count + 1
+      simulant.advance_state!("breach_count", new_count)
+
+      Publisher.publish(
+        event_type: "breach_completed",
+        hackr_alias: simulant.hackr_alias,
+        data: {"template_name" => template_name, "tier" => tier},
+        simulated: true
+      )
+    end
+
+    def generate_rep_tier_changed(simulant)
+      faction_name = FACTION_NAMES.sample
+      direction = (rand < 0.8) ? "up" : "down"
+
+      standings = simulant.faction_standings.dup
+      current_idx = REP_TIERS.index(standings[faction_name]) || 0
+
+      if direction == "up" && current_idx < REP_TIERS.length - 1
+        new_tier = REP_TIERS[current_idx + 1]
+      elsif direction == "down" && current_idx > 0
+        new_tier = REP_TIERS[current_idx - 1]
+      else
+        new_tier = REP_TIERS[current_idx]
+        direction = "up" # No actual change, just show current
+      end
+
+      standings[faction_name] = new_tier
+      simulant.advance_state!("faction_standings", standings)
+
+      Publisher.publish(
+        event_type: "rep_tier_changed",
+        hackr_alias: simulant.hackr_alias,
+        data: {"faction_name" => faction_name, "new_tier" => new_tier, "direction" => direction},
+        simulated: true
+      )
+    end
+
+    def generate_achievement_unlocked(simulant)
+      available = SIMULATED_ACHIEVEMENTS - simulant.achievements_earned
+      if available.empty?
+        # All achievements earned — fall back to breach
+        return generate_breach_completed(simulant)
+      end
+
+      achievement_name = available.sample
+      earned = simulant.achievements_earned + [achievement_name]
+      simulant.advance_state!("achievements_earned", earned)
+
+      Publisher.publish(
+        event_type: "achievement_unlocked",
+        hackr_alias: simulant.hackr_alias,
+        data: {"achievement_name" => achievement_name},
+        simulated: true
+      )
+    end
+
+    def generate_hackr_registered
+      # Use a random simulant as the "new registration" — won't repeat
+      # aliases often with 125 simulants in the pool
+      simulant = @simulants.sample
+      Publisher.publish(
+        event_type: "hackr_registered",
+        hackr_alias: simulant.hackr_alias,
+        data: {},
+        simulated: true
+      )
+    end
+
+    def generate_wire_post(simulant)
+      Publisher.publish(
+        event_type: "wire_post",
+        hackr_alias: simulant.hackr_alias,
+        data: {"content" => WIRE_POSTS.sample},
+        simulated: true
+      )
+    end
+
+    def pick_mission(simulant)
+      # Avoid repeating recently completed missions
+      available = SIMULATED_MISSIONS - simulant.completed_missions.last(5)
+      available = SIMULATED_MISSIONS if available.empty?
+      available.sample
+    end
+  end
+end

--- a/app/views/admin/shared/_nav.html.erb
+++ b/app/views/admin/shared/_nav.html.erb
@@ -120,6 +120,7 @@
           <%= link_to "Red Flags", admin_data_audit_flags_path, style: "color: #ff6600;" %>
           <%= link_to "Analytics", admin_analytics_dashboard_path, class: "cyan-168-text" %>
           <%= link_to "Overlays", admin_overlays_path, class: "yellow-168-text" %>
+          <%= link_to "World Feed", admin_world_event_feed_index_path, class: "cyan-168-text" %>
           <%= link_to "Redirects", admin_redirects_path, class: "cyan-168-text" %>
         </div>
       </div>

--- a/app/views/admin/world_event_feed/index.html.erb
+++ b/app/views/admin/world_event_feed/index.html.erb
@@ -7,7 +7,7 @@
       <%= form_with(model: @settings, url: settings_admin_world_event_feed_index_path, method: :patch, local: true) do |f| %>
         <div style="margin-bottom: 10px;">
           <label style="color: #9ca3af;">Target Events/Minute:</label><br>
-          <%= f.number_field :target_events_per_minute, min: 1, max: 120, class: "tui-input", style: "width: 80px; font-family: monospace;" %>
+          <%= f.number_field :target_events_per_minute, min: 1, max: 60, class: "tui-input", style: "width: 80px; font-family: monospace;" %>
         </div>
         <div style="margin-bottom: 10px;">
           <label style="color: #9ca3af;">

--- a/app/views/admin/world_event_feed/index.html.erb
+++ b/app/views/admin/world_event_feed/index.html.erb
@@ -1,0 +1,124 @@
+<h1 class="cyan-255-text">World Event Feed</h1>
+
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-bottom: 20px;">
+  <div class="tui-window" style="padding: 15px;">
+    <fieldset>
+      <legend class="cyan-255-text">Settings</legend>
+      <%= form_with(model: @settings, url: settings_admin_world_event_feed_index_path, method: :patch, local: true) do |f| %>
+        <div style="margin-bottom: 10px;">
+          <label style="color: #9ca3af;">Target Events/Minute:</label><br>
+          <%= f.number_field :target_events_per_minute, min: 1, max: 120, class: "tui-input", style: "width: 80px; font-family: monospace;" %>
+        </div>
+        <div style="margin-bottom: 10px;">
+          <label style="color: #9ca3af;">
+            <%= f.check_box :simulator_enabled %> Simulator Enabled
+          </label>
+        </div>
+        <div style="margin-bottom: 10px;">
+          <label style="color: <%= @settings.visible? ? '#34d399' : '#ef4444' %>;">
+            <%= f.check_box :visible %> Visible to Hackrs
+          </label>
+        </div>
+        <%= f.submit "Save", class: "tui-button", style: "font-family: monospace;" %>
+      <% end %>
+    </fieldset>
+  </div>
+
+  <div class="tui-window" style="padding: 15px;">
+    <fieldset>
+      <legend class="green-255-text">Status</legend>
+      <table style="width: 100%; font-family: monospace;">
+        <tr>
+          <td style="color: #9ca3af;">Organic Rate:</td>
+          <td style="color: #34d399;"><%= @organic_rate %>/min</td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Target:</td>
+          <td style="color: #22d3ee;"><%= @settings.target_events_per_minute %>/min</td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Simulator:</td>
+          <td style="color: <%= @settings.simulator_enabled? ? '#34d399' : '#ef4444' %>;"><%= @settings.simulator_enabled? ? "ON" : "OFF" %></td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Visible:</td>
+          <td style="color: <%= @settings.visible? ? '#34d399' : '#ef4444' %>;"><%= @settings.visible? ? "YES" : "NO" %></td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Total Events:</td>
+          <td style="color: #d0d0d0;"><%= @total_events %></td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Organic:</td>
+          <td style="color: #34d399;"><%= @organic_count %></td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Simulated:</td>
+          <td style="color: #a78bfa;"><%= @simulated_count %></td>
+        </tr>
+        <tr>
+          <td style="color: #9ca3af;">Simulants:</td>
+          <td style="color: #d0d0d0;"><%= @simulants.size %></td>
+        </tr>
+      </table>
+    </fieldset>
+  </div>
+
+  <div class="tui-window" style="padding: 15px;">
+    <fieldset>
+      <legend class="yellow-255-text">Manual Publish</legend>
+      <%= form_with(url: publish_admin_world_event_feed_index_path, method: :post, local: true) do |f| %>
+        <div style="margin-bottom: 8px;">
+          <label style="color: #9ca3af;">Event Type:</label><br>
+          <%= f.select :event_type, WorldEvent::EVENT_TYPES.map { |t| [t.titleize, t] }, {}, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+        </div>
+        <div style="margin-bottom: 8px;">
+          <label style="color: #9ca3af;">Simulant:</label><br>
+          <%= f.select :hackr_alias, @simulants.map { |s| [s.hackr_alias, s.hackr_alias] }, { include_blank: "-- Select --" }, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+        </div>
+        <div style="margin-bottom: 8px;">
+          <label style="color: #9ca3af;">Message (for manual type):</label><br>
+          <%= f.text_field :message, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+        </div>
+        <div style="margin-bottom: 8px;">
+          <label style="color: #9ca3af;">Mission/Achievement/Template Name:</label><br>
+          <%= f.text_field :mission_name, class: "tui-input", style: "width: 100%; font-family: monospace;" %>
+        </div>
+        <%= f.submit "Publish", class: "tui-button", style: "font-family: monospace;" %>
+      <% end %>
+    </fieldset>
+  </div>
+</div>
+
+<div class="tui-window" style="padding: 15px;">
+  <fieldset>
+    <legend class="cyan-255-text">Recent Events (last 50)</legend>
+    <table style="width: 100%; font-family: monospace; font-size: 0.85em;">
+      <thead>
+        <tr style="border-bottom: 1px solid #333;">
+          <th style="text-align: left; padding: 4px 8px; color: #666;">Time</th>
+          <th style="text-align: left; padding: 4px 8px; color: #666;">Type</th>
+          <th style="text-align: left; padding: 4px 8px; color: #666;">Hackr</th>
+          <th style="text-align: left; padding: 4px 8px; color: #666;">Message</th>
+          <th style="text-align: center; padding: 4px 8px; color: #666;">Sim</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @recent_events.each_with_index do |event, i| %>
+          <tr style="background: <%= i.even? ? '#111' : '#0a0a0a' %>;">
+            <td style="padding: 4px 8px; color: #666; white-space: nowrap;"><%= event.created_at.strftime("%H:%M:%S") %></td>
+            <td style="padding: 4px 8px; color: #22d3ee;"><%= event.event_type %></td>
+            <td style="padding: 4px 8px; color: #d0d0d0;"><%= event.hackr_alias %></td>
+            <td style="padding: 4px 8px; color: #9ca3af;"><%= WorldEventFeed::Publisher.render_message(event) %></td>
+            <td style="padding: 4px 8px; text-align: center; color: <%= event.simulated? ? '#a78bfa' : '#34d399' %>;"><%= event.simulated? ? "SIM" : "ORG" %></td>
+          </tr>
+        <% end %>
+        <% if @recent_events.empty? %>
+          <tr>
+            <td colspan="5" style="padding: 20px; text-align: center; color: #666;">No events yet. Start the simulator or publish manually.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+</div>

--- a/app/views/overlays/world_feed.html.erb
+++ b/app/views/overlays/world_feed.html.erb
@@ -1,0 +1,293 @@
+<style>
+  .world-feed-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 960px;
+    height: 1080px;
+    background: rgba(0, 0, 0, 0.92);
+    font-family: var(--overlay-font);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 40px 60px;
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+
+  .world-feed-header {
+    position: absolute;
+    top: 30px;
+    left: 60px;
+    right: 60px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #22d3ee;
+    padding-bottom: 12px;
+  }
+
+  .world-feed-header-title {
+    color: #22d3ee;
+    font-size: 28px;
+    font-weight: bold;
+    letter-spacing: 4px;
+  }
+
+  .world-feed-header-status {
+    color: #666;
+    font-size: 18px;
+  }
+
+  .world-feed-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: calc(1080px - 160px);
+    overflow: hidden;
+  }
+
+  .world-feed-line {
+    font-size: 26px;
+    line-height: 1.4;
+    color: #d0d0d0;
+    white-space: normal;
+    word-wrap: break-word;
+    opacity: 1;
+    transition: opacity 0.5s ease-out;
+  }
+
+  .world-feed-line .wf-alias {
+    color: #22d3ee;
+    font-weight: bold;
+  }
+
+  .world-feed-line .wf-action {
+    color: #9ca3af;
+  }
+
+  .world-feed-line .wf-target {
+    color: #a78bfa;
+  }
+
+  .world-feed-line .wf-value {
+    color: #fbbf24;
+  }
+
+  .world-feed-line .wf-time {
+    color: #4b5563;
+    font-size: 20px;
+    margin-right: 12px;
+  }
+
+  .world-feed-line.fading {
+    opacity: 0.3;
+  }
+
+  .world-feed-line.very-faded {
+    opacity: 0.15;
+  }
+
+  /* Typing cursor */
+  .wf-cursor {
+    display: inline-block;
+    width: 14px;
+    height: 26px;
+    background: #22d3ee;
+    vertical-align: bottom;
+    animation: wf-blink 0.6s step-end infinite;
+  }
+
+  @keyframes wf-blink {
+    50% { opacity: 0; }
+  }
+</style>
+
+<div class="world-feed-overlay" id="world-feed-overlay">
+  <div class="world-feed-header">
+    <span class="world-feed-header-title">HACKR.TV // WORLD FEED</span>
+    <span class="world-feed-header-status" id="world-feed-status">CONNECTED</span>
+  </div>
+  <div class="world-feed-lines" id="world-feed-lines"></div>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+(function() {
+  'use strict';
+
+  var MAX_LINES = 20;
+  var TYPING_SPEED_MS = 18;
+  var container = document.getElementById('world-feed-lines');
+  var statusEl = document.getElementById('world-feed-status');
+  var typeQueue = [];
+  var isTyping = false;
+
+  function escapeHtml(text) {
+    if (!text) return '';
+    var div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  var seenIds = {};
+
+  function isDuplicate(id) {
+    if (seenIds[id]) return true;
+    seenIds[id] = true;
+    // Cap size — drop oldest entries when over 300
+    var keys = Object.keys(seenIds);
+    if (keys.length > 300) {
+      for (var i = 0; i < 150; i++) delete seenIds[keys[i]];
+    }
+    return false;
+  }
+
+  function formatEvent(event) {
+    var alias = escapeHtml(event.hackr_alias);
+    var d = event.data || {};
+    var parts = '<span class="wf-alias">' + alias + '</span> ';
+
+    switch (event.event_type) {
+      case 'clearance_up':
+        parts += '<span class="wf-action">reached</span> <span class="wf-value">CLEARANCE ' + escapeHtml(String(d.new_clearance)) + '</span>';
+        break;
+      case 'mission_accepted':
+        parts += '<span class="wf-action">accepted mission:</span> <span class="wf-target">' + escapeHtml(d.mission_name) + '</span>';
+        break;
+      case 'mission_completed':
+        parts += '<span class="wf-action">completed mission:</span> <span class="wf-target">' + escapeHtml(d.mission_name) + '</span>';
+        break;
+      case 'breach_completed':
+        parts += '<span class="wf-action">completed a</span> <span class="wf-value">' + escapeHtml(d.tier) + '</span><span class="wf-action">-tier BREACH:</span> <span class="wf-target">' + escapeHtml(d.template_name) + '</span>';
+        break;
+      case 'rep_tier_changed':
+        var verb = d.direction === 'down' ? 'dropped to' : 'reached';
+        parts += '<span class="wf-action">' + verb + '</span> <span class="wf-value">' + escapeHtml(d.new_tier) + '</span> <span class="wf-action">with</span> <span class="wf-target">' + escapeHtml(d.faction_name) + '</span>';
+        break;
+      case 'achievement_unlocked':
+        var icon = d.badge_icon ? escapeHtml(d.badge_icon) + ' ' : '';
+        parts += '<span class="wf-action">unlocked</span> <span class="wf-value">' + icon + escapeHtml(d.achievement_name) + '</span>';
+        break;
+      case 'hackr_registered':
+        parts += '<span class="wf-action">jacked into THE PULSE GRID for the first time</span>';
+        break;
+      case 'wire_post':
+        parts += '<span class="wf-action">posted to THE WIRE:</span> <span class="wf-target">"' + escapeHtml(d.content) + '"</span>';
+        break;
+      case 'manual':
+        parts = '<span class="wf-action">' + escapeHtml(d.message || event.message || '') + '</span>';
+        break;
+      default:
+        parts += '<span class="wf-action">' + escapeHtml(event.event_type) + '</span>';
+    }
+    return parts;
+  }
+
+  function applyFading() {
+    var lines = container.querySelectorAll('.world-feed-line');
+    for (var i = 0; i < lines.length; i++) {
+      var age = lines.length - 1 - i;
+      lines[i].classList.remove('fading', 'very-faded');
+      if (age > 14) {
+        lines[i].classList.add('very-faded');
+      } else if (age > 10) {
+        lines[i].classList.add('fading');
+      }
+    }
+  }
+
+  function trimLines() {
+    while (container.children.length > MAX_LINES) {
+      container.removeChild(container.firstChild);
+    }
+  }
+
+  function typeNextInQueue() {
+    if (typeQueue.length === 0) {
+      isTyping = false;
+      return;
+    }
+    isTyping = true;
+    var event = typeQueue.shift();
+    var html = formatEvent(event);
+
+    var line = document.createElement('div');
+    line.className = 'world-feed-line';
+    line.innerHTML = '';
+    container.appendChild(line);
+    trimLines();
+
+    // Type out the plain text version character by character,
+    // then replace with the styled HTML version
+    var plainText = line.ownerDocument.createElement('div');
+    plainText.innerHTML = html;
+    var fullPlain = plainText.textContent || plainText.innerText;
+    var charIndex = 0;
+
+    var cursor = document.createElement('span');
+    cursor.className = 'wf-cursor';
+
+    function typeChar() {
+      if (charIndex < fullPlain.length) {
+        line.textContent = fullPlain.substring(0, charIndex + 1);
+        line.appendChild(cursor);
+        charIndex++;
+        setTimeout(typeChar, TYPING_SPEED_MS + Math.random() * 10);
+      } else {
+        // Done typing — swap to styled HTML
+        line.innerHTML = html;
+        applyFading();
+        // Small pause before next event
+        setTimeout(typeNextInQueue, 200 + Math.random() * 400);
+      }
+    }
+
+    typeChar();
+  }
+
+  function addEvent(event) {
+    typeQueue.push(event);
+    if (!isTyping) {
+      typeNextInQueue();
+    }
+  }
+
+  // ActionCable subscription
+  if (typeof ActionCable !== 'undefined') {
+    var consumer = ActionCable.createConsumer();
+    consumer.subscriptions.create('WorldEventFeedChannel', {
+      connected: function() {
+        statusEl.textContent = 'CONNECTED';
+        statusEl.style.color = '#34d399';
+      },
+      disconnected: function() {
+        statusEl.textContent = 'DISCONNECTED';
+        statusEl.style.color = '#ef4444';
+      },
+      received: function(data) {
+        if (data.type === 'initial_events') {
+          // Load initial events without typing animation
+          (data.events || []).forEach(function(evt) {
+            if (isDuplicate(evt.id)) return;
+            var line = document.createElement('div');
+            line.className = 'world-feed-line';
+            line.innerHTML = formatEvent(evt);
+            container.appendChild(line);
+          });
+          trimLines();
+          applyFading();
+        } else if (data.type === 'world_event') {
+          if (!isDuplicate(data.event.id)) {
+            addEvent(data.event);
+          }
+        }
+      }
+    });
+  }
+
+  // Flicker integration
+  if (window.flickerManager) {
+    window.flickerManager.refresh();
+  }
+})();
+</script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,10 +20,11 @@ Rails.application.configure do
     policy.script_src :self, :https
 
     if Rails.env.development?
-      # Vite dev server needs additional permissions
+      # Vite dev server + ActionCable need ws: access.
+      # Allow all ws: in dev so LAN IP access works (e.g. 192.168.x.x).
       vite_host = ViteRuby.config.host_with_port
       policy.script_src(*policy.script_src, "http://#{vite_host}", :unsafe_eval)
-      policy.connect_src(*policy.connect_src, "ws://#{vite_host}", "http://#{vite_host}")
+      policy.connect_src(*policy.connect_src, "ws:", "http://#{vite_host}")
     end
 
     policy.script_src(*policy.script_src, :blob) if Rails.env.test?

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -41,3 +41,11 @@ production:
   data_audit_scan:
     class: DataAudit::ScanJob
     schedule: every 6 hours
+
+  world_event_simulator:
+    class: WorldEventFeed::SimulatorJob
+    schedule: every 30 seconds
+
+  world_event_retention:
+    class: WorldEventFeed::RetentionJob
+    schedule: at 5am every day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,9 @@ Rails.application.routes.draw do
   # Stream schedule (SPA)
   get "schedule", to: "pages#spa_root", as: :streams_schedule
 
+  # World Event Feed (SPA)
+  get "feed", to: "pages#spa_root", as: :world_feed
+
   # Codex (wiki) routes - SPA
   scope "codex" do
     get "/", to: "pages#spa_root", as: :codex
@@ -248,6 +251,9 @@ Rails.application.routes.draw do
       get "moderation_log", to: "moderation#moderation_log", as: :moderation_log
     end
 
+    # World Event Feed (public)
+    get "world_events", to: "world_events#index"
+
     # Error reporting (frontend JS errors)
     post "error_report", to: "error_reports#create"
 
@@ -284,6 +290,9 @@ Rails.application.routes.draw do
 
       # Code sync
       post "code/sync", to: "code#sync"
+
+      # World Event Feed
+      post "world_events", to: "world_events#create"
     end
   end
 
@@ -642,6 +651,14 @@ Rails.application.routes.draw do
     resources :overlay_elements, path: "overlays/elements", only: %i[index show]
     resources :overlay_lower_thirds, path: "overlays/lower-thirds", only: %i[index show]
     resources :overlay_scene_groups, path: "overlays/groups", only: %i[index show]
+
+    # World Event Feed admin
+    resources :world_event_feed, only: [:index] do
+      collection do
+        patch :settings, action: :update_settings
+        post :publish
+      end
+    end
   end
 
   # OBS Overlay routes (Rails server-rendered, NOT SPA)
@@ -654,6 +671,7 @@ Rails.application.routes.draw do
     get "codex/:slug", to: "overlays#codex", as: :overlay_codex
     get "ticker/:position", to: "overlays#ticker", as: :overlay_ticker
     get "scenes/:slug", to: "overlays#scene", as: :overlay_scene
+    get "world-feed", to: "overlays#world_feed", as: :overlay_world_feed
   end
 
   # Development-only error page testing routes

--- a/data/system/simulant_hackrs.yml
+++ b/data/system/simulant_hackrs.yml
@@ -1,0 +1,130 @@
+# Population simulant accounts for the World Event Feed.
+# These are "22nd century hackrs" — background population that generates
+# plausible activity events to make the world feel alive.
+# All are login_disabled. None are playable accounts.
+simulants:
+  - Axiom-7
+  - BlkVoid
+  - Brynn Solis
+  - BurnLayer
+  - ByteRot
+  - C4scade
+  - Calyx
+  - Cerberus Node
+  - ChalkLine
+  - Chromakey
+  - Circuit Wraith
+  - Coldframe
+  - Copperwire
+  - Cortex-9
+  - CrashNull
+  - Cryogen
+  - DarkPulse
+  - DataGrave
+  - DeadSignal
+  - DeepNode
+  - Dex Malware
+  - Drift Halo
+  - Dustline
+  - Echo Null
+  - EdgRunner
+  - Ember Cask
+  - Fadeout
+  - Fenris Loop
+  - FluxGate
+  - Forge Ash
+  - Fragment-11
+  - FrostBit
+  - G0stShell
+  - GlassJaw
+  - GlitchMob
+  - GrayMatter
+  - Grindcore
+  - Halfpipe
+  - Hashbrown
+  - Hex Orbit
+  - Hollowpoint
+  - HotPatch
+  - Hydra Cell
+  - IcePick
+  - Inkblot
+  - Iron Veil
+  - JackNull
+  - Jinxed
+  - KernelPanic
+  - Killswitch
+  - Knightfall
+  - LatchKey
+  - LazerGrid
+  - LiveWire
+  - LoopBack
+  - LowGrav
+  - Malware Dex
+  - MaskOff
+  - Mercury Ash
+  - MeshPoint
+  - Midnight Run
+  - Mirage-4
+  - MoltFrame
+  - Morph Lock
+  - NeonBleed
+  - NetBurn
+  - Nightcrawl
+  - NullByte
+  - Onyx Drift
+  - OverClock
+  - Oxidize
+  - PatchWork
+  - Phase Lock
+  - Photon Vex
+  - PinDrop
+  - Pixel Rot
+  - Praxis Node
+  - PrimeRoot
+  - Proxy Ghost
+  - QBit
+  - QuickSilver
+  - Radix
+  - Razorback
+  - RedShift
+  - RefluxWave
+  - Riptide
+  - Rogue Spark
+  - RootKit Rex
+  - RuneGlyph
+  - SaltHash
+  - Sandstorm
+  - Scrapheap
+  - ShardLink
+  - Shellcode
+  - SilkThread
+  - Singularity
+  - Slipstream X
+  - SmokePing
+  - SnakeEyes
+  - SplitBit
+  - StaticLine
+  - SteelTrap
+  - StormDrain
+  - SubZero
+  - SwitchBlade
+  - SynFault
+  - TarPit
+  - Terraform
+  - ThreadBare
+  - Tombstone
+  - TraceRoute
+  - TripWire
+  - TurboVolt
+  - Umbra-6
+  - Uplink Raze
+  - VectorDash
+  - Vertigo
+  - VoltSpike
+  - Warden-XII
+  - WarpGate
+  - Watchfire
+  - WildCard
+  - XeroTrace
+  - ZenithArc
+  - ZeroDay

--- a/db/migrate/20260520170500_create_world_event_feed.rb
+++ b/db/migrate/20260520170500_create_world_event_feed.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateWorldEventFeed < ActiveRecord::Migration[8.0]
+  def change
+    create_table :world_events do |t|
+      t.string :event_type, null: false
+      t.string :hackr_alias, null: false
+      t.json :data, null: false, default: {}
+      t.boolean :simulated, null: false, default: false
+      t.datetime :created_at, null: false
+    end
+
+    add_index :world_events, :created_at
+    add_index :world_events, :event_type
+    add_index :world_events, :simulated
+
+    create_table :world_event_simulants do |t|
+      t.references :grid_hackr, null: false, foreign_key: true, index: { unique: true }
+      t.json :state, null: false, default: {}
+
+      t.timestamps
+    end
+
+    create_table :world_event_settings do |t|
+      t.integer :target_events_per_minute, null: false, default: 12
+      t.boolean :simulator_enabled, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260520170500_create_world_event_feed.rb
+++ b/db/migrate/20260520170500_create_world_event_feed.rb
@@ -15,7 +15,7 @@ class CreateWorldEventFeed < ActiveRecord::Migration[8.0]
     add_index :world_events, :simulated
 
     create_table :world_event_simulants do |t|
-      t.references :grid_hackr, null: false, foreign_key: true, index: { unique: true }
+      t.references :grid_hackr, null: false, foreign_key: true, index: {unique: true}
       t.json :state, null: false, default: {}
 
       t.timestamps

--- a/db/migrate/20260528153223_add_visible_to_world_event_settings.rb
+++ b/db/migrate/20260528153223_add_visible_to_world_event_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibleToWorldEventSettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :world_event_settings, :visible, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_194536) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_153223) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -1406,6 +1406,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_194536) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  create_table "world_event_settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "simulator_enabled", default: true, null: false
+    t.integer "target_events_per_minute", default: 12, null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visible", default: false, null: false
+  end
+
+  create_table "world_event_simulants", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.json "state", default: {}, null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id"], name: "index_world_event_simulants_on_grid_hackr_id", unique: true
+  end
+
+  create_table "world_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.json "data", default: {}, null: false
+    t.string "event_type", null: false
+    t.string "hackr_alias", null: false
+    t.boolean "simulated", default: false, null: false
+    t.index ["created_at"], name: "index_world_events_on_created_at"
+    t.index ["event_type"], name: "index_world_events_on_event_type"
+    t.index ["simulated"], name: "index_world_events_on_simulated"
+  end
+
   create_table "zone_playlist_tracks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "position", null: false
@@ -1546,6 +1573,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_194536) do
   add_foreign_key "tracks", "releases"
   add_foreign_key "user_punishments", "grid_hackrs"
   add_foreign_key "user_punishments", "grid_hackrs", column: "issued_by_id"
+  add_foreign_key "world_event_simulants", "grid_hackrs"
   add_foreign_key "zone_playlist_tracks", "tracks"
   add_foreign_key "zone_playlist_tracks", "zone_playlists"
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -2838,6 +2838,65 @@ namespace :data do
       puts "  Run `git diff data/world/` to review changes."
     end
   end
+
+  desc "Load simulant hackrs for World Event Feed"
+  task simulants: :environment do
+    puts "\n--- Loading Simulant Hackrs ---"
+    yaml_file = Rails.root.join("data", "system", "simulant_hackrs.yml")
+
+    unless File.exist?(yaml_file)
+      puts "  ✗ File not found: #{yaml_file}"
+      next
+    end
+
+    data = YAML.load_file(yaml_file)
+    aliases = data["simulants"]
+    created = 0
+    skipped = 0
+
+    # Default password for simulants — they are login_disabled so this
+    # is never usable, but GridHackr requires a password on create.
+    default_password = "simulant-#{SecureRandom.hex(8)}"
+
+    aliases.each do |hackr_alias|
+      hackr = GridHackr.find_or_initialize_by(hackr_alias: hackr_alias)
+      if hackr.persisted?
+        # Ensure simulant row exists even if hackr was already created
+        if WorldEventSimulant.exists?(grid_hackr_id: hackr.id)
+          skipped += 1
+          next
+        end
+      else
+        hackr.assign_attributes(
+          email: "#{hackr_alias.parameterize}@simulant.hackr.tv",
+          role: "operative",
+          password: default_password,
+          skip_reserved_check: true,
+          login_disabled: true
+        )
+        hackr.save!
+      end
+
+      # Create simulant state row with randomized initial state
+      cl = rand(0..35)
+      WorldEventSimulant.find_or_create_by!(grid_hackr: hackr) do |sim|
+        sim.state = {
+          "clearance" => cl,
+          "breach_count" => rand(0..(cl * 2)),
+          "completed_missions" => [],
+          "active_mission" => nil,
+          "faction_standings" => {},
+          "achievements_earned" => [],
+          "deck_name" => nil
+        }
+      end
+
+      created += 1
+      puts "  ✓ Created simulant: #{hackr_alias} (CL#{cl})"
+    end
+
+    puts "Simulants: #{created} created, #{skipped} skipped, #{WorldEventSimulant.count} total"
+  end
 end
 
 # Helper module for data loading utilities

--- a/spec/channels/world_event_feed_channel_spec.rb
+++ b/spec/channels/world_event_feed_channel_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe WorldEventFeedChannel, type: :channel do
   before do
-    stub_connection
+    WorldEventSetting.create!(target_events_per_minute: 12, simulator_enabled: true, visible: true)
   end
 
-  describe "#subscribed" do
+  describe "#subscribed when visible" do
+    before { stub_connection }
+
     it "streams from world_event_feed" do
       subscribe
       expect(subscription).to be_confirmed
@@ -40,6 +42,33 @@ RSpec.describe WorldEventFeedChannel, type: :channel do
 
       events = transmissions.last["events"]
       expect(events.length).to eq(50)
+    end
+  end
+
+  describe "#subscribed when hidden" do
+    before do
+      WorldEventSetting.current.update!(visible: false)
+    end
+
+    it "rejects anonymous subscriptions" do
+      stub_connection(current_hackr: nil)
+      subscribe
+      expect(subscription).to be_rejected
+    end
+
+    it "rejects non-admin subscriptions" do
+      hackr = create(:grid_hackr, role: "operative")
+      stub_connection(current_hackr: hackr)
+      subscribe
+      expect(subscription).to be_rejected
+    end
+
+    it "allows admin subscriptions" do
+      admin = create(:grid_hackr, role: "admin")
+      stub_connection(current_hackr: admin)
+      subscribe
+      expect(subscription).to be_confirmed
+      expect(subscription).to have_stream_from("world_event_feed")
     end
   end
 end

--- a/spec/channels/world_event_feed_channel_spec.rb
+++ b/spec/channels/world_event_feed_channel_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe WorldEventFeedChannel, type: :channel do
+  before do
+    stub_connection
+  end
+
+  describe "#subscribed" do
+    it "streams from world_event_feed" do
+      subscribe
+      expect(subscription).to be_confirmed
+      expect(subscription).to have_stream_from("world_event_feed")
+    end
+
+    it "transmits initial events on subscribe" do
+      WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Test", data: {new_clearance: 5})
+
+      subscribe
+
+      transmission = transmissions.last
+      expect(transmission["type"]).to eq("initial_events")
+      expect(transmission["events"].length).to eq(1)
+    end
+
+    it "transmits events in chronological order" do
+      WorldEvent.create!(event_type: "clearance_up", hackr_alias: "First", created_at: 2.minutes.ago)
+      WorldEvent.create!(event_type: "breach_completed", hackr_alias: "Second")
+
+      subscribe
+
+      events = transmissions.last["events"]
+      expect(events.first["hackr_alias"]).to eq("First")
+      expect(events.last["hackr_alias"]).to eq("Second")
+    end
+
+    it "limits initial events to 50" do
+      60.times { |i| WorldEvent.create!(event_type: "clearance_up", hackr_alias: "H#{i}") }
+
+      subscribe
+
+      events = transmissions.last["events"]
+      expect(events.length).to eq(50)
+    end
+  end
+end

--- a/spec/jobs/world_event_feed/retention_job_spec.rb
+++ b/spec/jobs/world_event_feed/retention_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe WorldEventFeed::RetentionJob do
+  describe "#perform" do
+    it "deletes events older than 7 days" do
+      old = WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Old", created_at: 8.days.ago)
+      recent = WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Recent")
+
+      described_class.new.perform
+
+      expect(WorldEvent.exists?(old.id)).to be false
+      expect(WorldEvent.exists?(recent.id)).to be true
+    end
+
+    it "preserves events within 7 days" do
+      edge = WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Edge", created_at: 6.days.ago)
+
+      described_class.new.perform
+
+      expect(WorldEvent.exists?(edge.id)).to be true
+    end
+  end
+end

--- a/spec/jobs/world_event_feed/simulator_job_spec.rb
+++ b/spec/jobs/world_event_feed/simulator_job_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe WorldEventFeed::SimulatorJob do
       expect { described_class.new.perform }.not_to change { WorldEvent.count }
     end
 
-    it "does not exceed safety cap of 20 events per tick" do
-      WorldEventSetting.current.update!(target_events_per_minute: 120)
+    it "does not exceed safety cap of 30 events per tick" do
+      WorldEventSetting.current.update!(target_events_per_minute: 60)
       described_class.new.perform
-      # Even with 120/min target and 0 organic, one tick should not exceed 20
-      expect(WorldEvent.simulated.count).to be <= 20
+      # Even with 60/min target and 0 organic, one tick should not exceed 30
+      expect(WorldEvent.simulated.count).to be <= 30
     end
 
     it "generates zero events when organic rate exceeds target" do

--- a/spec/jobs/world_event_feed/simulator_job_spec.rb
+++ b/spec/jobs/world_event_feed/simulator_job_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe WorldEventFeed::SimulatorJob do
+  let!(:simulants) do
+    3.times.map do
+      hackr = create(:grid_hackr)
+      WorldEventSimulant.create!(grid_hackr: hackr, state: {"clearance" => 5, "breach_count" => 0, "completed_missions" => [], "active_mission" => nil, "faction_standings" => {}, "achievements_earned" => [], "deck_name" => nil})
+    end
+  end
+
+  before do
+    WorldEventSetting.create!(target_events_per_minute: 12, simulator_enabled: true, visible: true)
+  end
+
+  describe "#perform" do
+    it "generates events when organic rate is below target" do
+      expect { described_class.new.perform }.to change { WorldEvent.simulated.count }
+    end
+
+    it "skips when simulator is disabled" do
+      WorldEventSetting.current.update!(simulator_enabled: false)
+      expect { described_class.new.perform }.not_to change { WorldEvent.count }
+    end
+
+    it "skips when feed is not visible" do
+      WorldEventSetting.current.update!(visible: false)
+      expect { described_class.new.perform }.not_to change { WorldEvent.count }
+    end
+
+    it "does not exceed safety cap of 20 events per tick" do
+      WorldEventSetting.current.update!(target_events_per_minute: 120)
+      described_class.new.perform
+      # Even with 120/min target and 0 organic, one tick should not exceed 20
+      expect(WorldEvent.simulated.count).to be <= 20
+    end
+
+    it "generates zero events when organic rate exceeds target" do
+      # Simulate high organic rate by creating many recent organic events
+      15.times { WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Real", simulated: false) }
+      allow(WorldEventFeed::Publisher).to receive(:current_organic_rate).and_return(20.0)
+
+      expect { described_class.new.perform }.not_to change { WorldEvent.simulated.count }
+    end
+  end
+end

--- a/spec/models/pulse_spec.rb
+++ b/spec/models/pulse_spec.rb
@@ -138,6 +138,9 @@ RSpec.describe Pulse, type: :model do
       it "broadcasts to pulse_wire channel after create" do
         hackr = create(:grid_hackr)
 
+        # Allow world event feed broadcast (root pulses also publish to feed)
+        allow(ActionCable.server).to receive(:broadcast).with("world_event_feed", anything)
+
         expect(ActionCable.server).to receive(:broadcast).with(
           "pulse_wire",
           hash_including(
@@ -158,7 +161,10 @@ RSpec.describe Pulse, type: :model do
       it "includes pulse id and pulsed_at in broadcast" do
         hackr = create(:grid_hackr)
 
-        expect(ActionCable.server).to receive(:broadcast) do |channel, data|
+        # Allow world event feed broadcast
+        allow(ActionCable.server).to receive(:broadcast).with("world_event_feed", anything)
+
+        expect(ActionCable.server).to receive(:broadcast).with("pulse_wire", anything) do |channel, data|
           expect(channel).to eq("pulse_wire")
           expect(data[:type]).to eq("new_pulse")
           expect(data[:pulse][:id]).to be_present
@@ -182,6 +188,9 @@ RSpec.describe Pulse, type: :model do
       end
 
       it "sets parent_pulse_id to nil for root pulses" do
+        # Allow world event feed broadcast
+        allow(ActionCable.server).to receive(:broadcast).with("world_event_feed", anything)
+
         expect(ActionCable.server).to receive(:broadcast).with(
           "pulse_wire",
           hash_including(

--- a/spec/models/world_event_setting_spec.rb
+++ b/spec/models/world_event_setting_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe WorldEventSetting do
       expect(setting).not_to be_valid
     end
 
-    it "requires target_events_per_minute <= 120" do
-      setting = WorldEventSetting.new(target_events_per_minute: 121)
+    it "requires target_events_per_minute <= 60" do
+      setting = WorldEventSetting.new(target_events_per_minute: 61)
       expect(setting).not_to be_valid
     end
 

--- a/spec/models/world_event_setting_spec.rb
+++ b/spec/models/world_event_setting_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe WorldEventSetting do
+  describe "validations" do
+    it "requires target_events_per_minute > 0" do
+      setting = WorldEventSetting.new(target_events_per_minute: 0)
+      expect(setting).not_to be_valid
+    end
+
+    it "requires target_events_per_minute <= 120" do
+      setting = WorldEventSetting.new(target_events_per_minute: 121)
+      expect(setting).not_to be_valid
+    end
+
+    it "accepts valid target_events_per_minute" do
+      setting = WorldEventSetting.new(target_events_per_minute: 30)
+      expect(setting).to be_valid
+    end
+  end
+
+  describe ".current" do
+    it "creates a singleton row on first call" do
+      expect { WorldEventSetting.current }.to change { WorldEventSetting.count }.by(1)
+    end
+
+    it "returns the same record on subsequent calls" do
+      first = WorldEventSetting.current
+      second = WorldEventSetting.current
+      expect(first.id).to eq(second.id)
+    end
+
+    it "defaults to 12 events per minute" do
+      expect(WorldEventSetting.current.target_events_per_minute).to eq(12)
+    end
+  end
+
+  describe ".target_rate" do
+    it "returns the configured target" do
+      WorldEventSetting.create!(target_events_per_minute: 42)
+      expect(WorldEventSetting.target_rate).to eq(42)
+    end
+  end
+
+  describe ".simulator_enabled?" do
+    it "returns true by default" do
+      expect(WorldEventSetting.simulator_enabled?).to be true
+    end
+  end
+
+  describe ".visible?" do
+    it "returns false by default" do
+      expect(WorldEventSetting.visible?).to be false
+    end
+
+    it "returns true when set" do
+      WorldEventSetting.current.update!(visible: true)
+      expect(WorldEventSetting.visible?).to be true
+    end
+  end
+end

--- a/spec/models/world_event_simulant_spec.rb
+++ b/spec/models/world_event_simulant_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe WorldEventSimulant do
+  let(:hackr) { create(:grid_hackr) }
+
+  describe "validations" do
+    it "requires unique grid_hackr_id" do
+      WorldEventSimulant.create!(grid_hackr: hackr, state: {"clearance" => 0})
+      dup = WorldEventSimulant.new(grid_hackr: hackr, state: {"clearance" => 5})
+      expect(dup).not_to be_valid
+    end
+  end
+
+  describe "state accessors" do
+    let(:simulant) do
+      WorldEventSimulant.create!(grid_hackr: hackr, state: {
+        "clearance" => 15,
+        "breach_count" => 7,
+        "completed_missions" => ["Signal Recovery"],
+        "active_mission" => "Data Salvage",
+        "faction_standings" => {"Hackrcore" => "TRUSTED"},
+        "achievements_earned" => ["First Steps"],
+        "deck_name" => "Phantom DECK"
+      })
+    end
+
+    it "reads clearance" do
+      expect(simulant.clearance).to eq(15)
+    end
+
+    it "reads breach_count" do
+      expect(simulant.breach_count).to eq(7)
+    end
+
+    it "reads completed_missions" do
+      expect(simulant.completed_missions).to eq(["Signal Recovery"])
+    end
+
+    it "reads active_mission" do
+      expect(simulant.active_mission).to eq("Data Salvage")
+    end
+
+    it "reads faction_standings" do
+      expect(simulant.faction_standings).to eq({"Hackrcore" => "TRUSTED"})
+    end
+
+    it "reads achievements_earned" do
+      expect(simulant.achievements_earned).to eq(["First Steps"])
+    end
+
+    it "reads deck_name" do
+      expect(simulant.deck_name).to eq("Phantom DECK")
+    end
+
+    it "returns defaults for missing keys" do
+      empty = WorldEventSimulant.create!(grid_hackr: create(:grid_hackr), state: {})
+      expect(empty.clearance).to eq(0)
+      expect(empty.breach_count).to eq(0)
+      expect(empty.completed_missions).to eq([])
+      expect(empty.active_mission).to be_nil
+    end
+  end
+
+  describe "#advance_state!" do
+    let(:simulant) { WorldEventSimulant.create!(grid_hackr: hackr, state: {"clearance" => 5}) }
+
+    it "updates a single key and persists" do
+      simulant.advance_state!("clearance", 6)
+      expect(simulant.clearance).to eq(6)
+      expect(simulant.reload.clearance).to eq(6)
+    end
+
+    it "preserves other state keys" do
+      simulant.advance_state!("breach_count", 1)
+      expect(simulant.clearance).to eq(5)
+      expect(simulant.breach_count).to eq(1)
+    end
+  end
+
+  describe "#hackr_alias" do
+    it "delegates to grid_hackr" do
+      simulant = WorldEventSimulant.create!(grid_hackr: hackr, state: {})
+      expect(simulant.hackr_alias).to eq(hackr.hackr_alias)
+    end
+  end
+end

--- a/spec/models/world_event_spec.rb
+++ b/spec/models/world_event_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe WorldEvent do
+  describe "validations" do
+    it "requires event_type" do
+      event = WorldEvent.new(hackr_alias: "Test", event_type: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:event_type]).to be_present
+    end
+
+    it "requires hackr_alias" do
+      event = WorldEvent.new(event_type: "clearance_up", hackr_alias: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:hackr_alias]).to be_present
+    end
+
+    it "rejects unknown event types" do
+      event = WorldEvent.new(event_type: "bogus", hackr_alias: "Test")
+      expect(event).not_to be_valid
+    end
+
+    it "accepts all defined event types" do
+      WorldEvent::EVENT_TYPES.each do |type|
+        event = WorldEvent.new(event_type: type, hackr_alias: "Test")
+        expect(event).to be_valid, "expected #{type} to be valid"
+      end
+    end
+  end
+
+  describe "scopes" do
+    before do
+      WorldEvent.create!(event_type: "clearance_up", hackr_alias: "A", simulated: false)
+      WorldEvent.create!(event_type: "breach_completed", hackr_alias: "B", simulated: true)
+      WorldEvent.create!(event_type: "wire_post", hackr_alias: "C", simulated: false, created_at: 2.hours.ago)
+    end
+
+    it ".organic returns non-simulated events" do
+      expect(WorldEvent.organic.count).to eq(2)
+    end
+
+    it ".simulated returns simulated events" do
+      expect(WorldEvent.simulated.count).to eq(1)
+    end
+
+    it ".recent orders by created_at desc" do
+      aliases = WorldEvent.recent.pluck(:hackr_alias)
+      expect(aliases.first).not_to eq("C") # oldest last
+    end
+
+    it ".since filters by time" do
+      expect(WorldEvent.since(1.hour.ago).count).to eq(2)
+    end
+  end
+
+  describe ".organic_rate_per_minute" do
+    it "returns 0 with no events" do
+      expect(WorldEvent.organic_rate_per_minute).to eq(0.0)
+    end
+
+    it "counts only organic events in the window" do
+      3.times { WorldEvent.create!(event_type: "clearance_up", hackr_alias: "A", simulated: false) }
+      2.times { WorldEvent.create!(event_type: "clearance_up", hackr_alias: "B", simulated: true) }
+
+      rate = WorldEvent.organic_rate_per_minute(window_seconds: 60)
+      expect(rate).to eq(3.0)
+    end
+  end
+end

--- a/spec/services/grid/achievement_awarder_spec.rb
+++ b/spec/services/grid/achievement_awarder_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe Grid::AchievementAwarder do
     end
 
     it "broadcasts to the per-hackr AchievementChannel stream" do
+      # Allow world event feed broadcasts
+      allow(ActionCable.server).to receive(:broadcast).with("world_event_feed", anything)
+
       expect(ActionCable.server).to receive(:broadcast).with(
         "achievement_channel_#{hackr.id}",
         hash_including(type: "achievement_unlocked")

--- a/spec/services/grid/mission_reward_granter_spec.rb
+++ b/spec/services/grid/mission_reward_granter_spec.rb
@@ -88,6 +88,9 @@ RSpec.describe Grid::MissionRewardGranter do
     it "broadcasts mission_completed to the AchievementChannel stream" do
       create(:grid_mission_reward, grid_mission: mission, reward_type: "xp", amount: 10)
 
+      # Allow world event feed broadcasts
+      allow(ActionCable.server).to receive(:broadcast).with("world_event_feed", anything)
+
       expect(ActionCable.server).to receive(:broadcast).with(
         "achievement_channel_#{hackr.id}",
         hash_including(type: "mission_completed")

--- a/spec/services/world_event_feed/publisher_spec.rb
+++ b/spec/services/world_event_feed/publisher_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe WorldEventFeed::Publisher do
+  describe ".publish" do
+    it "creates a WorldEvent record" do
+      expect {
+        described_class.publish(event_type: "clearance_up", hackr_alias: "TestHackr", data: {new_clearance: 5})
+      }.to change { WorldEvent.count }.by(1)
+    end
+
+    it "returns the created event" do
+      event = described_class.publish(event_type: "breach_completed", hackr_alias: "TestHackr", data: {})
+      expect(event).to be_a(WorldEvent)
+      expect(event).to be_persisted
+    end
+
+    it "broadcasts to ActionCable" do
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "world_event_feed",
+        hash_including(type: "world_event")
+      )
+      described_class.publish(event_type: "clearance_up", hackr_alias: "TestHackr", data: {})
+    end
+
+    it "marks simulated events" do
+      event = described_class.publish(event_type: "clearance_up", hackr_alias: "Sim", data: {}, simulated: true)
+      expect(event.simulated?).to be true
+    end
+
+    it "never raises — returns nil on error" do
+      allow(WorldEvent).to receive(:create!).and_raise(StandardError, "DB down")
+      result = described_class.publish(event_type: "clearance_up", hackr_alias: "Test", data: {})
+      expect(result).to be_nil
+    end
+
+    it "tracks organic rate for non-simulated events" do
+      expect(described_class).to receive(:track_organic_rate)
+      described_class.publish(event_type: "clearance_up", hackr_alias: "Test", data: {})
+    end
+
+    it "skips rate tracking for simulated events" do
+      expect(described_class).not_to receive(:track_organic_rate)
+      described_class.publish(event_type: "clearance_up", hackr_alias: "Test", data: {}, simulated: true)
+    end
+  end
+
+  describe ".publish_level_up" do
+    it "publishes clearance_up when leveled_up is true" do
+      expect {
+        described_class.publish_level_up(hackr_alias: "Test", xp_result: {leveled_up: true, new_clearance: 10})
+      }.to change { WorldEvent.where(event_type: "clearance_up").count }.by(1)
+    end
+
+    it "does nothing when leveled_up is false" do
+      expect {
+        described_class.publish_level_up(hackr_alias: "Test", xp_result: {leveled_up: false})
+      }.not_to change { WorldEvent.count }
+    end
+
+    it "does nothing when xp_result is nil" do
+      expect {
+        described_class.publish_level_up(hackr_alias: "Test", xp_result: nil)
+      }.not_to change { WorldEvent.count }
+    end
+  end
+
+  describe ".serialize" do
+    it "returns canonical hash shape" do
+      event = WorldEvent.create!(event_type: "clearance_up", hackr_alias: "Test", data: {new_clearance: 5})
+      result = described_class.serialize(event)
+
+      expect(result).to include(:id, :event_type, :hackr_alias, :data, :message, :created_at)
+      expect(result[:event_type]).to eq("clearance_up")
+      expect(result[:hackr_alias]).to eq("Test")
+      expect(result[:message]).to include("CLEARANCE 5")
+    end
+  end
+
+  describe ".render_message" do
+    it "formats clearance_up" do
+      event = WorldEvent.new(event_type: "clearance_up", hackr_alias: "Neo", data: {"new_clearance" => 15})
+      expect(described_class.render_message(event)).to eq("Neo reached CLEARANCE 15")
+    end
+
+    it "formats mission_accepted" do
+      event = WorldEvent.new(event_type: "mission_accepted", hackr_alias: "Neo", data: {"mission_name" => "Signal Recovery"})
+      expect(described_class.render_message(event)).to eq("Neo accepted mission: Signal Recovery")
+    end
+
+    it "formats mission_completed" do
+      event = WorldEvent.new(event_type: "mission_completed", hackr_alias: "Neo", data: {"mission_name" => "Signal Recovery"})
+      expect(described_class.render_message(event)).to eq("Neo completed mission: Signal Recovery")
+    end
+
+    it "formats breach_completed" do
+      event = WorldEvent.new(event_type: "breach_completed", hackr_alias: "Neo", data: {"template_name" => "Deep Net", "tier" => "advanced"})
+      expect(described_class.render_message(event)).to eq("Neo completed advanced-tier BREACH: Deep Net")
+    end
+
+    it "formats rep_tier_changed up" do
+      event = WorldEvent.new(event_type: "rep_tier_changed", hackr_alias: "Neo", data: {"faction_name" => "Hackrcore", "new_tier" => "TRUSTED", "direction" => "up"})
+      expect(described_class.render_message(event)).to eq("Neo reached TRUSTED standing with Hackrcore")
+    end
+
+    it "formats rep_tier_changed down" do
+      event = WorldEvent.new(event_type: "rep_tier_changed", hackr_alias: "Neo", data: {"direction" => "down", "new_tier" => "FLAGGED", "faction_name" => "GovCorp"})
+      expect(described_class.render_message(event)).to eq("Neo dropped to FLAGGED standing with GovCorp")
+    end
+
+    it "formats achievement_unlocked" do
+      event = WorldEvent.new(event_type: "achievement_unlocked", hackr_alias: "Neo", data: {"achievement_name" => "First Steps"})
+      expect(described_class.render_message(event)).to eq("Neo unlocked First Steps")
+    end
+
+    it "formats hackr_registered" do
+      event = WorldEvent.new(event_type: "hackr_registered", hackr_alias: "Neo", data: {})
+      expect(described_class.render_message(event)).to eq("Neo jacked into THE PULSE GRID for the first time")
+    end
+
+    it "formats wire_post with truncation" do
+      event = WorldEvent.new(event_type: "wire_post", hackr_alias: "Neo", data: {"content" => "hello world"})
+      expect(described_class.render_message(event)).to include("hello world")
+    end
+
+    it "formats manual events" do
+      event = WorldEvent.new(event_type: "manual", hackr_alias: "SYSTEM", data: {"message" => "Server restarting"})
+      expect(described_class.render_message(event)).to eq("Server restarting")
+    end
+  end
+
+  describe ".current_organic_rate" do
+    it "returns 0 with no cached data" do
+      expect(described_class.current_organic_rate).to eq(0)
+    end
+  end
+end

--- a/spec/services/world_event_feed/simulator_spec.rb
+++ b/spec/services/world_event_feed/simulator_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe WorldEventFeed::Simulator do
+  let!(:simulants) do
+    5.times.map do |i|
+      hackr = create(:grid_hackr)
+      WorldEventSimulant.create!(grid_hackr: hackr, state: {
+        "clearance" => i * 5,
+        "breach_count" => i,
+        "completed_missions" => [],
+        "active_mission" => nil,
+        "faction_standings" => {},
+        "achievements_earned" => [],
+        "deck_name" => nil
+      })
+    end
+  end
+
+  subject(:simulator) { described_class.new }
+
+  describe "#generate_event!" do
+    it "creates a WorldEvent" do
+      expect { simulator.generate_event! }.to change { WorldEvent.count }.by(1)
+    end
+
+    it "marks events as simulated" do
+      event = simulator.generate_event!
+      expect(event.simulated?).to be true
+    end
+
+    it "uses a simulant alias" do
+      event = simulator.generate_event!
+      aliases = simulants.map(&:hackr_alias)
+      expect(aliases).to include(event.hackr_alias)
+    end
+
+    it "returns nil with no simulants" do
+      WorldEventSimulant.delete_all
+      sim = described_class.new
+      expect(sim.generate_event!).to be_nil
+    end
+  end
+
+  describe "state consistency" do
+    it "advances clearance on clearance_up events" do
+      simulant = simulants.find { |s| s.clearance < 99 }
+      old_cl = simulant.clearance
+
+      # Force a clearance_up event by calling the private method
+      event = simulator.send(:generate_clearance_up, simulant)
+
+      expect(event.event_type).to eq("clearance_up")
+      expect(simulant.reload.clearance).to eq(old_cl + 1)
+    end
+
+    it "tracks completed missions" do
+      simulant = simulants.first
+      simulator.send(:generate_mission_completed, simulant)
+
+      expect(simulant.reload.completed_missions).not_to be_empty
+    end
+
+    it "increments breach count" do
+      simulant = simulants.first
+      old_count = simulant.breach_count
+      simulator.send(:generate_breach_completed, simulant)
+
+      expect(simulant.reload.breach_count).to eq(old_count + 1)
+    end
+
+    it "tracks faction standings" do
+      simulant = simulants.first
+      simulator.send(:generate_rep_tier_changed, simulant)
+
+      expect(simulant.reload.faction_standings).not_to be_empty
+    end
+
+    it "tracks earned achievements" do
+      simulant = simulants.first
+      simulator.send(:generate_achievement_unlocked, simulant)
+
+      expect(simulant.reload.achievements_earned).not_to be_empty
+    end
+  end
+
+  describe "event type distribution" do
+    it "generates all event types over many iterations" do
+      50.times { simulator.generate_event! }
+      types = WorldEvent.distinct.pluck(:event_type)
+
+      # With 50 events and weighted distribution, most types should appear
+      expect(types.length).to be >= 5
+    end
+  end
+end


### PR DESCRIPTION
  Real-time event feed mixing organic game activity with simulated
  22nd-century hackr population. Two display surfaces: OBS overlay
  (/overlays/world-feed) with terminal typing animation at 960px
  for stream readability, and React SPA page (/feed) with TTY
  aesthetic and ActionCable live updates.

  Publisher service provides single fire-and-forget entry point for
  all event writes — 8 organic hooks across AchievementAwarder,
  MissionService, MissionRewardGranter, BreachService,
  ReputationService, GridController registration, and Pulse model.
  Never raises, never disrupts parent services.

  Simulator generates consistent events from 125 seeded population
  accounts with tracked state (clearance, missions, factions,
  achievements). SimulatorJob runs every 30s, dynamically fills
  gap between organic rate and configurable target (default 12/min).
  Admin visibility toggle controls /feed nav link, page access,
  and simulator activation.

  9 event types: clearance_up, mission_accepted, mission_completed,
  breach_completed, rep_tier_changed, achievement_unlocked,
  hackr_registered, wire_post, manual.

  Admin panel at /root/world_event_feed with settings, manual
  publish (simulant accounts only), and recent events table.
  External API (POST /api/admin/world_events) for Synthia with
  data value sanitization (256 char cap).