### PR TITLE
Full admin CRUD for overlay system, ticker refactor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)

--- a/app/assets/javascripts/overlay.js
+++ b/app/assets/javascripts/overlay.js
@@ -94,7 +94,7 @@
   // ========================================
   // Rebuilds ticker content with correct copy count and animation duration
   // for seamless looping at the given speed (px/s).
-  function rebuildTicker(tickerEl, text, speed) {
+  function rebuildTicker(tickerEl, text, speed, direction) {
     var content = tickerEl.querySelector('.ticker-content');
     if (!content) return;
 
@@ -104,6 +104,7 @@
     var copyPx = text.length * CHAR_PX + SEP_PX;
     var copies = Math.max(2, Math.ceil(VIEWPORT / copyPx) + 1);
     var duration = Math.max(copyPx / speed, 3);
+    var scrollPct = (direction === 'right' ? 100.0 : -100.0) / copies;
 
     // Build content: N copies of text + separator
     var escaped = OverlayManager.prototype.escapeHtml(text);
@@ -112,9 +113,25 @@
     for (var i = 0; i < copies; i++) html += unit;
     content.innerHTML = html;
 
-    // Set copy count for CSS keyframe calc and duration
-    content.style.setProperty('--ticker-copies', copies);
-    content.style.animationDuration = duration + 's';
+    // Replace the <style> block with recalculated keyframes + animation.
+    // Server-rendered style uses !important, so we must replace the whole
+    // rule rather than setting inline properties.
+    var slug = tickerEl.dataset.slug;
+    var styleId = 'ticker-style-' + slug;
+    var existing = document.getElementById(styleId);
+    if (existing) existing.remove();
+
+    var style = document.createElement('style');
+    style.id = styleId;
+    style.textContent =
+      '#ticker-' + slug + '-overlay .ticker-content {' +
+      '  animation: ticker-seamless-' + slug + ' ' + duration.toFixed(1) + 's linear infinite !important;' +
+      '}' +
+      '@keyframes ticker-seamless-' + slug + ' {' +
+      '  0% { transform: translateX(0); }' +
+      '  100% { transform: translateX(' + scrollPct.toFixed(4) + '%); }' +
+      '}';
+    document.head.appendChild(style);
 
     tickerEl.dataset.speed = speed;
     tickerEl.dataset.copies = copies;
@@ -294,12 +311,8 @@
     var ticker = document.querySelector('#ticker-' + data.slug + '-overlay');
     if (!ticker) return;
 
-    // Update animation direction
-    ticker.classList.remove('ticker-scroll-left', 'ticker-scroll-right');
-    ticker.classList.add('ticker-scroll-' + data.direction);
-
-    // Rebuild content with correct copy count and speed
-    rebuildTicker(ticker, data.content, data.speed);
+    // Rebuild content with correct copy count, speed, direction, and keyframes
+    rebuildTicker(ticker, data.content, data.speed, data.direction);
 
     // Show/hide based on active state
     ticker.style.display = data.active ? '' : 'none';

--- a/app/assets/javascripts/overlay.js
+++ b/app/assets/javascripts/overlay.js
@@ -89,6 +89,37 @@
     this.running = false;
   };
 
+  // ========================================
+  // TICKER HELPERS
+  // ========================================
+  // Rebuilds ticker content with correct copy count and animation duration
+  // for seamless looping at the given speed (px/s).
+  function rebuildTicker(tickerEl, text, speed) {
+    var content = tickerEl.querySelector('.ticker-content');
+    if (!content) return;
+
+    var CHAR_PX = 9.6;  // Terminus monospace at 1rem
+    var SEP_PX = 41;    // separator character + padding
+    var VIEWPORT = 1920;
+    var copyPx = text.length * CHAR_PX + SEP_PX;
+    var copies = Math.max(2, Math.ceil(VIEWPORT / copyPx) + 1);
+    var duration = Math.max(copyPx / speed, 3);
+
+    // Build content: N copies of text + separator
+    var escaped = OverlayManager.prototype.escapeHtml(text);
+    var unit = escaped + '<span class="ticker-separator"></span>';
+    var html = '';
+    for (var i = 0; i < copies; i++) html += unit;
+    content.innerHTML = html;
+
+    // Set copy count for CSS keyframe calc and duration
+    content.style.setProperty('--ticker-copies', copies);
+    content.style.animationDuration = duration + 's';
+
+    tickerEl.dataset.speed = speed;
+    tickerEl.dataset.copies = copies;
+  }
+
   // OverlayManager class for handling real-time updates
   function OverlayManager() {
     this.consumer = null;
@@ -263,24 +294,12 @@
     var ticker = document.querySelector('#ticker-' + data.slug + '-overlay');
     if (!ticker) return;
 
-    var content = ticker.querySelector('.ticker-content');
-    if (content) {
-      // Use span separators for TUI style
-      content.innerHTML = this.escapeHtml(data.content) +
-        '<span class="ticker-separator"></span>' +
-        this.escapeHtml(data.content) +
-        '<span class="ticker-separator"></span>' +
-        this.escapeHtml(data.content);
-    }
-
     // Update animation direction
     ticker.classList.remove('ticker-scroll-left', 'ticker-scroll-right');
     ticker.classList.add('ticker-scroll-' + data.direction);
 
-    // Update speed (recalculate duration)
-    var charCount = data.content.length;
-    var baseDuration = Math.max((charCount * 10) / data.speed, 10);
-    ticker.style.setProperty('--ticker-duration', baseDuration + 's');
+    // Rebuild content with correct copy count and speed
+    rebuildTicker(ticker, data.content, data.speed);
 
     // Show/hide based on active state
     ticker.style.display = data.active ? '' : 'none';

--- a/app/assets/stylesheets/overlay.css
+++ b/app/assets/stylesheets/overlay.css
@@ -107,13 +107,13 @@
 }
 
 @keyframes ticker-scroll-left {
-  0% { transform: translateX(100%); }
-  100% { transform: translateX(-100%); }
+  0% { transform: translateX(0); }
+  100% { transform: translateX(calc(-100% / var(--ticker-copies, 3))); }
 }
 
 @keyframes ticker-scroll-right {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  0% { transform: translateX(calc(-100% / var(--ticker-copies, 3))); }
+  100% { transform: translateX(0); }
 }
 
 @keyframes type-in {
@@ -562,7 +562,7 @@
   width: 100%;
   overflow: hidden;
   background: var(--overlay-bg);
-  padding: 6px 0;
+  padding: 8px 0;
   border: 1px solid var(--overlay-purple);
 }
 
@@ -577,8 +577,7 @@
 .ticker-content {
   display: inline-block;
   white-space: nowrap;
-  padding-left: 100%;
-  font-size: 1rem;
+  font-size: 1.5rem;
   color: var(--overlay-purple);
   letter-spacing: 1px;
 }

--- a/app/controllers/admin/overlay_alerts_controller.rb
+++ b/app/controllers/admin/overlay_alerts_controller.rb
@@ -1,0 +1,52 @@
+class Admin::OverlayAlertsController < Admin::ApplicationController
+  def index
+    @alerts = OverlayAlert.recent
+    @alerts = @alerts.by_type(params[:alert_type]) if params[:alert_type].present?
+    @alerts = @alerts.limit(100)
+  end
+
+  def show
+    @alert = OverlayAlert.find(params[:id])
+  end
+
+  def new
+    @alert = OverlayAlert.new(alert_type: "custom")
+  end
+
+  def create
+    ap = alert_params
+    alert = OverlayAlert.queue!(
+      type: ap[:alert_type] || "custom",
+      title: ap[:title],
+      message: ap[:message],
+      data: parse_alert_data(ap[:data_json]),
+      expires_in: 10.seconds
+    )
+    set_flash_success("Alert '#{alert.title || alert.alert_type}' sent and broadcast.")
+    redirect_to admin_overlay_alerts_path
+  rescue => e
+    set_flash_error("Failed to send alert: #{e.message}")
+    redirect_to new_admin_overlay_alert_path
+  end
+
+  def destroy
+    alert = OverlayAlert.find(params[:id])
+    alert.destroy!
+    set_flash_success("Alert deleted.")
+    redirect_to admin_overlay_alerts_path
+  end
+
+  private
+
+  def alert_params
+    params.require(:overlay_alert).permit(:alert_type, :title, :message, :data_json)
+  end
+
+  def parse_alert_data(raw)
+    return {} if raw.blank?
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    flash[:warning] = "Alert data JSON was invalid and was ignored."
+    {}
+  end
+end

--- a/app/controllers/admin/overlay_elements_controller.rb
+++ b/app/controllers/admin/overlay_elements_controller.rb
@@ -1,12 +1,76 @@
-# Read-only controller - Overlay elements are managed via YAML files
-# Edit data/overlays/elements.yml and run: rails data:overlay_elements
 class Admin::OverlayElementsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable OverlayElement, find_by: :slug
+
+  before_action :set_element, only: %i[show edit update destroy]
+
   def index
     @elements = OverlayElement.order(:element_type, :name)
   end
 
   def show
-    @element = OverlayElement.find_by!(slug: params[:id])
     @used_in_scenes = @element.overlay_scenes.ordered
+  end
+
+  def new
+    @element = OverlayElement.new
+  end
+
+  def create
+    @element = OverlayElement.new(element_params)
+    if @element.save
+      set_flash_success("Element '#{@element.name}' created.")
+      redirect_to admin_overlay_elements_path
+    else
+      flash.now[:error] = @element.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @element.update(element_params)
+      set_flash_success("Element '#{@element.name}' updated.")
+      redirect_to admin_overlay_elements_path
+    else
+      flash.now[:error] = @element.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @element.name
+    if @element.overlay_scene_elements.any?
+      set_flash_error("Can't delete '#{name}' — still used in #{@element.overlay_scene_elements.count} scene(s).")
+    else
+      @element.destroy!
+      set_flash_success("Element '#{name}' deleted.")
+    end
+    redirect_to admin_overlay_elements_path
+  end
+
+  private
+
+  def set_element
+    @element = OverlayElement.find_by!(slug: params[:id])
+  end
+
+  def element_params
+    permitted = params.require(:overlay_element).permit(:name, :slug, :element_type, :active)
+    raw = params[:overlay_element][:settings_json]
+    if raw.present?
+      begin
+        permitted[:settings] = JSON.parse(raw)
+      rescue JSON::ParserError
+        permitted[:settings] = {}
+        flash.now[:warning] = "Settings JSON was invalid and was reset to {}."
+      end
+    else
+      permitted[:settings] = {}
+    end
+    permitted
   end
 end

--- a/app/controllers/admin/overlay_lower_thirds_controller.rb
+++ b/app/controllers/admin/overlay_lower_thirds_controller.rb
@@ -1,11 +1,60 @@
-# Read-only controller - Overlay lower thirds are managed via YAML files
-# Edit data/overlays/lower_thirds.yml and run: rails data:overlay_lower_thirds
 class Admin::OverlayLowerThirdsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable OverlayLowerThird, find_by: :slug
+
+  before_action :set_lower_third, only: %i[show edit update destroy]
+
   def index
     @lower_thirds = OverlayLowerThird.order(:name)
   end
 
   def show
+  end
+
+  def new
+    @lower_third = OverlayLowerThird.new
+  end
+
+  def create
+    @lower_third = OverlayLowerThird.new(lower_third_params)
+    if @lower_third.save
+      set_flash_success("Lower third '#{@lower_third.name}' created.")
+      redirect_to admin_overlay_lower_thirds_path
+    else
+      flash.now[:error] = @lower_third.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @lower_third.update(lower_third_params)
+      @lower_third.broadcast_update!
+      set_flash_success("Lower third '#{@lower_third.name}' updated and broadcast.")
+      redirect_to admin_overlay_lower_thirds_path
+    else
+      flash.now[:error] = @lower_third.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @lower_third.name
+    @lower_third.destroy!
+    set_flash_success("Lower third '#{name}' deleted.")
+    redirect_to admin_overlay_lower_thirds_path
+  end
+
+  private
+
+  def set_lower_third
     @lower_third = OverlayLowerThird.find_by!(slug: params[:id])
+  end
+
+  def lower_third_params
+    params.require(:overlay_lower_third).permit(:name, :slug, :primary_text, :secondary_text, :logo_url, :active)
   end
 end

--- a/app/controllers/admin/overlay_scene_groups_controller.rb
+++ b/app/controllers/admin/overlay_scene_groups_controller.rb
@@ -1,12 +1,88 @@
-# Read-only controller - Overlay scene groups are managed via YAML files
-# Edit data/overlays/scene_groups.yml and run: rails data:overlay_scene_groups
 class Admin::OverlaySceneGroupsController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable OverlaySceneGroup, find_by: :slug
+
+  before_action :set_group, only: %i[show edit update destroy add_scene remove_scene]
+
   def index
     @scene_groups = OverlaySceneGroup.ordered.includes(:overlay_scenes)
   end
 
   def show
+    @group_scenes = @scene_group.overlay_scene_group_scenes.includes(:overlay_scene).order(position: :asc)
+  end
+
+  def new
+    @scene_group = OverlaySceneGroup.new
+  end
+
+  def create
+    @scene_group = OverlaySceneGroup.new(group_params)
+    if @scene_group.save
+      set_flash_success("Scene group '#{@scene_group.name}' created.")
+      redirect_to admin_overlay_scene_groups_path
+    else
+      flash.now[:error] = @scene_group.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_group_scenes
+  end
+
+  def update
+    if @scene_group.update(group_params)
+      set_flash_success("Scene group '#{@scene_group.name}' updated.")
+      redirect_to edit_admin_overlay_scene_group_path(@scene_group)
+    else
+      load_group_scenes
+      flash.now[:error] = @scene_group.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @scene_group.name
+    @scene_group.destroy!
+    set_flash_success("Scene group '#{name}' deleted.")
+    redirect_to admin_overlay_scene_groups_path
+  end
+
+  def add_scene
+    group_scene = @scene_group.overlay_scene_group_scenes.build(group_scene_params)
+    if group_scene.save
+      set_flash_success("Scene added to group.")
+    else
+      set_flash_error(group_scene.errors.full_messages.join(", "))
+    end
+    redirect_to edit_admin_overlay_scene_group_path(@scene_group)
+  end
+
+  def remove_scene
+    group_scene = @scene_group.overlay_scene_group_scenes.find(params[:group_scene_id])
+    group_scene.destroy!
+    set_flash_success("Scene removed from group.")
+    redirect_to edit_admin_overlay_scene_group_path(@scene_group)
+  end
+
+  private
+
+  def set_group
     @scene_group = OverlaySceneGroup.find_by!(slug: params[:id])
+  end
+
+  def load_group_scenes
+    @group_scenes = @scene_group.overlay_scene_group_scenes.includes(:overlay_scene).order(position: :asc)
     @available_scenes = OverlayScene.where.not(id: @scene_group.overlay_scenes.pluck(:id)).ordered
+  end
+
+  def group_params
+    params.require(:overlay_scene_group).permit(:name, :slug)
+  end
+
+  def group_scene_params
+    params.require(:overlay_scene_group_scene).permit(:overlay_scene_id, :position)
   end
 end

--- a/app/controllers/admin/overlay_scenes_controller.rb
+++ b/app/controllers/admin/overlay_scenes_controller.rb
@@ -1,12 +1,104 @@
-# Read-only controller - Overlay scenes are managed via YAML files
-# Edit data/overlays/scenes.yml and run: rails data:overlay_scenes
 class Admin::OverlayScenesController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable OverlayScene, find_by: :slug
+
+  before_action :set_scene, only: %i[show edit update destroy add_element remove_element]
+
   def index
     @scenes = OverlayScene.ordered
   end
 
   def show
-    @scene = OverlayScene.find_by!(slug: params[:id])
     @elements = @scene.overlay_scene_elements.includes(:overlay_element).ordered
+  end
+
+  def new
+    @scene = OverlayScene.new(scene_type: "composition", width: 1920, height: 1080)
+  end
+
+  def create
+    @scene = OverlayScene.new(scene_params)
+    if @scene.save
+      set_flash_success("Scene '#{@scene.name}' created.")
+      redirect_to admin_overlay_scenes_path
+    else
+      flash.now[:error] = @scene.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_scene_elements
+  end
+
+  def update
+    if @scene.update(scene_params)
+      set_flash_success("Scene '#{@scene.name}' updated.")
+      redirect_to edit_admin_overlay_scene_path(@scene)
+    else
+      load_scene_elements
+      flash.now[:error] = @scene.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @scene.name
+    if @scene.overlay_scene_group_scenes.any?
+      set_flash_error("Can't delete '#{name}' — still assigned to #{@scene.overlay_scene_group_scenes.count} group(s).")
+    else
+      @scene.destroy!
+      set_flash_success("Scene '#{name}' deleted.")
+    end
+    redirect_to admin_overlay_scenes_path
+  end
+
+  def add_element
+    scene_element = @scene.overlay_scene_elements.build(scene_element_params)
+    if scene_element.save
+      set_flash_success("Element added to scene.")
+    else
+      set_flash_error(scene_element.errors.full_messages.join(", "))
+    end
+    redirect_to edit_admin_overlay_scene_path(@scene)
+  end
+
+  def remove_element
+    scene_element = @scene.overlay_scene_elements.find(params[:scene_element_id])
+    scene_element.destroy!
+    set_flash_success("Element removed from scene.")
+    redirect_to edit_admin_overlay_scene_path(@scene)
+  end
+
+  private
+
+  def set_scene
+    @scene = OverlayScene.find_by!(slug: params[:id])
+  end
+
+  def load_scene_elements
+    @scene_elements = @scene.overlay_scene_elements.includes(:overlay_element).ordered
+    @available_elements = OverlayElement.order(:element_type, :name)
+  end
+
+  def scene_params
+    permitted = params.require(:overlay_scene).permit(:name, :slug, :scene_type, :width, :height, :active, :position)
+    raw = params[:overlay_scene][:settings_json]
+    if raw.present?
+      begin
+        permitted[:settings] = JSON.parse(raw)
+      rescue JSON::ParserError
+        permitted[:settings] = {}
+        flash.now[:warning] = "Settings JSON was invalid and was reset to {}."
+      end
+    else
+      permitted[:settings] = {}
+    end
+    permitted
+  end
+
+  def scene_element_params
+    params.require(:overlay_scene_element).permit(:overlay_element_id, :x, :y, :width, :height, :z_index)
   end
 end

--- a/app/controllers/admin/overlay_tickers_controller.rb
+++ b/app/controllers/admin/overlay_tickers_controller.rb
@@ -1,0 +1,60 @@
+class Admin::OverlayTickersController < Admin::ApplicationController
+  include Admin::Versionable
+
+  versionable OverlayTicker, find_by: :slug
+
+  before_action :set_ticker, only: %i[show edit update destroy]
+
+  def index
+    @tickers = OverlayTicker.ordered
+  end
+
+  def show
+  end
+
+  def new
+    @ticker = OverlayTicker.new(content_type: "static", direction: "left", speed: 50)
+  end
+
+  def create
+    @ticker = OverlayTicker.new(ticker_params)
+    if @ticker.save
+      set_flash_success("Ticker '#{@ticker.name}' created.")
+      redirect_to admin_overlay_tickers_path
+    else
+      flash.now[:error] = @ticker.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @ticker.update(ticker_params)
+      @ticker.broadcast_update!
+      set_flash_success("Ticker '#{@ticker.name}' updated and broadcast.")
+      redirect_to admin_overlay_tickers_path
+    else
+      flash.now[:error] = @ticker.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    name = @ticker.name
+    @ticker.destroy!
+    set_flash_success("Ticker '#{name}' deleted.")
+    redirect_to admin_overlay_tickers_path
+  end
+
+  private
+
+  def set_ticker
+    @ticker = OverlayTicker.find_by!(slug: params[:id])
+  end
+
+  def ticker_params
+    params.require(:overlay_ticker).permit(:name, :slug, :content, :content_type, :feed_source, :direction, :speed, :active)
+  end
+end

--- a/app/controllers/admin/overlays_controller.rb
+++ b/app/controllers/admin/overlays_controller.rb
@@ -5,39 +5,51 @@ class Admin::OverlaysController < Admin::ApplicationController
     @scenes = OverlayScene.ordered
     @elements = OverlayElement.order(:element_type, :name)
     @lower_thirds = OverlayLowerThird.order(:name)
-    @tickers = OverlayTicker.all
+    @tickers = OverlayTicker.ordered
     @now_playing = OverlayNowPlaying.current
-    @tracks = Track.includes(:artist).order("artists.name, tracks.title")
     @pending_alerts = OverlayAlert.pending.count
   end
 
-  # PATCH /root/overlays/ticker/:ticker_slug
-  def update_ticker
-    @ticker = OverlayTicker.find_by!(slug: params[:ticker_slug])
-    if @ticker.update(ticker_params)
-      @ticker.broadcast_update!
-      set_flash_success("Ticker '#{@ticker.name}' updated!")
-    else
-      set_flash_error(@ticker.errors.full_messages.join(", "))
-    end
-    redirect_to admin_overlays_path
+  # GET /root/overlays/now-playing/edit
+  def edit_now_playing
+    @now_playing = OverlayNowPlaying.current
+    @tracks = Track.includes(:artist).order("artists.name, tracks.title")
   end
 
-  # POST /root/overlays/alert
-  def send_alert
-    OverlayAlert.queue!(
-      type: params[:alert_type] || "custom",
-      title: params[:alert_title],
-      message: params[:alert_message],
-      expires_in: 10.seconds
-    )
-    set_flash_success("Alert sent!")
-    redirect_to admin_overlays_path
+  # PATCH /root/overlays/now-playing
+  def update_now_playing
+    @now_playing = OverlayNowPlaying.current
+
+    if params[:clear].present?
+      OverlayNowPlaying.clear!
+      set_flash_success("Now playing cleared and broadcast.")
+      redirect_to admin_edit_overlay_now_playing_path
+      return
+    end
+
+    np = now_playing_params
+    if np[:track_id].present?
+      track = Track.find_by(id: np[:track_id])
+      if track
+        OverlayNowPlaying.set_track!(track, paused: np[:paused] == "1")
+        set_flash_success("Now playing set to '#{track.title}' and broadcast.")
+      else
+        set_flash_error("Track not found.")
+      end
+    elsif np[:custom_title].present?
+      OverlayNowPlaying.set_custom!(title: np[:custom_title], artist: np[:custom_artist])
+      set_flash_success("Now playing set to custom track and broadcast.")
+    else
+      OverlayNowPlaying.set_paused!(np[:paused] == "1")
+      set_flash_success("Now playing pause state updated and broadcast.")
+    end
+
+    redirect_to admin_edit_overlay_now_playing_path
   end
 
   private
 
-  def ticker_params
-    params.require(:overlay_ticker).permit(:content, :speed, :direction, :active)
+  def now_playing_params
+    params.require(:overlay_now_playing).permit(:track_id, :custom_title, :custom_artist, :paused)
   end
 end

--- a/app/controllers/api/admin/overlay_controller.rb
+++ b/app/controllers/api/admin/overlay_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  module Admin
+    class OverlayController < BaseController
+      # POST /api/admin/overlay/ticker_feed
+      #
+      # Push content to a dynamic ticker. Used by Synthia and other
+      # external services to feed real-time text into overlay tickers.
+      #
+      # Params:
+      #   slug: (required) Ticker slug to update
+      #   content: (required) Text content to display
+      def ticker_feed
+        slug = params[:slug].to_s.strip
+        content = params[:content].to_s.strip
+
+        if slug.blank?
+          return render json: {success: false, error: "Missing required parameter: slug"}, status: :unprocessable_entity
+        end
+
+        if content.blank?
+          return render json: {success: false, error: "Missing required parameter: content"}, status: :unprocessable_entity
+        end
+
+        ticker = OverlayTicker.find_by(slug: slug)
+        unless ticker
+          return render json: {success: false, error: "Ticker not found: #{slug}"}, status: :not_found
+        end
+
+        unless ticker.dynamic? && ticker.feed_source == "api"
+          return render json: {success: false, error: "Ticker '#{slug}' is not configured for API feed"}, status: :unprocessable_entity
+        end
+
+        ticker.update!(content: content.truncate(1024))
+        ticker.broadcast_update!
+
+        render json: {
+          success: true,
+          ticker: {
+            slug: ticker.slug,
+            content: ticker.content,
+            content_type: ticker.content_type,
+            feed_source: ticker.feed_source
+          }
+        }
+      end
+    end
+  end
+end

--- a/app/models/overlay_element.rb
+++ b/app/models/overlay_element.rb
@@ -19,6 +19,8 @@
 #  index_overlay_elements_on_slug          (slug) UNIQUE
 #
 class OverlayElement < ApplicationRecord
+  has_paper_trail
+
   ELEMENT_TYPES = %w[
     now_playing
     pulsewire_feed

--- a/app/models/overlay_lower_third.rb
+++ b/app/models/overlay_lower_third.rb
@@ -19,6 +19,8 @@
 #  index_overlay_lower_thirds_on_slug    (slug) UNIQUE
 #
 class OverlayLowerThird < ApplicationRecord
+  has_paper_trail
+
   # Validations
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, format: {with: /\A[a-z0-9-]+\z/, message: "must be lowercase alphanumeric with hyphens"}

--- a/app/models/overlay_scene.rb
+++ b/app/models/overlay_scene.rb
@@ -24,6 +24,8 @@
 class OverlayScene < ApplicationRecord
   SCENE_TYPES = %w[fullscreen composition].freeze
 
+  has_paper_trail
+
   # Associations
   has_many :overlay_scene_elements, dependent: :destroy
   has_many :overlay_elements, through: :overlay_scene_elements

--- a/app/models/overlay_scene_group.rb
+++ b/app/models/overlay_scene_group.rb
@@ -14,6 +14,8 @@
 #  index_overlay_scene_groups_on_slug  (slug) UNIQUE
 #
 class OverlaySceneGroup < ApplicationRecord
+  has_paper_trail
+
   # Associations
   has_many :overlay_scene_group_scenes, -> { order(position: :asc) }, dependent: :destroy
   has_many :overlay_scenes, through: :overlay_scene_group_scenes

--- a/app/models/overlay_ticker.rb
+++ b/app/models/overlay_ticker.rb
@@ -3,15 +3,17 @@
 # Table name: overlay_tickers
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  active     :boolean          default(TRUE)
-#  content    :text             not null
-#  direction  :string           default("left")
-#  name       :string           not null
-#  slug       :string           not null
-#  speed      :integer          default(50)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :integer          not null, primary key
+#  active       :boolean          default(TRUE)
+#  content      :text             not null
+#  content_type :string           default("static"), not null
+#  direction    :string           default("left")
+#  feed_source  :string
+#  name         :string           not null
+#  slug         :string           not null
+#  speed        :integer          default(50)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #
@@ -21,24 +23,40 @@
 class OverlayTicker < ApplicationRecord
   POSITIONS = %w[top bottom].freeze
   DIRECTIONS = %w[left right].freeze
+  CONTENT_TYPES = %w[static dynamic].freeze
+  FEED_SOURCES = %w[pulsewire world_events now_playing api].freeze
+
+  has_paper_trail
 
   # Validations
   validates :name, presence: true
-  validates :slug, presence: true, uniqueness: true, inclusion: {in: POSITIONS}
-  validates :content, presence: true
+  validates :slug, presence: true, uniqueness: true, format: {with: /\A[a-z0-9-]+\z/, message: "must be lowercase alphanumeric with hyphens"}
+  validates :content, presence: true, if: :static?
   validates :speed, numericality: {greater_than: 0}
   validates :direction, inclusion: {in: DIRECTIONS}
+  validates :content_type, presence: true, inclusion: {in: CONTENT_TYPES}
+  validates :feed_source, inclusion: {in: FEED_SOURCES}, allow_blank: true
+  validates :feed_source, presence: true, if: :dynamic?
+
+  # Callbacks
+  before_validation :generate_slug, if: -> { slug.blank? && name.present? }
+  before_validation :set_default_content, if: -> { dynamic? && content.blank? }
 
   # Scopes
   scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(name: :asc) }
 
-  # Find by position
-  def self.top
-    find_by(slug: "top")
+  # Instance methods
+  def to_param
+    slug
   end
 
-  def self.bottom
-    find_by(slug: "bottom")
+  def static?
+    content_type == "static"
+  end
+
+  def dynamic?
+    content_type == "dynamic"
   end
 
   # Broadcast update to overlay channel
@@ -48,10 +66,22 @@ class OverlayTicker < ApplicationRecord
       data: {
         slug: slug,
         content: content,
+        content_type: content_type,
+        feed_source: feed_source,
         speed: speed,
         direction: direction,
         active: active
       }
     })
