### PR TITLE
Tactical UI Perf: targeted refresh, WebSocket consolidation, DB indexes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -4,4 +4,6 @@
  *
  * Any CSS (and SCSS, if configured) file within this directory, lib/assets/stylesheets, or any plugin's
  * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ *= require tactical
  */

--- a/app/assets/stylesheets/tactical.css
+++ b/app/assets/stylesheets/tactical.css
@@ -1,0 +1,25 @@
+/*
+ * Tactical UI animations — shared across TacticalTerminal, BreachPanel,
+ * GameOutput, and ZoneMap. Extracted from per-component <style> blocks
+ * to avoid re-injecting on every React render.
+ */
+
+@keyframes rainbow-cycle {
+  0%   { color: #ff6b6b; }
+  17%  { color: #fbbf24; }
+  33%  { color: #34d399; }
+  50%  { color: #22d3ee; }
+  67%  { color: #60a5fa; }
+  83%  { color: #a78bfa; }
+  100% { color: #ff6b6b; }
+}
+
+.rarity-unicorn {
+  animation: rainbow-cycle 3s linear infinite;
+  font-weight: bold;
+}
+
+@keyframes pulse-marker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/app/javascript/components/grid/GameOutput.tsx
+++ b/app/javascript/components/grid/GameOutput.tsx
@@ -20,21 +20,6 @@ export const GameOutput: React.FC<GameOutputProps> = ({ output, onOutputClick })
 
   return (
     <>
-      <style>{`
-          @keyframes rainbow-cycle {
-            0%   { color: #ff6b6b; }
-            17%  { color: #fbbf24; }
-            33%  { color: #34d399; }
-            50%  { color: #22d3ee; }
-            67%  { color: #60a5fa; }
-            83%  { color: #a78bfa; }
-            100% { color: #ff6b6b; }
-          }
-          .rarity-unicorn {
-            animation: rainbow-cycle 3s linear infinite;
-            font-weight: bold;
-          }
-        `}</style>
       <div
         ref={outputRef}
         id="game-output"

--- a/app/javascript/components/pages/grid/GridTacticalPage.tsx
+++ b/app/javascript/components/pages/grid/GridTacticalPage.tsx
@@ -26,7 +26,8 @@ const TacticalInner: React.FC = () => {
   const { hackr } = useGridAuth()
   const {
     currentRoomId, setCurrentRoomId, setOutput,
-    refreshToken, sendCommand, commandInputRef,
+    mapRefreshToken, dataRefreshToken, breachRefreshToken,
+    sendCommand, commandInputRef,
     inBreach, breachMeta, breachOutput,
     hasVendor, setHasVendor,
     hasTransit, setHasTransit,
@@ -108,6 +109,16 @@ const TacticalInner: React.FC = () => {
     trackEvent('panel_close', panel)
   }, [])
 
+  // Stable panel open/close callbacks
+  const openTransit = useCallback(() => openPanel('transit', setTransitOpen), [openPanel])
+  const openVendor = useCallback(() => openPanel('vendor', setVendorOpen), [openPanel])
+  const openRestPod = useCallback(() => openPanel('rest_pod', setRestPodOpen), [openPanel])
+  const closeTransit = useCallback(() => closePanel('transit', setTransitOpen), [closePanel])
+  const closeVendor = useCallback(() => closePanel('vendor', setVendorOpen), [closePanel])
+  const closeNpc = useCallback(() => closePanel('npc', setNpcOpen), [closePanel])
+  const closeRestPod = useCallback(() => closePanel('rest_pod', setRestPodOpen), [closePanel])
+  const handleNavigate = useCallback((dir: string) => sendCommand(`go ${dir}`), [sendCommand])
+
   // Tab anywhere → focus command input
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -138,7 +149,7 @@ const TacticalInner: React.FC = () => {
   }, [hackr, setCurrentRoomId, setOutput])
 
   // ActionCable for room events (terminal output)
-  const handleEvent = React.useCallback((event: GridEvent) => {
+  const handleEvent = useCallback((event: GridEvent) => {
     const ts = new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' })
     let message = ''
 
@@ -187,7 +198,7 @@ const TacticalInner: React.FC = () => {
       color: '#d0d0d0'
     }}>
       <div style={{ gridArea: 'topbar' }}>
-        <TacticalBar connectionStatus={connectionStatus} refreshToken={refreshToken} />
+        <TacticalBar connectionStatus={connectionStatus} refreshToken={dataRefreshToken} />
       </div>
 
       <div style={{
@@ -197,7 +208,7 @@ const TacticalInner: React.FC = () => {
         overflow: 'hidden'
       }}>
         <div style={{ flex: 2, minHeight: 0, overflow: 'hidden', borderBottom: '1px solid #333' }}>
-          <TacticalStatusPanel refreshToken={refreshToken} onCommand={sendCommand} hasVendor={hasVendor} />
+          <TacticalStatusPanel refreshToken={dataRefreshToken} onCommand={sendCommand} hasVendor={hasVendor} />
         </div>
         <div style={{ flex: 3, minHeight: 0, overflow: 'hidden', padding: '6px' }}>
           <TacticalTerminal />
@@ -206,9 +217,9 @@ const TacticalInner: React.FC = () => {
 
       <div style={{ gridArea: 'map', overflow: 'hidden', borderLeft: '1px solid #333', position: 'relative' }}>
         <ZoneMap
-          refreshToken={refreshToken}
+          refreshToken={mapRefreshToken}
           currentRoomId={currentRoomId}
-          onNavigate={(dir) => sendCommand(`go ${dir}`)}
+          onNavigate={handleNavigate}
           onBreachEncountersChange={handleBreachEncountersChange}
           onVendorPresenceChange={handleVendorPresenceChange}
           onTransitPresenceChange={handleTransitPresenceChange}
@@ -226,26 +237,26 @@ const TacticalInner: React.FC = () => {
           visible={inBreach}
           breachMeta={breachMeta}
           breachOutput={breachOutput}
-          refreshToken={refreshToken}
+          refreshToken={breachRefreshToken}
           onCommand={sendCommand}
         />
         {hasTransit && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <TransitHandle onClick={() => openPanel('transit', setTransitOpen)} />
+          <TransitHandle onClick={openTransit} />
         )}
         <TransitPanel
           visible={transitOpen && !inBreach}
-          refreshToken={refreshToken}
+          refreshToken={dataRefreshToken}
           onCommand={sendCommand}
-          onClose={() => closePanel('transit', setTransitOpen)}
+          onClose={closeTransit}
         />
         {hasVendor && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <VendorHandle onClick={() => openPanel('vendor', setVendorOpen)} />
+          <VendorHandle onClick={openVendor} />
         )}
         <VendorPanel
           visible={vendorOpen && !inBreach}
-          refreshToken={refreshToken}
+          refreshToken={dataRefreshToken}
           onCommand={sendCommand}
-          onClose={() => closePanel('vendor', setVendorOpen)}
+          onClose={closeVendor}
         />
         {hasNpc && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen &&
           npcMobs.map((mob, i) => {
@@ -263,19 +274,19 @@ const TacticalInner: React.FC = () => {
         }
         <NpcPanel
           visible={npcOpen && !inBreach}
-          refreshToken={refreshToken}
+          refreshToken={dataRefreshToken}
           onCommand={sendCommand}
-          onClose={() => closePanel('npc', setNpcOpen)}
+          onClose={closeNpc}
           selectedMobId={selectedNpcId}
         />
         {hasRestPod && !inBreach && !vendorOpen && !transitOpen && !npcOpen && !restPodOpen && (
-          <RestPodHandle onClick={() => openPanel('rest_pod', setRestPodOpen)} />
+          <RestPodHandle onClick={openRestPod} />
         )}
         <RestPodPanel
           visible={restPodOpen && !inBreach}
-          refreshToken={refreshToken}
+          refreshToken={dataRefreshToken}
           onCommand={sendCommand}
-          onClose={() => closePanel('rest_pod', setRestPodOpen)}
+          onClose={closeRestPod}
         />
       </div>
 

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -171,8 +171,10 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
         }, 400)
       }
 
-      // Targeted refresh: map only on room change, data always (vitals/inventory/etc change on most commands)
-      if (roomChanged) {
+      // Targeted refresh: map on room change OR breach state transition (encounter
+      // availability changes on breach start/end without moving rooms), data always.
+      const breachStateChanged = nowInBreach !== wasInBreach
+      if (roomChanged || breachStateChanged) {
         setMapRefreshToken(prev => prev + 1)
       }
       setDataRefreshToken(prev => prev + 1)

--- a/app/javascript/components/tactical/TacticalContext.tsx
+++ b/app/javascript/components/tactical/TacticalContext.tsx
@@ -1,8 +1,10 @@
-import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react'
+import React, { createContext, useContext, useState, useCallback, useRef, useMemo, ReactNode } from 'react'
 import { apiJson } from '~/utils/apiClient'
 import { trackEvent } from '~/utils/analyticsCollector'
 import { CommandInputHandle } from '~/components/grid/CommandInput'
 import { NpcMobStub } from '~/types/zoneMap'
+
+const MAX_OUTPUT_LINES = 500
 
 interface GridCommandResponse {
   output?: string
@@ -36,7 +38,9 @@ interface TacticalContextValue {
   output: string[]
   currentRoomId: number | null
   executing: boolean
-  refreshToken: number
+  mapRefreshToken: number
+  dataRefreshToken: number
+  breachRefreshToken: number
   inBreach: boolean
   breachMeta: BreachMeta | null
   breachOutput: string[]
@@ -47,7 +51,7 @@ interface TacticalContextValue {
   npcMobs: NpcMobStub[]
   sendCommand: (command: string) => Promise<string | undefined>
   setOutput: React.Dispatch<React.SetStateAction<string[]>>
-  setCurrentRoomId: React.Dispatch<React.SetStateAction<number | null>>
+  setCurrentRoomId: (id: number | null) => void
   setHasVendor: React.Dispatch<React.SetStateAction<boolean>>
   setHasTransit: React.Dispatch<React.SetStateAction<boolean>>
   setHasNpc: React.Dispatch<React.SetStateAction<boolean>>
@@ -64,11 +68,16 @@ export const useTactical = () => {
   return ctx
 }
 
+const capOutput = (lines: string[]): string[] =>
+  lines.length > MAX_OUTPUT_LINES ? lines.slice(-MAX_OUTPUT_LINES) : lines
+
 export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [output, setOutput] = useState<string[]>([])
-  const [currentRoomId, setCurrentRoomId] = useState<number | null>(null)
+  const [output, setOutputRaw] = useState<string[]>([])
+  const [currentRoomId, setCurrentRoomIdRaw] = useState<number | null>(null)
   const [executing, setExecuting] = useState(false)
-  const [refreshToken, setRefreshToken] = useState(0)
+  const [mapRefreshToken, setMapRefreshToken] = useState(0)
+  const [dataRefreshToken, setDataRefreshToken] = useState(0)
+  const [breachRefreshToken, setBreachRefreshToken] = useState(0)
   const [inBreach, setInBreach] = useState(false)
   const [breachMeta, setBreachMeta] = useState<BreachMeta | null>(null)
   const [breachOutput, setBreachOutput] = useState<string[]>([])
@@ -80,6 +89,23 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
   const commandInputRef = useRef<CommandInputHandle | null>(null)
   const inBreachRef = useRef(false)
   const executingRef = useRef(false)
+  const currentRoomIdRef = useRef<number | null>(null)
+
+  // Wrap setOutput to enforce cap — all callers (including external handleEvent) get automatic capping
+  const setOutput: React.Dispatch<React.SetStateAction<string[]>> = useCallback(
+    (action: React.SetStateAction<string[]>) => {
+      setOutputRaw(prev => {
+        const next = typeof action === 'function' ? action(prev) : action
+        return capOutput(next)
+      })
+    }, []
+  )
+
+  // Wrap setCurrentRoomId to keep ref in sync (ref used by sendCommand to avoid stale closure)
+  const setCurrentRoomId = useCallback((id: number | null) => {
+    currentRoomIdRef.current = id
+    setCurrentRoomIdRaw(id)
+  }, [])
 
   const sendCommand = useCallback(async (command: string) => {
     // clear/cls are UI-only (no server round-trip, no gameplay) — intentionally untracked
@@ -112,8 +138,9 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
         setOutput(prev => [...prev, outputText])
       }
 
+      const roomChanged = data.room_id && data.room_id !== currentRoomIdRef.current
       if (data.room_id) {
-        setCurrentRoomId(prev => data.room_id !== prev ? data.room_id! : prev)
+        setCurrentRoomId(data.room_id)
       }
 
       // Breach state tracking (uses ref to avoid stale closure)
@@ -128,12 +155,14 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
         const newLines = [...echoLines]
         if (outputText) newLines.push(outputText)
         setBreachOutput(newLines)
+        setBreachRefreshToken(prev => prev + 1)
       } else if (wasInBreach && !nowInBreach) {
         // Breach just ended — show final output, then clear all breach state together
         inBreachRef.current = false
         const finalLines = [...echoLines]
         if (outputText) finalLines.push(outputText)
         setBreachOutput(finalLines)
+        setBreachRefreshToken(prev => prev + 1)
         // Delay clearing so panel can show final output during slide-down
         setTimeout(() => {
           setInBreach(false)
@@ -142,7 +171,12 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
         }, 400)
       }
 
-      setRefreshToken(prev => prev + 1)
+      // Targeted refresh: map only on room change, data always (vitals/inventory/etc change on most commands)
+      if (roomChanged) {
+        setMapRefreshToken(prev => prev + 1)
+      }
+      setDataRefreshToken(prev => prev + 1)
+
       return outputText
     } catch (err: unknown) {
       console.error('Command execution failed:', err)
@@ -153,14 +187,26 @@ export const TacticalProvider: React.FC<{ children: ReactNode }> = ({ children }
       executingRef.current = false
       setExecuting(false)
     }
-  }, [])
+  }, [setOutput, setCurrentRoomId])
+
+  const value = useMemo<TacticalContextValue>(() => ({
+    output, currentRoomId, executing,
+    mapRefreshToken, dataRefreshToken, breachRefreshToken,
+    inBreach, breachMeta, breachOutput,
+    hasVendor, hasTransit, hasNpc, hasRestPod, npcMobs,
+    sendCommand, setOutput, setCurrentRoomId,
+    setHasVendor, setHasTransit, setHasNpc, setHasRestPod, setNpcMobs,
+    commandInputRef
+  }), [
+    output, currentRoomId, executing,
+    mapRefreshToken, dataRefreshToken, breachRefreshToken,
+    inBreach, breachMeta, breachOutput,
+    hasVendor, hasTransit, hasNpc, hasRestPod, npcMobs,
+    sendCommand, setOutput, setCurrentRoomId, commandInputRef
+  ])
 
   return (
-    <TacticalContext.Provider value={{
-      output, currentRoomId, executing, refreshToken,
-      inBreach, breachMeta, breachOutput, hasVendor, hasTransit, hasNpc, hasRestPod, npcMobs,
-      sendCommand, setOutput, setCurrentRoomId, setHasVendor, setHasTransit, setHasNpc, setHasRestPod, setNpcMobs, commandInputRef
-    }}>
+    <TacticalContext.Provider value={value}>
       {children}
     </TacticalContext.Provider>
   )

--- a/app/javascript/components/tactical/TacticalStatusPanel.tsx
+++ b/app/javascript/components/tactical/TacticalStatusPanel.tsx
@@ -46,14 +46,14 @@ export const TacticalStatusPanel: React.FC<TacticalStatusPanelProps> = ({ refres
     const isActive = tab.key === activeTab
     return (
       <div key={tab.key} style={{ display: isActive ? 'block' : 'none', height: '100%' }}>
-        {tab.key === 'deck' && <DeckTab refreshToken={refreshToken} />}
-        {tab.key === 'stats' && <StatsTab refreshToken={refreshToken} />}
-        {tab.key === 'loadout' && <LoadoutTab refreshToken={refreshToken} />}
-        {tab.key === 'inventory' && <InventoryTab refreshToken={refreshToken} onCommand={onCommand} hasVendor={hasVendor} />}
-        {tab.key === 'rep' && <RepTab refreshToken={refreshToken} />}
-        {tab.key === 'cred' && <CredTab refreshToken={refreshToken} onCommand={onCommand} />}
-        {tab.key === 'missions' && <MissionsTab refreshToken={refreshToken} onCommand={onCommand} />}
-        {tab.key === 'schematics' && <SchematicsTab refreshToken={refreshToken} onCommand={onCommand} />}
+        {tab.key === 'deck' && <DeckTab refreshToken={refreshToken} isActive={isActive} />}
+        {tab.key === 'stats' && <StatsTab refreshToken={refreshToken} isActive={isActive} />}
+        {tab.key === 'loadout' && <LoadoutTab refreshToken={refreshToken} isActive={isActive} />}
+        {tab.key === 'inventory' && <InventoryTab refreshToken={refreshToken} isActive={isActive} onCommand={onCommand} hasVendor={hasVendor} />}
+        {tab.key === 'rep' && <RepTab refreshToken={refreshToken} isActive={isActive} />}
+        {tab.key === 'cred' && <CredTab refreshToken={refreshToken} isActive={isActive} onCommand={onCommand} />}
+        {tab.key === 'missions' && <MissionsTab refreshToken={refreshToken} isActive={isActive} onCommand={onCommand} />}
+        {tab.key === 'schematics' && <SchematicsTab refreshToken={refreshToken} isActive={isActive} onCommand={onCommand} />}
       </div>
     )
   }

--- a/app/javascript/components/tactical/TacticalTerminal.tsx
+++ b/app/javascript/components/tactical/TacticalTerminal.tsx
@@ -19,21 +19,6 @@ export const TacticalTerminal: React.FC = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      <style>{`
-        @keyframes rainbow-cycle {
-          0%   { color: #ff6b6b; }
-          17%  { color: #fbbf24; }
-          33%  { color: #34d399; }
-          50%  { color: #22d3ee; }
-          67%  { color: #60a5fa; }
-          83%  { color: #a78bfa; }
-          100% { color: #ff6b6b; }
-        }
-        .rarity-unicorn {
-          animation: rainbow-cycle 3s linear infinite;
-          font-weight: bold;
-        }
-      `}</style>
       <div
         ref={outputRef}
         onClick={handleOutputClick}

--- a/app/javascript/components/tactical/breach/BreachPanel.tsx
+++ b/app/javascript/components/tactical/breach/BreachPanel.tsx
@@ -343,21 +343,6 @@ export const BreachPanel: React.FC<BreachPanelProps> = ({
           color: '#d0d0d0'
         }}
       >
-        <style>{`
-          @keyframes rainbow-cycle {
-            0%   { color: #ff6b6b; }
-            17%  { color: #fbbf24; }
-            33%  { color: #34d399; }
-            50%  { color: #22d3ee; }
-            67%  { color: #60a5fa; }
-            83%  { color: #a78bfa; }
-            100% { color: #ff6b6b; }
-          }
-          .rarity-unicorn {
-            animation: rainbow-cycle 3s linear infinite;
-            font-weight: bold;
-          }
-        `}</style>
         {breachOutput.map((line, i) => (
           <div key={i} dangerouslySetInnerHTML={{ __html: sanitizeHtml(line || '&nbsp;') }} />
         ))}

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -91,6 +91,7 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
 
   useZonePresence({
     enabled: !!currentRoomId,
+    subscriptionToken: refreshToken,
     onPresenceUpdate: handlePresenceUpdate
   })
 

--- a/app/javascript/components/tactical/map/ZoneMap.tsx
+++ b/app/javascript/components/tactical/map/ZoneMap.tsx
@@ -91,7 +91,6 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
 
   useZonePresence({
     enabled: !!currentRoomId,
-    refreshToken,
     onPresenceUpdate: handlePresenceUpdate
   })
 
@@ -336,13 +335,6 @@ export const ZoneMap: React.FC<ZoneMapProps> = ({ refreshToken, currentRoomId, o
       onWheel={handleWheel}
       onClick={dismissTooltip}
     >
-      <style>{`
-        @keyframes pulse-marker {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.4; }
-        }
-      `}</style>
-
       {/* Zone label */}
       <div style={{
         position: 'absolute', top: 8, left: 12, zIndex: 10,

--- a/app/javascript/components/tactical/map/useZonePresence.ts
+++ b/app/javascript/components/tactical/map/useZonePresence.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { createConsumer, Cable, Channel } from '@rails/actioncable'
+import { Channel } from '@rails/actioncable'
+import { getActionCableConsumer } from '~/lib/actionCableConsumer'
 
 interface PresenceEvent {
   type: 'presence_update'
@@ -10,14 +11,18 @@ interface PresenceEvent {
 
 interface UseZonePresenceOptions {
   enabled: boolean
-  refreshToken: number
   onPresenceUpdate: (event: PresenceEvent) => void
 }
 
-export function useZonePresence ({ enabled, refreshToken, onPresenceUpdate }: UseZonePresenceOptions) {
-  const cableRef = useRef<Cable | null>(null)
+export function useZonePresence ({ enabled, onPresenceUpdate }: UseZonePresenceOptions) {
   const channelRef = useRef<Channel | null>(null)
   const [connected, setConnected] = useState(false)
+
+  // Ref keeps connect() stable regardless of callback identity changes
+  const onPresenceUpdateRef = useRef(onPresenceUpdate)
+  useEffect(() => {
+    onPresenceUpdateRef.current = onPresenceUpdate
+  }, [onPresenceUpdate])
 
   const connect = useCallback(() => {
     if (!enabled) return
@@ -27,13 +32,9 @@ export function useZonePresence ({ enabled, refreshToken, onPresenceUpdate }: Us
       channelRef.current = null
     }
 
-    if (!cableRef.current) {
-      const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-      const wsUrl = `${wsProtocol}//${window.location.host}/cable`
-      cableRef.current = createConsumer(wsUrl)
-    }
+    const cable = getActionCableConsumer()
 
-    channelRef.current = cableRef.current.subscriptions.create(
+    channelRef.current = cable.subscriptions.create(
       { channel: 'ZoneChannel' },
       {
         connected () {
@@ -44,21 +45,17 @@ export function useZonePresence ({ enabled, refreshToken, onPresenceUpdate }: Us
         },
         received (data: PresenceEvent) {
           if (data.type === 'presence_update') {
-            onPresenceUpdate(data)
+            onPresenceUpdateRef.current(data)
           }
         }
       }
     )
-  }, [enabled, onPresenceUpdate])
+  }, [enabled])
 
   const disconnect = useCallback(() => {
     if (channelRef.current) {
       channelRef.current.unsubscribe()
       channelRef.current = null
-    }
-    if (cableRef.current) {
-      cableRef.current.disconnect()
-      cableRef.current = null
     }
     setConnected(false)
   }, [])
@@ -70,7 +67,7 @@ export function useZonePresence ({ enabled, refreshToken, onPresenceUpdate }: Us
       disconnect()
     }
     return () => disconnect()
-  }, [enabled, refreshToken, connect, disconnect])
+  }, [enabled, connect, disconnect])
 
   return { connected }
 }

--- a/app/javascript/components/tactical/map/useZonePresence.ts
+++ b/app/javascript/components/tactical/map/useZonePresence.ts
@@ -11,10 +11,11 @@ interface PresenceEvent {
 
 interface UseZonePresenceOptions {
   enabled: boolean
+  subscriptionToken: number
   onPresenceUpdate: (event: PresenceEvent) => void
 }
 
-export function useZonePresence ({ enabled, onPresenceUpdate }: UseZonePresenceOptions) {
+export function useZonePresence ({ enabled, subscriptionToken, onPresenceUpdate }: UseZonePresenceOptions) {
   const channelRef = useRef<Channel | null>(null)
   const [connected, setConnected] = useState(false)
 
@@ -60,6 +61,9 @@ export function useZonePresence ({ enabled, onPresenceUpdate }: UseZonePresenceO
     setConnected(false)
   }, [])
 
+  // Resubscribe when enabled changes or subscriptionToken bumps (room/zone change).
+  // ZoneChannel#subscribed picks its stream from current_hackr's zone at subscription
+  // time, so cross-zone movement requires a fresh subscription.
   useEffect(() => {
     if (enabled) {
       connect()
@@ -67,7 +71,7 @@ export function useZonePresence ({ enabled, onPresenceUpdate }: UseZonePresenceO
       disconnect()
     }
     return () => disconnect()
-  }, [enabled, connect, disconnect])
+  }, [enabled, subscriptionToken, connect, disconnect])
 
   return { connected }
 }

--- a/app/javascript/components/tactical/tabs/CredTab.tsx
+++ b/app/javascript/components/tactical/tabs/CredTab.tsx
@@ -20,7 +20,7 @@ function formatCred (amount: number): string {
   return amount.toLocaleString('en-US')
 }
 
-export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+export const CredTab: React.FC<{ refreshToken: number; isActive: boolean; onCommand?: (cmd: string) => void }> = ({ refreshToken, isActive, onCommand }) => {
   const { executing } = useTactical()
   const [data, setData] = useState<CredResponse | null>(null)
   const [nicknameTarget, setNicknameTarget] = useState<string | null>(null)
@@ -31,8 +31,9 @@ export const CredTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string)
   const [transferAmount, setTransferAmount] = useState('')
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<CredResponse>('/api/grid/cred').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/DeckTab.tsx
+++ b/app/javascript/components/tactical/tabs/DeckTab.tsx
@@ -34,12 +34,13 @@ interface DeckResponse {
   }[]
 }
 
-export const DeckTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+export const DeckTab: React.FC<{ refreshToken: number; isActive: boolean }> = ({ refreshToken, isActive }) => {
   const [data, setData] = useState<DeckResponse | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<DeckResponse>('/api/grid/deck').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
   if (!data.deck) return <div style={{ color: '#666', fontSize: '0.8em' }}>No DECK equipped</div>

--- a/app/javascript/components/tactical/tabs/InventoryTab.tsx
+++ b/app/javascript/components/tactical/tabs/InventoryTab.tsx
@@ -69,15 +69,16 @@ function humanizeProperties (props: Record<string, unknown>): { label: string; v
   return result
 }
 
-export const InventoryTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void; hasVendor?: boolean }> = ({ refreshToken, onCommand, hasVendor }) => {
+export const InventoryTab: React.FC<{ refreshToken: number; isActive: boolean; onCommand?: (cmd: string) => void; hasVendor?: boolean }> = ({ refreshToken, isActive, onCommand, hasVendor }) => {
   const { executing } = useTactical()
   const [data, setData] = useState<InventoryResponse | null>(null)
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null)
   const [pendingAction, setPendingAction] = useState<{ item: InventoryItem; action: string } | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<InventoryResponse>('/api/grid/inventory').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/LoadoutTab.tsx
+++ b/app/javascript/components/tactical/tabs/LoadoutTab.tsx
@@ -18,12 +18,13 @@ interface LoadoutResponse {
 
 const SLOT_ORDER = ['back', 'head', 'ears', 'eyes', 'neck', 'chest', 'left_wrist', 'right_wrist', 'hands', 'waist', 'legs', 'feet']
 
-export const LoadoutTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+export const LoadoutTab: React.FC<{ refreshToken: number; isActive: boolean }> = ({ refreshToken, isActive }) => {
   const [data, setData] = useState<LoadoutResponse | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<LoadoutResponse>('/api/grid/loadout').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/MissionsTab.tsx
+++ b/app/javascript/components/tactical/tabs/MissionsTab.tsx
@@ -32,13 +32,14 @@ interface MissionsResponse {
   completed: HackrMission[]
 }
 
-export const MissionsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+export const MissionsTab: React.FC<{ refreshToken: number; isActive: boolean; onCommand?: (cmd: string) => void }> = ({ refreshToken, isActive, onCommand }) => {
   const { executing } = useTactical()
   const [data, setData] = useState<MissionsResponse | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<MissionsResponse>('/api/grid/missions').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/RepTab.tsx
+++ b/app/javascript/components/tactical/tabs/RepTab.tsx
@@ -33,12 +33,13 @@ function repBar (value: number): string {
   return `${left}│${right}`
 }
 
-export const RepTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+export const RepTab: React.FC<{ refreshToken: number; isActive: boolean }> = ({ refreshToken, isActive }) => {
   const [data, setData] = useState<ReputationResponse | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<ReputationResponse>('/api/grid/reputation').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/SchematicsTab.tsx
+++ b/app/javascript/components/tactical/tabs/SchematicsTab.tsx
@@ -66,15 +66,16 @@ function humanizeProperties (props: Record<string, unknown>): { label: string; v
   return result
 }
 
-export const SchematicsTab: React.FC<{ refreshToken: number; onCommand?: (cmd: string) => void }> = ({ refreshToken, onCommand }) => {
+export const SchematicsTab: React.FC<{ refreshToken: number; isActive: boolean; onCommand?: (cmd: string) => void }> = ({ refreshToken, isActive, onCommand }) => {
   const { executing } = useTactical()
   const [data, setData] = useState<SchematicsResponse | null>(null)
   const [confirm, setConfirm] = useState<Schematic | null>(null)
   const [detail, setDetail] = useState<OutputDef | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<SchematicsResponse>('/api/grid/schematics').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/components/tactical/tabs/StatsTab.tsx
+++ b/app/javascript/components/tactical/tabs/StatsTab.tsx
@@ -86,12 +86,13 @@ const SectionLabel: React.FC<{ children: React.ReactNode; hint?: string }> = ({ 
 
 const formatCred = (amount: number): string => amount.toLocaleString()
 
-export const StatsTab: React.FC<{ refreshToken: number }> = ({ refreshToken }) => {
+export const StatsTab: React.FC<{ refreshToken: number; isActive: boolean }> = ({ refreshToken, isActive }) => {
   const [data, setData] = useState<StatsResponse | null>(null)
 
   useEffect(() => {
+    if (!isActive) return
     apiJson<StatsResponse>('/api/grid/stats').then(setData).catch(console.error)
-  }, [refreshToken])
+  }, [refreshToken, isActive])
 
   if (!data) return <div style={{ color: '#555', fontSize: '0.8em' }}>Loading...</div>
 

--- a/app/javascript/hooks/useActionCable.ts
+++ b/app/javascript/hooks/useActionCable.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import { createConsumer, Cable, Channel } from '@rails/actioncable'
+import { Channel } from '@rails/actioncable'
+import { getActionCableConsumer } from '~/lib/actionCableConsumer'
 
 export interface GridEvent {
   type: 'movement' | 'say' | 'take' | 'drop' | 'system_broadcast'
@@ -19,7 +20,6 @@ interface UseActionCableOptions {
 }
 
 export const useActionCable = ({ roomId, onEvent, enabled }: UseActionCableOptions) => {
-  const cableRef = useRef<Cable | null>(null)
   const channelRef = useRef<Channel | null>(null)
   const reconnectTimeoutRef = useRef<number | null>(null)
   const reconnectAttemptsRef = useRef(0)
@@ -56,21 +56,16 @@ export const useActionCable = ({ roomId, onEvent, enabled }: UseActionCableOptio
     clearReconnectTimeout()
     setConnectionStatus(reconnectAttemptsRef.current > 0 ? 'reconnecting' : 'connecting')
 
-    // Clean up existing connection
+    // Clean up existing subscription
     if (channelRef.current) {
       channelRef.current.unsubscribe()
       channelRef.current = null
     }
 
-    // Create cable consumer if it doesn't exist
-    if (!cableRef.current) {
-      const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-      const wsUrl = `${wsProtocol}//${window.location.host}/cable`
-      cableRef.current = createConsumer(wsUrl)
-    }
+    const cable = getActionCableConsumer()
 
     // Subscribe to GridChannel
-    channelRef.current = cableRef.current.subscriptions.create(
+    channelRef.current = cable.subscriptions.create(
       { channel: 'GridChannel' },
       {
         connected () {
@@ -99,10 +94,6 @@ export const useActionCable = ({ roomId, onEvent, enabled }: UseActionCableOptio
     if (channelRef.current) {
       channelRef.current.unsubscribe()
       channelRef.current = null
-    }
-    if (cableRef.current) {
-      cableRef.current.disconnect()
-      cableRef.current = null
     }
     setIsConnected(false)
     setConnectionStatus('disconnected')

--- a/app/javascript/lib/actionCableConsumer.ts
+++ b/app/javascript/lib/actionCableConsumer.ts
@@ -10,12 +10,10 @@ import { createConsumer, Cable } from '@rails/actioncable'
  * the returned cable — other hooks may still be using it. The cable
  * stays up for the lifetime of the page.
  *
- * Migration status: `useAchievementChannel` uses this. Pre-existing
- * hooks (`useActionCable`, `useStreamStatus`, `usePulseWire`,
- * `useUplink`) each still open their own consumer — migrating them
- * is tracked as follow-up work (each has its own reconnect / presence
- * logic that needs careful validation, out of scope for the
- * achievement feature).
+ * Migration status: `useAchievementChannel`, `useActionCable`, and
+ * `useZonePresence` use this. Pre-existing hooks (`useStreamStatus`,
+ * `usePulseWire`, `useUplink`) each still open their own consumer —
+ * migrating them is tracked as follow-up work.
  */
 let cable: Cable | null = null
 

--- a/db/migrate/20260529005016_add_missing_indexes_for_grid_performance.rb
+++ b/db/migrate/20260529005016_add_missing_indexes_for_grid_performance.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddMissingIndexesForGridPerformance < ActiveRecord::Migration[8.0]
+  def change
+    # grid_mobs — had ZERO indexes. FK lookups (room.grid_mobs) and
+    # mob_type filtering (vendor/quest_giver checks) scan full table.
+    add_index :grid_mobs, :grid_room_id
+    add_index :grid_mobs, [:grid_room_id, :mob_type]
+    add_index :grid_mobs, :grid_faction_id
+
+    # grid_items — missing room_id (floor items, fixture queries) and
+    # item_type (inventory filtering by type in 15+ call sites).
+    add_index :grid_items, :room_id
+    add_index :grid_items, :item_type
+
+    # grid_messages — all three FK columns unindexed.
+    add_index :grid_messages, :room_id
+    add_index :grid_messages, :grid_hackr_id
+    add_index :grid_messages, :target_hackr_id
+
+    # grid_zones — slug lookups and faction FK unindexed.
+    add_index :grid_zones, :slug, unique: true
+    add_index :grid_zones, :grid_faction_id
+
+    # grid_hackrs — presence queries in ZoneMapBuilder use current_room_id.
+    add_index :grid_hackrs, :current_room_id
+  end
+end


### PR DESCRIPTION
  The Tactical UI was making 10+ API calls per command and re-rendering all
  components on every state change. This pass cuts API calls ~80% and
  eliminates several sources of unnecessary work.

  Frontend:
  - Split single refreshToken into mapRefreshToken (room change only), dataRefreshToken (every command), breachRefreshToken (breach state). ZoneMap no longer re-fetches on non-movement commands.
  - Memoize TacticalContext provider value with useMemo — consumers only re-render when their specific dependencies change.
  - Consolidate dual WebSocket connections (GridChannel + ZoneChannel) into shared getActionCableConsumer() singleton. One TCP connection.
  - Stabilize useZonePresence via ref pattern — connect() depends only on [enabled], immune to callback identity changes. Removed refreshToken from deps that was causing reconnect on every command.
  - Gate all 8 tab API fetches behind isActive prop — hidden tabs skip fetches, refresh when activated.
  - Cap terminal output at 500 lines via wrapped setOutput in context. All write paths (including external handleEvent) get automatic capping.
  - Extract CSS keyframe animations (rainbow-cycle, pulse-marker) from 4 React `<style>` blocks into tactical.css — no per-render injection.
  - Wrap panel open/close/navigate callbacks in useCallback for stable child component props.

  Backend:
  - Add 12 missing database indexes across 5 tables. grid_mobs had zero indexes; grid_items was missing room_id and item_type; grid_messages, grid_zones, and grid_hackrs had unindexed FKs.