### PR TITLE
WIRE profiles: vanity @handles, bio, pinned pulses, watch-time

### DIFF
--- a/app/channels/stream_watch_channel.rb
+++ b/app/channels/stream_watch_channel.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Tracks how long a logged-in hackr watches the live stream. Modeled on
+# LiveChatChannel's server-side `periodically` heartbeat — the client
+# subscribes while the stream is live and the tab is visible, and the
+# channel accrues watch time with no client-side timer. Anonymous
+# viewers are rejected (no per-hackr accounting possible). The iframe
+# player is opaque, so "subscribed + tab visible" is the watch signal.
+class StreamWatchChannel < ApplicationCable::Channel
+  TICK_SECONDS = 60
+
+  # Credit watch time while the socket is alive and the stream is live.
+  periodically every: TICK_SECONDS.seconds do
+    credit_tick if @session_id
+  end
+
+  def subscribed
+    return reject unless current_hackr
+
+    stream = HackrStream.current_live
+    return reject unless stream
+
+    # Free the unique slot if a prior socket died without unsubscribing,
+    # then claim it. The partial unique index (one open session per hackr)
+    # makes this atomic — a concurrent subscribe loses the race and is
+    # rejected, so watch time is never double-counted.
+    current_hackr.watch_sessions.stale.update_all(
+      "disconnected_at = last_heartbeat_at, updated_at = CURRENT_TIMESTAMP"
+    )
+
+    @session_id = HackrWatchSession.create!(
+      grid_hackr: current_hackr,
+      hackr_stream: stream,
+      connected_at: Time.current,
+      last_heartbeat_at: Time.current,
+      accumulated_seconds: 0
+    ).id
+    # No stream_from — this channel is write-only telemetry.
+  rescue ActiveRecord::RecordNotUnique
+    reject
+  end
+
+  def unsubscribed
+    HackrWatchSession.find_by(id: @session_id)&.close! if @session_id
+  end
+
+  private
+
+  def credit_tick
+    return unless HackrStream.current_live # stream ended — stop crediting
+
+    HackrWatchSession.find_by(id: @session_id)&.heartbeat!(TICK_SECONDS)
+    current_hackr&.touch_activity!
+  rescue => e
+    Rails.logger.error "=== StreamWatchChannel: tick error: #{e.message} ==="
+  end
+end

--- a/app/controllers/api/grid_controller.rb
+++ b/app/controllers/api/grid_controller.rb
@@ -2,7 +2,7 @@ class Api::GridController < ApplicationController
   include GridAuthentication
   include GridSerialization
 
-  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index shop_index npc_index rest_pod_index stats_index]
+  before_action :require_login_api, only: %i[current_hackr_info command disconnect request_password_reset request_email_change update_identity debit achievements_index missions_index schematics_index loadout_index deck_index transit_index zone_map inventory_index reputation_index cred_index shop_index npc_index rest_pod_index stats_index]
   before_action -> { require_feature_api(FeatureGrant::PULSE_GRID) }, only: [:command]
   before_action -> { require_feature_api(FeatureGrant::TACTICAL_GRID) }, only: %i[zone_map shop_index npc_index rest_pod_index stats_index]
   before_action :require_admin_api, only: [:debit]
@@ -973,6 +973,22 @@ class Api::GridController < ApplicationController
     }
   end
 
+  # PATCH /api/grid/identity - Update the current hackr's editable profile
+  # fields (currently bio). Profanity on bio is rejected by the model.
+  # skip_reserved_check neutralizes the always-on reserved-alias re-check,
+  # since the alias is not changing here.
+  def update_identity
+    current_hackr.skip_reserved_check = true
+    current_hackr.assign_attributes(identity_params)
+
+    if current_hackr.save
+      render json: {success: true, hackr: auth_hackr_json(current_hackr)}
+    else
+      error = current_hackr.errors[:bio].first || current_hackr.errors.full_messages.to_sentence
+      render json: {success: false, error: error}, status: :unprocessable_entity
+    end
+  end
+
   # POST /api/grid/debit - External service debit (e.g., Synthia redemptions)
   # Authenticated via Bearer token (service account)
   def debit
@@ -1155,6 +1171,10 @@ class Api::GridController < ApplicationController
 
   def hackr_params
     params.permit(:hackr_alias, :password, :password_confirmation)
+  end
+
+  def identity_params
+    params.permit(:bio)
   end
 
   def broadcast_event(room, event)