+  end
+
+  private
+
+  def set_default_content
+    self.content = "Awaiting #{feed_source} feed..."
+  end
+
+  def generate_slug
+    self.slug = name.downcase.gsub(/[^a-z0-9\s-]/, "").gsub(/\s+/, "-").squeeze("-").strip
   end
 end

--- a/app/views/admin/overlay_alerts/index.html.erb
+++ b/app/views/admin/overlay_alerts/index.html.erb
@@ -1,0 +1,77 @@
+<% content_for(:title) { "/root/overlays/alerts :: Manage Alerts" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/alerts :: ALERT MANAGEMENT</legend>
+
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
+      </div>
+    <% end %>
+
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
+      <%= link_to "+ Send Alert", new_admin_overlay_alert_path, class: "tui-button green-168" %>
+    </div>
+
+    <!-- Type Filter -->
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
+      <span style="color: #888;">Filter:</span>
+      <%= link_to "All", admin_overlay_alerts_path, class: "tui-button #{params[:alert_type].blank? ? "green-168" : ""}", style: "padding: 4px 12px;" %>
+      <% OverlayAlert::ALERT_TYPES.each do |type| %>
+        <%= link_to type.titleize, admin_overlay_alerts_path(alert_type: type), class: "tui-button #{params[:alert_type] == type ? "green-168" : ""}", style: "padding: 4px 12px;" %>
+      <% end %>
+    </div>
+
+    <table class="tui-table" style="width: 100%;">
+      <thead>
+        <tr>
+          <th style="text-align: left;">Type</th>
+          <th style="text-align: left;">Title</th>
+          <th style="text-align: left;">Message</th>
+          <th style="text-align: center;">Status</th>
+          <th style="text-align: center;">Created</th>
+          <th style="text-align: center;">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @alerts.each_with_index do |alert, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
+            <td><code class="purple-168-text"><%= alert.alert_type %></code></td>
+            <td><%= alert.title || "-" %></td>
+            <td><%= truncate(alert.message, length: 50) || "-" %></td>
+            <td style="text-align: center;">
+              <% if alert.displayed? %>
+                <span style="color: #888;">Displayed</span>
+              <% elsif alert.expired? %>
+                <span class="red-168-text">Expired</span>
+              <% else %>
+                <span class="green-255-text">Pending</span>
+              <% end %>
+            </td>
+            <td style="text-align: center;"><%= alert.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "View", admin_overlay_alert_path(alert), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_alert_path(alert), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete this alert?" } %>
+            </td>
+          </tr>
+        <% end %>
+        <% if @alerts.empty? %>
+          <tr>
+            <td colspan="6" style="text-align: center; color: #666;">No alerts found.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_alerts/new.html.erb
+++ b/app/views/admin/overlay_alerts/new.html.erb
@@ -1,0 +1,39 @@
+<% content_for(:title) { "/root/overlays/alerts/new :: Send Alert" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/alerts/new :: SEND ALERT</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @alert, url: admin_overlay_alerts_path, local: true do |f| %>
+        <div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+          <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+            <div style="flex: 1;">
+              <%= f.label :alert_type, "ALERT TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.select :alert_type, OverlayAlert::ALERT_TYPES.map { |t| [t.titleize, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+            </div>
+            <div style="flex: 1;">
+              <%= f.label :title, "TITLE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+              <%= f.text_field :title, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+            </div>
+          </div>
+
+          <div style="margin-bottom: 15px;">
+            <%= f.label :message, "MESSAGE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+            <%= f.text_area :message, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 80px;" %>
+          </div>
+
+          <div style="margin-bottom: 15px;">
+            <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">DATA (JSON)</label>
+            <textarea name="overlay_alert[data_json]" class="tui-input" style="width: 100%; padding: 8px; font-family: monospace; min-height: 80px;">{}</textarea>
+            <small style="color: #666;">Optional JSON data payload</small>
+          </div>
+
+          <div style="margin-top: 20px;">
+            <%= f.submit "Send Alert", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+            <%= link_to "Cancel", admin_overlay_alerts_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_alerts/show.html.erb
+++ b/app/views/admin/overlay_alerts/show.html.erb
@@ -1,0 +1,50 @@
+<% content_for(:title) { "/root/overlays/alerts/#{@alert.id} :: Alert Details" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 800px; margin: 30px auto;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/alerts/<%= @alert.id %> :: ALERT DETAILS</legend>
+
+    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Alerts", admin_overlay_alerts_path, class: "tui-button green-168" %>
+    </div>
+
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div>
+          <p style="color: #888; margin: 0;">Alert Type</p>
+          <p style="margin: 5px 0 15px;"><code class="purple-168-text"><%= @alert.alert_type %></code></p>
+
+          <p style="color: #888; margin: 0;">Title</p>
+          <p style="margin: 5px 0 15px;"><%= @alert.title || "-" %></p>
+
+          <p style="color: #888; margin: 0;">Message</p>
+          <p style="margin: 5px 0 15px;"><%= @alert.message || "-" %></p>
+        </div>
+        <div>
+          <p style="color: #888; margin: 0;">Status</p>
+          <p style="margin: 5px 0 15px;">
+            <% if @alert.displayed? %>
+              <span style="color: #888;">Displayed at <%= @alert.displayed_at&.strftime("%H:%M:%S") %></span>
+            <% elsif @alert.expired? %>
+              <span class="red-168-text">Expired</span>
+            <% else %>
+              <span class="green-255-text">Pending</span>
+            <% end %>
+          </p>
+
+          <p style="color: #888; margin: 0;">Created</p>
+          <p style="margin: 5px 0 15px;"><%= @alert.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+
+          <p style="color: #888; margin: 0;">Expires</p>
+          <p style="margin: 5px 0 15px;"><%= @alert.expires_at&.strftime("%Y-%m-%d %H:%M:%S") || "Never" %></p>
+        </div>
+      </div>
+
+      <% if @alert.data.present? && @alert.data.any? %>
+        <p style="color: #888; margin: 0;">Data</p>
+        <pre style="margin: 5px 0 0; background: #111; padding: 10px; border: 1px solid #333; overflow-x: auto;"><%= JSON.pretty_generate(@alert.data) %></pre>
+      <% end %>
+    </div>
+
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_elements/_form.html.erb
+++ b/app/views/admin/overlay_elements/_form.html.erb
@@ -1,0 +1,46 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @element.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @element.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Leave blank to auto-generate from name</small>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :element_type, "ELEMENT TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :element_type, OverlayElement::ELEMENT_TYPES.map { |t| [t.titleize, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :active, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :active, style: "margin-right: 8px;" %> ACTIVE
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">SETTINGS (JSON)</label>
+    <% settings_json = @element.settings.present? ? JSON.pretty_generate(@element.settings) : "{}" %>
+    <textarea name="overlay_element[settings_json]" class="tui-input" style="width: 100%; padding: 8px; font-family: monospace; min-height: 120px;"><%= settings_json %></textarea>
+    <small style="color: #666;">Element-specific configuration (e.g. codex_entry_slug, max_items, ticker_slug, lower_third_slug)</small>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @element.new_record? ? "Create Element" : "Update Element", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_overlay_elements_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @element.persisted? %>
+      <%= link_to "History", history_admin_overlay_element_path(@element), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/overlay_elements/edit.html.erb
+++ b/app/views/admin/overlay_elements/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/elements/#{@element.slug} :: Edit Element" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/elements/<%= @element.slug %> :: EDIT ELEMENT</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @element, url: admin_overlay_element_path(@element), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_elements/index.html.erb
+++ b/app/views/admin/overlay_elements/index.html.erb
@@ -18,49 +18,45 @@
       </div>
     <% end %>
 
-    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/elements.yml</code> → <code style="color: #888;">rails data:overlay_elements</code>
-      </span>
+      <%= link_to "+ New Element", new_admin_overlay_element_path, class: "tui-button green-168" %>
     </div>
 
     <table class="tui-table" style="width: 100%;">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Slug</th>
-          <th>Type</th>
-          <th>Used In</th>
-          <th>Status</th>
+          <th style="text-align: left;">Name</th>
+          <th style="text-align: left;">Slug</th>
+          <th style="text-align: left;">Type</th>
+          <th style="text-align: center;">Used In</th>
+          <th style="text-align: center;">Status</th>
+          <th style="text-align: center;">Actions</th>
         </tr>
       </thead>
       <tbody>
-        <% @elements.each do |element| %>
-          <tr class="admin-table-row">
-            <td><strong><%= link_to element.name, admin_overlay_element_path(element), class: "white-text" %></strong></td>
-            <td><code><%= element.slug %></code></td>
-            <td><code><%= element.element_type %></code></td>
-            <td><%= element.overlay_scenes.count %> scene(s)</td>
-            <td><%= element.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+        <% @elements.each_with_index do |element, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
+            <td><strong><%= element.name %></strong></td>
+            <td style="font-family: monospace; color: #888;"><%= element.slug %></td>
+            <td><code class="purple-168-text"><%= element.element_type %></code></td>
+            <td style="text-align: center;"><%= element.overlay_scenes.count %> scene(s)</td>
+            <td style="text-align: center;"><%= element.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "View", admin_overlay_element_path(element), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Edit", edit_admin_overlay_element_path(element), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "History", history_admin_overlay_element_path(element), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_element_path(element), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete element '#{element.name}'?" } %>
+            </td>
           </tr>
         <% end %>
         <% if @elements.empty? %>
           <tr>
-            <td colspan="6" style="text-align: center; color: #666;">No elements yet. Create one to get started.</td>
+            <td colspan="6" style="text-align: center; color: #666;">No elements yet.</td>
           </tr>
         <% end %>
       </tbody>
     </table>
-
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #333;">
-      <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: AVAILABLE ELEMENT TYPES ::]</h3>
-      <div style="display: flex; flex-wrap: wrap; gap: 10px;">
-        <% OverlayElement::ELEMENT_TYPES.each do |type| %>
-          <code style="background: #1a1a1a; padding: 5px 10px; border: 1px solid #333;"><%= type %></code>
-        <% end %>
-      </div>
-    </div>
 
   </fieldset>
 </div>

--- a/app/views/admin/overlay_elements/new.html.erb
+++ b/app/views/admin/overlay_elements/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/elements/new :: New Element" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/elements/new :: NEW ELEMENT</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @element, url: admin_overlay_elements_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_elements/show.html.erb
+++ b/app/views/admin/overlay_elements/show.html.erb
@@ -6,9 +6,7 @@
 
     <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Elements", admin_overlay_elements_path, class: "tui-button green-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/elements.yml</code>
-      </span>
+      <%= link_to "Edit", edit_admin_overlay_element_path(@element), class: "tui-button", style: "padding: 8px 20px;" %>
     </div>
 
     <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
@@ -28,6 +26,11 @@
           <p style="margin: 5px 0 15px;"><%= @element.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></p>
         </div>
       </div>
+
+      <% if @element.settings.present? && @element.settings.any? %>
+        <p style="color: #888; margin: 0;">Settings</p>
+        <pre style="margin: 5px 0 0; background: #111; padding: 10px; border: 1px solid #333; overflow-x: auto;"><%= JSON.pretty_generate(@element.settings) %></pre>
+      <% end %>
     </div>
 
     <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: USED IN SCENES (<%= @used_in_scenes.count %>) ::]</h3>
