### PR TITLE
Read-only JSON API for overlay system (8 endpoints)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem "paper_trail"
 # Rate limiting and request throttling
 gem "rack-attack"
 
+# CORS for cross-origin API access (overlay read endpoints)
+gem "rack-cors"
+
 # Structured request logging (single-line JSON per request)
 gem "lograge"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,9 @@ GEM
     rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.2)
@@ -444,6 +447,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rack-attack
+  rack-cors
   rails (~> 8.1.3)
   rails-controller-testing
   redcarpet

--- a/app/controllers/api/overlay_controller.rb
+++ b/app/controllers/api/overlay_controller.rb
@@ -39,7 +39,7 @@ class Api::OverlayController < ApplicationController
 
   # GET /api/overlay/now-playing
   def now_playing
-    render json: OverlayNowPlaying.current.as_api_json
+    render json: OverlayNowPlaying.current.as_api_json(base_url: request.base_url)
   end
 
   # GET /api/overlay/tickers
@@ -95,7 +95,7 @@ class Api::OverlayController < ApplicationController
 
   # GET /api/overlay/scenes/:slug
   def scene
-    scene = OverlayScene.find_by(slug: params[:slug])
+    scene = OverlayScene.active.find_by(slug: params[:slug])
     return render json: {error: "Scene not found"}, status: :not_found unless scene
 
     elements = scene.overlay_scene_elements

--- a/app/controllers/api/overlay_controller.rb
+++ b/app/controllers/api/overlay_controller.rb
@@ -1,6 +1,8 @@
 class Api::OverlayController < ApplicationController
   include GridAuthentication
 
+  before_action :require_login_api, only: %i[set_now_playing]
+
   # POST /api/overlay/now-playing
   # Called by the React player when a track starts playing, pauses, or resumes
   def set_now_playing
@@ -32,6 +34,178 @@ class Api::OverlayController < ApplicationController
       render json: {success: true, now_playing: nil}
     else
       render json: {success: false, error: "Missing track_id, paused, or clear parameter"}, status: :bad_request