--- a/app/controllers/api/hackr_streams_controller.rb
+++ b/app/controllers/api/hackr_streams_controller.rb
@@ -9,6 +9,7 @@ class Api::HackrStreamsController < ApplicationController
     response = if @stream
       {
         is_live: true,
+        id: @stream.id,
         artist: {
           id: @stream.artist.id,
           name: @stream.artist.name,

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  # Public, read-only WIRE profile data for the overhauled /wire/:alias
+  # page. No auth required; when the viewer is logged in and owns the
+  # profile, `is_self` unlocks inline editing affordances on the client.
+  class ProfilesController < ApplicationController
+    include GridAuthentication
+    include PulseSerialization
+
+    # last_active is coarsened to this granularity so the public endpoint
+    # can't be polled for fine-grained presence tracking.
+    LAST_ACTIVE_GRANULARITY = 5.minutes
+
+    # GET /api/profiles/:alias
+    def show
+      hackr = GridHackr.where("LOWER(hackr_alias) = ?", params[:alias].to_s.downcase).first
+
+      return render json: {error: "No such hackr"}, status: :not_found unless hackr
+
+      render json: {
+        profile: public_hackr_json(hackr),
+        is_self: logged_in? && current_hackr.id == hackr.id
+      }
+    end
+
+    private
+
+    def public_hackr_json(hackr)
+      {
+        id: hackr.id,
+        hackr_alias: hackr.hackr_alias,
+        role: hackr.role,
+        bio: hackr.bio,
+        clearance: hackr.stat("clearance").to_i,
+        joined_at: hackr.created_at,
+        last_active_at: coarse_last_active(hackr.last_activity_at),
+        stats: Grid::ProfileStats.for(hackr),
+        pinned_pulses: pinned_pulses_json(hackr)
+      }
+    end
+
+    def coarse_last_active(time)
+      return nil unless time
+
+      step = LAST_ACTIVE_GRANULARITY.to_i
+      Time.zone.at((time.to_i / step) * step)
+    end
+  end
+end

--- a/app/controllers/api/pulse_pins_controller.rb
+++ b/app/controllers/api/pulse_pins_controller.rb
@@ -34,12 +34,9 @@ module Api
       end
     end
 
-    # DELETE /api/pulses/:pulse_id/pin
+    # DELETE /api/pulses/:pulse_id/pin — PulsePin#after_destroy resequences.
     def destroy
-      PulsePin.transaction do
-        current_hackr.pulse_pins.find_by(pulse_id: params[:pulse_id])&.destroy
-        resequence!
-      end
+      current_hackr.pulse_pins.find_by(pulse_id: params[:pulse_id])&.destroy
       render json: {success: true, pinned_pulses: pinned_pulses_json(current_hackr)}
     end
 
@@ -67,13 +64,6 @@ module Api
 
     def next_position
       (current_hackr.pulse_pins.maximum(:position) || -1) + 1
-    end
-
-    # Close gaps after a removal so positions stay 0..n-1.
-    def resequence!
-      current_hackr.pulse_pins.ordered.each_with_index do |pin, idx|
-        pin.update_column(:position, idx) unless pin.position == idx
-      end
     end
   end
 end

--- a/app/controllers/api/pulse_pins_controller.rb
+++ b/app/controllers/api/pulse_pins_controller.rb
@@ -1,0 +1,79 @@
+module Api
+  # Manage the pulses a hackr pins to the top of their WIRE profile.
+  # Pins are always the current hackr's own pulses (enforced on the
+  # model), capped at PulsePin::MAX_PINS, ordered by `position`.
+  class PulsePinsController < ApplicationController
+    include GridAuthentication
+    include PulseSerialization
+
+    before_action :require_login_api
+
+    # POST /api/pulses/:pulse_id/pin
+    def create
+      pulse = Pulse.find_by(id: params[:pulse_id])
+      return render json: {success: false, error: "Pulse not found"}, status: :not_found unless pulse
+
+      pin = nil
+      over_limit = false
+
+      # Lock the hackr row so two concurrent pins can't both pass the cap.
+      current_hackr.with_lock do
+        if current_hackr.pulse_pins.count >= PulsePin::MAX_PINS
+          over_limit = true
+        else
+          pin = current_hackr.pulse_pins.create(pulse: pulse, position: next_position)
+        end
+      end
+
+      if over_limit
+        render json: {success: false, error: "You can pin at most #{PulsePin::MAX_PINS} pulses"}, status: :unprocessable_entity
+      elsif pin&.persisted?
+        render json: {success: true, pinned_pulses: pinned_pulses_json(current_hackr)}, status: :created
+      else
+        render json: {success: false, error: pin&.errors&.full_messages&.to_sentence || "Unable to pin pulse"}, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /api/pulses/:pulse_id/pin
+    def destroy
+      PulsePin.transaction do
+        current_hackr.pulse_pins.find_by(pulse_id: params[:pulse_id])&.destroy
+        resequence!
+      end
+      render json: {success: true, pinned_pulses: pinned_pulses_json(current_hackr)}
+    end
+
+    # PATCH /api/profile/pins  { pulse_ids: [...] } — set pin order
+    def reorder
+      requested = Array(params[:pulse_ids]).map(&:to_i).uniq
+      pins = current_hackr.pulse_pins.to_a
+
+      # Honor the requested order for known pins, then append any pins the
+      # caller omitted (e.g. a concurrently-added pin) so positions stay
+      # contiguous and nothing is silently stranded at a stale position.
+      ordered = requested.filter_map { |pid| pins.find { |p| p.pulse_id == pid } }
+      ordered += (pins - ordered).sort_by(&:position)
+
+      PulsePin.transaction do
+        ordered.each_with_index do |pin, idx|
+          pin.update_column(:position, idx) unless pin.position == idx
+        end
+      end
+
+      render json: {success: true, pinned_pulses: pinned_pulses_json(current_hackr)}
+    end
+
+    private
+
+    def next_position
+      (current_hackr.pulse_pins.maximum(:position) || -1) + 1
+    end
+
+    # Close gaps after a removal so positions stay 0..n-1.
+    def resequence!
+      current_hackr.pulse_pins.ordered.each_with_index do |pin, idx|
+        pin.update_column(:position, idx) unless pin.position == idx
+      end
+    end
+  end
+end

--- a/app/controllers/api/pulses_controller.rb
+++ b/app/controllers/api/pulses_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class PulsesController < ApplicationController
     include GridAuthentication
+    include PulseSerialization
 
     before_action :require_login_api, only: %i[create destroy signal_drop]
     before_action :set_pulse, only: %i[show destroy signal_drop]
@@ -164,31 +165,6 @@ module Api
 
     def pulse_params
       params.require(:pulse).permit(:content, :parent_pulse_id)
-    end
-
-    def pulse_json(pulse)
-      {
-        id: pulse.id,
-        content: pulse.content,
-        pulsed_at: pulse.pulsed_at,
-        echo_count: pulse.echo_count,
-        splice_count: pulse.splices.count, # Real-time count
-        signal_dropped: pulse.signal_dropped,
-        signal_dropped_at: pulse.signal_dropped_at,
-        parent_pulse_id: pulse.parent_pulse_id,
-        thread_root_id: pulse.thread_root_id,
-        is_splice: pulse.is_splice?,
-        is_echoed_by_current_hackr: logged_in? ? pulse.is_echo_by?(current_hackr) : false,
-        current_hackr_is_logged_in: logged_in?,
-        current_hackr_is_admin: logged_in? ? current_hackr.admin? : false,
-        grid_hackr: {
-          id: pulse.grid_hackr.id,
-          hackr_alias: pulse.grid_hackr.hackr_alias,
-          role: pulse.grid_hackr.role
-        },
-        created_at: pulse.created_at,
-        updated_at: pulse.updated_at
-      }
     end
   end
 end

--- a/app/controllers/concerns/grid_serialization.rb
+++ b/app/controllers/concerns/grid_serialization.rb
@@ -9,6 +9,7 @@ module GridSerialization
       hackr_alias: hackr.hackr_alias,
       email: hackr.email,
       role: hackr.role,
+      bio: hackr.bio,
       current_room: hackr.current_room ? auth_room_json(hackr.current_room) : nil,
       features: hackr.admin? ? [FeatureGrant::PULSE_GRID] : hackr.feature_grants.pluck(:feature),
       otp_enabled: hackr.otp_required_for_login?

--- a/app/controllers/concerns/pulse_serialization.rb
+++ b/app/controllers/concerns/pulse_serialization.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Shared JSON serializer for Pulse records, used by any API controller
+# that emits pulses (timeline, profile header, pinned pulses). Viewer-
+# specific flags rely on `current_hackr`/`logged_in?` from
+# GridAuthentication, so including controllers must also include it.
+module PulseSerialization
+  extend ActiveSupport::Concern
+
+  private
+
+  # A hackr's pinned pulses in display order, profanity/serialization
+  # shared with the timeline. Signal-dropped pulses are hidden.
+  def pinned_pulses_json(hackr)
+    hackr.pinned_pulses
+      .where(signal_dropped: false)
+      .includes(:grid_hackr)
+      .map { |pulse| pulse_json(pulse) }
+  end
+
+  def pulse_json(pulse)
+    {
+      id: pulse.id,
+      content: pulse.content,
+      pulsed_at: pulse.pulsed_at,
+      echo_count: pulse.echo_count,
+      splice_count: pulse.splices.count, # Real-time count
+      signal_dropped: pulse.signal_dropped,
+      signal_dropped_at: pulse.signal_dropped_at,
+      parent_pulse_id: pulse.parent_pulse_id,
+      thread_root_id: pulse.thread_root_id,
+      is_splice: pulse.is_splice?,
+      is_echoed_by_current_hackr: logged_in? ? pulse.is_echo_by?(current_hackr) : false,
+      current_hackr_is_logged_in: logged_in?,
+      current_hackr_is_admin: logged_in? ? current_hackr.admin? : false,
+      grid_hackr: {
+        id: pulse.grid_hackr.id,
+        hackr_alias: pulse.grid_hackr.hackr_alias,
+        role: pulse.grid_hackr.role
+      },
+      created_at: pulse.created_at,
+      updated_at: pulse.updated_at
+    }
+  end
+end

--- a/app/javascript/components/pages/HomePage.tsx
+++ b/app/javascript/components/pages/HomePage.tsx
@@ -6,6 +6,8 @@ import { UplinkPanel } from '~/components/uplink/UplinkPanel'
 import { ScheduledStreamBanner } from '~/components/stream/ScheduledStreamBanner'
 import { StartingSoonHero } from '~/components/stream/StartingSoonHero'
 import { apiJson } from '~/utils/apiClient'
+import { useGridAuth } from '~/hooks/useGridAuth'
+import { useStreamWatch } from '~/hooks/useStreamWatch'
 import type { ScheduledStreamInfo } from '~/types/uplink'
 
 interface StreamData {
@@ -37,6 +39,11 @@ export const HomePage: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const [chatPoppedOut, setChatPoppedOut] = useState(isPopoutAlive)
   const [theaterMode, setTheaterMode] = useState(false)
+  const { hackr } = useGridAuth()
+
+  // Accrue livestream watch time while live + logged in (tab-visibility
+  // gated inside the hook). Anonymous viewers aren't tracked.
+  useStreamWatch(!!streamData?.is_live && !!hackr)
 
   const fetchStreamStatus = async () => {
     try {

--- a/app/javascript/components/pages/grid/IdentityPage.tsx
+++ b/app/javascript/components/pages/grid/IdentityPage.tsx
@@ -1,12 +1,13 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { GridLayout } from '~/components/layouts/GridLayout'
 import { useGridAuth } from '~/hooks/useGridAuth'
 import { useGridAuthContext } from '~/contexts/GridAuthContext'
+import { BIO_MAX } from '~/types/profile'
 
 export const IdentityPage: React.FC = () => {
   const { hackr } = useGridAuth()
-  const { requestPasswordReset, requestEmailChange } = useGridAuthContext()
+  const { requestPasswordReset, requestEmailChange, updateProfile } = useGridAuthContext()
   const [message, setMessage] = useState<string | null>(null)
   const [messageType, setMessageType] = useState<'success' | 'error'>('success')
   const [loading, setLoading] = useState(false)
@@ -14,6 +15,15 @@ export const IdentityPage: React.FC = () => {
   const [emailLoading, setEmailLoading] = useState(false)
   const [emailMessage, setEmailMessage] = useState<string | null>(null)
   const [emailMessageType, setEmailMessageType] = useState<'success' | 'error'>('success')
+  const [bio, setBio] = useState(hackr?.bio ?? '')
+  const [bioSaving, setBioSaving] = useState(false)
+  const [bioMessage, setBioMessage] = useState<string | null>(null)
+  const [bioMessageType, setBioMessageType] = useState<'success' | 'error'>('success')
+
+  // Sync local bio when the hackr loads or changes elsewhere.
+  useEffect(() => {
+    setBio(hackr?.bio ?? '')
+  }, [hackr?.bio])
 
   const handleChangePassword = async () => {
     setLoading(true)
@@ -57,6 +67,27 @@ export const IdentityPage: React.FC = () => {
     }
   }
 
+  const handleSaveBio = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setBioSaving(true)
+    setBioMessage(null)
+    try {
+      const result = await updateProfile(bio)
+      if (result.success) {
+        setBioMessageType('success')
+        setBioMessage('Bio updated.')
+      } else {
+        setBioMessageType('error')
+        setBioMessage(result.error || 'Failed to update bio.')
+      }
+    } catch {
+      setBioMessageType('error')
+      setBioMessage('Network error. Please try again.')
+    } finally {
+      setBioSaving(false)
+    }
+  }
+
   return (
     <GridLayout>
       <div className="tui-window white-text" style={{ maxWidth: '600px', margin: '50px auto', display: 'block', background: '#1a1a2e', border: '1px solid #4a4a6a' }}>
@@ -81,6 +112,48 @@ export const IdentityPage: React.FC = () => {
               <span className="cyan-255-text">ROLE:</span> {hackr?.role}
             </p>
           </div>
+
+          <form onSubmit={handleSaveBio} style={{ margin: '20px 0', padding: '15px', border: '1px solid #4a4a6a' }}>
+            <p className="cyan-255-text" style={{ margin: '0 0 15px 0', fontWeight: 'bold', letterSpacing: '0.05em' }}>
+              BIO
+            </p>
+            <textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value.slice(0, BIO_MAX))}
+              placeholder="Broadcast a short bio to the WIRE. @mention other hackrs to link them."
+              rows={4}
+              disabled={bioSaving}
+              className="tui-input"
+              style={{ width: '100%', resize: 'vertical', fontFamily: '\'Courier New\', monospace' }}
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '10px', flexWrap: 'wrap', gap: '10px' }}>
+              <span style={{ color: bio.length >= BIO_MAX ? '#ff4444' : '#888', fontSize: '0.85em' }}>
+                {bio.length}/{BIO_MAX}
+              </span>
+              <button
+                type="submit"
+                disabled={bioSaving}
+                className="tui-button"
+                style={{
+                  background: '#00ff00',
+                  color: '#0a0a0a',
+                  border: 'none',
+                  padding: '10px 20px',
+                  fontFamily: '\'Courier New\', monospace',
+                  fontWeight: 'bold',
+                  cursor: bioSaving ? 'not-allowed' : 'pointer',
+                  opacity: bioSaving ? 0.6 : 1
+                }}
+              >
+                {bioSaving ? 'SAVING...' : 'SAVE BIO'}
+              </button>
+            </div>
+            {bioMessage && (
+              <p style={{ margin: '10px 0 0 0', color: bioMessageType === 'success' ? '#00ff00' : '#ff4444' }}>
+                {bioMessage}
+              </p>
+            )}
+          </form>
 
           <div style={{ margin: '20px 0', padding: '15px', border: '1px solid #4a4a6a' }}>
             <p className="cyan-255-text" style={{ margin: '0 0 15px 0', fontWeight: 'bold', letterSpacing: '0.05em' }}>

--- a/app/javascript/components/pulsewire/ProfileHeader.tsx
+++ b/app/javascript/components/pulsewire/ProfileHeader.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react'
+import type { ProfileData } from '~/types/profile'
+import { BIO_MAX } from '~/types/profile'
+import { BioText } from '../shared/BioText'
+import { useGridAuthContext } from '~/contexts/GridAuthContext'
+
+const ROLE_COLORS: Record<string, string> = {
+  admin: '#ff4444',
+  operator: '#c084fc',
+  operative: '#22d3ee'
+}
+
+const formatJoinDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+
+const formatWatch = (seconds: number): string => {
+  if (!seconds || seconds < 60) return '—'
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+const formatLastActive = (iso: string): string => {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000)
+  if (mins < 5) return 'online now'
+  if (mins < 60) return `active ${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `active ${hrs}h ago`
+  return `active ${Math.floor(hrs / 24)}d ago`
+}
+
+const isOnlineNow = (iso: string | null): boolean =>
+  !!iso && (Date.now() - new Date(iso).getTime()) < 5 * 60000
+
+interface ProfileHeaderProps {
+  profile: ProfileData
+  isSelf: boolean
+  onBioSaved: (bio: string) => void
+}
+
+export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, isSelf, onBioSaved }) => {
+  const { updateProfile } = useGridAuthContext()
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(profile.bio ?? '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const roleColor = ROLE_COLORS[profile.role] ?? '#888'
+
+  const startEdit = () => {
+    setDraft(profile.bio ?? '')
+    setError(null)
+    setEditing(true)
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    const result = await updateProfile(draft)
+    setSaving(false)
+    if (result.success) {
+      onBioSaved(draft)
+      setEditing(false)
+    } else {
+      setError(result.error || 'Failed to save bio.')
+    }
+  }
+
+  const share = async () => {
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/@${profile.hackr_alias}`)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable — silently ignore.
+    }
+  }
+
+  const s = profile.stats
+  const tiles: Array<{ label: string, value: number | string }> = [
+    { label: 'WIRE PULSES', value: s.pulses },
+    { label: 'ECHOES', value: s.echoes_received },
+    { label: 'PACKETS', value: s.packets },
+    { label: 'ACHIEVEMENTS', value: s.achievements },
+    { label: 'BREACHES', value: s.breaches_completed },
+    { label: 'WATCH TIME', value: formatWatch(s.watch_seconds) }
+  ]
+
+  return (
+    <div style={{
+      border: '1px solid #2a3a4a',
+      background: 'rgba(10,20,30,0.6)',
+      padding: '24px',
+      marginBottom: '24px',
+      fontFamily: '\'Courier New\', monospace'
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+        <h1 style={{ margin: 0, fontSize: '2em', color: '#fff' }}>@{profile.hackr_alias}</h1>
+        <span style={{ border: `1px solid ${roleColor}`, color: roleColor, padding: '2px 8px', fontSize: '0.7em', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+          {profile.role}
+        </span>
+        <span style={{ border: '1px solid #facc15', color: '#facc15', padding: '2px 8px', fontSize: '0.7em', letterSpacing: '0.1em' }}>
+          CL{profile.clearance}
+        </span>
+        <button
+          onClick={share}
+          style={{ marginLeft: 'auto', background: 'none', border: '1px solid #2a3a4a', color: '#22d3ee', padding: '4px 10px', cursor: 'pointer', fontFamily: 'inherit', fontSize: '0.8em' }}
+        >
+          {copied ? 'COPIED ✓' : '⧉ SHARE'}
+        </button>
+      </div>
+
+      <div style={{ marginTop: '6px', color: '#7a8a9a', fontSize: '0.85em', display: 'flex', gap: '14px', flexWrap: 'wrap' }}>
+        <span>MEMBER SINCE {formatJoinDate(profile.joined_at)}</span>
+        {profile.last_active_at && (
+          <span style={{ color: isOnlineNow(profile.last_active_at) ? '#34d399' : '#7a8a9a' }}>
+            ● {formatLastActive(profile.last_active_at)}
+          </span>
+        )}
+      </div>
+
+      <div style={{ marginTop: '16px' }}>
+        {editing ? (
+          <div>
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value.slice(0, BIO_MAX))}
+              rows={4}
+              autoFocus
+              style={{ width: '100%', resize: 'vertical', fontFamily: 'inherit', background: '#0a141e', color: '#e0e0e0', border: '1px solid #2a3a4a', padding: '8px', boxSizing: 'border-box' }}
+            />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginTop: '8px' }}>
+              <button onClick={save} disabled={saving} style={{ background: '#22d3ee', color: '#0a0a0a', border: 'none', padding: '6px 14px', cursor: saving ? 'not-allowed' : 'pointer', fontFamily: 'inherit', fontWeight: 'bold' }}>
+                {saving ? 'SAVING...' : 'SAVE'}
+              </button>
+              <button onClick={() => setEditing(false)} disabled={saving} style={{ background: 'none', color: '#888', border: '1px solid #2a3a4a', padding: '6px 14px', cursor: 'pointer', fontFamily: 'inherit' }}>
+                CANCEL
+              </button>
+              <span style={{ color: draft.length >= BIO_MAX ? '#ff4444' : '#666', fontSize: '0.8em', marginLeft: 'auto' }}>
+                {draft.length}/{BIO_MAX}
+              </span>
+            </div>
+            {error && <p style={{ color: '#ff4444', margin: '8px 0 0' }}>{error}</p>}
+          </div>
+        ) : (
+          <div style={{ color: '#c0d0e0', lineHeight: 1.5 }}>
+            {profile.bio
+              ? <BioText>{profile.bio}</BioText>
+              : <span style={{ color: '#566b7a', fontStyle: 'italic' }}>{isSelf ? 'No bio yet — broadcast something about yourself.' : 'No bio on record.'}</span>}
+            {isSelf && (
+              <button onClick={startEdit} style={{ marginLeft: '10px', background: 'none', border: 'none', color: '#22d3ee', cursor: 'pointer', fontFamily: 'inherit', fontSize: '0.8em' }}>
+                ✎ EDIT
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: '20px', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(110px, 1fr))', gap: '10px' }}>
+        {tiles.map((t) => (
+          <div key={t.label} style={{ border: '1px solid #1f2f3f', background: 'rgba(20,30,40,0.5)', padding: '10px', textAlign: 'center' }}>
+            <div style={{ color: '#fff', fontSize: '1.4em', fontWeight: 'bold' }}>{t.value}</div>
+            <div style={{ color: '#7a8a9a', fontSize: '0.65em', letterSpacing: '0.08em', marginTop: '4px' }}>{t.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/pulsewire/PulseCard.tsx
+++ b/app/javascript/components/pulsewire/PulseCard.tsx
@@ -16,6 +16,13 @@ interface PulseCardProps {
   onEchoToggle?: (pulseId: number, newEchoCount: number, isEchoed: boolean) => void
   onPulseCreated?: (pulse: Pulse) => void
   onPulseDeleted?: (pulseId: number) => void
+  pinnable?: boolean
+  isPinned?: boolean
+  onPinToggle?: (pulseId: number, isPinned: boolean) => void
+  canMoveUp?: boolean
+  canMoveDown?: boolean
+  onMoveUp?: () => void
+  onMoveDown?: () => void
 }
 
 export const PulseCard: React.FC<PulseCardProps> = ({
@@ -26,7 +33,14 @@ export const PulseCard: React.FC<PulseCardProps> = ({
   indentSplice = true,
   onEchoToggle,
   onPulseCreated,
-  onPulseDeleted
+  onPulseDeleted,
+  pinnable = false,
+  isPinned = false,
+  onPinToggle,
+  canMoveUp = false,
+  canMoveDown = false,
+  onMoveUp,
+  onMoveDown
 }) => {
   const { hackr: currentHackr } = useGridAuth()
   const [showReplyForm, setShowReplyForm] = useState(false)
@@ -187,6 +201,40 @@ export const PulseCard: React.FC<PulseCardProps> = ({
               title="Delete pulse"
             >
               ×
+            </button>
+          )}
+
+          {pinnable && (onMoveUp || onMoveDown) && (
+            <>
+              <button
+                className="pin-move-button"
+                onClick={onMoveUp}
+                disabled={!canMoveUp}
+                title="Move up"
+                style={{ background: 'none', border: 'none', cursor: canMoveUp ? 'pointer' : 'default', color: canMoveUp ? '#facc15' : '#555', padding: 0, fontSize: '0.95rem' }}
+              >
+                ↑
+              </button>
+              <button
+                className="pin-move-button"
+                onClick={onMoveDown}
+                disabled={!canMoveDown}
+                title="Move down"
+                style={{ background: 'none', border: 'none', cursor: canMoveDown ? 'pointer' : 'default', color: canMoveDown ? '#facc15' : '#555', padding: 0, fontSize: '0.95rem' }}
+              >
+                ↓
+              </button>
+            </>
+          )}
+
+          {pinnable && (
+            <button
+              className="pin-button"
+              onClick={() => onPinToggle?.(pulse.id, isPinned)}
+              title={isPinned ? 'Unpin from profile' : 'Pin to profile'}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: isPinned ? '#facc15' : '#888', padding: 0, fontSize: '0.85rem' }}
+            >
+              {isPinned ? '📌 UNPIN' : '📌 PIN'}
             </button>
           )}
         </div>

--- a/app/javascript/components/pulsewire/UserPulsesPage.tsx
+++ b/app/javascript/components/pulsewire/UserPulsesPage.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { DefaultLayout } from '~/components/layouts/DefaultLayout'
 import type { Pulse } from '../../types/pulse'
+import type { ProfileData, ProfileResponse, PinResponse } from '~/types/profile'
 import { PulseCard } from './PulseCard'
-import { apiJson } from '~/utils/apiClient'
+import { ProfileHeader } from './ProfileHeader'
+import { apiJson, ApiError } from '~/utils/apiClient'
 
 interface ProfilePulse extends Pulse {
   is_echo_on_profile?: boolean
@@ -15,115 +17,204 @@ interface PulsesResponse {
 
 export const UserPulsesPage: React.FC = () => {
   const { username } = useParams<{ username: string }>()
+  const [profile, setProfile] = useState<ProfileData | null>(null)
+  const [isSelf, setIsSelf] = useState(false)
+  const [pinnedPulses, setPinnedPulses] = useState<Pulse[]>([])
   const [pulses, setPulses] = useState<ProfilePulse[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [authoredCount, setAuthoredCount] = useState(0)
-  const [echoedCount, setEchoedCount] = useState(0)
+  const [notFound, setNotFound] = useState(false)
 
   useEffect(() => {
-    const fetchUserPulses = async () => {
-      try {
-        setIsLoading(true)
+    const load = async () => {
+      if (!username) return
+      setIsLoading(true)
+      setError(null)
+      setNotFound(false)
 
-        // Fetch both authored pulses and echoed pulses in parallel
-        const [authoredData, echoedData] = await Promise.all([
+      try {
+        const [profileData, authoredData, echoedData] = await Promise.all([
+          apiJson<ProfileResponse>(`/api/profiles/${encodeURIComponent(username)}`),
           apiJson<PulsesResponse>(`/api/pulses?hackr=${username}&filter=active&per_page=100&include_splices=true`),
           apiJson<PulsesResponse>(`/api/pulses?echoed_by=${username}&filter=active&per_page=100&include_splices=true`)
         ])
 
-        // Mark echoed pulses and merge
-        const authoredPulses: ProfilePulse[] = authoredData.pulses.map((p: Pulse) => ({
-          ...p,
-          is_echo_on_profile: false
-        }))
+        setProfile(profileData.profile)
+        setIsSelf(profileData.is_self)
+        setPinnedPulses(profileData.profile.pinned_pulses)
 
+        const authoredPulses: ProfilePulse[] = authoredData.pulses.map((p) => ({ ...p, is_echo_on_profile: false }))
         const echoedPulses: ProfilePulse[] = echoedData.pulses
-          // Filter out pulses that the user also authored (don't show both)
-          .filter((p: Pulse) => p.grid_hackr.hackr_alias.toLowerCase() !== username?.toLowerCase())
-          .map((p: Pulse) => ({
-            ...p,
-            is_echo_on_profile: true
-          }))
+          .filter((p) => p.grid_hackr.hackr_alias.toLowerCase() !== username.toLowerCase())
+          .map((p) => ({ ...p, is_echo_on_profile: true }))
 
-        // Combine and sort by pulsed_at descending
         const combined = [...authoredPulses, ...echoedPulses].sort((a, b) =>
           new Date(b.pulsed_at).getTime() - new Date(a.pulsed_at).getTime()
         )
 
         setPulses(combined)
-        setAuthoredCount(authoredPulses.length)
-        setEchoedCount(echoedPulses.length)
         setIsLoading(false)
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load user pulses')
+        if (err instanceof ApiError && err.status === 404) {
+          setNotFound(true)
+        } else {
+          setError(err instanceof Error ? err.message : 'Failed to load profile')
+        }
         setIsLoading(false)
       }
     }
 
-    if (username) {
-      fetchUserPulses()
-    }
+    load()
   }, [username])
 
+  const applyEcho = (list: ProfilePulse[], pulseId: number, newEchoCount: number, isEchoed: boolean) =>
+    list.map((p) => p.id === pulseId ? { ...p, echo_count: newEchoCount, is_echoed_by_current_hackr: isEchoed } : p)
+
   const handleEchoToggle = (pulseId: number, newEchoCount: number, isEchoed: boolean) => {
-    setPulses(prev => prev.map(p =>
-      p.id === pulseId
-        ? { ...p, echo_count: newEchoCount, is_echoed_by_current_hackr: isEchoed }
-        : p
-    ))
+    setPulses((prev) => applyEcho(prev, pulseId, newEchoCount, isEchoed))
+    setPinnedPulses((prev) => applyEcho(prev as ProfilePulse[], pulseId, newEchoCount, isEchoed))
   }
 
   const handlePulseCreated = (newPulse: Pulse) => {
-    setPulses(prev => [{ ...newPulse, is_echo_on_profile: false }, ...prev])
+    setPulses((prev) => [{ ...newPulse, is_echo_on_profile: false }, ...prev])
   }
 
   const handlePulseDeleted = (pulseId: number) => {
-    setPulses(prev => prev.filter(p => p.id !== pulseId))
+    setPulses((prev) => prev.filter((p) => p.id !== pulseId))
+    setPinnedPulses((prev) => prev.filter((p) => p.id !== pulseId))
+  }
+
+  const pinBusyRef = useRef(false)
+
+  const handlePinToggle = async (pulseId: number, currentlyPinned: boolean) => {
+    if (pinBusyRef.current) return
+    pinBusyRef.current = true
+    try {
+      const resp = await apiJson<PinResponse>(`/api/pulses/${pulseId}/pin`, {
+        method: currentlyPinned ? 'DELETE' : 'POST'
+      })
+      setPinnedPulses(resp.pinned_pulses)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to update pin')
+    } finally {
+      pinBusyRef.current = false
+    }
+  }
+
+  const handlePinMove = async (pulseId: number, direction: 'up' | 'down') => {
+    if (pinBusyRef.current) return
+    const ids = pinnedPulses.map((p) => p.id)
+    const idx = ids.indexOf(pulseId)
+    const swapWith = direction === 'up' ? idx - 1 : idx + 1
+    if (idx < 0 || swapWith < 0 || swapWith >= ids.length) return
+
+    const next = [...ids];
+    [next[idx], next[swapWith]] = [next[swapWith], next[idx]]
+
+    pinBusyRef.current = true
+    try {
+      const resp = await apiJson<PinResponse>('/api/profile/pins', {
+        method: 'PATCH',
+        body: JSON.stringify({ pulse_ids: next })
+      })
+      setPinnedPulses(resp.pinned_pulses)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to reorder pins')
+    } finally {
+      pinBusyRef.current = false
+    }
+  }
+
+  const handleBioSaved = (bio: string) => {
+    setProfile((prev) => prev ? { ...prev, bio } : prev)
   }
 
   if (isLoading) {
     return (
       <DefaultLayout>
         <div className="white-168-text" style={{ textAlign: 'center', padding: '40px' }}>
-          Loading pulses...
+          Loading profile...
         </div>
       </DefaultLayout>
     )
   }
 
-  if (error) {
+  if (notFound) {
+    return (
+      <DefaultLayout>
+        <div className="white-168-text" style={{ maxWidth: '800px', margin: '0 auto', paddingTop: '40px', textAlign: 'center' }}>
+          <h1>NO SIGNAL</h1>
+          <p>No hackr known as <strong>@{username}</strong> on the WIRE.</p>
+          <Link to="/wire" className="btn btn-primary">← Back to the WIRE</Link>
+        </div>
+      </DefaultLayout>
+    )
+  }
+
+  if (error || !profile) {
     return (
       <DefaultLayout>
         <div className="red-255-text" style={{ padding: '20px', border: '1px solid #ff0000', marginBottom: '20px' }}>
-          {error}
+          {error || 'Profile unavailable'}
         </div>
         <Link to="/wire" className="btn btn-primary">Back to Hotwire</Link>
       </DefaultLayout>
     )
   }
 
+  const pinnedIds = new Set(pinnedPulses.map((p) => p.id))
+  const canPin = (pulse: ProfilePulse) => isSelf && !pulse.is_echo_on_profile && pulse.grid_hackr.id === profile.id
+  // Pinned pulses render in the PINNED section, not again in the feed.
+  const timelinePulses = pulses.filter((p) => !pinnedIds.has(p.id))
+
   return (
     <DefaultLayout showAsciiArt={false}>
       <div className="user-pulses-page white-168-text" style={{ maxWidth: '800px', margin: '0 auto', paddingTop: '30px' }}>
-        <div className="user-header">
-          <h1>@{username}</h1>
-          <div className="user-stats">
-            {authoredCount} {authoredCount === 1 ? 'pulse' : 'pulses'} · {echoedCount} {echoedCount === 1 ? 'echo' : 'echoes'}
-          </div>
-        </div>
+        <ProfileHeader profile={profile} isSelf={isSelf} onBioSaved={handleBioSaved} />
 
-        <div className="back-link" style={{ marginBottom: '20px', marginTop: '10px' }}>
-          <Link to="/wire">← Back to the WIRE</Link>
+        {pinnedPulses.length > 0 && (
+          <div className="pinned-pulses" style={{
+            marginBottom: '24px',
+            padding: '16px',
+            border: '1px solid rgba(250, 204, 21, 0.35)',
+            background: 'rgba(250, 204, 21, 0.04)'
+          }}>
+            <div style={{ color: '#facc15', letterSpacing: '0.1em', fontSize: '0.8rem', marginBottom: '10px', fontFamily: '\'Courier New\', monospace' }}>
+              📌 PINNED
+            </div>
+            {pinnedPulses.map((pulse, idx) => (
+              <PulseCard
+                key={`pin-${pulse.id}`}
+                pulse={pulse}
+                showReplies={false}
+                indentSplice={false}
+                pinnable={isSelf}
+                isPinned
+                onPinToggle={handlePinToggle}
+                onEchoToggle={handleEchoToggle}
+                onPulseDeleted={handlePulseDeleted}
+                canMoveUp={isSelf && idx > 0}
+                canMoveDown={isSelf && idx < pinnedPulses.length - 1}
+                onMoveUp={() => handlePinMove(pulse.id, 'up')}
+                onMoveDown={() => handlePinMove(pulse.id, 'down')}
+              />
+            ))}
+          </div>
+        )}
+
+        <div style={{ color: '#7a8a9a', letterSpacing: '0.1em', fontSize: '0.8rem', marginBottom: '10px', fontFamily: '\'Courier New\', monospace' }}>
+          BROADCASTS
         </div>
 
         <div className="user-timeline">
-          {pulses.length === 0 ? (
+          {timelinePulses.length === 0 ? (
             <div className="empty-state">
-              <p>@{username} hasn't broadcast any pulses yet.</p>
+              <p>{pinnedPulses.length > 0
+                ? `@${profile.hackr_alias}'s broadcasts are all pinned above.`
+                : `@${profile.hackr_alias} hasn't broadcast any pulses yet.`}</p>
             </div>
           ) : (
-            pulses.map(pulse => (
+            timelinePulses.map((pulse) => (
               <div key={`${pulse.is_echo_on_profile ? 'echo-' : ''}${pulse.id}`}>
                 {pulse.is_echo_on_profile && (
                   <div className="echo-indicator" style={{
@@ -141,7 +232,7 @@ export const UserPulsesPage: React.FC = () => {
                     fontFamily: '\'Courier New\', Courier, monospace'
                   }}>
                     <span style={{ fontSize: '1.1rem' }}>↻</span>
-                    <span>@{username} echoed</span>
+                    <span>@{profile.hackr_alias} echoed</span>
                   </div>
                 )}
                 {pulse.is_splice && !pulse.is_echo_on_profile && (
@@ -171,6 +262,9 @@ export const UserPulsesPage: React.FC = () => {
                 <PulseCard
                   pulse={pulse}
                   indentSplice={false}
+                  pinnable={canPin(pulse)}
+                  isPinned={pinnedIds.has(pulse.id)}
+                  onPinToggle={handlePinToggle}
                   onEchoToggle={handleEchoToggle}
                   onPulseCreated={handlePulseCreated}
                   onPulseDeleted={handlePulseDeleted}
@@ -180,7 +274,7 @@ export const UserPulsesPage: React.FC = () => {
           )}
         </div>
 
-        <div className="back-link">
+        <div className="back-link" style={{ marginTop: '20px' }}>
           <Link to="/wire">← Back to the WIRE</Link>
         </div>
       </div>

--- a/app/javascript/components/shared/BioText.test.tsx
+++ b/app/javascript/components/shared/BioText.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { BioText } from './BioText'
+
+const renderWithRouter = (node: React.ReactNode) => render(<BrowserRouter>{node}</BrowserRouter>)
+
+describe('BioText', () => {
+  it('renders plain text unchanged', () => {
+    renderWithRouter(<BioText>Just a ghost in the wire.</BioText>)
+    expect(screen.getByText('Just a ghost in the wire.')).toBeInTheDocument()
+  })
+
+  it('links @mentions to the profile route', () => {
+    renderWithRouter(<BioText>shouting out @xeraen today</BioText>)
+    const link = screen.getByRole('link', { name: '@xeraen' })
+    expect(link).toHaveAttribute('href', '/wire/xeraen')
+  })
+
+  it('does not linkify external URLs', () => {
+    renderWithRouter(<BioText>visit https://evil.example.com now</BioText>)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('does not treat an email local-part as a mention', () => {
+    renderWithRouter(<BioText>reach me at me@gmail.com anytime</BioText>)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('only links mentions at a word boundary', () => {
+    renderWithRouter(<BioText>email me@host but ping @xeraen</BioText>)
+    const links = screen.queryAllByRole('link')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', '/wire/xeraen')
+  })
+})

--- a/app/javascript/components/shared/BioText.tsx
+++ b/app/javascript/components/shared/BioText.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+/**
+ * Renders a hackr bio with @mentions linked to internal profile pages
+ * (keeping traffic on-platform); newlines preserved, everything else plain.
+ *
+ * A mention is matched only at the start of the string or right after
+ * whitespace, so email local-parts (me@gmail.com) and other inline x@y
+ * text are NOT turned into mentions. External URLs are left as plain text.
+ */
+export const BioText: React.FC<{ children: string }> = ({ children }) => {
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+
+  for (const match of children.matchAll(/(^|\s)(@[a-zA-Z0-9_]+)/g)) {
+    const lead = match[1]
+    const mention = match[2]
+    const idx = match.index ?? 0
+    const before = children.slice(lastIndex, idx) + lead
+    if (before) nodes.push(<React.Fragment key={key++}>{before}</React.Fragment>)
+    nodes.push(
+      <Link key={key++} to={`/wire/${mention.slice(1)}`} style={{ color: '#22d3ee' }}>
+        {mention}
+      </Link>
+    )
+    lastIndex = idx + match[0].length
+  }
+
+  const rest = children.slice(lastIndex)
+  if (rest) nodes.push(<React.Fragment key={key++}>{rest}</React.Fragment>)
+
+  return <span style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{nodes}</span>
+}

--- a/app/javascript/contexts/GridAuthContext.tsx
+++ b/app/javascript/contexts/GridAuthContext.tsx
@@ -9,6 +9,7 @@ export interface GridHackr {
   current_room: GridRoom | null
   features: string[]
   otp_enabled?: boolean
+  bio?: string
 }
 
 export interface GridRoom {
@@ -100,6 +101,13 @@ interface ConfirmEmailChangeResponse {
   error?: string
 }
 
+interface UpdateProfileResponse {
+  success: boolean
+  message?: string
+  error?: string
+  hackr?: GridHackr
+}
+
 interface CurrentHackrResponse {
   logged_in: boolean
   hackr?: GridHackr
@@ -120,6 +128,7 @@ interface GridAuthContextType {
   resetPassword: (token: string, password: string, password_confirmation: string) => Promise<ResetPasswordResponse>
   requestEmailChange: (new_email: string) => Promise<RequestEmailChangeResponse>
   confirmEmailChange: (token: string) => Promise<ConfirmEmailChangeResponse>
+  updateProfile: (bio: string) => Promise<UpdateProfileResponse>
   disconnect: () => Promise<{ success: boolean; error?: string }>
   checkAuth: () => Promise<void>
   hasFeature: (feature: string) => boolean
@@ -396,6 +405,27 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     }
   }, [])
 
+  const updateProfile = useCallback(async (bio: string): Promise<UpdateProfileResponse> => {
+    setError(null)
+    try {
+      const data = await apiJson<UpdateProfileResponse>('/api/grid/identity', {
+        method: 'PATCH',
+        body: JSON.stringify({ bio })
+      })
+
+      if (data.success && data.hackr) {
+        setHackr(data.hackr)
+      }
+      return data
+    } catch (err) {
+      // apiFetch throws ApiError on 422; its message carries the backend
+      // error string (e.g. the GovCorp profanity rejection).
+      const errorMsg = err instanceof Error ? err.message : 'Failed to update profile.'
+      setError(errorMsg)
+      return { success: false, error: errorMsg }
+    }
+  }, [])
+
   const hasFeature = useCallback((feature: string): boolean => {
     if (!hackr) return false
     if (hackr.role === 'admin') return true
@@ -507,6 +537,7 @@ export const GridAuthProvider: React.FC<GridAuthProviderProps> = ({ children }) 
     resetPassword,
     requestEmailChange,
     confirmEmailChange,
+    updateProfile,
     disconnect,
     checkAuth,
     hasFeature,

--- a/app/javascript/hooks/useStreamWatch.ts
+++ b/app/javascript/hooks/useStreamWatch.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react'
+import { getActionCableConsumer } from '~/lib/actionCableConsumer'
+
+interface Unsubscribable {
+  unsubscribe: () => void
+}
+
+/**
+ * Accrues livestream watch time for the current hackr by holding a
+ * StreamWatchChannel subscription while the stream is live AND the tab
+ * is visible. The server credits watch time on a 60s `periodically`
+ * tick — the client only opens/closes the subscription. Tearing down on
+ * tab-hidden keeps the recorded time ≈ time actually looking at the page
+ * (the iframe player itself is opaque, so this is the best signal we get).
+ */
+export const useStreamWatch = (enabled: boolean): void => {
+  const subRef = useRef<Unsubscribable | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    const open = () => {
+      if (subRef.current || cancelled) return
+      subRef.current = getActionCableConsumer().subscriptions.create({
+        channel: 'StreamWatchChannel'
+      }) as unknown as Unsubscribable
+    }
+
+    const close = () => {
+      subRef.current?.unsubscribe()
+      subRef.current = null
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        open()
+      } else {
+        close()
+      }
+    }
+
+    if (document.visibilityState === 'visible') open()
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', handleVisibility)
+      close()
+    }
+  }, [enabled])
+}

--- a/app/javascript/types/profile.ts
+++ b/app/javascript/types/profile.ts
@@ -1,0 +1,36 @@
+import type { Pulse } from './pulse'
+
+// Max bio length — mirrors the model validation (validates :bio, maximum: 512).
+export const BIO_MAX = 512
+
+export interface ProfileStats {
+  pulses: number
+  echoes_received: number
+  packets: number
+  achievements: number
+  breaches_completed: number
+  watch_seconds: number
+}
+
+export interface ProfileData {
+  id: number
+  hackr_alias: string
+  role: string
+  bio: string | null
+  clearance: number
+  joined_at: string
+  last_active_at: string | null
+  stats: ProfileStats
+  pinned_pulses: Pulse[]
+}
+
+export interface ProfileResponse {
+  profile: ProfileData
+  is_self: boolean
+}
+
+export interface PinResponse {
+  success: boolean
+  error?: string
+  pinned_pulses: Pulse[]
+}

--- a/app/jobs/live_watch/sweep_job.rb
+++ b/app/jobs/live_watch/sweep_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module LiveWatch
+  # Closes watch sessions abandoned without a clean unsubscribe (lost
+  # socket, crashed tab). Dates each close to the session's last good
+  # heartbeat so idle time after the disconnect isn't credited.
+  class SweepJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      HackrWatchSession.close_stale!
+    end
+  end
+end

--- a/app/models/grid_hackr.rb
+++ b/app/models/grid_hackr.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  api_token_digest        :string
+#  bio                     :text
 #  email                   :string
 #  hackr_alias             :string
 #  last_activity_at        :datetime
@@ -50,7 +51,10 @@ class GridHackr < ApplicationRecord
   has_secure_password
   encrypts :otp_secret
 
-  filter_profanity :hackr_alias
+  validates :bio, length: {maximum: 512}, allow_blank: true
+  validate :bio_excludes_email
+
+  filter_profanity :hackr_alias, :bio
 
   # Reserved aliases that cannot be registered (exact matches, case-insensitive)
   RESERVED_ALIASES = %w[
@@ -83,6 +87,9 @@ class GridHackr < ApplicationRecord
 
   MINIMUM_ALIAS_LENGTH = 6
 
+  # Bios stay on-platform — reject anything that looks like an email address.
+  BIO_EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i
+
   # Virtual attribute to enforce length validation during UI registration
   attr_accessor :enforce_alias_length
 
@@ -97,6 +104,9 @@ class GridHackr < ApplicationRecord
   has_many :grid_uplink_presences, dependent: :destroy
   has_many :playlists, dependent: :destroy
   has_many :pulses, dependent: :destroy
+  has_many :pulse_pins, dependent: :destroy
+  has_many :pinned_pulses, -> { order("pulse_pins.position ASC") }, through: :pulse_pins, source: :pulse
+  has_many :watch_sessions, class_name: "HackrWatchSession", dependent: :destroy
   has_many :echoes, dependent: :destroy
   has_many :chat_messages, dependent: :destroy
   has_many :user_punishments, dependent: :destroy
@@ -123,6 +133,7 @@ class GridHackr < ApplicationRecord
 
   validates :hackr_alias, presence: true, uniqueness: {case_sensitive: false}
   validates :hackr_alias, length: {minimum: MINIMUM_ALIAS_LENGTH, message: "must be at least #{MINIMUM_ALIAS_LENGTH} characters"}, if: :enforce_alias_length
+  validates :hackr_alias, format: {with: /\A[a-zA-Z0-9_]+\z/, message: "may only contain letters, numbers, and underscores"}, if: :enforce_alias_length
   validates :email, uniqueness: {case_sensitive: false}, allow_nil: true
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_nil: true
   validates :role, inclusion: {in: %w[operative operator admin], message: "%{value} is not a valid role"}
@@ -352,6 +363,12 @@ class GridHackr < ApplicationRecord
     else
       digits.each_cons(2).all? { |a, b| b - a == -1 || (a == 0 && b == 9) }
     end
+  end
+
+  def bio_excludes_email
+    return if bio.blank?
+
+    errors.add(:bio, "can't contain an email address") if bio.match?(BIO_EMAIL_PATTERN)
   end
 
   def alias_not_reserved

--- a/app/models/hackr_stream.rb
+++ b/app/models/hackr_stream.rb
@@ -32,6 +32,7 @@ class HackrStream < ApplicationRecord
   belongs_to :artist
   belongs_to :track, primary_key: :slug, foreign_key: :track_slug, optional: true
   has_many :hackr_vod_watches, dependent: :destroy
+  has_many :hackr_watch_sessions, dependent: :nullify
 
   validates :live_url, presence: true, if: :is_live?
   validates :title, length: {maximum: 255}

--- a/app/models/hackr_watch_session.rb
+++ b/app/models/hackr_watch_session.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# One livestream viewing session for a logged-in hackr. Opened when the
+# StreamWatchChannel subscribes, credited +60s on each `periodically`
+# heartbeat while the stream is live, and finalized on unsubscribe.
+# A hackr accrues many sessions; their `accumulated_seconds` sum is the
+# total watch time shown on the public profile.
+# == Schema Information
+#
+# Table name: hackr_watch_sessions
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  accumulated_seconds :integer          default(0), not null
+#  connected_at        :datetime         not null
+#  disconnected_at     :datetime
+#  last_heartbeat_at   :datetime         not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  grid_hackr_id       :integer          not null
+#  hackr_stream_id     :integer
+#
+# Indexes
+#
+#  idx_on_grid_hackr_id_disconnected_at_e34a883d93  (grid_hackr_id,disconnected_at)
+#  index_hackr_watch_sessions_on_grid_hackr_id      (grid_hackr_id)
+#  index_hackr_watch_sessions_on_hackr_stream_id    (hackr_stream_id)
+#  index_hackr_watch_sessions_on_last_heartbeat_at  (last_heartbeat_at)
+#  index_hackr_watch_sessions_one_open_per_hackr    (grid_hackr_id) UNIQUE WHERE disconnected_at IS NULL
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id)
+#  hackr_stream_id  (hackr_stream_id => hackr_streams.id)
+#
+class HackrWatchSession < ApplicationRecord
+  # Open sessions whose heartbeat has gone quiet this long are presumed
+  # dead (lost socket, no clean unsubscribe) and closed by the sweep job.
+  STALE_AFTER = 5.minutes
+
+  belongs_to :grid_hackr
+  belongs_to :hackr_stream, optional: true
+
+  scope :open_sessions, -> { where(disconnected_at: nil) }
+  scope :stale, -> { open_sessions.where(last_heartbeat_at: ..STALE_AFTER.ago) }
+
+  # Advance the heartbeat and credit elapsed watch time. Called from the
+  # channel tick. update_columns skips callbacks/validation for speed.
+  def heartbeat!(seconds)
+    return if disconnected_at.present?
+
+    update_columns(
+      last_heartbeat_at: Time.current,
+      accumulated_seconds: accumulated_seconds + seconds.to_i,
+      updated_at: Time.current
+    )
+  end
+
+  # Finalize on clean disconnect. Idempotent.
+  def close!
+    return if disconnected_at.present?
+
+    update_columns(disconnected_at: Time.current, updated_at: Time.current)
+  end
+
+  # Close sessions abandoned without an unsubscribe, dating the close to
+  # the last good heartbeat so idle time after disconnect isn't credited.
+  def self.close_stale!
+    stale.update_all("disconnected_at = last_heartbeat_at, updated_at = CURRENT_TIMESTAMP")
+  end
+end

--- a/app/models/pulse.rb
+++ b/app/models/pulse.rb
@@ -40,6 +40,7 @@ class Pulse < ApplicationRecord
   belongs_to :thread_root, class_name: "Pulse", optional: true
   has_many :echoes, dependent: :destroy
   has_many :splices, class_name: "Pulse", foreign_key: :parent_pulse_id, dependent: :destroy
+  has_many :pulse_pins, dependent: :destroy
   has_many :hackrs_who_echoed, through: :echoes, source: :grid_hackr
 
   validates :content, presence: true, length: {maximum: 256}

--- a/app/models/pulse.rb
+++ b/app/models/pulse.rb
@@ -53,6 +53,7 @@ class Pulse < ApplicationRecord
   after_create_commit :broadcast_new_pulse
   after_destroy_commit :broadcast_deletion
   after_update_commit :broadcast_signal_drop, if: :saved_change_to_signal_dropped?
+  after_update :unpin_on_signal_drop, if: :saved_change_to_signal_dropped?
 
   scope :active, -> { where(signal_dropped: false) }
   scope :dropped, -> { where(signal_dropped: true) }
@@ -88,6 +89,13 @@ class Pulse < ApplicationRecord
   end
 
   private
+
+  # A signal-dropped pulse is hidden from its owner's profile, so its pin
+  # would silently occupy a cap slot the owner can't clear. Remove it (the
+  # PulsePin#after_destroy resequences the rest).
+  def unpin_on_signal_drop
+    pulse_pins.destroy_all if signal_dropped?
+  end
 
   def set_pulsed_at
     self.pulsed_at ||= Time.current

--- a/app/models/pulse_pin.rb
+++ b/app/models/pulse_pin.rb
@@ -39,7 +39,21 @@ class PulsePin < ApplicationRecord
 
   scope :ordered, -> { order(:position) }
 
+  after_destroy :resequence_siblings
+
+  # Renumber a hackr's pins to a contiguous 0..n-1 after any removal
+  # (unpin, owner pulse deleted, or pulse signal-dropped).
+  def self.resequence_for!(grid_hackr_id)
+    where(grid_hackr_id: grid_hackr_id).ordered.each_with_index do |pin, idx|
+      pin.update_column(:position, idx) unless pin.position == idx
+    end
+  end
+
   private
+
+  def resequence_siblings
+    self.class.resequence_for!(grid_hackr_id)
+  end
 
   def pulse_authored_by_pinner
     return if pulse.nil? || grid_hackr_id.nil?

--- a/app/models/pulse_pin.rb
+++ b/app/models/pulse_pin.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# A hackr pinning one of their own pulses to the top of their WIRE
+# profile. Capped at MAX_PINS, ordered by `position` (ascending).
+# == Schema Information
+#
+# Table name: pulse_pins
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  position      :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  pulse_id      :integer          not null
+#
+# Indexes
+#
+#  index_pulse_pins_on_grid_hackr_id               (grid_hackr_id)
+#  index_pulse_pins_on_grid_hackr_id_and_position  (grid_hackr_id,position)
+#  index_pulse_pins_on_grid_hackr_id_and_pulse_id  (grid_hackr_id,pulse_id) UNIQUE
+#  index_pulse_pins_on_pulse_id                    (pulse_id)
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  pulse_id       (pulse_id => pulses.id)
+#
+class PulsePin < ApplicationRecord
+  MAX_PINS = 3
+
+  belongs_to :grid_hackr
+  belongs_to :pulse
+
+  validates :pulse_id, uniqueness: {scope: :grid_hackr_id}
+  validate :pulse_authored_by_pinner
+  validate :pulse_not_signal_dropped
+  validate :within_pin_limit, on: :create
+
+  scope :ordered, -> { order(:position) }
+
+  private
+
+  def pulse_authored_by_pinner
+    return if pulse.nil? || grid_hackr_id.nil?
+    return if pulse.grid_hackr_id == grid_hackr_id
+
+    errors.add(:pulse, "must be one of your own pulses")
+  end
+
+  def pulse_not_signal_dropped
+    return if pulse.nil?
+    return unless pulse.signal_dropped?
+
+    errors.add(:pulse, "cannot pin a signal-dropped pulse")
+  end
+
+  def within_pin_limit
+    return if grid_hackr_id.nil?
+    return if PulsePin.where(grid_hackr_id: grid_hackr_id).count < MAX_PINS
+
+    errors.add(:base, "You can pin at most #{MAX_PINS} pulses")
+  end
+end

--- a/app/services/grid/profile_stats.rb
+++ b/app/services/grid/profile_stats.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Grid
+  # Gathers the public, countable stats shown on a hackr's WIRE profile
+  # header. Every value is a vanity counter, so a short cache keeps
+  # profile views cheap without hammering the DB on each hit. Bust is by
+  # natural expiry — staleness up to CACHE_TTL is acceptable here.
+  class ProfileStats
+    CACHE_TTL = 5.minutes
+
+    def self.for(hackr)
+      new(hackr).to_h
+    end
+
+    def initialize(hackr)
+      @hackr = hackr
+    end
+
+    def to_h
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL, race_condition_ttl: 30.seconds) do
+        {
+          pulses: pulses_count,
+          echoes_received: echoes_received,
+          packets: @hackr.chat_messages.count,
+          achievements: @hackr.grid_hackr_achievements.count,
+          breaches_completed: @hackr.stat("breach_completed_count").to_i,
+          watch_seconds: @hackr.watch_sessions.sum(:accumulated_seconds)
+        }
+      end
+    end
+
+    private
+
+    def cache_key
+      "profile/v1/stats/hackr:#{@hackr.id}"
+    end
+
+    # Root pulses only — matches the wire_pulses_count achievement metric.
+    def pulses_count
+      @hackr.pulses.where(parent_pulse_id: nil).count
+    end
+
+    # Clout: how many times others have echoed this hackr's pulses.
+    def echoes_received
+      @hackr.pulses.sum(:echo_count)
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -49,3 +49,7 @@ production:
   world_event_retention:
     class: WorldEventFeed::RetentionJob
     schedule: at 5am every day
+
+  live_watch_sweep:
+    class: LiveWatch::SweepJob
+    schedule: every 10 minutes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,11 @@ Rails.application.routes.draw do
     get ":slug", to: "pages#spa_root", as: :handbook_article
   end
 
+  # Vanity profile URLs: /@alias redirects to the canonical /wire/alias.
+  # Rails-only (React Router can't match a partial-segment param); covers
+  # external links and address-bar entry, which hit Rails first.
+  get "/@:alias", to: redirect("/wire/%{alias}"), constraints: {alias: /[A-Za-z0-9_]+/}
+
   # PulseWire routes - SPA
   scope "wire" do
     get "/", to: "pages#spa_root", as: :wire
@@ -199,6 +204,7 @@ Rails.application.routes.draw do
     post "grid/reset_password", to: "grid#reset_password"
     post "grid/request_email_change", to: "grid#request_email_change"
     post "grid/confirm_email_change", to: "grid#confirm_email_change"
+    patch "grid/identity", to: "grid#update_identity"
     get "grid/zone_map", to: "grid#zone_map"
 
     # TOTP two-factor authentication
@@ -232,7 +238,13 @@ Rails.application.routes.draw do
       post "signal_drop", on: :member
       post "echo", to: "echoes#create"
       get "echoes", to: "echoes#index"
+      post "pin", to: "pulse_pins#create"
+      delete "pin", to: "pulse_pins#destroy"
     end
+
+    # Public WIRE profile + pin ordering
+    get "profiles/:alias", to: "profiles#show", constraints: {alias: /[^\/]+/}
+    patch "profile/pins", to: "pulse_pins#reorder"
 
     # Overlay API routes
     post "overlay/now-playing", to: "overlay#set_now_playing"

--- a/db/migrate/20260615120000_add_bio_to_grid_hackrs.rb
+++ b/db/migrate/20260615120000_add_bio_to_grid_hackrs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBioToGridHackrs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :grid_hackrs, :bio, :text
+  end
+end

--- a/db/migrate/20260615120001_create_pulse_pins.rb
+++ b/db/migrate/20260615120001_create_pulse_pins.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePulsePins < ActiveRecord::Migration[8.1]
+  def change
+    create_table :pulse_pins do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :pulse, null: false, foreign_key: true
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    # A hackr can pin a given pulse at most once.
+    add_index :pulse_pins, [:grid_hackr_id, :pulse_id], unique: true
+    # Ordered retrieval of a hackr's pins.
+    add_index :pulse_pins, [:grid_hackr_id, :position]
+  end
+end

--- a/db/migrate/20260615120002_create_hackr_watch_sessions.rb
+++ b/db/migrate/20260615120002_create_hackr_watch_sessions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateHackrWatchSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hackr_watch_sessions do |t|
+      t.references :grid_hackr, null: false, foreign_key: true
+      t.references :hackr_stream, foreign_key: true
+      t.datetime :connected_at, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.datetime :disconnected_at
+      t.integer :accumulated_seconds, null: false, default: 0
+
+      t.timestamps
+    end
+
+    # Open-session sweeps (disconnected_at IS NULL) + per-hackr totals.
+    add_index :hackr_watch_sessions, [:grid_hackr_id, :disconnected_at]
+    # Stale-heartbeat sweep for orphaned sessions.
+    add_index :hackr_watch_sessions, :last_heartbeat_at
+  end
+end

--- a/db/migrate/20260619120000_add_unique_open_watch_session_index.rb
+++ b/db/migrate/20260619120000_add_unique_open_watch_session_index.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddUniqueOpenWatchSessionIndex < ActiveRecord::Migration[8.1]
+  def up
+    # Close any currently-open sessions so the new constraint applies
+    # cleanly (pre-fix artifacts; at most one open session per hackr now).
+    execute(<<~SQL)
+      UPDATE hackr_watch_sessions
+      SET disconnected_at = last_heartbeat_at, updated_at = CURRENT_TIMESTAMP
+      WHERE disconnected_at IS NULL
+    SQL
+
+    # At most one open watch session per hackr — enforces the anti-double-
+    # count guarantee atomically (the channel's check-then-create was raceable).
+    add_index :hackr_watch_sessions, :grid_hackr_id,
+      unique: true,
+      where: "disconnected_at IS NULL",
+      name: "index_hackr_watch_sessions_one_open_per_hackr"
+  end
+
+  def down
+    remove_index :hackr_watch_sessions, name: "index_hackr_watch_sessions_one_open_per_hackr"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_120000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -466,6 +466,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
 
   create_table "grid_hackrs", force: :cascade do |t|
     t.string "api_token_digest"
+    t.text "bio"
     t.datetime "created_at", null: false
     t.integer "current_room_id"
     t.string "email"
@@ -1058,6 +1059,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
     t.index ["hackr_stream_id"], name: "index_hackr_vod_watches_on_hackr_stream_id"
   end
 
+  create_table "hackr_watch_sessions", force: :cascade do |t|
+    t.integer "accumulated_seconds", default: 0, null: false
+    t.datetime "connected_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "disconnected_at"
+    t.integer "grid_hackr_id", null: false
+    t.integer "hackr_stream_id"
+    t.datetime "last_heartbeat_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "disconnected_at"], name: "idx_on_grid_hackr_id_disconnected_at_e34a883d93"
+    t.index ["grid_hackr_id"], name: "index_hackr_watch_sessions_on_grid_hackr_id"
+    t.index ["grid_hackr_id"], name: "index_hackr_watch_sessions_one_open_per_hackr", unique: true, where: "disconnected_at IS NULL"
+    t.index ["hackr_stream_id"], name: "index_hackr_watch_sessions_on_hackr_stream_id"
+    t.index ["last_heartbeat_at"], name: "index_hackr_watch_sessions_on_last_heartbeat_at"
+  end
+
   create_table "handbook_articles", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -1251,6 +1268,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
     t.datetime "updated_at", null: false
     t.index ["grid_hackr_id"], name: "index_playlists_on_grid_hackr_id"
     t.index ["share_token"], name: "index_playlists_on_share_token", unique: true
+  end
+
+  create_table "pulse_pins", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "grid_hackr_id", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "pulse_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_hackr_id", "position"], name: "index_pulse_pins_on_grid_hackr_id_and_position"
+    t.index ["grid_hackr_id", "pulse_id"], name: "index_pulse_pins_on_grid_hackr_id_and_pulse_id", unique: true
+    t.index ["grid_hackr_id"], name: "index_pulse_pins_on_grid_hackr_id"
+    t.index ["pulse_id"], name: "index_pulse_pins_on_pulse_id"
   end
 
   create_table "pulses", force: :cascade do |t|
@@ -1562,6 +1591,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
   add_foreign_key "hackr_streams", "artists"
   add_foreign_key "hackr_vod_watches", "grid_hackrs"
   add_foreign_key "hackr_vod_watches", "hackr_streams"
+  add_foreign_key "hackr_watch_sessions", "grid_hackrs"
+  add_foreign_key "hackr_watch_sessions", "hackr_streams"
   add_foreign_key "handbook_articles", "handbook_sections"
   add_foreign_key "moderation_logs", "chat_messages"
   add_foreign_key "moderation_logs", "grid_hackrs", column: "actor_id"
@@ -1574,6 +1605,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000001) do
   add_foreign_key "playlist_tracks", "playlists"
   add_foreign_key "playlist_tracks", "tracks"
   add_foreign_key "playlists", "grid_hackrs"
+  add_foreign_key "pulse_pins", "grid_hackrs"
+  add_foreign_key "pulse_pins", "pulses"
   add_foreign_key "pulses", "grid_hackrs"
   add_foreign_key "pulses", "pulses", column: "parent_pulse_id"
   add_foreign_key "pulses", "pulses", column: "thread_root_id"

--- a/lib/terminal/handlers/register_handler.rb
+++ b/lib/terminal/handlers/register_handler.rb
@@ -122,6 +122,11 @@ module Terminal
           current_room: starting_room,
           role: "operative"
         )
+        # Enforce the same handle rules as web registration (min length +
+        # [A-Za-z0-9_] format) so terminal-created handles work with the
+        # /@alias vanity URL and @mention parser. System/seed accounts
+        # (which may use spaces, e.g. "Sora Nexa") skip this by not setting it.
+        hackr.enforce_alias_length = true
 
         if hackr.save
           Grid::TutorialService.new(hackr).start!

--- a/spec/channels/stream_watch_channel_spec.rb
+++ b/spec/channels/stream_watch_channel_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe StreamWatchChannel, type: :channel do
+  let(:hackr) { create(:grid_hackr) }
+
+  it "rejects anonymous connections" do
+    stub_connection current_hackr: nil
+    subscribe
+    expect(subscription).to be_rejected
+  end
+
+  it "rejects when no stream is live" do
+    stub_connection current_hackr: hackr
+    subscribe
+    expect(subscription).to be_rejected
+  end
+
+  context "with a live stream" do
+    before { create(:hackr_stream, :live) }
+
+    it "opens a watch session on subscribe" do
+      stub_connection current_hackr: hackr
+      expect { subscribe }.to change { hackr.watch_sessions.open_sessions.count }.by(1)
+      expect(subscription).to be_confirmed
+    end
+
+    it "closes the session on unsubscribe" do
+      stub_connection current_hackr: hackr
+      subscribe
+      session = hackr.watch_sessions.last
+      unsubscribe
+      expect(session.reload.disconnected_at).to be_present
+    end
+
+    it "rejects a second concurrent subscription for the same hackr" do
+      stub_connection current_hackr: hackr
+      subscribe
+      expect(subscription).to be_confirmed
+
+      stub_connection current_hackr: hackr
+      subscribe
+      expect(subscription).to be_rejected
+    end
+
+    it "credits watch time on a tick while live" do
+      stub_connection current_hackr: hackr
+      subscribe
+      session = hackr.watch_sessions.last
+      expect { subscription.send(:credit_tick) }
+        .to change { session.reload.accumulated_seconds }.by(StreamWatchChannel::TICK_SECONDS)
+    end
+
+    it "stops crediting once the stream ends" do
+      stub_connection current_hackr: hackr
+      subscribe
+      HackrStream.current_live.update!(is_live: false)
+      session = hackr.watch_sessions.last
+      expect { subscription.send(:credit_tick) }
+        .not_to(change { session.reload.accumulated_seconds })
+    end
+  end
+end

--- a/spec/factories/grid_hackrs.rb
+++ b/spec/factories/grid_hackrs.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  api_token_digest        :string
+#  bio                     :text
 #  email                   :string
 #  hackr_alias             :string
 #  last_activity_at        :datetime

--- a/spec/jobs/live_watch/sweep_job_spec.rb
+++ b/spec/jobs/live_watch/sweep_job_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe LiveWatch::SweepJob, type: :job do
+  it "closes stale open sessions" do
+    hackr = create(:grid_hackr)
+    stale = HackrWatchSession.create!(
+      grid_hackr: hackr,
+      connected_at: 10.minutes.ago,
+      last_heartbeat_at: 10.minutes.ago,
+      accumulated_seconds: 60
+    )
+
+    described_class.perform_now
+
+    expect(stale.reload.disconnected_at).to be_present
+  end
+end

--- a/spec/models/grid_hackr_spec.rb
+++ b/spec/models/grid_hackr_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id                      :integer          not null, primary key
 #  api_token_digest        :string
+#  bio                     :text
 #  email                   :string
 #  hackr_alias             :string
 #  last_activity_at        :datetime

--- a/spec/models/grid_hackr_spec.rb
+++ b/spec/models/grid_hackr_spec.rb
@@ -233,6 +233,25 @@ RSpec.describe GridHackr, type: :model do
         end
       end
     end
+
+    describe "alias format" do
+      it "rejects non-conforming handles when enforce_alias_length is set" do
+        hackr = build(:grid_hackr, hackr_alias: "foo-bar")
+        hackr.enforce_alias_length = true
+        expect(hackr).not_to be_valid
+        expect(hackr.errors[:hackr_alias].join).to match(/letters, numbers, and underscores/)
+      end
+
+      it "allows letters, numbers, and underscores" do
+        hackr = build(:grid_hackr, hackr_alias: "neo_kat_42")
+        hackr.enforce_alias_length = true
+        expect(hackr).to be_valid
+      end
+
+      it "allows system/seed handles with spaces when the flag is off" do
+        expect(build(:grid_hackr, hackr_alias: "Sora Nexa")).to be_valid
+      end
+    end
   end
 
   describe "associations" do

--- a/spec/models/hackr_watch_session_spec.rb
+++ b/spec/models/hackr_watch_session_spec.rb
@@ -1,0 +1,107 @@
+# == Schema Information
+#
+# Table name: hackr_watch_sessions
+# Database name: primary
+#
+#  id                  :integer          not null, primary key
+#  accumulated_seconds :integer          default(0), not null
+#  connected_at        :datetime         not null
+#  disconnected_at     :datetime
+#  last_heartbeat_at   :datetime         not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  grid_hackr_id       :integer          not null
+#  hackr_stream_id     :integer
+#
+# Indexes
+#
+#  idx_on_grid_hackr_id_disconnected_at_e34a883d93  (grid_hackr_id,disconnected_at)
+#  index_hackr_watch_sessions_on_grid_hackr_id      (grid_hackr_id)
+#  index_hackr_watch_sessions_on_hackr_stream_id    (hackr_stream_id)
+#  index_hackr_watch_sessions_on_last_heartbeat_at  (last_heartbeat_at)
+#  index_hackr_watch_sessions_one_open_per_hackr    (grid_hackr_id) UNIQUE WHERE disconnected_at IS NULL
+#
+# Foreign Keys
+#
+#  grid_hackr_id    (grid_hackr_id => grid_hackrs.id)
+#  hackr_stream_id  (hackr_stream_id => hackr_streams.id)
+#
+require "rails_helper"
+
+RSpec.describe HackrWatchSession, type: :model do
+  let(:hackr) { create(:grid_hackr) }
+
+  def open_session(owner: hackr, heartbeat_at: Time.current)
+    HackrWatchSession.create!(
+      grid_hackr: owner,
+      connected_at: heartbeat_at,
+      last_heartbeat_at: heartbeat_at,
+      accumulated_seconds: 0
+    )
+  end
+
+  describe "#heartbeat!" do
+    it "credits seconds and advances the heartbeat" do
+      session = open_session(heartbeat_at: 2.minutes.ago)
+      session.heartbeat!(60)
+      session.reload
+      expect(session.accumulated_seconds).to eq(60)
+      expect(session.last_heartbeat_at).to be_within(2.seconds).of(Time.current)
+    end
+
+    it "does not credit a closed session" do
+      session = open_session
+      session.close!
+      expect { session.heartbeat!(60) }.not_to(change { session.reload.accumulated_seconds })
+    end
+  end
+
+  describe "#close!" do
+    it "stamps disconnected_at and is idempotent" do
+      session = open_session
+      session.close!
+      first = session.reload.disconnected_at
+      expect(first).to be_present
+      session.close!
+      expect(session.reload.disconnected_at).to eq(first)
+    end
+  end
+
+  describe ".close_stale!" do
+    it "closes stale open sessions dated to their last heartbeat, leaving fresh ones open" do
+      stale = open_session(heartbeat_at: 10.minutes.ago)
+      fresh = open_session(owner: create(:grid_hackr), heartbeat_at: 1.minute.ago)
+
+      HackrWatchSession.close_stale!
+
+      expect(stale.reload.disconnected_at).to be_within(2.seconds).of(stale.last_heartbeat_at)
+      expect(fresh.reload.disconnected_at).to be_nil
+    end
+  end
+
+  describe "one open session per hackr" do
+    it "rejects a second open session for the same hackr" do
+      open_session
+      expect { open_session }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "allows a new open session after the prior one closes" do
+      open_session.close!
+      expect { open_session }.not_to raise_error
+    end
+  end
+
+  describe "stream deletion" do
+    it "nullifies the FK instead of blocking, preserving the watch total" do
+      stream = create(:hackr_stream, :live)
+      session = HackrWatchSession.create!(
+        grid_hackr: hackr, hackr_stream: stream,
+        connected_at: Time.current, last_heartbeat_at: Time.current, accumulated_seconds: 120
+      )
+
+      expect { stream.destroy! }.not_to raise_error
+      expect(session.reload.hackr_stream_id).to be_nil
+      expect(session.accumulated_seconds).to eq(120)
+    end
+  end
+end

--- a/spec/models/pulse_pin_spec.rb
+++ b/spec/models/pulse_pin_spec.rb
@@ -69,4 +69,18 @@ RSpec.describe PulsePin, type: :model do
     PulsePin.create!(grid_hackr: hackr, pulse: pulse)
     expect { pulse.destroy! }.to change(PulsePin, :count).by(-1)
   end
+
+  it "frees the cap and resequences when a pinned pulse is signal-dropped" do
+    pulses = Array.new(PulsePin::MAX_PINS) { create(:pulse, grid_hackr: hackr) }
+    pulses.each_with_index { |p, i| PulsePin.create!(grid_hackr: hackr, pulse: p, position: i) }
+
+    pulses[1].signal_drop!
+
+    expect(PulsePin.where(pulse_id: pulses[1].id)).not_to exist
+    expect(hackr.pulse_pins.ordered.pluck(:position)).to eq([0, 1])
+
+    # cap now has room for another pin
+    fresh = PulsePin.create(grid_hackr: hackr, pulse: create(:pulse, grid_hackr: hackr))
+    expect(fresh).to be_persisted
+  end
 end

--- a/spec/models/pulse_pin_spec.rb
+++ b/spec/models/pulse_pin_spec.rb
@@ -1,0 +1,72 @@
+# == Schema Information
+#
+# Table name: pulse_pins
+# Database name: primary
+#
+#  id            :integer          not null, primary key
+#  position      :integer          default(0), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  grid_hackr_id :integer          not null
+#  pulse_id      :integer          not null
+#
+# Indexes
+#
+#  index_pulse_pins_on_grid_hackr_id               (grid_hackr_id)
+#  index_pulse_pins_on_grid_hackr_id_and_position  (grid_hackr_id,position)
+#  index_pulse_pins_on_grid_hackr_id_and_pulse_id  (grid_hackr_id,pulse_id) UNIQUE
+#  index_pulse_pins_on_pulse_id                    (pulse_id)
+#
+# Foreign Keys
+#
+#  grid_hackr_id  (grid_hackr_id => grid_hackrs.id)
+#  pulse_id       (pulse_id => pulses.id)
+#
+require "rails_helper"
+
+RSpec.describe PulsePin, type: :model do
+  let(:hackr) { create(:grid_hackr) }
+  let(:pulse) { create(:pulse, grid_hackr: hackr) }
+
+  it "pins a hackr's own pulse" do
+    expect(PulsePin.new(grid_hackr: hackr, pulse: pulse)).to be_valid
+  end
+
+  it "rejects pinning another hackr's pulse" do
+    pin = PulsePin.new(grid_hackr: hackr, pulse: create(:pulse))
+    expect(pin).not_to be_valid
+    expect(pin.errors[:pulse]).to include("must be one of your own pulses")
+  end
+
+  it "rejects pinning a signal-dropped pulse" do
+    dropped = create(:pulse, :signal_dropped, grid_hackr: hackr)
+    expect(PulsePin.new(grid_hackr: hackr, pulse: dropped)).not_to be_valid
+  end
+
+  it "rejects pinning the same pulse twice" do
+    PulsePin.create!(grid_hackr: hackr, pulse: pulse)
+    expect(PulsePin.new(grid_hackr: hackr, pulse: pulse)).not_to be_valid
+  end
+
+  it "enforces the MAX_PINS cap on create" do
+    PulsePin::MAX_PINS.times do
+      PulsePin.create!(grid_hackr: hackr, pulse: create(:pulse, grid_hackr: hackr))
+    end
+    over = PulsePin.new(grid_hackr: hackr, pulse: create(:pulse, grid_hackr: hackr))
+    expect(over.save).to be false
+    expect(over.errors[:base].join).to match(/at most #{PulsePin::MAX_PINS}/o)
+  end
+
+  it "exposes pinned_pulses in ascending position order" do
+    first = create(:pulse, grid_hackr: hackr)
+    second = create(:pulse, grid_hackr: hackr)
+    PulsePin.create!(grid_hackr: hackr, pulse: first, position: 1)
+    PulsePin.create!(grid_hackr: hackr, pulse: second, position: 0)
+    expect(hackr.pinned_pulses.to_a).to eq([second, first])
+  end
+
+  it "is destroyed (no FK error) when its pulse is deleted" do
+    PulsePin.create!(grid_hackr: hackr, pulse: pulse)
+    expect { pulse.destroy! }.to change(PulsePin, :count).by(-1)
+  end
+end

--- a/spec/requests/api/grid_identity_spec.rb
+++ b/spec/requests/api/grid_identity_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Api::Grid identity", type: :request do
+  let(:hackr) { create(:grid_hackr) }
+
+  def login_as(h)
+    post "/api/grid/login", params: {hackr_alias: h.hackr_alias, password: "hackthegrid"}, as: :json
+  end
+
+  describe "PATCH /api/grid/identity" do
+    it "requires login" do
+      patch "/api/grid/identity", params: {bio: "hello"}, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "updates the bio" do
+      login_as(hackr)
+      patch "/api/grid/identity", params: {bio: "Operative on the wire."}, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(hackr.reload.bio).to eq("Operative on the wire.")
+      expect(response.parsed_body["hackr"]["bio"]).to eq("Operative on the wire.")
+    end
+
+    it "rejects a profane bio via the GovCorp censor" do
+      login_as(hackr)
+      patch "/api/grid/identity", params: {bio: "This is bullshit"}, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to start_with("GOVCORP CENSOR:")
+    end
+
+    it "rejects a bio over the length cap" do
+      login_as(hackr)
+      patch "/api/grid/identity", params: {bio: "x" * 513}, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "rejects a bio containing an email address" do
+      login_as(hackr)
+      patch "/api/grid/identity", params: {bio: "reach me at ops@hackr.tv"}, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to match(/email/i)
+    end
+
+    it "still allows @mentions (which are not emails)" do
+      login_as(hackr)
+      patch "/api/grid/identity", params: {bio: "shouting out @xeraen"}, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Api::Profiles", type: :request do
+  # Stored alias is mixed-case; URLs reach the controller lowercased (the
+  # LowercaseRedirect Rack middleware canonicalizes paths), so requesting
+  # the lowercase form also exercises the case-insensitive lookup.
+  let(:hackr) { create(:grid_hackr, hackr_alias: "GhostWire", bio: "Just a ghost in the wire.") }
+
+  before { Rails.cache.clear }
+
+  def login_as(h)
+    post "/api/grid/login", params: {hackr_alias: h.hackr_alias, password: "hackthegrid"}, as: :json
+  end
+
+  describe "GET /api/profiles/:alias" do
+    it "returns the public profile (case-insensitive alias) with stats and pinned pulses" do
+      create_list(:pulse, 2, grid_hackr: hackr)
+      pinned = create(:pulse, grid_hackr: hackr)
+      PulsePin.create!(grid_hackr: hackr, pulse: pinned)
+
+      get "/api/profiles/ghostwire"
+
+      expect(response).to have_http_status(:ok)
+      profile = response.parsed_body["profile"]
+      expect(profile["hackr_alias"]).to eq("GhostWire")
+      expect(profile["bio"]).to eq("Just a ghost in the wire.")
+      expect(profile["stats"]["pulses"]).to eq(3)
+      expect(profile["pinned_pulses"].map { |p| p["id"] }).to eq([pinned.id])
+      expect(response.parsed_body["is_self"]).to be false
+    end
+
+    it "404s for an unknown alias" do
+      get "/api/profiles/nobody_here"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "omits signal-dropped pulses from the pinned set" do
+      dropped = create(:pulse, grid_hackr: hackr)
+      PulsePin.create!(grid_hackr: hackr, pulse: dropped)
+      dropped.signal_drop!
+
+      get "/api/profiles/ghostwire"
+
+      expect(response.parsed_body["profile"]["pinned_pulses"]).to be_empty
+    end
+
+    it "marks is_self when the viewer owns the profile" do
+      login_as(hackr)
+      get "/api/profiles/ghostwire"
+      expect(response.parsed_body["is_self"]).to be true
+    end
+
+    it "sums watch_seconds across the hackr's sessions" do
+      HackrWatchSession.create!(grid_hackr: hackr, connected_at: Time.current,
+        last_heartbeat_at: Time.current, accumulated_seconds: 180, disconnected_at: Time.current)
+      get "/api/profiles/ghostwire"
+      expect(response.parsed_body["profile"]["stats"]["watch_seconds"]).to eq(180)
+    end
+
+    it "coarsens last_active_at to a 5-minute boundary" do
+      ts = Time.zone.parse("2026-06-15 12:03:47")
+      hackr.update_column(:last_activity_at, ts)
+      get "/api/profiles/ghostwire"
+      coarse = Time.zone.parse(response.parsed_body["profile"]["last_active_at"])
+      expect(coarse.to_i % 300).to eq(0)
+      expect(coarse).to eq(Time.zone.at((ts.to_i / 300) * 300))
+    end
+  end
+end

--- a/spec/requests/api/pulse_pins_spec.rb
+++ b/spec/requests/api/pulse_pins_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Api::PulsePins", type: :request do
+  let(:hackr) { create(:grid_hackr) }
+  let(:pulse) { create(:pulse, grid_hackr: hackr) }
+
+  def login_as(h)
+    post "/api/grid/login", params: {hackr_alias: h.hackr_alias, password: "hackthegrid"}, as: :json
+  end
+
+  describe "POST /api/pulses/:pulse_id/pin" do
+    it "requires login" do
+      post "/api/pulses/#{pulse.id}/pin"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "pins an own pulse and returns the pinned set" do
+      login_as(hackr)
+      post "/api/pulses/#{pulse.id}/pin"
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body["pinned_pulses"].map { |p| p["id"] }).to eq([pulse.id])
+      expect(hackr.pulse_pins.count).to eq(1)
+    end
+
+    it "refuses to pin another hackr's pulse" do
+      login_as(hackr)
+      post "/api/pulses/#{create(:pulse).id}/pin"
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "enforces the pin cap" do
+      login_as(hackr)
+      PulsePin::MAX_PINS.times { post "/api/pulses/#{create(:pulse, grid_hackr: hackr).id}/pin" }
+      post "/api/pulses/#{pulse.id}/pin"
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to match(/at most/)
+    end
+  end
+
+  describe "DELETE /api/pulses/:pulse_id/pin" do
+    it "unpins the pulse" do
+      login_as(hackr)
+      post "/api/pulses/#{pulse.id}/pin"
+      delete "/api/pulses/#{pulse.id}/pin"
+      expect(response).to have_http_status(:ok)
+      expect(hackr.pulse_pins.count).to eq(0)
+    end
+
+    it "resequences remaining pins to 0..n-1 after a middle delete" do
+      login_as(hackr)
+      a = create(:pulse, grid_hackr: hackr)
+      b = create(:pulse, grid_hackr: hackr)
+      c = create(:pulse, grid_hackr: hackr)
+      post "/api/pulses/#{a.id}/pin"
+      post "/api/pulses/#{b.id}/pin"
+      post "/api/pulses/#{c.id}/pin"
+
+      delete "/api/pulses/#{b.id}/pin"
+
+      expect(hackr.pulse_pins.ordered.pluck(:position)).to eq([0, 1])
+      expect(hackr.pinned_pulses.to_a).to eq([a, c])
+    end
+  end
+
+  describe "PATCH /api/profile/pins" do
+    it "reorders pins by the given pulse_ids" do
+      login_as(hackr)
+      a = create(:pulse, grid_hackr: hackr)
+      b = create(:pulse, grid_hackr: hackr)
+      post "/api/pulses/#{a.id}/pin"
+      post "/api/pulses/#{b.id}/pin"
+
+      patch "/api/profile/pins", params: {pulse_ids: [b.id, a.id]}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(hackr.pinned_pulses.to_a).to eq([b, a])
+    end
+
+    it "ignores duplicate/foreign ids, appends omitted, and resequences 0..n-1" do
+      login_as(hackr)
+      a = create(:pulse, grid_hackr: hackr)
+      b = create(:pulse, grid_hackr: hackr)
+      post "/api/pulses/#{a.id}/pin"
+      post "/api/pulses/#{b.id}/pin"
+
+      # b twice + a foreign id; a omitted entirely
+      patch "/api/profile/pins", params: {pulse_ids: [b.id, b.id, 999_999]}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(hackr.pinned_pulses.to_a).to eq([b, a])
+      expect(hackr.pulse_pins.ordered.pluck(:position)).to eq([0, 1])
+    end
+  end
+end

--- a/spec/requests/vanity_profile_spec.rb
+++ b/spec/requests/vanity_profile_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Vanity profile URLs", type: :request do
+  it "redirects /@alias to the canonical /wire/alias" do
+    get "/@xeraen"
+    expect(response).to have_http_status(:moved_permanently)
+    expect(response).to redirect_to("/wire/xeraen")
+  end
+end


### PR DESCRIPTION
  Overhaul of the /wire/:alias page into a real public profile, plus
  vanity URLs and per-hackr livestream watch-time tracking.

  Profiles
  - GET /api/profiles/:alias (public, case-insensitive) backed by a new ProfileHeader: role/clearance badges, member-since, last-active, bio, stat tiles (pulses, echoes, packets, achievements, breaches, watch time), and a share link. ProfileStats service, 5-min cached.
  - Vanity /@handle -> 301 to /wire/handle (Rails route; React Router can't match a partial-segment param).

  Bio
  - grid_hackrs.bio (<=512), editable on /identity and inline on your own profile via PATCH /api/grid/identity. Profanity-filtered and email-blocked (keep contact on-platform). @mentions link to profiles (word-boundary only, so emails don't mislink); external URLs stay inert.

  Pinned pulses
  - pulse_pins join table (max 3, own non-dropped pulses, reorderable). PIN/UNPIN + up/down arrows on your own pulses; pinned render once, above the feed. Atomic cap (with_lock); cascade on pulse delete.

  Watch-time
  - StreamWatchChannel accrues per-hackr livestream minutes via a 60s server tick, visibility-gated client-side. One open session per hackr enforced by a partial unique index (no double-counting); a recurring sweep job closes orphaned sessions. Player is an opaque iframe, so watch-time approximates "live + tab visible".

  Misc
  - hackr_alias format validation at registration ([A-Za-z0-9_]+).
  - Shared PulseSerialization concern (pulse_json + pinned_pulses_json).
  - 4 migrations. 3043 RSpec / 249 Vitest green; StandardRB, ESLint, and vite build clean.