@@ -49,7 +52,7 @@
                 <td><%= scene.scene_type.titleize %></td>
                 <td><%= scene.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
                 <td>
-                  <%= link_to "View", admin_overlay_scene_path(scene), class: "tui-button purple-168", style: "padding: 4px 8px; font-size: 0.8rem;" %>
+                  <%= link_to "Edit", edit_admin_overlay_scene_path(scene), class: "tui-button", style: "padding: 4px 8px;" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/admin/overlay_lower_thirds/_form.html.erb
+++ b/app/views/admin/overlay_lower_thirds/_form.html.erb
@@ -1,0 +1,49 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @lower_third.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @lower_third.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Leave blank to auto-generate from name</small>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :primary_text, "PRIMARY TEXT", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :primary_text, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <%= f.label :secondary_text, "SECONDARY TEXT", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_field :secondary_text, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :logo_url, "LOGO URL", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :logo_url, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :active, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :active, style: "margin-right: 8px;" %> ACTIVE
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @lower_third.new_record? ? "Create Lower Third" : "Update Lower Third", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_overlay_lower_thirds_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @lower_third.persisted? %>
+      <%= link_to "History", history_admin_overlay_lower_third_path(@lower_third), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/overlay_lower_thirds/edit.html.erb
+++ b/app/views/admin/overlay_lower_thirds/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/lower-thirds/#{@lower_third.slug} :: Edit Lower Third" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/lower-thirds/<%= @lower_third.slug %> :: EDIT LOWER THIRD</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @lower_third, url: admin_overlay_lower_third_path(@lower_third), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_lower_thirds/index.html.erb
+++ b/app/views/admin/overlay_lower_thirds/index.html.erb
@@ -18,38 +18,40 @@
       </div>
     <% end %>
 
-    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/lower_thirds.yml</code> → <code style="color: #888;">rails data:overlay_lower_thirds</code>
-      </span>
+      <%= link_to "+ New Lower Third", new_admin_overlay_lower_third_path, class: "tui-button green-168" %>
     </div>
 
     <table class="tui-table" style="width: 100%;">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Primary Text</th>
-          <th>Secondary Text</th>
-          <th>Status</th>
-          <th>Preview</th>
+          <th style="text-align: left;">Name</th>
+          <th style="text-align: left;">Primary Text</th>
+          <th style="text-align: left;">Secondary Text</th>
+          <th style="text-align: center;">Status</th>
+          <th style="text-align: center;">Actions</th>
         </tr>
       </thead>
       <tbody>
-        <% @lower_thirds.each do |lt| %>
-          <tr class="admin-table-row">
-            <td><strong><%= link_to lt.name, admin_overlay_lower_third_path(lt), class: "white-text" %></strong></td>
+        <% @lower_thirds.each_with_index do |lt, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
+            <td><strong><%= lt.name %></strong></td>
             <td><%= truncate(lt.primary_text, length: 40) %></td>
             <td><%= truncate(lt.secondary_text, length: 40) || "-" %></td>