+    end
+  end
+
+  # GET /api/overlay/now-playing
+  def now_playing
+    render json: OverlayNowPlaying.current.as_api_json
+  end
+
+  # GET /api/overlay/tickers
+  def tickers
+    scope = OverlayTicker.ordered
+    scope = filter_active(scope)
+    scope = scope.where(slug: params[:slug]) if params[:slug].present?
+
+    render json: {
+      tickers: scope.map { |t| ticker_json(t) }
+    }
+  end
+
+  # GET /api/overlay/lower-thirds
+  def lower_thirds
+    scope = OverlayLowerThird.order(name: :asc)
+    scope = filter_active(scope)
+    scope = scope.where(slug: params[:slug]) if params[:slug].present?
+
+    render json: {
+      lower_thirds: scope.map { |lt| lower_third_json(lt) }
+    }
+  end
+
+  # GET /api/overlay/scenes
+  def scenes
+    scope = OverlayScene.ordered
+    scope = filter_active(scope)
+
+    if params[:group].present?
+      scene_ids = OverlaySceneGroupScene
+        .joins(:overlay_scene_group)
+        .where(overlay_scene_groups: {slug: params[:group]})
+        .select(:overlay_scene_id)
+      scope = scope.where(id: scene_ids)
+    end
+
+    render json: {
+      scenes: scope.includes(:overlay_scene_elements, :overlay_scene_groups).map { |s|
+        {
+          slug: s.slug,
+          name: s.name,
+          scene_type: s.scene_type,
+          width: s.width,
+          height: s.height,
+          active: s.active,
+          element_count: s.overlay_scene_elements.size,
+          groups: s.overlay_scene_groups.map(&:slug)
+        }
+      }
+    }
+  end
+
+  # GET /api/overlay/scenes/:slug
+  def scene
+    scene = OverlayScene.find_by(slug: params[:slug])
+    return render json: {error: "Scene not found"}, status: :not_found unless scene
+
+    elements = scene.overlay_scene_elements
+      .includes(:overlay_element)
+      .order(z_index: :asc)
+
+    render json: {
+      scene: {
+        slug: scene.slug,
+        name: scene.name,
+        scene_type: scene.scene_type,
+        width: scene.width,
+        height: scene.height,
+        active: scene.active,
+        settings: scene.settings || {},
+        elements: elements.filter_map { |se|
+          el = se.overlay_element
+          next unless el
+          {
+            element_name: el.name,
+            element_slug: el.slug,
+            element_type: el.element_type,
+            x: se.x,
+            y: se.y,
+            width: se.width,
+            height: se.height,
+            z_index: se.z_index,
+            settings: el.settings || {},
+            overrides: se.overrides || {}
+          }
+        }
+      }
+    }
+  end
+
+  # GET /api/overlay/scene-groups
+  def scene_groups
+    groups = OverlaySceneGroup.ordered
+      .includes(overlay_scene_group_scenes: :overlay_scene)
+
+    render json: {
+      scene_groups: groups.map { |g|
+        {
+          slug: g.slug,
+          name: g.name,
+          scenes: g.overlay_scene_group_scenes.filter_map { |sgs|
+            next unless sgs.overlay_scene
+            {slug: sgs.overlay_scene.slug, position: sgs.position}
+          }
+        }
+      }
+    }
+  end
+
+  # GET /api/overlay/elements
+  def elements
+    scope = OverlayElement.order(name: :asc)
+    scope = filter_active(scope)
+
+    render json: {
+      elements: scope.map { |e|
+        {
+          slug: e.slug,
+          name: e.name,
+          element_type: e.element_type,
+          active: e.active,
+          settings: e.settings || {}
+        }
+      }
+    }
+  end
+
+  # GET /api/overlay/alerts/pending
+  def alerts_pending
+    render json: {
+      alerts: OverlayAlert.pending.order(created_at: :asc).map(&:as_broadcast_json)
+    }
+  end
+
+  private
+
+  def ticker_json(ticker)
+    {
+      slug: ticker.slug,
+      name: ticker.name,
+      content: ticker.content,
+      content_type: ticker.content_type,
+      feed_source: ticker.feed_source,
+      direction: ticker.direction,
+      speed: ticker.speed,
+      active: ticker.active
+    }
+  end
+
+  def lower_third_json(lt)
+    {
+      slug: lt.slug,
+      name: lt.name,
+      primary_text: lt.primary_text,
+      secondary_text: lt.secondary_text,
+      logo_url: lt.logo_url,
+      active: lt.active
+    }
+  end
+
+  def filter_active(scope)
+    if params[:active] == "all"
+      scope
+    else
+      scope.active
     end
   end
 end

--- a/app/models/overlay_alert.rb
+++ b/app/models/overlay_alert.rb
@@ -64,8 +64,9 @@ class OverlayAlert < ApplicationRecord
       alert_type: alert_type,
       title: title,
       message: message,
-      data: data,
-      created_at: created_at.iso8601
+      data: data || {},
+      created_at: created_at.iso8601,
+      expires_at: expires_at&.iso8601
     }
   end
 end

--- a/app/models/overlay_now_playing.rb
+++ b/app/models/overlay_now_playing.rb
@@ -92,17 +92,24 @@ class OverlayNowPlaying < ApplicationRecord
     )
   end
 
+  def absolute_album_cover_url(base_url)
+    path = album_cover_url
+    return nil unless path
+
+    "#{base_url}#{path}"
+  end
+
   def playing?
     track.present? || custom_title.present?
   end
 