-            <td><%= lt.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
-            <td>
-              <%= link_to "Open", overlay_lower_third_path(slug: lt.slug), target: "_blank", class: "tui-button purple-168", style: "padding: 4px 8px; font-size: 0.8rem;" %>
+            <td style="text-align: center;"><%= lt.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "View", admin_overlay_lower_third_path(lt), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Edit", edit_admin_overlay_lower_third_path(lt), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Preview", overlay_lower_third_path(slug: lt.slug), target: "_blank", class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= link_to "History", history_admin_overlay_lower_third_path(lt), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_lower_third_path(lt), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete lower third '#{lt.name}'?" } %>
             </td>
           </tr>
         <% end %>
         <% if @lower_thirds.empty? %>
           <tr>
-            <td colspan="5" style="text-align: center; color: #666;">No lower thirds yet. Create one to get started.</td>
+            <td colspan="5" style="text-align: center; color: #666;">No lower thirds yet.</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/overlay_lower_thirds/new.html.erb
+++ b/app/views/admin/overlay_lower_thirds/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/lower-thirds/new :: New Lower Third" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/lower-thirds/new :: NEW LOWER THIRD</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @lower_third, url: admin_overlay_lower_thirds_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_lower_thirds/show.html.erb
+++ b/app/views/admin/overlay_lower_thirds/show.html.erb
@@ -6,15 +6,16 @@
 
     <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Lower Thirds", admin_overlay_lower_thirds_path, class: "tui-button green-168" %>
+      <%= link_to "Edit", edit_admin_overlay_lower_third_path(@lower_third), class: "tui-button", style: "padding: 8px 20px;" %>
       <%= link_to "Preview", overlay_lower_third_path(slug: @lower_third.slug), target: "_blank", class: "tui-button purple-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/lower_thirds.yml</code>
-      </span>
     </div>
 
-    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
       <p style="color: #888; margin: 0;">Name</p>
       <p style="margin: 5px 0 15px; font-size: 1.2rem;"><strong><%= @lower_third.name %></strong></p>
+
+      <p style="color: #888; margin: 0;">Slug</p>
+      <p style="margin: 5px 0 15px;"><code><%= @lower_third.slug %></code></p>
 
       <p style="color: #888; margin: 0;">Primary Text</p>
       <p style="margin: 5px 0 15px; font-size: 1.1rem;"><%= @lower_third.primary_text %></p>

--- a/app/views/admin/overlay_scene_groups/_form.html.erb
+++ b/app/views/admin/overlay_scene_groups/_form.html.erb
@@ -1,0 +1,27 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @scene_group.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @scene_group.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Leave blank to auto-generate from name</small>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @scene_group.new_record? ? "Create Group" : "Update Group", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_overlay_scene_groups_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @scene_group.persisted? %>
+      <%= link_to "History", history_admin_overlay_scene_group_path(@scene_group), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/overlay_scene_groups/edit.html.erb
+++ b/app/views/admin/overlay_scene_groups/edit.html.erb
@@ -1,0 +1,86 @@
+<% content_for(:title) { "/root/overlays/groups/#{@scene_group.slug} :: Edit Group" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1100px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/groups/<%= @scene_group.slug %> :: EDIT GROUP</legend>
+
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
+      </div>
+    <% end %>
+
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="padding: 20px;">
+      <%= form_with model: @scene_group, url: admin_overlay_scene_group_path(@scene_group), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+
+      <!-- Inline Scene Membership Management -->
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 2px solid #333;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SCENES IN GROUP (<%= @group_scenes.count %>) ::]</h3>
+
+        <% if @group_scenes.any? %>
+          <table class="tui-table" style="width: 100%; margin-bottom: 20px;">
+            <thead>
+              <tr>
+                <th>Position</th>
+                <th>Scene</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @group_scenes.each do |sgs| %>
+                <tr>
+                  <td><%= sgs.position %></td>
+                  <td><strong><%= sgs.overlay_scene.name %></strong></td>
+                  <td><code><%= sgs.overlay_scene.scene_type %></code></td>
+                  <td><%= sgs.overlay_scene.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+                  <td>
+                    <%= button_to "Remove", remove_scene_admin_overlay_scene_group_path(@scene_group, group_scene_id: sgs.id), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 8px;", data: { confirm: "Remove scene '#{sgs.overlay_scene.name}' from group?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <p style="color: #666; margin-bottom: 20px;">No scenes in this group yet.</p>
+        <% end %>
+
+        <% if @available_scenes.any? %>
+          <div style="background: #111; border: 1px solid #333; padding: 15px;">
+            <h4 class="green-255-text" style="margin: 0 0 15px;">+ Add Scene</h4>
+            <%= form_with url: add_scene_admin_overlay_scene_group_path(@scene_group), method: :post, local: true do |f| %>
+              <div style="display: flex; gap: 10px; align-items: flex-end;">
+                <div style="flex: 2;">
+                  <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">SCENE</label>
+                  <select name="overlay_scene_group_scene[overlay_scene_id]" class="tui-input" style="width: 100%; padding: 8px;">
+                    <% @available_scenes.each do |scene| %>
+                      <option value="<%= scene.id %>"><%= scene.name %> (<%= scene.scene_type %>)</option>
+                    <% end %>
+                  </select>
+                </div>
+                <div style="flex: 0 0 100px;">
+                  <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">POSITION</label>
+                  <input type="number" name="overlay_scene_group_scene[position]" value="<%= @group_scenes.count %>" class="tui-input" style="width: 100%; padding: 8px;">
+                </div>
+                <div>
+                  <button type="submit" class="tui-button green-168" style="padding: 8px 20px;">Add</button>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_scene_groups/index.html.erb
+++ b/app/views/admin/overlay_scene_groups/index.html.erb
@@ -1,46 +1,58 @@
-<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+<% content_for(:title) { "/root/overlays/groups :: Scene Groups" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto;">
   <fieldset class="admin-panel-border">
-    <legend class="center">SCENE GROUPS</legend>
+    <legend class="center">/root/overlays/groups :: SCENE GROUP MANAGEMENT</legend>
 
-    <div style="padding: 20px;">
-      <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
-        <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168", style: "padding: 10px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/overlays/scene_groups.yml</code> → <code style="color: #888;">rails data:overlay_scene_groups</code>
-        </span>
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
       </div>
+    <% end %>
 
-      <% if @scene_groups.empty? %>
-        <div class="tui-window yellow-168 white-text" style="display: block; margin: 20px 0;">
-          <fieldset class="yellow-168-border">
-            <legend>No Groups</legend>
-            <div style="padding: 20px; text-align: center;">
-              No scene groups found. Add them to <code>data/overlays/scene_groups.yml</code> and run <code>rails data:overlay_scene_groups</code>.
-            </div>
-          </fieldset>
-        </div>
-      <% else %>
-        <div class="tui-window white-text" style="display: block; background: #0a0a0a;">
-          <table class="tui-table" style="width: 100%;">
-            <thead>
-              <tr style="border-bottom: 2px solid #00ffff;">
-                <th style="padding: 10px; text-align: left;">Name</th>
-                <th style="padding: 10px; text-align: left;">Slug</th>
-                <th style="padding: 10px; text-align: center;">Scenes</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @scene_groups.each do |group| %>
-                <tr class="admin-table-row">
-                  <td style="padding: 10px;"><%= link_to group.name, admin_overlay_scene_group_path(group), class: "white-text" %></td>
-                  <td style="padding: 10px;"><code class="cyan-168-text"><%= group.slug %></code></td>
-                  <td style="padding: 10px; text-align: center;"><%= group.overlay_scenes.count %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      <% end %>
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
+      <%= link_to "+ New Group", new_admin_overlay_scene_group_path, class: "tui-button green-168" %>
     </div>
+
+    <table class="tui-table" style="width: 100%;">
+      <thead>
+        <tr>
+          <th style="text-align: left;">Name</th>
+          <th style="text-align: left;">Slug</th>
+          <th style="text-align: center;">Scenes</th>
+          <th style="text-align: center;">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @scene_groups.each_with_index do |group, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
+            <td><strong><%= group.name %></strong></td>
+            <td style="font-family: monospace; color: #888;"><%= group.slug %></td>
+            <td style="text-align: center;"><%= group.overlay_scenes.count %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "View", admin_overlay_scene_group_path(group), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Edit", edit_admin_overlay_scene_group_path(group), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "History", history_admin_overlay_scene_group_path(group), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_scene_group_path(group), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete group '#{group.name}'?" } %>
+            </td>
+          </tr>
+        <% end %>
+        <% if @scene_groups.empty? %>
+          <tr>
+            <td colspan="4" style="text-align: center; color: #666;">No scene groups yet.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
   </fieldset>
 </div>

--- a/app/views/admin/overlay_scene_groups/new.html.erb
+++ b/app/views/admin/overlay_scene_groups/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/groups/new :: New Scene Group" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/groups/new :: NEW SCENE GROUP</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @scene_group, url: admin_overlay_scene_groups_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_scene_groups/show.html.erb
+++ b/app/views/admin/overlay_scene_groups/show.html.erb
@@ -1,53 +1,43 @@
-<div class="tui-window white-text admin-panel" style="display: block; max-width: 1400px; margin: 30px auto; padding: 20px;">
+<% content_for(:title) { "/root/overlays/groups/#{@scene_group.slug} :: Group Details" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1000px; margin: 30px auto;">
   <fieldset class="admin-panel-border">
-    <legend class="center"><%= @scene_group.name %></legend>
+    <legend class="center">/root/overlays/groups/<%= @scene_group.slug %> :: GROUP DETAILS</legend>
 
-    <div style="padding: 20px;">
-      <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
-        <%= link_to "< Back to Groups", admin_overlay_scene_groups_path, class: "tui-button green-168", style: "padding: 10px 20px;" %>
-        <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-          Edit via: <code style="color: #888;">data/overlays/scene_groups.yml</code>
-        </span>
-      </div>
+    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Groups", admin_overlay_scene_groups_path, class: "tui-button green-168" %>
+      <%= link_to "Edit", edit_admin_overlay_scene_group_path(@scene_group), class: "tui-button", style: "padding: 8px 20px;" %>
+    </div>
 
-      <div class="tui-window purple-168 white-text" style="display: block; margin-bottom: 30px;">
-        <fieldset class="purple-168-border">
-          <legend>GROUP DETAILS</legend>
-          <div style="padding: 20px;">
-            <table style="width: 100%; border-collapse: collapse;">
-              <tr style="border-bottom: 1px solid #444;">
-                <td style="padding: 10px; font-weight: bold; width: 200px;">Name</td>
-                <td style="padding: 10px;"><%= @scene_group.name %></td>
-              </tr>
-              <tr>
-                <td style="padding: 10px; font-weight: bold;">Slug</td>
-                <td style="padding: 10px;"><code class="cyan-168-text"><%= @scene_group.slug %></code></td>
-              </tr>
-            </table>
-          </div>
-        </fieldset>
-      </div>
-
-      <div class="tui-window green-168 white-text">
-        <fieldset class="green-168-border">
-          <legend class="cyan-255-text">SCENES (<%= @scene_group.overlay_scenes.count %>)</legend>
-          <div style="padding: 20px; background: #0a0a0a;">
-            <% if @scene_group.overlay_scenes.any? %>
-              <% @scene_group.overlay_scene_group_scenes.includes(:overlay_scene).order(position: :asc).each do |sgs| %>
-                <div style="background: #1a1a1a; border: 2px solid #00ff00; padding: 15px; margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center;">
-                  <div>
-                    <strong style="color: #00d9ff; font-size: 1.1em;"><%= sgs.overlay_scene.name %></strong>
-                    <small style="color: #888; margin-left: 10px;">(<%= sgs.overlay_scene.scene_type %>)</small>
-                  </div>
-                  <%= link_to "View Scene", admin_overlay_scene_path(sgs.overlay_scene), class: "tui-button purple-168", style: "padding: 5px 15px;" %>
-                </div>
-              <% end %>
-            <% else %>
-              <p style="color: #888;">No scenes assigned to this group.</p>
-            <% end %>
-          </div>
-        </fieldset>
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div>
+          <p style="color: #888; margin: 0;">Name</p>
+          <p style="margin: 5px 0 15px; font-size: 1.2rem;"><strong><%= @scene_group.name %></strong></p>
+        </div>
+        <div>
+          <p style="color: #888; margin: 0;">Slug</p>
+          <p style="margin: 5px 0 15px;"><code><%= @scene_group.slug %></code></p>
+        </div>
       </div>
     </div>
+
+    <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SCENES (<%= @group_scenes.count %>) ::]</h3>
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+      <% if @group_scenes.any? %>
+        <% @group_scenes.each do |sgs| %>
+          <div style="background: #1a1a1a; border: 1px solid #333; padding: 15px; margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center;">
+            <div>
+              <strong class="cyan-168-text" style="font-size: 1.1em;"><%= sgs.overlay_scene.name %></strong>
+              <small style="color: #888; margin-left: 10px;">(<%= sgs.overlay_scene.scene_type %>) — Position: <%= sgs.position %></small>
+            </div>
+            <%= link_to "View Scene", admin_overlay_scene_path(sgs.overlay_scene), class: "tui-button purple-168", style: "padding: 5px 15px;" %>
+          </div>
+        <% end %>
+      <% else %>
+        <p style="color: #666; text-align: center; margin: 0;">No scenes in this group.</p>
+      <% end %>
+    </div>
+
   </fieldset>
 </div>

--- a/app/views/admin/overlay_scenes/_form.html.erb
+++ b/app/views/admin/overlay_scenes/_form.html.erb
@@ -1,0 +1,60 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @scene.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @scene.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Leave blank to auto-generate from name</small>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :scene_type, "SCENE TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :scene_type, OverlayScene::SCENE_TYPES.map { |t| [t.titleize, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :position, "POSITION (sort order)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :position, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :active, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :active, style: "margin-right: 8px;" %> ACTIVE
+      <% end %>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :width, "WIDTH (px)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :width, class: "tui-input", style: "width: 100%; padding: 8px;", min: 1 %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :height, "HEIGHT (px)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :height, class: "tui-input", style: "width: 100%; padding: 8px;", min: 1 %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;">
+    <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold;">SETTINGS (JSON)</label>
+    <% settings_json = @scene.settings.present? ? JSON.pretty_generate(@scene.settings) : "{}" %>
+    <textarea name="overlay_scene[settings_json]" class="tui-input" style="width: 100%; padding: 8px; font-family: monospace; min-height: 120px;"><%= settings_json %></textarea>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @scene.new_record? ? "Create Scene" : "Update Scene", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_overlay_scenes_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @scene.persisted? %>
+      <%= link_to "History", history_admin_overlay_scene_path(@scene), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/overlay_scenes/edit.html.erb
+++ b/app/views/admin/overlay_scenes/edit.html.erb
@@ -1,0 +1,107 @@
+<% content_for(:title) { "/root/overlays/scenes/#{@scene.slug} :: Edit Scene" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1100px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/scenes/<%= @scene.slug %> :: EDIT SCENE</legend>
+
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
+      </div>
+    <% end %>
+
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="padding: 20px;">
+      <%= form_with model: @scene, url: admin_overlay_scene_path(@scene), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+
+      <!-- Inline Scene Elements Management -->
+      <div style="margin-top: 30px; padding-top: 20px; border-top: 2px solid #333;">
+        <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SCENE ELEMENTS (<%= @scene_elements.count %>) ::]</h3>
+
+        <% if @scene_elements.any? %>
+          <table class="tui-table" style="width: 100%; margin-bottom: 20px;">
+            <thead>
+              <tr>
+                <th>Z</th>
+                <th>Element</th>
+                <th>Type</th>
+                <th>X</th>
+                <th>Y</th>
+                <th>Width</th>
+                <th>Height</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @scene_elements.each do |se| %>
+                <tr>
+                  <td><%= se.z_index || 0 %></td>
+                  <td><strong><%= se.overlay_element.name %></strong></td>
+                  <td><code><%= se.overlay_element.element_type %></code></td>
+                  <td><%= se.x || 0 %></td>
+                  <td><%= se.y || 0 %></td>
+                  <td><%= se.width || "auto" %></td>
+                  <td><%= se.height || "auto" %></td>
+                  <td>
+                    <%= button_to "Remove", remove_element_admin_overlay_scene_path(@scene, scene_element_id: se.id), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 8px;", data: { confirm: "Remove element '#{se.overlay_element.name}' from scene?" } %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <p style="color: #666; margin-bottom: 20px;">No elements in this scene yet.</p>
+        <% end %>
+
+        <!-- Add Element Form -->
+        <div style="background: #111; border: 1px solid #333; padding: 15px;">
+          <h4 class="green-255-text" style="margin: 0 0 15px;">+ Add Element</h4>
+          <%= form_with url: add_element_admin_overlay_scene_path(@scene), method: :post, local: true do |f| %>
+            <div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end;">
+              <div style="flex: 2;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">ELEMENT</label>
+                <select name="overlay_scene_element[overlay_element_id]" class="tui-input" style="width: 100%; padding: 8px;">
+                  <% @available_elements.each do |el| %>
+                    <option value="<%= el.id %>"><%= el.name %> (<%= el.element_type %>)</option>
+                  <% end %>
+                </select>
+              </div>
+              <div style="flex: 0 0 70px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">X</label>
+                <input type="number" name="overlay_scene_element[x]" value="0" class="tui-input" style="width: 100%; padding: 8px;">
+              </div>
+              <div style="flex: 0 0 70px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">Y</label>
+                <input type="number" name="overlay_scene_element[y]" value="0" class="tui-input" style="width: 100%; padding: 8px;">
+              </div>
+              <div style="flex: 0 0 80px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">WIDTH</label>
+                <input type="number" name="overlay_scene_element[width]" class="tui-input" style="width: 100%; padding: 8px;" placeholder="auto">
+              </div>
+              <div style="flex: 0 0 80px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">HEIGHT</label>
+                <input type="number" name="overlay_scene_element[height]" class="tui-input" style="width: 100%; padding: 8px;" placeholder="auto">
+              </div>
+              <div style="flex: 0 0 70px;">
+                <label class="white-text" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 0.85em;">Z-INDEX</label>
+                <input type="number" name="overlay_scene_element[z_index]" value="0" class="tui-input" style="width: 100%; padding: 8px;">
+              </div>
+              <div>
+                <button type="submit" class="tui-button green-168" style="padding: 8px 20px;">Add</button>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_scenes/index.html.erb
+++ b/app/views/admin/overlay_scenes/index.html.erb
@@ -18,43 +18,44 @@
       </div>
     <% end %>
 
-    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/scenes.yml</code> → <code style="color: #888;">rails data:overlay_scenes</code>
-      </span>
+      <%= link_to "+ New Scene", new_admin_overlay_scene_path, class: "tui-button green-168" %>
     </div>
 
     <table class="tui-table" style="width: 100%;">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Slug</th>
-          <th>Type</th>
-          <th>Size</th>
-          <th>Elements</th>
-          <th>Status</th>
-          <th>Preview</th>
+          <th style="text-align: left;">Name</th>
+          <th style="text-align: left;">Slug</th>
+          <th style="text-align: center;">Type</th>
+          <th style="text-align: center;">Size</th>
+          <th style="text-align: center;">Elements</th>
+          <th style="text-align: center;">Status</th>
+          <th style="text-align: center;">Actions</th>
         </tr>
       </thead>
       <tbody>
-        <% @scenes.each do |scene| %>
-          <tr class="admin-table-row">
+        <% @scenes.each_with_index do |scene, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
             <td><strong><%= scene.name %></strong></td>
-            <td><code><%= scene.slug %></code></td>
-            <td><%= scene.scene_type.titleize %></td>
-            <td><%= scene.width %>x<%= scene.height %></td>
-            <td><%= scene.overlay_scene_elements.count %></td>
-            <td><%= scene.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
-            <td>
-              <%= link_to "View", admin_overlay_scene_path(scene), class: "tui-button purple-168", style: "padding: 4px 8px; font-size: 0.8rem;" %>
-              <%= link_to "Open", overlay_scene_path(slug: scene.slug), target: "_blank", class: "tui-button green-168", style: "padding: 4px 8px; font-size: 0.8rem;" %>
+            <td style="font-family: monospace; color: #888;"><%= scene.slug %></td>
+            <td style="text-align: center;"><%= scene.scene_type.titleize %></td>
+            <td style="text-align: center;"><%= scene.width %>x<%= scene.height %></td>
+            <td style="text-align: center;"><%= scene.overlay_scene_elements.count %></td>
+            <td style="text-align: center;"><%= scene.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "View", admin_overlay_scene_path(scene), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Edit", edit_admin_overlay_scene_path(scene), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "Preview", overlay_scene_path(slug: scene.slug), target: "_blank", class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= link_to "History", history_admin_overlay_scene_path(scene), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_scene_path(scene), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete scene '#{scene.name}'?" } %>
             </td>
           </tr>
         <% end %>
         <% if @scenes.empty? %>
           <tr>
-            <td colspan="7" style="text-align: center; color: #666;">No scenes yet. Create one to get started.</td>
+            <td colspan="7" style="text-align: center; color: #666;">No scenes yet.</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/overlay_scenes/new.html.erb
+++ b/app/views/admin/overlay_scenes/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/scenes/new :: New Scene" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/scenes/new :: NEW SCENE</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @scene, url: admin_overlay_scenes_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_scenes/show.html.erb
+++ b/app/views/admin/overlay_scenes/show.html.erb
@@ -6,10 +6,8 @@
 
     <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
       <%= link_to "< Back to Scenes", admin_overlay_scenes_path, class: "tui-button green-168" %>
+      <%= link_to "Edit", edit_admin_overlay_scene_path(@scene), class: "tui-button", style: "padding: 8px 20px;" %>
       <%= link_to "Preview", overlay_scene_path(slug: @scene.slug), target: "_blank", class: "tui-button purple-168" %>
-      <span style="color: #666; margin-left: 15px; font-size: 0.9em;">
-        Edit via: <code style="color: #888;">data/overlays/scenes.yml</code>
-      </span>
     </div>
 
     <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
@@ -35,6 +33,11 @@
           <p style="margin: 5px 0 15px;"><code class="cyan-168-text"><%= overlay_scene_url(slug: @scene.slug) %></code></p>
         </div>
       </div>
+
+      <% if @scene.settings.present? && @scene.settings.any? %>
+        <p style="color: #888; margin: 0;">Settings</p>
+        <pre style="margin: 5px 0 0; background: #111; padding: 10px; border: 1px solid #333; overflow-x: auto;"><%= JSON.pretty_generate(@scene.settings) %></pre>
+      <% end %>
     </div>
 
     <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SCENE ELEMENTS (<%= @elements.count %>) ::]</h3>
@@ -72,9 +75,6 @@
       <% else %>
         <p style="color: #666; text-align: center; margin: 0;">No elements in this scene.</p>
       <% end %>
-      <p style="color: #666; font-size: 0.9em; margin-top: 15px;">
-        Manage elements via: <code style="color: #888;">data/overlays/scene_elements.yml</code>
-      </p>
     </div>
 
   </fieldset>

--- a/app/views/admin/overlay_tickers/_form.html.erb
+++ b/app/views/admin/overlay_tickers/_form.html.erb
@@ -1,0 +1,80 @@
+<div class="tui-window white-text" style="display: block; background: #0a0a0a; padding: 20px;">
+  <% if @ticker.errors.any? %>
+    <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+      <p class="red-255-text"><%= @ticker.errors.full_messages.join(", ") %></p>
+    </div>
+  <% end %>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :name, "NAME", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :name, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :slug, "SLUG", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.text_field :slug, class: "tui-input", style: "width: 100%; padding: 8px; font-family: monospace;" %>
+      <small style="color: #666;">Leave blank to auto-generate from name</small>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :content_type, "CONTENT TYPE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :content_type, OverlayTicker::CONTENT_TYPES.map { |t| [t.titleize, t] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;", id: "ticker_content_type" %>
+    </div>
+    <div style="flex: 1;" id="feed_source_field">
+      <%= f.label :feed_source, "FEED SOURCE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :feed_source, OverlayTicker::FEED_SOURCES.map { |s| [s.titleize, s] }, { include_blank: "— Select —" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+      <small style="color: #666;">Required for dynamic tickers</small>
+    </div>
+  </div>
+
+  <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+    <div style="flex: 1;">
+      <%= f.label :direction, "DIRECTION", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.select :direction, OverlayTicker::DIRECTIONS.map { |d| [d.titleize, d] }, {}, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :speed, "SPEED (px/sec)", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+      <%= f.number_field :speed, class: "tui-input", style: "width: 100%; padding: 8px;", min: 1 %>
+    </div>
+    <div style="flex: 1;">
+      <%= f.label :active, class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" do %>
+        <%= f.check_box :active, style: "margin-right: 8px;" %> ACTIVE
+      <% end %>
+    </div>
+  </div>
+
+  <div style="margin-bottom: 15px;" id="content_field">
+    <%= f.label :content, "CONTENT", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+    <%= f.text_area :content, class: "tui-input", style: "width: 100%; padding: 8px; min-height: 100px;" %>
+    <small style="color: #666;">Static text to scroll. For dynamic tickers, content is populated by the feed source.</small>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <%= f.submit @ticker.new_record? ? "Create Ticker" : "Update Ticker", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+    <%= link_to "Cancel", admin_overlay_tickers_path, class: "tui-button", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% if @ticker.persisted? %>
+      <%= link_to "History", history_admin_overlay_ticker_path(@ticker), class: "tui-button purple-168", style: "padding: 10px 20px; margin-left: 10px;" %>
+    <% end %>
+  </div>
+</div>
+
+<script nonce="<%= content_security_policy_nonce %>">
+  document.addEventListener('DOMContentLoaded', function() {
+    var contentType = document.getElementById('ticker_content_type');
+    var feedSourceField = document.getElementById('feed_source_field');
+    var contentField = document.getElementById('content_field');
+
+    function toggleFields() {
+      if (contentType.value === 'dynamic') {
+        feedSourceField.style.display = '';
+      } else {
+        feedSourceField.style.display = 'none';
+      }
+    }
+
+    contentType.addEventListener('change', toggleFields);
+    toggleFields();
+  });
+</script>