-  def as_api_json
+  def as_api_json(base_url: nil)
     {
       playing: playing?,
       title: display_title,
       artist: display_artist,
       album: display_album,
-      album_cover: album_cover_url,
+      album_cover: base_url ? absolute_album_cover_url(base_url) : album_cover_url,
       track_id: track_id,
       paused: paused,
       is_live: is_live,

--- a/app/models/overlay_now_playing.rb
+++ b/app/models/overlay_now_playing.rb
@@ -96,22 +96,25 @@ class OverlayNowPlaying < ApplicationRecord
     track.present? || custom_title.present?
   end
 
+  def as_api_json
+    {
+      playing: playing?,
+      title: display_title,
+      artist: display_artist,
+      album: display_album,
+      album_cover: album_cover_url,
+      track_id: track_id,
+      paused: paused,
+      is_live: is_live,
+      started_at: started_at&.iso8601
+    }
+  end
+
   # Broadcast to overlay channel
   def self.broadcast_change!
-    now_playing = current
     ActionCable.server.broadcast("overlay_updates", {
       type: "now_playing_changed",
-      data: {
-        track_id: now_playing.track_id,
-        title: now_playing.display_title,
-        artist: now_playing.display_artist,
-        album: now_playing.display_album,
-        album_cover: now_playing.album_cover_url,
-        started_at: now_playing.started_at&.iso8601,
-        is_live: now_playing.is_live,
-        playing: now_playing.playing?,
-        paused: now_playing.paused
-      }
+      data: current.as_api_json
     })
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "/api/overlay/*", headers: :any, methods: [:get]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,14 @@ Rails.application.routes.draw do
 
     # Overlay API routes
     post "overlay/now-playing", to: "overlay#set_now_playing"
+    get "overlay/now-playing", to: "overlay#now_playing"
+    get "overlay/tickers", to: "overlay#tickers"
+    get "overlay/lower-thirds", to: "overlay#lower_thirds"
+    get "overlay/scenes", to: "overlay#scenes"
+    get "overlay/scenes/:slug", to: "overlay#scene"
+    get "overlay/scene-groups", to: "overlay#scene_groups"
+    get "overlay/elements", to: "overlay#elements"
+    get "overlay/alerts/pending", to: "overlay#alerts_pending"
 
     # Uplink API routes
     namespace :uplink do

--- a/spec/controllers/api/overlay_controller_spec.rb
+++ b/spec/controllers/api/overlay_controller_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Api::OverlayController, type: :controller do
+  let(:hackr) { create(:grid_hackr) }
   let(:artist) { create(:artist) }
   let(:track) { create(:track, artist: artist) }
 
   before do
+    session[:grid_hackr_id] = hackr.id
     allow(ActionCable.server).to receive(:broadcast)
   end
 

--- a/spec/factories/overlay.rb
+++ b/spec/factories/overlay.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :overlay_scene_group do
+    sequence(:name) { |n| "Group #{n}" }
+    sequence(:slug) { |n| "group-#{n}" }
+  end
+
+  factory :overlay_scene_group_scene do
+    overlay_scene_group
+    overlay_scene
+    sequence(:position) { |n| n }
+  end
+end

--- a/spec/factories/overlay_alerts.rb
+++ b/spec/factories/overlay_alerts.rb
@@ -30,6 +30,11 @@ FactoryBot.define do
     displayed_at { nil }
     expires_at { nil }
 
+    trait :pending do
+      displayed { false }
+      expires_at { 1.hour.from_now }
+    end
+
     trait :displayed do
       displayed { true }
       displayed_at { Time.current }

--- a/spec/requests/api/overlay_read_spec.rb
+++ b/spec/requests/api/overlay_read_spec.rb
@@ -1,0 +1,317 @@
+require "rails_helper"
+
+RSpec.describe "Overlay Read API", type: :request do
+  describe "GET /api/overlay/now-playing" do
+    it "returns current now-playing state when nothing playing" do
+      get "/api/overlay/now-playing"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["playing"]).to be false
+      expect(body["title"]).to eq("Nothing Playing")
+      expect(body["artist"]).to eq("")
+      expect(body["album"]).to eq("")
+      expect(body["album_cover"]).to be_nil
+      expect(body["track_id"]).to be_nil
+      expect(body["paused"]).to be false
+      expect(body["is_live"]).to be false
+      expect(body["started_at"]).to be_nil
+    end
+
+    it "returns track info when a track is playing" do
+      artist = create(:artist)
+      release = create(:release, artist: artist)
+      track = create(:track, artist: artist, release: release)
+      OverlayNowPlaying.set_track!(track)
+
+      get "/api/overlay/now-playing"
+
+      body = JSON.parse(response.body)
+      expect(body["playing"]).to be true
+      expect(body["title"]).to eq(track.title)
+      expect(body["artist"]).to eq(artist.name)
+      expect(body["album"]).to eq(release.name)
+      expect(body["track_id"]).to eq(track.id)
+      expect(body["paused"]).to be false
+      expect(body["started_at"]).to be_present
+    end
+
+    it "returns custom title when set" do
+      OverlayNowPlaying.set_custom!(title: "Custom Song", artist: "Custom Artist")
+
+      get "/api/overlay/now-playing"
+
+      body = JSON.parse(response.body)
+      expect(body["playing"]).to be true
+      expect(body["title"]).to eq("Custom Song")
+      expect(body["artist"]).to eq("Custom Artist")
+    end
+  end
+
+  describe "GET /api/overlay/tickers" do
+    let!(:active_ticker) { create(:overlay_ticker, name: "Top Ticker", slug: "top-ticker") }
+    let!(:dynamic_ticker) { create(:overlay_ticker, :dynamic, name: "Bottom Ticker", slug: "bottom-ticker") }
+    let!(:inactive_ticker) { create(:overlay_ticker, :inactive, name: "Hidden Ticker", slug: "hidden-ticker") }
+
+    it "returns active tickers by default" do
+      get "/api/overlay/tickers"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      slugs = body["tickers"].map { |t| t["slug"] }
+      expect(slugs).to include("top-ticker", "bottom-ticker")
+      expect(slugs).not_to include("hidden-ticker")
+    end
+
+    it "returns all tickers when active=all" do
+      get "/api/overlay/tickers", params: {active: "all"}
+
+      body = JSON.parse(response.body)
+      slugs = body["tickers"].map { |t| t["slug"] }
+      expect(slugs).to include("top-ticker", "bottom-ticker", "hidden-ticker")
+    end
+
+    it "filters by slug" do
+      get "/api/overlay/tickers", params: {slug: "top-ticker"}
+
+      body = JSON.parse(response.body)
+      expect(body["tickers"].size).to eq(1)
+      expect(body["tickers"][0]["slug"]).to eq("top-ticker")
+    end
+
+    it "includes all expected fields" do
+      get "/api/overlay/tickers"
+
+      body = JSON.parse(response.body)
+      ticker = body["tickers"].find { |t| t["slug"] == "bottom-ticker" }
+      expect(ticker["name"]).to eq("Bottom Ticker")
+      expect(ticker["content_type"]).to eq("dynamic")
+      expect(ticker["feed_source"]).to eq("api")
+      expect(ticker["direction"]).to eq("left")
+      expect(ticker["speed"]).to eq(50)
+      expect(ticker["active"]).to be true
+    end
+  end
+
+  describe "GET /api/overlay/lower-thirds" do
+    let!(:active_lt) { create(:overlay_lower_third, name: "Guest", slug: "guest", primary_text: "DJ Phantom") }
+    let!(:inactive_lt) { create(:overlay_lower_third, :inactive, name: "Hidden", slug: "hidden") }
+
+    it "returns active lower thirds by default" do
+      get "/api/overlay/lower-thirds"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      slugs = body["lower_thirds"].map { |lt| lt["slug"] }
+      expect(slugs).to include("guest")
+      expect(slugs).not_to include("hidden")
+    end
+
+    it "returns all when active=all" do
+      get "/api/overlay/lower-thirds", params: {active: "all"}
+
+      body = JSON.parse(response.body)
+      expect(body["lower_thirds"].size).to eq(2)
+    end
+
+    it "filters by slug" do
+      get "/api/overlay/lower-thirds", params: {slug: "guest"}
+
+      body = JSON.parse(response.body)
+      expect(body["lower_thirds"].size).to eq(1)
+      expect(body["lower_thirds"][0]["primary_text"]).to eq("DJ Phantom")
+    end
+
+    it "includes all expected fields" do
+      get "/api/overlay/lower-thirds"
+
+      body = JSON.parse(response.body)
+      lt = body["lower_thirds"][0]
+      expect(lt).to include("slug", "name", "primary_text", "secondary_text", "logo_url", "active")
+    end
+  end
+
+  describe "GET /api/overlay/scenes" do
+    let!(:scene) { create(:overlay_scene, name: "Main", slug: "main") }
+    let!(:inactive_scene) { create(:overlay_scene, :inactive, name: "Draft", slug: "draft") }
+
+    before do
+      create_list(:overlay_scene_element, 3, overlay_scene: scene)
+    end
+
+    it "returns active scenes by default" do
+      get "/api/overlay/scenes"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      slugs = body["scenes"].map { |s| s["slug"] }
+      expect(slugs).to include("main")
+      expect(slugs).not_to include("draft")
+    end
+
+    it "returns all when active=all" do
+      get "/api/overlay/scenes", params: {active: "all"}
+
+      body = JSON.parse(response.body)
+      expect(body["scenes"].size).to eq(2)
+    end
+
+    it "includes element count and groups" do
+      group = create(:overlay_scene_group, slug: "cyberpulse")
+      create(:overlay_scene_group_scene, overlay_scene_group: group, overlay_scene: scene)
+
+      get "/api/overlay/scenes"
+
+      body = JSON.parse(response.body)
+      s = body["scenes"].find { |s| s["slug"] == "main" }
+      expect(s["element_count"]).to eq(3)
+      expect(s["groups"]).to include("cyberpulse")
+    end
+
+    it "filters by group slug" do
+      group = create(:overlay_scene_group, slug: "test-group")
+      create(:overlay_scene_group_scene, overlay_scene_group: group, overlay_scene: scene)
+      create(:overlay_scene, name: "Other", slug: "other")
+
+      get "/api/overlay/scenes", params: {group: "test-group"}
+
+      body = JSON.parse(response.body)
+      slugs = body["scenes"].map { |s| s["slug"] }
+      expect(slugs).to eq(["main"])
+    end
+  end
+
+  describe "GET /api/overlay/scenes/:slug" do
+    let!(:scene) { create(:overlay_scene, slug: "cyberpulse-main", settings: {"bg" => "#000"}) }
+    let!(:element) { create(:overlay_element, name: "Now Playing Widget", slug: "now-playing", element_type: "now_playing", settings: {"theme" => "dark"}) }
+    let!(:scene_element) do
+      create(:overlay_scene_element,
+        overlay_scene: scene,
+        overlay_element: element,
+        x: 50, y: 900, width: 400, height: 150, z_index: 10,
+        overrides: {"color" => "#fff"})
+    end
+
+    it "returns full scene composition" do
+      get "/api/overlay/scenes/cyberpulse-main"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      s = body["scene"]
+      expect(s["slug"]).to eq("cyberpulse-main")
+      expect(s["settings"]).to eq({"bg" => "#000"})
+      expect(s["elements"].size).to eq(1)
+
+      el = s["elements"][0]
+      expect(el["element_name"]).to eq("Now Playing Widget")
+      expect(el["element_slug"]).to eq("now-playing")
+      expect(el["element_type"]).to eq("now_playing")
+      expect(el["x"]).to eq(50)
+      expect(el["y"]).to eq(900)
+      expect(el["width"]).to eq(400)
+      expect(el["height"]).to eq(150)
+      expect(el["z_index"]).to eq(10)
+      expect(el["settings"]).to eq({"theme" => "dark"})
+      expect(el["overrides"]).to eq({"color" => "#fff"})
+    end
+
+    it "returns 404 for unknown slug" do
+      get "/api/overlay/scenes/nonexistent"
+
+      expect(response).to have_http_status(:not_found)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Scene not found")
+    end
+  end
+
+  describe "GET /api/overlay/scene-groups" do
+    it "returns groups with scene slugs and positions" do
+      group = create(:overlay_scene_group, name: "CyberPulse", slug: "cyberpulse")
+      scene_a = create(:overlay_scene, slug: "cyberpulse-main")
+      scene_b = create(:overlay_scene, slug: "cyberpulse-break")
+      create(:overlay_scene_group_scene, overlay_scene_group: group, overlay_scene: scene_a, position: 1)
+      create(:overlay_scene_group_scene, overlay_scene_group: group, overlay_scene: scene_b, position: 2)
+
+      get "/api/overlay/scene-groups"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      g = body["scene_groups"][0]
+      expect(g["slug"]).to eq("cyberpulse")
+      expect(g["name"]).to eq("CyberPulse")
+      expect(g["scenes"]).to eq([
+        {"slug" => "cyberpulse-main", "position" => 1},
+        {"slug" => "cyberpulse-break", "position" => 2}
+      ])
+    end
+  end
+
+  describe "GET /api/overlay/elements" do
+    let!(:active_element) { create(:overlay_element, slug: "now-playing", settings: {"theme" => "dark"}) }
+    let!(:inactive_element) { create(:overlay_element, :inactive, slug: "hidden-element") }
+
+    it "returns active elements by default" do
+      get "/api/overlay/elements"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      slugs = body["elements"].map { |e| e["slug"] }
+      expect(slugs).to include("now-playing")
+      expect(slugs).not_to include("hidden-element")
+    end
+
+    it "returns all when active=all" do
+      get "/api/overlay/elements", params: {active: "all"}
+
+      body = JSON.parse(response.body)
+      expect(body["elements"].size).to eq(2)
+    end
+
+    it "includes all expected fields" do
+      get "/api/overlay/elements"
+
+      body = JSON.parse(response.body)
+      el = body["elements"][0]
+      expect(el).to include("slug", "name", "element_type", "active", "settings")
+      expect(el["settings"]).to eq({"theme" => "dark"})
+    end
+  end
+
+  describe "GET /api/overlay/alerts/pending" do
+    it "returns pending undisplayed alerts" do
+      pending_alert = create(:overlay_alert, :pending, title: "New Sub!", alert_type: "subscriber")
+      create(:overlay_alert, :displayed) # should be excluded
+      create(:overlay_alert, :expired) # should be excluded
+
+      get "/api/overlay/alerts/pending"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["alerts"].size).to eq(1)
+      alert = body["alerts"][0]
+      expect(alert["id"]).to eq(pending_alert.id)
+      expect(alert["alert_type"]).to eq("subscriber")
+      expect(alert["title"]).to eq("New Sub!")
+      expect(alert["expires_at"]).to be_present
+      expect(alert["created_at"]).to be_present
+    end
+
+    it "includes alerts without expiry" do
+      create(:overlay_alert, title: "No Expiry")
+
+      get "/api/overlay/alerts/pending"
+
+      body = JSON.parse(response.body)
+      expect(body["alerts"].size).to eq(1)
+      expect(body["alerts"][0]["expires_at"]).to be_nil
+    end
+  end
+
+  describe "CORS headers" do
+    it "includes Access-Control-Allow-Origin on overlay read endpoints" do
+      get "/api/overlay/now-playing", headers: {"Origin" => "http://localhost:3001"}
+
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+    end
+  end
+end


### PR DESCRIPTION
  Enable external overlay apps (OBS browser sources) to bootstrap and
  resync state via REST, complementing existing WebSocket push channels.

  8 public GET endpoints under /api/overlay/:
  - now-playing: current track state (reuses OverlayNowPlaying display helpers)
  - tickers: ticker config + content (?active=all, ?slug= filters)
  - lower-thirds: lower third state (?active=all, ?slug= filters)
  - scenes: scene index with element counts + group slugs (?active=all, ?group=)
  - scenes/:slug: full scene composition with positioned elements + settings
  - scene-groups: groups with ordered scene slugs
  - elements: element catalog (?active=all)
  - alerts/pending: undisplayed alert queue (FIFO order)

  Cross-cutting:
  - rack-cors gem for CORS on /api/overlay/* GET (origins "*")
  - OverlayNowPlaying#as_api_json extracted — shared by REST + broadcast_change!
  - OverlayAlert#as_broadcast_json gains expires_at — REST and WebSocket shapes unified
  - filter_map nil guards on scene composition and scene group joins
  - before_action :require_login_api on existing set_now_playing POST (was unauthed)