--- a/app/views/admin/overlay_tickers/edit.html.erb
+++ b/app/views/admin/overlay_tickers/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/tickers/#{@ticker.slug} :: Edit Ticker" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/tickers/<%= @ticker.slug %> :: EDIT TICKER</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @ticker, url: admin_overlay_ticker_path(@ticker), method: :patch, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_tickers/index.html.erb
+++ b/app/views/admin/overlay_tickers/index.html.erb
@@ -1,0 +1,77 @@
+<% content_for(:title) { "/root/overlays/tickers :: Manage Tickers" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 1200px; margin: 30px auto;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/tickers :: TICKER MANAGEMENT</legend>
+
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
+      </div>
+    <% end %>
+
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
+      <%= link_to "+ New Ticker", new_admin_overlay_ticker_path, class: "tui-button green-168" %>
+    </div>
+
+    <table class="tui-table" style="width: 100%;">
+      <thead>
+        <tr>
+          <th style="text-align: left;">Name</th>
+          <th style="text-align: left;">Slug</th>
+          <th style="text-align: center;">Content Type</th>
+          <th style="text-align: center;">Feed</th>
+          <th style="text-align: center;">Direction</th>
+          <th style="text-align: center;">Speed</th>
+          <th style="text-align: center;">Status</th>
+          <th style="text-align: center;">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @tickers.each_with_index do |ticker, i| %>
+          <tr class="admin-table-row" style="<%= "background: #112;" if i.odd? %>">
+            <td><strong><%= ticker.name %></strong></td>
+            <td style="font-family: monospace; color: #888;"><%= ticker.slug %></td>
+            <td style="text-align: center;">
+              <% if ticker.static? %>
+                <span class="cyan-168-text">static</span>
+              <% else %>
+                <span class="yellow-168-text">dynamic</span>
+              <% end %>
+            </td>
+            <td style="text-align: center;">
+              <% if ticker.feed_source.present? %>
+                <code class="purple-168-text"><%= ticker.feed_source %></code>
+              <% else %>
+                <span style="color: #666;">-</span>
+              <% end %>
+            </td>
+            <td style="text-align: center;"><%= ticker.direction %></td>
+            <td style="text-align: center;"><%= ticker.speed %>px/s</td>
+            <td style="text-align: center;"><%= ticker.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
+            <td style="text-align: center; white-space: nowrap;">
+              <%= link_to "Edit", edit_admin_overlay_ticker_path(ticker), class: "tui-button", style: "padding: 4px 10px;" %>
+              <%= link_to "History", history_admin_overlay_ticker_path(ticker), class: "tui-button purple-168", style: "padding: 4px 10px;" %>
+              <%= button_to "Delete", admin_overlay_ticker_path(ticker), method: :delete, form: { style: "display: inline;" }, class: "tui-button red-168", style: "padding: 4px 10px;", data: { confirm: "Delete ticker '#{ticker.name}'?" } %>
+            </td>
+          </tr>
+        <% end %>
+        <% if @tickers.empty? %>
+          <tr>
+            <td colspan="8" style="text-align: center; color: #666;">No tickers yet.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_tickers/new.html.erb
+++ b/app/views/admin/overlay_tickers/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:title) { "/root/overlays/tickers/new :: New Ticker" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/tickers/new :: NEW TICKER</legend>
+    <div style="padding: 20px;">
+      <%= form_with model: @ticker, url: admin_overlay_tickers_path, local: true do |f| %>
+        <%= render "form", f: f %>
+      <% end %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/admin/overlay_tickers/show.html.erb
+++ b/app/views/admin/overlay_tickers/show.html.erb
@@ -1,0 +1,49 @@
+<% content_for(:title) { "/root/overlays/tickers/#{@ticker.slug} :: Ticker Details" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 800px; margin: 30px auto;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/tickers/<%= @ticker.slug %> :: TICKER DETAILS</legend>
+
+    <div style="margin-bottom: 30px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Tickers", admin_overlay_tickers_path, class: "tui-button green-168" %>
+      <%= link_to "Edit", edit_admin_overlay_ticker_path(@ticker), class: "tui-button", style: "padding: 8px 20px;" %>
+    </div>
+
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div>
+          <p style="color: #888; margin: 0;">Name</p>
+          <p style="margin: 5px 0 15px; font-size: 1.2rem;"><strong><%= @ticker.name %></strong></p>
+
+          <p style="color: #888; margin: 0;">Slug</p>
+          <p style="margin: 5px 0 15px;"><code><%= @ticker.slug %></code></p>
+
+          <p style="color: #888; margin: 0;">Content Type</p>
+          <p style="margin: 5px 0 15px;">
+            <% if @ticker.static? %>
+              <span class="cyan-168-text">Static</span>
+            <% else %>
+              <span class="yellow-168-text">Dynamic</span> &mdash; <code class="purple-168-text"><%= @ticker.feed_source %></code>
+            <% end %>
+          </p>
+        </div>
+        <div>
+          <p style="color: #888; margin: 0;">Direction</p>
+          <p style="margin: 5px 0 15px;"><%= @ticker.direction %></p>
+
+          <p style="color: #888; margin: 0;">Speed</p>
+          <p style="margin: 5px 0 15px;"><%= @ticker.speed %> px/sec</p>
+
+          <p style="color: #888; margin: 0;">Status</p>
+          <p style="margin: 5px 0 15px;"><%= @ticker.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></p>
+        </div>
+      </div>
+
+      <% if @ticker.content.present? %>
+        <p style="color: #888; margin: 0;">Content</p>
+        <pre style="margin: 5px 0 0; background: #111; padding: 10px; border: 1px solid #333; white-space: pre-wrap;"><%= @ticker.content %></pre>
+      <% end %>
+    </div>
+
+  </fieldset>
+</div>

--- a/app/views/admin/overlays/edit_now_playing.html.erb
+++ b/app/views/admin/overlays/edit_now_playing.html.erb
@@ -1,0 +1,81 @@
+<% content_for(:title) { "/root/overlays/now-playing :: Edit Now Playing" } %>
+
+<div class="tui-window white-text admin-panel" style="display: block; max-width: 900px; margin: 30px auto; padding: 20px;">
+  <fieldset class="admin-panel-border">
+    <legend class="center">/root/overlays/now-playing :: NOW PLAYING</legend>
+
+    <% if flash[:success] %>
+      <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
+      </div>
+    <% end %>
+
+    <% if flash[:error] %>
+      <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
+        <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
+      </div>
+    <% end %>
+
+    <div style="margin-bottom: 20px; display: flex; gap: 10px; align-items: center;">
+      <%= link_to "< Back to Overlays", admin_overlays_path, class: "tui-button green-168" %>
+      <%= link_to "Preview", overlay_now_playing_path, target: "_blank", class: "tui-button purple-168" %>
+    </div>
+
+    <!-- Current State -->
+    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
+      <h3 class="cyan-255-text" style="margin: 0 0 15px;">[:: CURRENT STATE ::]</h3>
+      <% if @now_playing.playing? %>
+        <p style="margin: 5px 0;"><strong>Title:</strong> <%= @now_playing.display_title %></p>
+        <p style="margin: 5px 0;"><strong>Artist:</strong> <%= @now_playing.display_artist %></p>
+        <% if @now_playing.display_album.present? %>
+          <p style="margin: 5px 0;"><strong>Album:</strong> <%= @now_playing.display_album %></p>
+        <% end %>
+        <p style="margin: 5px 0;"><strong>Status:</strong> <%= @now_playing.paused ? '<span class="yellow-168-text">Paused</span>'.html_safe : '<span class="green-255-text">Playing</span>'.html_safe %></p>
+      <% else %>
+        <p style="color: #666;">Nothing playing.</p>
+      <% end %>
+    </div>
+
+    <!-- Set Track -->
+    <%= form_with scope: :overlay_now_playing, url: admin_update_overlay_now_playing_path, method: :patch, local: true do |f| %>
+      <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 20px;">
+        <h3 class="green-255-text" style="margin: 0 0 15px;">[:: SET TRACK ::]</h3>
+
+        <div style="margin-bottom: 15px;">
+          <%= f.label :track_id, "TRACK", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+          <%= f.select :track_id, @tracks.map { |t| ["#{t.artist&.name} — #{t.title}", t.id] }, { include_blank: "— Select Track —" }, class: "tui-input", style: "width: 100%; padding: 8px;" %>
+        </div>
+
+        <div style="display: flex; gap: 20px; margin-bottom: 15px;">
+          <div style="flex: 1;">
+            <%= f.label :custom_title, "OR CUSTOM TITLE", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+            <%= f.text_field :custom_title, class: "tui-input", style: "width: 100%; padding: 8px;", value: @now_playing.custom_title %>
+          </div>
+          <div style="flex: 1;">
+            <%= f.label :custom_artist, "CUSTOM ARTIST", class: "white-text", style: "display: block; margin-bottom: 5px; font-weight: bold;" %>
+            <%= f.text_field :custom_artist, class: "tui-input", style: "width: 100%; padding: 8px;", value: @now_playing.custom_artist %>
+          </div>
+        </div>
+
+        <div style="margin-bottom: 15px;">
+          <%= f.label :paused, class: "white-text", style: "font-weight: bold;" do %>
+            <%= f.check_box :paused, checked: @now_playing.paused, style: "margin-right: 8px;" %> PAUSED
+          <% end %>
+        </div>
+
+        <div style="display: flex; gap: 10px;">
+          <%= f.submit "Update & Broadcast", class: "tui-button green-168", style: "padding: 10px 20px; font-weight: bold;" %>
+        </div>
+      </div>
+    <% end %>
+
+    <!-- Clear -->
+    <%= form_with url: admin_update_overlay_now_playing_path, method: :patch, local: true do %>
+      <input type="hidden" name="clear" value="1">
+      <button type="submit" class="tui-button red-168" style="padding: 10px 20px;" data-confirm="Clear now playing?">Clear Now Playing</button>
+    <% end %>
+
+  </fieldset>
+</div>

--- a/app/views/admin/overlays/index.html.erb
+++ b/app/views/admin/overlays/index.html.erb
@@ -6,25 +6,28 @@
 
     <% if flash[:success] %>
       <div style="background: #003300; border: 2px solid #00ff00; padding: 15px; margin-bottom: 20px;">
-        <p class="green-255-text" style="margin: 0;">✓ SUCCESS</p>
+        <p class="green-255-text" style="margin: 0;">&#10003; SUCCESS</p>
         <p class="white-text" style="margin: 5px 0 0;"><%= flash[:success] %></p>
       </div>
     <% end %>
 
     <% if flash[:error] %>
       <div style="background: #330000; border: 2px solid #ff0000; padding: 15px; margin-bottom: 20px;">
-        <p class="red-255-text" style="margin: 0;">✗ ERROR</p>
+        <p class="red-255-text" style="margin: 0;">&#10007; ERROR</p>
         <p class="white-text" style="margin: 5px 0 0;"><%= flash[:error] %></p>
       </div>
     <% end %>
 
     <!-- Navigation -->
-    <div style="margin-bottom: 30px; display: flex; gap: 10px;">
+    <div style="margin-bottom: 30px; display: flex; gap: 10px; flex-wrap: wrap;">
       <%= link_to "← Dashboard", admin_root_path, class: "tui-button green-168" %>
-      <%= link_to "Manage Scenes", admin_overlay_scenes_path, class: "tui-button cyan-168" %>
-      <%= link_to "Manage Scene Groups", admin_overlay_scene_groups_path, class: "tui-button cyan-168" %>
-      <%= link_to "Manage Elements", admin_overlay_elements_path, class: "tui-button cyan-168" %>
-      <%= link_to "Manage Lower Thirds", admin_overlay_lower_thirds_path, class: "tui-button cyan-168" %>
+      <%= link_to "Scenes", admin_overlay_scenes_path, class: "tui-button cyan-168" %>
+      <%= link_to "Elements", admin_overlay_elements_path, class: "tui-button cyan-168" %>
+      <%= link_to "Scene Groups", admin_overlay_scene_groups_path, class: "tui-button cyan-168" %>
+      <%= link_to "Lower Thirds", admin_overlay_lower_thirds_path, class: "tui-button cyan-168" %>
+      <%= link_to "Tickers", admin_overlay_tickers_path, class: "tui-button cyan-168" %>
+      <%= link_to "Alerts", admin_overlay_alerts_path, class: "tui-button cyan-168" %>
+      <%= link_to "Now Playing", admin_edit_overlay_now_playing_path, class: "tui-button cyan-168" %>
     </div>
 
     <!-- Overlay URLs Section -->
@@ -62,7 +65,7 @@
           <% end %>
         </tbody>
       </table>
-      <p id="no-scenes-message" style="color: #666; text-align: center; display: none; margin: 15px 0;">No scenes in this group. <%= link_to "Add scenes to this group", admin_overlay_scene_groups_path, class: "cyan-168-text" %>.</p>
+      <p id="no-scenes-message" style="color: #666; text-align: center; display: none; margin: 15px 0;">No scenes in this group.</p>
       <% if @scenes.empty? %>
         <p style="color: #666; text-align: center; margin: 15px 0;">No scenes yet. <%= link_to "Create one", new_admin_overlay_scene_path, class: "cyan-168-text" %>.</p>
       <% end %>
@@ -124,7 +127,6 @@
         const value = selectedOption.value;
 
         if (value === 'all') {
-          // Show all
           elementRows.forEach(row => row.style.display = '');
           sceneRows.forEach(row => row.style.display = '');
           elementsTable.style.display = '';
@@ -135,7 +137,6 @@
           const sceneIds = (selectedOption.dataset.sceneIds || '').split(',').filter(Boolean);
           const elementTypes = (selectedOption.dataset.elementTypes || '').split(',').filter(Boolean);
 
-          // Filter scenes
           let visibleScenes = 0;
           sceneRows.forEach(row => {
             const sceneId = row.dataset.sceneId;
@@ -147,7 +148,6 @@
             }
           });
 
-          // Filter elements
           let visibleElements = 0;
           elementRows.forEach(row => {
             const elementType = row.dataset.elementType;
@@ -159,7 +159,6 @@
             }
           });
 
-          // Show/hide empty messages
           if (visibleElements === 0) {
             elementsTable.style.display = 'none';
             noElementsMsg.style.display = 'block';
@@ -180,92 +179,41 @@
     });
     </script>
 
-    <!-- Ticker Control Section -->
-    <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: TICKER CONTROL ::]</h3>
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 30px;">
-      <% @tickers.each do |ticker| %>
-        <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
-          <h4 class="purple-168-text" style="margin: 0 0 15px;"><%= ticker.name %> (<%= ticker.slug.upcase %>)</h4>
-          <%= form_with url: admin_update_overlay_ticker_path(ticker_slug: ticker.slug), method: :patch, scope: :overlay_ticker, local: true do |f| %>
-            <div style="margin-bottom: 15px;">
-              <%= f.label :content, "CONTENT", style: "display: block; color: #888; margin-bottom: 5px;" %>
-              <%= f.text_area :content, value: ticker.content, class: "tui-input", rows: 3, style: "width: 100%;" %>
-            </div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; margin-bottom: 15px;">
-              <div>
-                <%= f.label :speed, "SPEED (px/s)", style: "display: block; color: #888; margin-bottom: 5px;" %>
-                <%= f.number_field :speed, value: ticker.speed, class: "tui-input", style: "width: 100%;" %>
-              </div>
-              <div>
-                <%= f.label :direction, "DIRECTION", style: "display: block; color: #888; margin-bottom: 5px;" %>
-                <%= f.select :direction, [["Left", "left"], ["Right", "right"]], {selected: ticker.direction}, class: "tui-input", style: "width: 100%;" %>
-              </div>
-              <div>
-                <%= f.label :active, "ACTIVE", style: "display: block; color: #888; margin-bottom: 5px;" %>
-                <%= f.select :active, [["Yes", true], ["No", false]], {selected: ticker.active}, class: "tui-input", style: "width: 100%;" %>
-              </div>
-            </div>
-            <%= f.submit "Update Ticker", class: "tui-button cyan-168" %>
-          <% end %>
-        </div>
-      <% end %>
-      <% if @tickers.empty? %>
-        <div style="grid-column: span 2; background: #0a0a0a; border: 1px solid #444; padding: 20px; text-align: center; color: #666;">
-          No tickers configured. Run seeds to create default tickers.
-        </div>
-      <% end %>
-    </div>
+    <!-- Quick Status Summary -->
+    <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 20px; margin-bottom: 30px;">
+      <!-- Now Playing Status -->
+      <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+        <h4 class="purple-168-text" style="margin: 0 0 10px;">NOW PLAYING</h4>
+        <% if @now_playing.playing? %>
+          <p style="margin: 0; font-size: 1.1rem;"><strong><%= @now_playing.display_title %></strong></p>
+          <p style="margin: 5px 0 0; color: #60a5fa;"><%= @now_playing.display_artist %></p>
+        <% else %>
+          <p style="margin: 0; color: #666;">Nothing playing.</p>
+        <% end %>
+        <p style="margin: 10px 0 0;"><%= link_to "Edit →", admin_edit_overlay_now_playing_path, class: "cyan-168-text" %></p>
+      </div>
 
-    <!-- Alert Control Section -->
-    <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: SEND ALERT ::]</h3>
-    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 30px;">
-      <%= form_with url: admin_send_overlay_alert_path, method: :post, local: true do |f| %>
-        <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 15px; margin-bottom: 15px;">
-          <div>
-            <%= label_tag :alert_type, "TYPE", style: "display: block; color: #888; margin-bottom: 5px;" %>
-            <%= select_tag :alert_type, options_for_select([
-              ["Custom", "custom"],
-              ["Subscriber", "subscriber"],
-              ["Donation", "donation"],
-              ["Raid", "raid"],
-              ["Follow", "follow"]
-            ]), class: "tui-input", style: "width: 100%;" %>
-          </div>
-          <div>
-            <%= label_tag :alert_title, "TITLE", style: "display: block; color: #888; margin-bottom: 5px;" %>
-            <%= text_field_tag :alert_title, nil, class: "tui-input", style: "width: 100%;", placeholder: "Alert Title" %>
-          </div>
-          <div>
-            <%= label_tag :alert_message, "MESSAGE", style: "display: block; color: #888; margin-bottom: 5px;" %>
-            <%= text_field_tag :alert_message, nil, class: "tui-input", style: "width: 100%;", placeholder: "Alert message" %>
-          </div>
-        </div>
-        <%= submit_tag "Send Alert", class: "tui-button purple-168" %>
+      <!-- Ticker Status -->
+      <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+        <h4 class="purple-168-text" style="margin: 0 0 10px;">TICKERS</h4>
+        <p style="margin: 0;"><%= @tickers.count %> ticker(s) configured</p>
+        <p style="margin: 5px 0 0; color: #888;"><%= @tickers.select(&:active?).count %> active</p>
+        <p style="margin: 10px 0 0;"><%= link_to "Manage →", admin_overlay_tickers_path, class: "cyan-168-text" %></p>
+      </div>
+
+      <!-- Alert Status -->
+      <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px;">
+        <h4 class="purple-168-text" style="margin: 0 0 10px;">ALERTS</h4>
         <% if @pending_alerts > 0 %>
-          <span style="margin-left: 15px; color: #fbbf24;"><%= @pending_alerts %> alert(s) pending</span>
+          <p style="margin: 0; color: #fbbf24;"><%= @pending_alerts %> pending</p>
+        <% else %>
+          <p style="margin: 0; color: #666;">No pending alerts.</p>
         <% end %>
-      <% end %>
+        <p style="margin: 10px 0 0;"><%= link_to "Manage →", admin_overlay_alerts_path, class: "cyan-168-text" %></p>
+      </div>
     </div>
 
-    <!-- Now Playing Status -->
-    <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: NOW PLAYING STATUS ::]</h3>
-    <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 30px;">
-      <% if @now_playing.playing? %>
-        <p class="green-255-text" style="margin: 0 0 10px;">▶ CURRENTLY PLAYING</p>
-        <p style="margin: 0; font-size: 1.2rem;"><strong><%= @now_playing.display_title %></strong></p>
-        <p style="margin: 5px 0 0; color: #60a5fa;"><%= @now_playing.display_artist %></p>
-        <% if @now_playing.display_album.present? %>
-          <p style="margin: 5px 0 0; color: #888;"><%= @now_playing.display_album %></p>
-        <% end %>
-      <% else %>
-        <p style="margin: 0; color: #666;">Nothing currently playing. Play a track in the SPA to update.</p>
-      <% end %>
-      <p style="margin: 15px 0 0; color: #888; font-size: 0.9rem;">
-        Note: Now Playing is automatically updated when tracks play in hackr.fm
-      </p>
-    </div>
-
-    <!-- Lower Thirds List -->
+    <!-- Lower Thirds Summary -->
     <h3 class="cyan-255-text" style="margin-bottom: 15px;">[:: LOWER THIRDS ::]</h3>
     <div style="background: #0a0a0a; border: 1px solid #444; padding: 20px; margin-bottom: 30px;">
       <% if @lower_thirds.any? %>
@@ -274,7 +222,6 @@
             <tr>
               <th>Name</th>
               <th>Primary Text</th>
-              <th>Secondary Text</th>
               <th>Status</th>
               <th>URL</th>
             </tr>
@@ -282,9 +229,8 @@
           <tbody>
             <% @lower_thirds.each do |lt| %>
               <tr class="admin-table-row">
-                <td><strong><%= lt.name %></strong></td>
-                <td><%= truncate(lt.primary_text, length: 30) %></td>
-                <td><%= truncate(lt.secondary_text, length: 30) || "-" %></td>
+                <td><strong><%= link_to lt.name, edit_admin_overlay_lower_third_path(lt), class: "white-text" %></strong></td>
+                <td><%= truncate(lt.primary_text, length: 40) %></td>
                 <td><%= lt.active ? '<span class="green-255-text">Active</span>'.html_safe : '<span class="red-168-text">Inactive</span>'.html_safe %></td>
                 <td>
                   <%= link_to "Open ↗", overlay_lower_third_path(slug: lt.slug), target: "_blank", class: "tui-button purple-168", style: "padding: 4px 8px; font-size: 0.8rem;" %>

--- a/app/views/overlays/elements/_ticker_bottom.html.erb
+++ b/app/views/overlays/elements/_ticker_bottom.html.erb
@@ -8,17 +8,30 @@
 %>
 <% if ticker %>
   <%
-    char_count = ticker.content.length
-    base_duration = (char_count * 10.0 / ticker.speed).round(1)
-    ticker_duration = [base_duration, 10].max
+    container_px = scene_element.width || 1920
+    copy_px = ticker.content.length * 9.6 + 41
+    copies = [2, (container_px.to_f / copy_px).ceil + 1].max
+    ticker_duration = [(copy_px / ticker.speed).round(1), 3].max
+    scroll_pct = -100.0 / copies
   %>
-  <div class="scene-element overlay-ticker ticker-bottom ticker-scroll-<%= ticker.direction %>"
+  <style>
+    #ticker-<%= ticker_slug %>-overlay .ticker-content {
+      animation: ticker-seamless-<%= ticker_slug %> <%= ticker_duration %>s linear infinite !important;
+    }
+    @keyframes ticker-seamless-<%= ticker_slug %> {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(<%= scroll_pct.round(4) %>%); }
+    }
+  </style>
+  <div class="scene-element overlay-ticker ticker-bottom"
        id="ticker-<%= ticker_slug %>-overlay"
-       style="<%= style %> --ticker-duration: <%= ticker_duration %>s;"
+       style="<%= style %>"
        data-element-type="ticker_bottom"
-       data-slug="<%= ticker_slug %>">
+       data-slug="<%= ticker_slug %>"
+       data-speed="<%= ticker.speed %>"
+       data-copies="<%= copies %>">
     <div class="ticker-content">
-      <%= ticker.content %><span class="ticker-separator"></span><%= ticker.content %><span class="ticker-separator"></span><%= ticker.content %>
+      <% copies.times do %><%= ticker.content %><span class="ticker-separator"></span><% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/overlays/elements/_ticker_bottom.html.erb
+++ b/app/views/overlays/elements/_ticker_bottom.html.erb
@@ -12,7 +12,7 @@
     copy_px = ticker.content.length * 9.6 + 41
     copies = [2, (container_px.to_f / copy_px).ceil + 1].max
     ticker_duration = [(copy_px / ticker.speed).round(1), 3].max
-    scroll_pct = -100.0 / copies
+    scroll_pct = (ticker.direction == "right" ? 100.0 : -100.0) / copies
   %>
   <style>
     #ticker-<%= ticker_slug %>-overlay .ticker-content {

--- a/app/views/overlays/elements/_ticker_top.html.erb
+++ b/app/views/overlays/elements/_ticker_top.html.erb
@@ -8,17 +8,30 @@
 %>
 <% if ticker %>
   <%
-    char_count = ticker.content.length
-    base_duration = (char_count * 10.0 / ticker.speed).round(1)
-    ticker_duration = [base_duration, 10].max
+    container_px = scene_element.width || 1920
+    copy_px = ticker.content.length * 9.6 + 41
+    copies = [2, (container_px.to_f / copy_px).ceil + 1].max
+    ticker_duration = [(copy_px / ticker.speed).round(1), 3].max
+    scroll_pct = -100.0 / copies
   %>
-  <div class="scene-element overlay-ticker ticker-top ticker-scroll-<%= ticker.direction %>"
+  <style>
+    #ticker-<%= ticker_slug %>-overlay .ticker-content {
+      animation: ticker-seamless-<%= ticker_slug %> <%= ticker_duration %>s linear infinite !important;
+    }
+    @keyframes ticker-seamless-<%= ticker_slug %> {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(<%= scroll_pct.round(4) %>%); }
+    }
+  </style>
+  <div class="scene-element overlay-ticker ticker-top"
        id="ticker-<%= ticker_slug %>-overlay"
-       style="<%= style %> --ticker-duration: <%= ticker_duration %>s;"
+       style="<%= style %>"
        data-element-type="ticker_top"
-       data-slug="<%= ticker_slug %>">
+       data-slug="<%= ticker_slug %>"
+       data-speed="<%= ticker.speed %>"
+       data-copies="<%= copies %>">
     <div class="ticker-content">
-      <%= ticker.content %><span class="ticker-separator"></span><%= ticker.content %><span class="ticker-separator"></span><%= ticker.content %>
+      <% copies.times do %><%= ticker.content %><span class="ticker-separator"></span><% end %>
     </div>
   </div>
 <% else %>

--- a/app/views/overlays/elements/_ticker_top.html.erb
+++ b/app/views/overlays/elements/_ticker_top.html.erb
@@ -12,7 +12,7 @@
     copy_px = ticker.content.length * 9.6 + 41
     copies = [2, (container_px.to_f / copy_px).ceil + 1].max
     ticker_duration = [(copy_px / ticker.speed).round(1), 3].max
-    scroll_pct = -100.0 / copies
+    scroll_pct = (ticker.direction == "right" ? 100.0 : -100.0) / copies
   %>
   <style>
     #ticker-<%= ticker_slug %>-overlay .ticker-content {

--- a/app/views/overlays/ticker.html.erb
+++ b/app/views/overlays/ticker.html.erb
@@ -4,7 +4,7 @@
   copy_px = @ticker.content.length * 9.6 + 41
   copies = [2, (1920.0 / copy_px).ceil + 1].max
   ticker_duration = [(copy_px / @ticker.speed).round(1), 3].max
-  scroll_pct = -100.0 / copies
+  scroll_pct = (@ticker.direction == "right" ? 100.0 : -100.0) / copies
 %>
 <style>
   #ticker-<%= @ticker.slug %>-overlay .ticker-content {

--- a/app/views/overlays/ticker.html.erb
+++ b/app/views/overlays/ticker.html.erb
@@ -1,15 +1,26 @@
 <%
-  # Calculate animation duration based on content length and speed
-  # Speed is in pixels/second, assume ~10px per character
-  char_count = @ticker.content.length
-  base_duration = (char_count * 10.0 / @ticker.speed).round(1)
-  ticker_duration = [base_duration, 10].max # Minimum 10 seconds
+  # Seamless ticker: enough copies to fill viewport, scroll by one copy, loop.
+  # Single copy = text + separator. Duration = copy_width / speed (true px/s).
+  copy_px = @ticker.content.length * 9.6 + 41
+  copies = [2, (1920.0 / copy_px).ceil + 1].max
+  ticker_duration = [(copy_px / @ticker.speed).round(1), 3].max
+  scroll_pct = -100.0 / copies
 %>
-<div class="overlay-ticker ticker-<%= @ticker.slug %> ticker-scroll-<%= @ticker.direction %>"
+<style>
+  #ticker-<%= @ticker.slug %>-overlay .ticker-content {
+    animation: ticker-seamless-<%= @ticker.slug %> <%= ticker_duration %>s linear infinite !important;
+  }
+  @keyframes ticker-seamless-<%= @ticker.slug %> {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(<%= scroll_pct.round(4) %>%); }
+  }
+</style>
+<div class="overlay-ticker ticker-<%= @ticker.slug %>"
      id="ticker-<%= @ticker.slug %>-overlay"
      data-slug="<%= @ticker.slug %>"
-     style="--ticker-duration: <%= ticker_duration %>s;">
+     data-speed="<%= @ticker.speed %>"
+     data-copies="<%= copies %>">
   <div class="ticker-content">
-    <%= @ticker.content %><span class="ticker-separator"></span><%= @ticker.content %><span class="ticker-separator"></span><%= @ticker.content %>
+    <% copies.times do %><%= @ticker.content %><span class="ticker-separator"></span><% end %>
   </div>
 </div>

--- a/config/initializers/clear_precompiled_assets.rb
+++ b/config/initializers/clear_precompiled_assets.rb
@@ -1,0 +1,10 @@
+# In development, precompiled assets in public/assets/ override live files
+# from app/assets/, silently preventing edits from taking effect.
+# Clear them on boot so Propshaft always serves from source.
+if Rails.env.development?
+  manifest = Rails.root.join("public/assets/.manifest.json")
+  if manifest.exist?
+    FileUtils.rm_rf(Rails.root.join("public/assets"))
+    Rails.logger.info "[Assets] Cleared stale precompiled assets from public/assets/"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,6 +293,9 @@ Rails.application.routes.draw do
 
       # World Event Feed
       post "world_events", to: "world_events#create"
+
+      # Overlay ticker feed
+      post "overlay/ticker_feed", to: "overlay#ticker_feed"
     end
   end
 
@@ -641,16 +644,35 @@ Rails.application.routes.draw do
     delete "uplink/punishments/:id", to: "uplink#lift_punishment", as: :lift_uplink_punishment
 
     # Overlay admin routes
-    # Runtime operations (ticker updates, alerts) are still functional
     get "overlays", to: "overlays#index", as: :overlays
-    patch "overlays/ticker/:ticker_slug", to: "overlays#update_ticker", as: :update_overlay_ticker
-    post "overlays/alert", to: "overlays#send_alert", as: :send_overlay_alert
+    get "overlays/now-playing/edit", to: "overlays#edit_now_playing", as: :edit_overlay_now_playing
+    patch "overlays/now-playing", to: "overlays#update_now_playing", as: :update_overlay_now_playing
 
-    # Read-only overlay resources (managed via data/overlays/*.yml)
-    resources :overlay_scenes, path: "overlays/scenes", only: %i[index show]
-    resources :overlay_elements, path: "overlays/elements", only: %i[index show]
-    resources :overlay_lower_thirds, path: "overlays/lower-thirds", only: %i[index show]
-    resources :overlay_scene_groups, path: "overlays/groups", only: %i[index show]
+    # Overlay CRUD resources
+    resources :overlay_scenes, path: "overlays/scenes" do
+      member do
+        post :add_element
+        delete :remove_element
+        get :history
+      end
+    end
+    resources :overlay_elements, path: "overlays/elements" do
+      member { get :history }
+    end
+    resources :overlay_lower_thirds, path: "overlays/lower-thirds" do
+      member { get :history }
+    end
+    resources :overlay_scene_groups, path: "overlays/groups" do
+      member do
+        post :add_scene
+        delete :remove_scene
+        get :history
+      end
+    end
+    resources :overlay_tickers, path: "overlays/tickers" do
+      member { get :history }
+    end
+    resources :overlay_alerts, path: "overlays/alerts", only: %i[index new create show destroy]
 
     # World Event Feed admin
     resources :world_event_feed, only: [:index] do

--- a/db/migrate/20260607000001_add_content_type_and_feed_source_to_overlay_tickers.rb
+++ b/db/migrate/20260607000001_add_content_type_and_feed_source_to_overlay_tickers.rb
@@ -1,0 +1,6 @@
+class AddContentTypeAndFeedSourceToOverlayTickers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :overlay_tickers, :content_type, :string, default: "static", null: false
+    add_column :overlay_tickers, :feed_source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_005016) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -1217,8 +1217,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_005016) do
   create_table "overlay_tickers", force: :cascade do |t|
     t.boolean "active", default: true
     t.text "content", null: false
+    t.string "content_type", default: "static", null: false
     t.datetime "created_at", null: false
     t.string "direction", default: "left"
+    t.string "feed_source"
     t.string "name", null: false
     t.string "slug", null: false
     t.integer "speed", default: 50

--- a/spec/controllers/admin/overlays_controller_spec.rb
+++ b/spec/controllers/admin/overlays_controller_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe Admin::OverlaysController, type: :controller do
       expect(assigns(:now_playing)).to eq(OverlayNowPlaying.current)
     end
 
-    it "loads tracks" do
-      artist = create(:artist)
-      track = create(:track, artist: artist)
-      get :index
-      expect(assigns(:tracks)).to include(track)
-    end
-
     it "loads pending alerts count" do
       create(:overlay_alert, displayed: false)
       create(:overlay_alert, :displayed)
@@ -57,88 +50,62 @@ RSpec.describe Admin::OverlaysController, type: :controller do
     end
   end
 
-  describe "PATCH #update_ticker" do
-    let!(:ticker) { create(:overlay_ticker, slug: "top", content: "Original") }
-
-    before do
-      allow(ActionCable.server).to receive(:broadcast)
+  describe "GET #edit_now_playing" do
+    it "returns success" do
+      get :edit_now_playing
+      expect(response).to have_http_status(:ok)
     end
 
-    it "updates the ticker" do
-      patch :update_ticker, params: {
-        ticker_slug: "top",
-        overlay_ticker: {content: "Updated content"}
-      }
-
-      ticker.reload
-      expect(ticker.content).to eq("Updated content")
+    it "loads now playing" do
+      get :edit_now_playing
+      expect(assigns(:now_playing)).to eq(OverlayNowPlaying.current)
     end
 
-    it "broadcasts update" do
-      expect_any_instance_of(OverlayTicker).to receive(:broadcast_update!)
-      patch :update_ticker, params: {
-        ticker_slug: "top",
-        overlay_ticker: {content: "New content"}
-      }
-    end
-
-    it "redirects to index" do
-      patch :update_ticker, params: {
-        ticker_slug: "top",
-        overlay_ticker: {content: "New"}
-      }
-      expect(response).to redirect_to(admin_overlays_path)
-    end
-
-    it "sets success flash" do
-      patch :update_ticker, params: {
-        ticker_slug: "top",
-        overlay_ticker: {content: "New"}
-      }
-      expect(flash[:success]).to include(ticker.name)
-    end
-
-    it "sets error flash on invalid update" do
-      patch :update_ticker, params: {
-        ticker_slug: "top",
-        overlay_ticker: {content: ""}
-      }
-      expect(flash[:error]).to be_present
+    it "loads tracks" do
+      artist = create(:artist)
+      track = create(:track, artist: artist)
+      get :edit_now_playing
+      expect(assigns(:tracks)).to include(track)
     end
   end
 
-  describe "POST #send_alert" do
+  describe "PATCH #update_now_playing" do
     before do
       allow(ActionCable.server).to receive(:broadcast)
     end
 
-    it "queues an alert" do
-      expect {
-        post :send_alert, params: {
-          alert_type: "custom",
-          alert_title: "Test Alert",
-          alert_message: "Test message"
-        }
-      }.to change(OverlayAlert, :count).by(1)
-    end
+    it "sets track and broadcasts" do
+      artist = create(:artist)
+      track = create(:track, artist: artist)
 
-    it "sets default alert type to custom" do
-      post :send_alert, params: {
-        alert_title: "Test"
+      patch :update_now_playing, params: {
+        overlay_now_playing: {track_id: track.id, paused: "0"}
       }
 
-      alert = OverlayAlert.last
-      expect(alert.alert_type).to eq("custom")
+      np = OverlayNowPlaying.current
+      expect(np.track).to eq(track)
+      expect(flash[:success]).to include(track.title)
+      expect(response).to redirect_to(admin_edit_overlay_now_playing_path)
     end
 
-    it "redirects to index" do
-      post :send_alert, params: {alert_title: "Test"}
-      expect(response).to redirect_to(admin_overlays_path)
+    it "sets custom title and broadcasts" do
+      patch :update_now_playing, params: {
+        overlay_now_playing: {custom_title: "Test Song", custom_artist: "Test Artist"}
+      }
+
+      np = OverlayNowPlaying.current
+      expect(np.custom_title).to eq("Test Song")
+      expect(flash[:success]).to include("custom track")
+      expect(response).to redirect_to(admin_edit_overlay_now_playing_path)
     end
 
-    it "sets success flash" do
-      post :send_alert, params: {alert_title: "Test"}
-      expect(flash[:success]).to include("Alert sent")
+    it "clears now playing" do
+      patch :update_now_playing, params: {clear: "1"}
+
+      np = OverlayNowPlaying.current
+      expect(np.playing?).to be false
+      expect(flash[:success]).to include("cleared")
+      expect(response).to redirect_to(admin_edit_overlay_now_playing_path)
     end
   end
 

--- a/spec/factories/overlay_tickers.rb
+++ b/spec/factories/overlay_tickers.rb
@@ -3,15 +3,17 @@
 # Table name: overlay_tickers
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  active     :boolean          default(TRUE)
-#  content    :text             not null
-#  direction  :string           default("left")
-#  name       :string           not null
-#  slug       :string           not null
-#  speed      :integer          default(50)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :integer          not null, primary key
+#  active       :boolean          default(TRUE)
+#  content      :text             not null
+#  content_type :string           default("static"), not null
+#  direction    :string           default("left")
+#  feed_source  :string
+#  name         :string           not null
+#  slug         :string           not null
+#  speed        :integer          default(50)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #
@@ -21,14 +23,17 @@
 FactoryBot.define do
   factory :overlay_ticker do
     sequence(:name) { |n| "Ticker #{n}" }
-    slug { "top" }
+    sequence(:slug) { |n| "ticker-#{n}" }
     content { "Breaking news: The Grid is online. Welcome to the future." }
+    content_type { "static" }
     speed { 50 }
     direction { "left" }
     active { true }
 
-    trait :bottom do
-      slug { "bottom" }
+    trait :dynamic do
+      content_type { "dynamic" }
+      feed_source { "api" }
+      content { "Awaiting feed..." }
     end
 
     trait :inactive do

--- a/spec/models/overlay_ticker_spec.rb
+++ b/spec/models/overlay_ticker_spec.rb
@@ -3,15 +3,17 @@
 # Table name: overlay_tickers
 # Database name: primary
 #
-#  id         :integer          not null, primary key
-#  active     :boolean          default(TRUE)
-#  content    :text             not null
-#  direction  :string           default("left")
-#  name       :string           not null
-#  slug       :string           not null
-#  speed      :integer          default(50)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :integer          not null, primary key
+#  active       :boolean          default(TRUE)
+#  content      :text             not null
+#  content_type :string           default("static"), not null
+#  direction    :string           default("left")
+#  feed_source  :string
+#  name         :string           not null
+#  slug         :string           not null
+#  speed        :integer          default(50)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 # Indexes
 #
@@ -25,17 +27,58 @@ RSpec.describe OverlayTicker, type: :model do
     subject { build(:overlay_ticker) }
 
     it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:slug) }
     it { should validate_uniqueness_of(:slug) }
-    it { should validate_inclusion_of(:slug).in_array(OverlayTicker::POSITIONS) }
-    it { should validate_presence_of(:content) }
+
+    it "requires slug when name is also blank" do
+      ticker = build(:overlay_ticker, name: nil, slug: nil)
+      expect(ticker).not_to be_valid
+      expect(ticker.errors[:slug]).to be_present
+    end
     it { should validate_numericality_of(:speed).is_greater_than(0) }
     it { should validate_inclusion_of(:direction).in_array(OverlayTicker::DIRECTIONS) }
+    it { should validate_inclusion_of(:content_type).in_array(OverlayTicker::CONTENT_TYPES) }
+
+    it "requires content for static tickers" do
+      ticker = build(:overlay_ticker, content_type: "static", content: nil)
+      expect(ticker).not_to be_valid
+      expect(ticker.errors[:content]).to be_present
+    end
+
+    it "auto-fills content for dynamic tickers when blank" do
+      ticker = build(:overlay_ticker, :dynamic, content: nil)
+      ticker.valid?
+      expect(ticker.content).to be_present
+    end
+
+    it "requires feed_source for dynamic tickers" do
+      ticker = build(:overlay_ticker, content_type: "dynamic", feed_source: nil)
+      expect(ticker).not_to be_valid
+      expect(ticker.errors[:feed_source]).to be_present
+    end
+
+    it "validates feed_source inclusion" do
+      ticker = build(:overlay_ticker, :dynamic, feed_source: "invalid")
+      expect(ticker).not_to be_valid
+    end
+
+    it "allows valid feed sources" do
+      OverlayTicker::FEED_SOURCES.each do |source|
+        ticker = build(:overlay_ticker, :dynamic, feed_source: source)
+        expect(ticker).to be_valid, "Expected feed_source '#{source}' to be valid"
+      end
+    end
+  end
+
+  describe "slug auto-generation" do
+    it "generates slug from name when blank" do
+      ticker = create(:overlay_ticker, name: "My Cool Ticker", slug: "")
+      expect(ticker.slug).to eq("my-cool-ticker")
+    end
   end
 
   describe "scopes" do
     let!(:active_ticker) { create(:overlay_ticker, active: true) }
-    let!(:inactive_ticker) { create(:overlay_ticker, :bottom, :inactive) }
+    let!(:inactive_ticker) { create(:overlay_ticker, :inactive) }
 
     it ".active returns only active tickers" do
       expect(OverlayTicker.active).to include(active_ticker)
@@ -43,47 +86,37 @@ RSpec.describe OverlayTicker, type: :model do
     end
   end
 
-  describe ".top" do
-    it "returns the top ticker" do
-      top = create(:overlay_ticker, slug: "top")
-      create(:overlay_ticker, slug: "bottom")
-
-      expect(OverlayTicker.top).to eq(top)
+  describe "#static? and #dynamic?" do
+    it "returns true for static content_type" do
+      ticker = build(:overlay_ticker, content_type: "static")
+      expect(ticker.static?).to be true
+      expect(ticker.dynamic?).to be false
     end
 
-    it "returns nil if no top ticker" do
-      expect(OverlayTicker.top).to be_nil
-    end
-  end
-
-  describe ".bottom" do
-    it "returns the bottom ticker" do
-      create(:overlay_ticker, slug: "top")
-      bottom = create(:overlay_ticker, slug: "bottom")
-
-      expect(OverlayTicker.bottom).to eq(bottom)
-    end
-
-    it "returns nil if no bottom ticker" do
-      expect(OverlayTicker.bottom).to be_nil
+    it "returns true for dynamic content_type" do
+      ticker = build(:overlay_ticker, :dynamic)
+      expect(ticker.static?).to be false
+      expect(ticker.dynamic?).to be true
     end
   end
 
   describe "#broadcast_update!" do
-    let(:ticker) { create(:overlay_ticker, slug: "top", content: "Test content", speed: 50, direction: "left", active: true) }
+    let(:ticker) { create(:overlay_ticker, slug: "test-ticker", content: "Test content", speed: 50, direction: "left", active: true) }
 
     before do
       allow(ActionCable.server).to receive(:broadcast)
     end
 
-    it "broadcasts to overlay channel" do
+    it "broadcasts to overlay channel with content_type and feed_source" do
       expect(ActionCable.server).to receive(:broadcast).with(
         "overlay_updates",
         {
           type: "ticker_updated",
           data: {
-            slug: "top",
+            slug: "test-ticker",
             content: "Test content",
+            content_type: "static",
+            feed_source: nil,
             speed: 50,
             direction: "left",
             active: true


### PR DESCRIPTION
  Upgrade all overlay resources from read-only YAML-managed views to
  full CRUD with Versionable history tracking.

  6 CRUD resources: scenes (+ inline scene_element positioning),
  elements (settings JSON editor, deletion guard), lower thirds
  (auto-broadcast), scene groups (+ inline scene membership), tickers
  (refactored), alerts (queue management with type filter).

  Ticker refactor: remove top/bottom slug constraint, add content_type
  (static/dynamic) and feed_source (pulsewire/world_events/now_playing/
  api) columns. Dynamic tickers auto-fill placeholder content. Any
  number of ticker configs with unique slugs.

  Now Playing: singleton edit/update with track select, custom title/
  artist, pause/clear. Auto-broadcasts on all changes.

  API: POST /api/admin/overlay/ticker_feed — Bearer token auth, pushes
  content to API-fed dynamic tickers.

  Dashboard simplified to status overview hub. Removed all "Edit via
  YAML" hints. JSON parse errors flash warnings. All models gained
  has_paper_trail.